### PR TITLE
Add support for zookeeper registry cluster

### DIFF
--- a/common/url.go
+++ b/common/url.go
@@ -136,6 +136,11 @@ func WithPath(path string) option {
 	}
 }
 
+func WithLocation(location string) option {
+	return func(url *URL) {
+		url.Location = location
+	}
+}
 func NewURLWithOptions(opts ...option) *URL {
 	url := &URL{}
 	for _, opt := range opts {

--- a/config/registry_config.go
+++ b/config/registry_config.go
@@ -68,11 +68,13 @@ func loadRegistries(targetRegistries string, registries map[string]*RegistryConf
 		}
 
 		if target {
-			var url common.URL
-			var err error
+			var (
+				url common.URL
+				err error
+			)
 			if addresses := strings.Split(registryConf.Address, ","); len(addresses) > 1 {
 				url, err = common.NewURL(
-					context.TODO(),
+					context.Background(),
 					constant.REGISTRY_PROTOCOL+"://"+addresses[0],
 					common.WithParams(registryConf.getUrlMap(roleType)),
 					common.WithUsername(registryConf.Username),
@@ -81,7 +83,7 @@ func loadRegistries(targetRegistries string, registries map[string]*RegistryConf
 				)
 			} else {
 				url, err = common.NewURL(
-					context.TODO(),
+					context.Background(),
 					constant.REGISTRY_PROTOCOL+"://"+registryConf.Address,
 					common.WithParams(registryConf.getUrlMap(roleType)),
 					common.WithUsername(registryConf.Username),

--- a/config/registry_config.go
+++ b/config/registry_config.go
@@ -68,13 +68,26 @@ func loadRegistries(targetRegistries string, registries map[string]*RegistryConf
 		}
 
 		if target {
-			url, err := common.NewURL(
-				context.TODO(),
-				constant.REGISTRY_PROTOCOL+"://"+registryConf.Address,
-				common.WithParams(registryConf.getUrlMap(roleType)),
-				common.WithUsername(registryConf.Username),
-				common.WithPassword(registryConf.Password),
-			)
+			var url common.URL
+			var err error
+			if addresses := strings.Split(registryConf.Address, ","); len(addresses) > 1 {
+				url, err = common.NewURL(
+					context.TODO(),
+					constant.REGISTRY_PROTOCOL+"://"+addresses[0],
+					common.WithParams(registryConf.getUrlMap(roleType)),
+					common.WithUsername(registryConf.Username),
+					common.WithPassword(registryConf.Password),
+					common.WithLocation(registryConf.Address),
+				)
+			} else {
+				url, err = common.NewURL(
+					context.TODO(),
+					constant.REGISTRY_PROTOCOL+"://"+registryConf.Address,
+					common.WithParams(registryConf.getUrlMap(roleType)),
+					common.WithUsername(registryConf.Username),
+					common.WithPassword(registryConf.Password),
+				)
+			}
 
 			if err != nil {
 				logger.Errorf("The registry id:%s url is invalid ,and will skip the registry, error: %#v", k, err)

--- a/config/registry_config_test.go
+++ b/config/registry_config_test.go
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package config
+
+import (
+	"fmt"
+	"github.com/apache/dubbo-go/common"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_loadRegistries(t *testing.T) {
+	target := "shanghai1"
+	regs := map[string]*RegistryConfig{
+
+		"shanghai1": {
+			Protocol:   "mock",
+			TimeoutStr: "2s",
+			Group:      "shanghai_idc",
+			Address:    "127.0.0.2:2181,128.0.0.1:2181",
+			Username:   "user1",
+			Password:   "pwd1",
+		},
+	}
+	urls := loadRegistries(target, regs, common.CONSUMER)
+	fmt.Println(urls[0])
+	assert.Equal(t, "127.0.0.2:2181,128.0.0.1:2181", urls[0].Location)
+}
+func Test_loadRegistries1(t *testing.T) {
+	target := "shanghai1"
+	regs := map[string]*RegistryConfig{
+
+		"shanghai1": {
+			Protocol:   "mock",
+			TimeoutStr: "2s",
+			Group:      "shanghai_idc",
+			Address:    "127.0.0.2:2181",
+			Username:   "user1",
+			Password:   "pwd1",
+		},
+	}
+	urls := loadRegistries(target, regs, common.CONSUMER)
+	fmt.Println(urls[0])
+	assert.Equal(t, "127.0.0.2:2181", urls[0].Location)
+}

--- a/config/registry_config_test.go
+++ b/config/registry_config_test.go
@@ -18,9 +18,11 @@ package config
 
 import (
 	"fmt"
+	"testing"
+)
+import (
 	"github.com/apache/dubbo-go/common"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func Test_loadRegistries(t *testing.T) {

--- a/remoting/zookeeper/client.go
+++ b/remoting/zookeeper/client.go
@@ -125,7 +125,8 @@ func ValidateZookeeperClient(container zkClientFacade, opts ...Option) error {
 				url.GetParam(constant.REGISTRY_TIMEOUT_KEY, constant.DEFAULT_REG_TIMEOUT), err.Error())
 			return perrors.WithMessagef(err, "newZookeeperClient(address:%+v)", url.Location)
 		}
-		newClient, err := newZookeeperClient(opions.zkName, []string{url.Location}, timeout)
+		zkAddresses := strings.Split(url.Location, ",")
+		newClient, err := newZookeeperClient(opions.zkName, zkAddresses, timeout)
 		if err != nil {
 			logger.Warnf("newZookeeperClient(name{%s}, zk addresss{%v}, timeout{%d}) = error{%v}",
 				opions.zkName, url.Location, timeout.String(), err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
Add support for zookeeper registry cluster, when zookeeper is a cluster. User can set address with multi location split with ',' 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```