### PR TITLE
Fix:url.Values is not safe map

### DIFF
--- a/common/url.go
+++ b/common/url.go
@@ -69,9 +69,9 @@ type baseUrl struct {
 	Location string // ip+port
 	Ip       string
 	Port     string
-	Params   url.Values
 	//url.Values is not safe map, add to avoid concurrent map read and map write error
 	paramsLock   sync.RWMutex
+	Params       url.Values
 	PrimitiveURL string
 	ctx          context.Context
 }
@@ -294,7 +294,7 @@ func (c *URL) AddParam(key string, value string) {
 func (c URL) GetParam(s string, d string) string {
 	var r string
 	c.paramsLock.RLock()
-	if r = c.Params.Get(s); r == "" {
+	if r = c.Params.Get(s); len(r) == 0 {
 		r = d
 	}
 	c.paramsLock.RUnlock()

--- a/common/url.go
+++ b/common/url.go
@@ -71,7 +71,7 @@ type baseUrl struct {
 	Port     string
 	Params   url.Values
 	//url.Values is not safe map, add to avoid concurrent map read and map write error
-	paramsLock   sync.Mutex
+	paramsLock   sync.RWMutex
 	PrimitiveURL string
 	ctx          context.Context
 }
@@ -293,11 +293,11 @@ func (c *URL) AddParam(key string, value string) {
 
 func (c URL) GetParam(s string, d string) string {
 	var r string
-	c.paramsLock.Lock()
+	c.paramsLock.RLock()
 	if r = c.Params.Get(s); r == "" {
 		r = d
 	}
-	c.paramsLock.Unlock()
+	c.paramsLock.RUnlock()
 	return r
 }
 func (c URL) GetParamAndDecoded(key string) (string, error) {


### PR DESCRIPTION

<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
Url.Values is not safe map, so add the lock to avoid concurrent map read and map write error

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```