### PR TITLE
Fix: tim.AfterFunc do not need to run in another goroutine

### DIFF
--- a/examples/consul/go-server/server.go
+++ b/examples/consul/go-server/server.go
@@ -57,7 +57,7 @@ func initSignal() {
 		case syscall.SIGHUP:
 			// reload()
 		default:
-			go time.AfterFunc(time.Duration(float64(survivalTimeout)*float64(time.Second)), func() {
+			time.AfterFunc(time.Duration(float64(survivalTimeout)*float64(time.Second)), func() {
 				logger.Warnf("app exit now by force...")
 				os.Exit(1)
 			})

--- a/examples/generic/go-client/app/client.go
+++ b/examples/generic/go-client/app/client.go
@@ -35,10 +35,6 @@ import (
 	_ "github.com/apache/dubbo-go/registry/zookeeper"
 )
 
-var (
-	survivalTimeout int = 10e9
-)
-
 // they are necessary:
 // 		export CONF_CONSUMER_FILE_PATH="xxx"
 // 		export APP_LOG_CONF_FILE="xxx"

--- a/examples/hystrixfilter/dubbo/with-hystrix-go-client/app/client.go
+++ b/examples/hystrixfilter/dubbo/with-hystrix-go-client/app/client.go
@@ -20,9 +20,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-	"os/signal"
-	"syscall"
 	"time"
 )
 
@@ -42,10 +39,6 @@ import (
 	_ "github.com/apache/dubbo-go/cluster/cluster_impl"
 	_ "github.com/apache/dubbo-go/cluster/loadbalance"
 	_ "github.com/apache/dubbo-go/registry/zookeeper"
-)
-
-var (
-	survivalTimeout int = 10e9
 )
 
 // they are necessary:
@@ -101,30 +94,5 @@ func main() {
 	for i := 1; i < 32; i++ {
 		resGot := <-getUser1Chan
 		logger.Infof("[GetUser1] %v", resGot)
-	}
-	//initSignal()
-}
-
-func initSignal() {
-	signals := make(chan os.Signal, 1)
-	// It is not possible to block SIGKILL or syscall.SIGSTOP
-	signal.Notify(signals, os.Interrupt, os.Kill, syscall.SIGHUP,
-		syscall.SIGQUIT, syscall.SIGTERM, syscall.SIGINT)
-	for {
-		sig := <-signals
-		logger.Infof("get signal %s", sig.String())
-		switch sig {
-		case syscall.SIGHUP:
-			// reload()
-		default:
-			go time.AfterFunc(time.Duration(survivalTimeout)*time.Second, func() {
-				logger.Warnf("app exit now by force...")
-				os.Exit(1)
-			})
-
-			// 要么fastFailTimeout时间内执行完毕下面的逻辑然后程序退出，要么执行上面的超时函数程序强行退出
-			fmt.Println("app exit now...")
-			return
-		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

remove `go` before `time.time.AfterFunc`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/apache/dubbo-go/issues/176.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```