### PR TITLE
fix dubbo serverConfig struct point check Validity issue

### DIFF
--- a/protocol/dubbo/server.go
+++ b/protocol/dubbo/server.go
@@ -68,6 +68,11 @@ func init() {
 
 func SetServerConfig(s ServerConfig) {
 	srvConf = &s
+	err := srvConf.CheckValidity()
+	if err != nil {
+		logger.Warnf("[ServerConfig CheckValidity] error: %v", err)
+		return
+	}
 }
 
 func GetServerConfig() ServerConfig {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
修复在使用dubbo client 的 SetServerConfig 函数并调用srvConf.CheckValidity() 方法后存在空指针问题
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```