### PR TITLE
fix dubbo clientConfig call SetClientConf func null pointer when check conf Validity

### DIFF
--- a/protocol/dubbo/client.go
+++ b/protocol/dubbo/client.go
@@ -82,6 +82,11 @@ func init() {
 
 func SetClientConf(c ClientConfig) {
 	clientConf = &c
+	err := clientConf.CheckValidity()
+	if err != nil {
+		logger.Warnf("[ClientConfig CheckValidity] error: %v", err)
+		return
+	}
 }
 
 func GetClientConf() ClientConfig {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
解决在使用dubbo client 的 SetClientConf 函数并调用clientConf.CheckValidity() 方法后存在空指针问题
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```