### PR TITLE
avoid wg counter negative

### DIFF
--- a/remoting/zookeeper/listener_test.go
+++ b/remoting/zookeeper/listener_test.go
@@ -18,7 +18,6 @@
 package zookeeper
 
 import (
-	"fmt"
 	"testing"
 	"time"
 )
@@ -28,6 +27,7 @@ import (
 )
 import (
 	"github.com/apache/dubbo-go/remoting"
+	"github.com/apache/dubbo-go/common/logger"
 )
 
 func initZkData(t *testing.T) (*zk.TestCluster, *ZookeeperClient, <-chan zk.Event) {
@@ -108,7 +108,7 @@ type mockDataListener struct {
 }
 
 func (m *mockDataListener) DataChange(eventType remoting.Event) bool {
-	fmt.Println(eventType)
+	logger.Info(eventType)
 	m.eventList = append(m.eventList, eventType)
 	if eventType.Content == m.changedData {
 		m.client.Close()

--- a/remoting/zookeeper/listener_test.go
+++ b/remoting/zookeeper/listener_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 import (
-	"github.com/apache/dubbo-go/remoting"
 	"github.com/apache/dubbo-go/common/logger"
+	"github.com/apache/dubbo-go/remoting"
 )
 
 func initZkData(t *testing.T) (*zk.TestCluster, *ZookeeperClient, <-chan zk.Event) {

--- a/remoting/zookeeper/listener_test.go
+++ b/remoting/zookeeper/listener_test.go
@@ -111,7 +111,7 @@ func (m *mockDataListener) DataChange(eventType remoting.Event) bool {
 	fmt.Println(eventType)
 	m.eventList = append(m.eventList, eventType)
 	if eventType.Content == m.changedData {
-		m.client.Wait.Done()
+		m.client.Close()
 	}
 	return true
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

If we use `client.Wait.Done` in `DataChange` in the test, we may encounter the `negative watigroup counter negative`, because we invoke `client.Wait.Add` only once at

https://github.com/apache/dubbo-go/blob/1178d9a142bda19c04f49a9f584c96f68540a029/remoting/zookeeper/listener_test.go#L92

but invoke `client.Wait.Done` twice at 

https://github.com/apache/dubbo-go/blob/1178d9a142bda19c04f49a9f584c96f68540a029/remoting/zookeeper/listener_test.go#L114

and 

https://github.com/apache/dubbo-go/blob/1178d9a142bda19c04f49a9f584c96f68540a029/remoting/zookeeper/client.go#L233

So just change `client.Wait.Done` into `client.Close` in `DataChange`, then we can handle this.
