### PR TITLE
bug fix for UnregisterEvent

### DIFF
--- a/remoting/zookeeper/client.go
+++ b/remoting/zookeeper/client.go
@@ -300,26 +300,25 @@ func (z *ZookeeperClient) UnregisterEvent(zkPath string, event *chan struct{}) {
 	}
 
 	z.Lock()
-	for {
-		a, ok := z.eventRegistry[zkPath]
-		if !ok {
-			break
-		}
-		for i, e := range a {
-			if e == event {
-				arr := a
-				a = append(arr[:i], arr[i+1:]...)
-				logger.Debugf("zkClient{%s} unregister event{path:%s, event:%p}", z.name, zkPath, event)
-			}
-		}
-		logger.Debugf("after zkClient{%s} unregister event{path:%s, event:%p}, array length %d",
-			z.name, zkPath, event, len(a))
-		if len(a) == 0 {
-			delete(z.eventRegistry, zkPath)
-		} else {
-			z.eventRegistry[zkPath] = a
+	a, ok := z.eventRegistry[zkPath]
+	if !ok {
+		return
+	}
+	for i, e := range a {
+		if e == event {
+			arr := a
+			a = append(arr[:i], arr[i+1:]...)
+			logger.Debugf("zkClient{%s} unregister event{path:%s, event:%p}", z.name, zkPath, event)
 		}
 	}
+	logger.Debugf("after zkClient{%s} unregister event{path:%s, event:%p}, array length %d",
+		z.name, zkPath, event, len(a))
+	if len(a) == 0 {
+		delete(z.eventRegistry, zkPath)
+	} else {
+		z.eventRegistry[zkPath] = a
+	}
+
 	z.Unlock()
 }
 

--- a/remoting/zookeeper/client.go
+++ b/remoting/zookeeper/client.go
@@ -299,25 +299,25 @@ func (z *ZookeeperClient) UnregisterEvent(zkPath string, event *chan struct{}) {
 		return
 	}
 	z.Lock()
-	a, ok := z.eventRegistry[zkPath]
+	defer z.Unlock()
+	infoList, ok := z.eventRegistry[zkPath]
 	if !ok {
 		return
 	}
-	for i, e := range a {
+	for i, e := range infoList {
 		if e == event {
-			arr := a
-			a = append(arr[:i], arr[i+1:]...)
+			arr := infoList
+			infoList = append(arr[:i], arr[i+1:]...)
 			logger.Debugf("zkClient{%s} unregister event{path:%s, event:%p}", z.name, zkPath, event)
 		}
 	}
 	logger.Debugf("after zkClient{%s} unregister event{path:%s, event:%p}, array length %d",
-		z.name, zkPath, event, len(a))
-	if len(a) == 0 {
+		z.name, zkPath, event, len(infoList))
+	if len(infoList) == 0 {
 		delete(z.eventRegistry, zkPath)
 	} else {
-		z.eventRegistry[zkPath] = a
+		z.eventRegistry[zkPath] = infoList
 	}
-	z.Unlock()
 }
 
 func (z *ZookeeperClient) Done() <-chan struct{} {

--- a/remoting/zookeeper/client.go
+++ b/remoting/zookeeper/client.go
@@ -298,7 +298,6 @@ func (z *ZookeeperClient) UnregisterEvent(zkPath string, event *chan struct{}) {
 	if zkPath == "" {
 		return
 	}
-
 	z.Lock()
 	a, ok := z.eventRegistry[zkPath]
 	if !ok {
@@ -318,7 +317,6 @@ func (z *ZookeeperClient) UnregisterEvent(zkPath string, event *chan struct{}) {
 	} else {
 		z.eventRegistry[zkPath] = a
 	}
-
 	z.Unlock()
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
将UnregisterEvent函数中的循环去掉，该事件意在删除满足if条件e == event的注册地址，而不是删除整个zkPath对应的注册列表。
原代码中：如果函数中a的长度是2，经过删除长度为1，能继续进入循环，但因为无满足的e == event，无法继续删除，造成死循环。
改动：函数并没有重复检查是否有zkPath的注册信息的必要，删除for循环。
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```