### PR TITLE
Fix: close client before close sessions

### DIFF
--- a/protocol/dubbo/pool.go
+++ b/protocol/dubbo/pool.go
@@ -225,13 +225,13 @@ func (c *gettyRPCClient) close() error {
 	c.once.Do(func() {
 		// delete @c from client pool
 		c.pool.remove(c)
+		c.gettyClient.Close()
+		c.gettyClient = nil
 		for _, s := range c.sessions {
 			logger.Infof("close client session{%s, last active:%s, request number:%d}",
 				s.session.Stat(), s.session.GetActive().String(), s.reqNum)
 			s.session.Close()
 		}
-		c.gettyClient.Close()
-		c.gettyClient = nil
 		c.sessions = c.sessions[:0]
 
 		c.created = 0


### PR DESCRIPTION

<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
 close client before close sessions to defeat client stop too slowly when got a signal
