### PR TITLE
Fix: [common/utils/net.go bug](https://github.com/apache/dubbo-go/issues/182)

### DIFF
--- a/cluster/cluster_impl/available_cluster_invoker.go
+++ b/cluster/cluster_impl/available_cluster_invoker.go
@@ -18,8 +18,14 @@ limitations under the License.
 package cluster_impl
 
 import (
-	"errors"
 	"fmt"
+)
+
+import (
+	"github.com/pkg/errors"
+)
+
+import (
 	"github.com/apache/dubbo-go/cluster"
 	"github.com/apache/dubbo-go/protocol"
 )

--- a/cluster/cluster_impl/available_cluster_invoker.go
+++ b/cluster/cluster_impl/available_cluster_invoker.go
@@ -18,14 +18,8 @@ limitations under the License.
 package cluster_impl
 
 import (
+	"errors"
 	"fmt"
-)
-
-import (
-	"github.com/pkg/errors"
-)
-
-import (
 	"github.com/apache/dubbo-go/cluster"
 	"github.com/apache/dubbo-go/protocol"
 )
@@ -44,12 +38,12 @@ func (invoker *availableClusterInvoker) Invoke(invocation protocol.Invocation) p
 	invokers := invoker.directory.List(invocation)
 	err := invoker.checkInvokers(invokers, invocation)
 	if err != nil {
-		return &protocol.RPCResult{Err: err}
+		return protocol.NewErrorRpcResult(err)
 	}
 
 	err = invoker.checkWhetherDestroyed()
 	if err != nil {
-		return &protocol.RPCResult{Err: err}
+		return protocol.NewErrorRpcResult(err)
 	}
 
 	for _, ivk := range invokers {
@@ -57,5 +51,5 @@ func (invoker *availableClusterInvoker) Invoke(invocation protocol.Invocation) p
 			return ivk.Invoke(invocation)
 		}
 	}
-	return &protocol.RPCResult{Err: errors.New(fmt.Sprintf("no provider available in %v", invokers))}
+	return protocol.NewErrorRpcResult(errors.New(fmt.Sprintf("no provider available in %v", invokers)))
 }

--- a/cluster/cluster_impl/available_cluster_invoker_test.go
+++ b/cluster/cluster_impl/available_cluster_invoker_test.go
@@ -62,7 +62,7 @@ func TestAvailableClusterInvokerSuccess(t *testing.T) {
 	invoker := mock.NewMockInvoker(ctrl)
 	clusterInvoker := registerAvailable(t, invoker)
 
-	mockResult := &protocol.RPCResult{Rest: rest{tried: 0, success: true}}
+	mockResult := protocol.NewRpcResult(rest{tried: 0, success: true})
 	invoker.EXPECT().IsAvailable().Return(true)
 	invoker.EXPECT().Invoke(gomock.Any()).Return(mockResult)
 

--- a/cluster/cluster_impl/base_cluster_invoker.go
+++ b/cluster/cluster_impl/base_cluster_invoker.go
@@ -63,7 +63,7 @@ func (invoker *baseClusterInvoker) IsAvailable() bool {
 //check invokers availables
 func (invoker *baseClusterInvoker) checkInvokers(invokers []protocol.Invoker, invocation protocol.Invocation) error {
 	if len(invokers) == 0 {
-		ip, _ := utils.GetLocalIP()
+		ip := utils.GetLocalIP()
 		return perrors.Errorf("Failed to invoke the method %v. No provider available for the service %v from "+
 			"registry %v on the consumer %v using the dubbo version %v .Please check if the providers have been started and registered.",
 			invocation.MethodName(), invoker.directory.GetUrl().SubURL.Key(), invoker.directory.GetUrl().String(), ip, constant.Version)
@@ -75,7 +75,7 @@ func (invoker *baseClusterInvoker) checkInvokers(invokers []protocol.Invoker, in
 //check cluster invoker is destroyed or not
 func (invoker *baseClusterInvoker) checkWhetherDestroyed() error {
 	if invoker.destroyed.Load() {
-		ip, _ := utils.GetLocalIP()
+		ip := utils.GetLocalIP()
 		return perrors.Errorf("Rpc cluster invoker for %v on consumer %v use dubbo version %v is now destroyed! can not invoke any more. ",
 			invoker.directory.GetUrl().Service(), ip, constant.Version)
 	}

--- a/cluster/cluster_impl/broadcast_cluster_invoker.go
+++ b/cluster/cluster_impl/broadcast_cluster_invoker.go
@@ -37,11 +37,11 @@ func (invoker *broadcastClusterInvoker) Invoke(invocation protocol.Invocation) p
 	invokers := invoker.directory.List(invocation)
 	err := invoker.checkInvokers(invokers, invocation)
 	if err != nil {
-		return &protocol.RPCResult{Err: err}
+		return protocol.NewErrorRpcResult(err)
 	}
 	err = invoker.checkWhetherDestroyed()
 	if err != nil {
-		return &protocol.RPCResult{Err: err}
+		return protocol.NewErrorRpcResult(err)
 	}
 
 	var result protocol.Result
@@ -53,7 +53,7 @@ func (invoker *broadcastClusterInvoker) Invoke(invocation protocol.Invocation) p
 		}
 	}
 	if err != nil {
-		return &protocol.RPCResult{Err: err}
+		return protocol.NewErrorRpcResult(err)
 	}
 	return result
 }

--- a/cluster/cluster_impl/broadcast_cluster_invoker_test.go
+++ b/cluster/cluster_impl/broadcast_cluster_invoker_test.go
@@ -65,7 +65,7 @@ func Test_BroadcastInvokeSuccess(t *testing.T) {
 
 	invokers := make([]*mock.MockInvoker, 0)
 
-	mockResult := &protocol.RPCResult{Rest: rest{tried: 0, success: true}}
+	mockResult := protocol.NewRpcResult(rest{tried: 0, success: true})
 	for i := 0; i < 3; i++ {
 		invoker := mock.NewMockInvoker(ctrl)
 		invokers = append(invokers, invoker)
@@ -84,8 +84,8 @@ func Test_BroadcastInvokeFailed(t *testing.T) {
 
 	invokers := make([]*mock.MockInvoker, 0)
 
-	mockResult := &protocol.RPCResult{Rest: rest{tried: 0, success: true}}
-	mockFailedResult := &protocol.RPCResult{Err: errors.New("just failed")}
+	mockResult := protocol.NewRpcResult(rest{tried: 0, success: true})
+	mockFailedResult := protocol.NewErrorRpcResult(errors.New("just failed"))
 	for i := 0; i < 10; i++ {
 		invoker := mock.NewMockInvoker(ctrl)
 		invokers = append(invokers, invoker)
@@ -105,5 +105,5 @@ func Test_BroadcastInvokeFailed(t *testing.T) {
 	clusterInvoker := registerBroadcast(t, invokers...)
 
 	result := clusterInvoker.Invoke(&invocation.RPCInvocation{})
-	assert.Equal(t, mockFailedResult.Err, result.Error())
+	assert.Equal(t, mockFailedResult.Error(), result.Error())
 }

--- a/cluster/cluster_impl/failback_cluster_test.go
+++ b/cluster/cluster_impl/failback_cluster_test.go
@@ -69,7 +69,7 @@ func Test_FailbackSuceess(t *testing.T) {
 
 	invoker.EXPECT().GetUrl().Return(failbackUrl).Times(1)
 
-	mockResult := &protocol.RPCResult{Rest: rest{tried: 0, success: true}}
+	mockResult := protocol.NewRpcResult(rest{tried: 0, success: true})
 	invoker.EXPECT().Invoke(gomock.Any()).Return(mockResult)
 
 	result := clusterInvoker.Invoke(&invocation.RPCInvocation{})
@@ -87,14 +87,14 @@ func Test_FailbackRetryOneSuccess(t *testing.T) {
 	invoker.EXPECT().GetUrl().Return(failbackUrl).AnyTimes()
 
 	// failed at first
-	mockFailedResult := &protocol.RPCResult{Err: perrors.New("error")}
+	mockFailedResult := protocol.NewErrorRpcResult(perrors.New("error"))
 	invoker.EXPECT().Invoke(gomock.Any()).Return(mockFailedResult)
 
 	// success second
 	var wg sync.WaitGroup
 	wg.Add(1)
 	now := time.Now()
-	mockSuccResult := &protocol.RPCResult{Rest: rest{tried: 0, success: true}}
+	mockSuccResult := protocol.NewRpcResult(rest{tried: 0, success: true})
 	invoker.EXPECT().Invoke(gomock.Any()).DoAndReturn(func(invocation protocol.Invocation) protocol.Result {
 		delta := time.Since(now).Nanoseconds() / int64(time.Second)
 		assert.True(t, delta >= 5)
@@ -129,7 +129,7 @@ func Test_FailbackRetryFailed(t *testing.T) {
 
 	invoker.EXPECT().GetUrl().Return(failbackUrl).AnyTimes()
 
-	mockFailedResult := &protocol.RPCResult{Err: perrors.New("error")}
+	mockFailedResult := protocol.NewErrorRpcResult(perrors.New("error"))
 	invoker.EXPECT().Invoke(gomock.Any()).Return(mockFailedResult)
 
 	//
@@ -177,7 +177,7 @@ func Test_FailbackRetryFailed10Times(t *testing.T) {
 	invoker.EXPECT().GetUrl().Return(failbackUrl).AnyTimes()
 
 	// 10 task should failed firstly.
-	mockFailedResult := &protocol.RPCResult{Err: perrors.New("error")}
+	mockFailedResult := protocol.NewErrorRpcResult(perrors.New("error"))
 	invoker.EXPECT().Invoke(gomock.Any()).Return(mockFailedResult).Times(10)
 
 	// 10 task should retry and failed.
@@ -218,7 +218,7 @@ func Test_FailbackOutOfLimit(t *testing.T) {
 
 	invoker.EXPECT().GetUrl().Return(failbackUrl).AnyTimes()
 
-	mockFailedResult := &protocol.RPCResult{Err: perrors.New("error")}
+	mockFailedResult := protocol.NewErrorRpcResult(perrors.New("error"))
 	invoker.EXPECT().Invoke(gomock.Any()).Return(mockFailedResult).Times(11)
 
 	// reached limit

--- a/cluster/cluster_impl/failfast_cluster_invoker.go
+++ b/cluster/cluster_impl/failfast_cluster_invoker.go
@@ -36,14 +36,14 @@ func (invoker *failfastClusterInvoker) Invoke(invocation protocol.Invocation) pr
 	invokers := invoker.directory.List(invocation)
 	err := invoker.checkInvokers(invokers, invocation)
 	if err != nil {
-		return &protocol.RPCResult{Err: err}
+		return protocol.NewErrorRpcResult(err)
 	}
 
 	loadbalance := getLoadBalance(invokers[0], invocation)
 
 	err = invoker.checkWhetherDestroyed()
 	if err != nil {
-		return &protocol.RPCResult{Err: err}
+		return protocol.NewErrorRpcResult(err)
 	}
 
 	ivk := invoker.doSelect(loadbalance, invocation, invokers, nil)

--- a/cluster/cluster_impl/failfast_cluster_test.go
+++ b/cluster/cluster_impl/failfast_cluster_test.go
@@ -66,7 +66,7 @@ func Test_FailfastInvokeSuccess(t *testing.T) {
 
 	invoker.EXPECT().GetUrl().Return(failfastUrl)
 
-	mockResult := &protocol.RPCResult{Rest: rest{tried: 0, success: true}}
+	mockResult := protocol.NewRpcResult(rest{tried: 0, success: true})
 
 	invoker.EXPECT().Invoke(gomock.Any()).Return(mockResult)
 	result := clusterInvoker.Invoke(&invocation.RPCInvocation{})
@@ -86,7 +86,7 @@ func Test_FailfastInvokeFail(t *testing.T) {
 
 	invoker.EXPECT().GetUrl().Return(failfastUrl)
 
-	mockResult := &protocol.RPCResult{Err: perrors.New("error")}
+	mockResult := protocol.NewErrorRpcResult(perrors.New("error"))
 
 	invoker.EXPECT().Invoke(gomock.Any()).Return(mockResult)
 	result := clusterInvoker.Invoke(&invocation.RPCInvocation{})

--- a/cluster/cluster_impl/failover_cluster_invoker.go
+++ b/cluster/cluster_impl/failover_cluster_invoker.go
@@ -44,7 +44,7 @@ func (invoker *failoverClusterInvoker) Invoke(invocation protocol.Invocation) pr
 	err := invoker.checkInvokers(invokers, invocation)
 
 	if err != nil {
-		return &protocol.RPCResult{Err: err}
+		return protocol.NewErrorRpcResult(err)
 	}
 
 	loadbalance := getLoadBalance(invokers[0], invocation)
@@ -68,12 +68,12 @@ func (invoker *failoverClusterInvoker) Invoke(invocation protocol.Invocation) pr
 		if i > 0 {
 			err := invoker.checkWhetherDestroyed()
 			if err != nil {
-				return &protocol.RPCResult{Err: err}
+				return protocol.NewErrorRpcResult(err)
 			}
 			invokers = invoker.directory.List(invocation)
 			err = invoker.checkInvokers(invokers, invocation)
 			if err != nil {
-				return &protocol.RPCResult{Err: err}
+				return protocol.NewErrorRpcResult(err)
 			}
 		}
 		ivk := invoker.doSelect(loadbalance, invocation, invokers, invoked)
@@ -88,8 +88,8 @@ func (invoker *failoverClusterInvoker) Invoke(invocation protocol.Invocation) pr
 		}
 	}
 	ip, _ := utils.GetLocalIP()
-	return &protocol.RPCResult{Err: perrors.Errorf("Failed to invoke the method %v in the service %v. Tried %v times of "+
+	return protocol.NewErrorRpcResult(perrors.Errorf("Failed to invoke the method %v in the service %v. Tried %v times of "+
 		"the providers %v (%v/%v)from the registry %v on the consumer %v using the dubbo version %v. Last error is %v.",
 		methodName, invoker.GetUrl().Service(), retries, providers, len(providers), len(invokers), invoker.directory.GetUrl(), ip, constant.Version, result.Error().Error(),
-	)}
+	))
 }

--- a/cluster/cluster_impl/failover_cluster_invoker.go
+++ b/cluster/cluster_impl/failover_cluster_invoker.go
@@ -87,7 +87,7 @@ func (invoker *failoverClusterInvoker) Invoke(invocation protocol.Invocation) pr
 			return result
 		}
 	}
-	ip, _ := utils.GetLocalIP()
+	ip := utils.GetLocalIP()
 	return protocol.NewErrorRpcResult(perrors.Errorf("Failed to invoke the method %v in the service %v. Tried %v times of "+
 		"the providers %v (%v/%v)from the registry %v on the consumer %v using the dubbo version %v. Last error is %v.",
 		methodName, invoker.GetUrl().Service(), retries, providers, len(providers), len(invokers), invoker.directory.GetUrl(), ip, constant.Version, result.Error().Error(),

--- a/cluster/cluster_impl/failover_cluster_test.go
+++ b/cluster/cluster_impl/failover_cluster_test.go
@@ -86,8 +86,7 @@ func (bi *MockInvoker) Invoke(invocation protocol.Invocation) protocol.Result {
 	} else {
 		err = perrors.New("error")
 	}
-	result := &protocol.RPCResult{Err: err, Rest: rest{tried: count, success: success}}
-
+	result := protocol.NewRpcResult(rest{tried: count, success: success}).SetError(err)
 	return result
 }
 

--- a/cluster/cluster_impl/failsafe_cluster_test.go
+++ b/cluster/cluster_impl/failsafe_cluster_test.go
@@ -66,7 +66,7 @@ func Test_FailSafeInvokeSuccess(t *testing.T) {
 
 	invoker.EXPECT().GetUrl().Return(failsafeUrl)
 
-	mockResult := &protocol.RPCResult{Rest: rest{tried: 0, success: true}}
+	mockResult := protocol.NewRpcResult(rest{tried: 0, success: true})
 
 	invoker.EXPECT().Invoke(gomock.Any()).Return(mockResult)
 	result := clusterInvoker.Invoke(&invocation.RPCInvocation{})
@@ -85,7 +85,7 @@ func Test_FailSafeInvokeFail(t *testing.T) {
 
 	invoker.EXPECT().GetUrl().Return(failsafeUrl)
 
-	mockResult := &protocol.RPCResult{Err: perrors.New("error")}
+	mockResult := protocol.NewErrorRpcResult(perrors.New("error"))
 
 	invoker.EXPECT().Invoke(gomock.Any()).Return(mockResult)
 	result := clusterInvoker.Invoke(&invocation.RPCInvocation{})

--- a/cluster/cluster_impl/forking_cluster_invoker.go
+++ b/cluster/cluster_impl/forking_cluster_invoker.go
@@ -47,13 +47,13 @@ func newForkingClusterInvoker(directory cluster.Directory) protocol.Invoker {
 func (invoker *forkingClusterInvoker) Invoke(invocation protocol.Invocation) protocol.Result {
 	err := invoker.checkWhetherDestroyed()
 	if err != nil {
-		return &protocol.RPCResult{Err: err}
+		return protocol.NewErrorRpcResult(err)
 	}
 
 	invokers := invoker.directory.List(invocation)
 	err = invoker.checkInvokers(invokers, invocation)
 	if err != nil {
-		return &protocol.RPCResult{Err: err}
+		return protocol.NewErrorRpcResult(err)
 	}
 
 	var selected []protocol.Invoker
@@ -85,15 +85,15 @@ func (invoker *forkingClusterInvoker) Invoke(invocation protocol.Invocation) pro
 
 	rsps, err := resultQ.Poll(1, time.Millisecond*time.Duration(timeouts))
 	if err != nil {
-		return &protocol.RPCResult{
-			Err: errors.New(fmt.Sprintf("failed to forking invoke provider %v, but no luck to perform the invocation. Last error is: %s", selected, err.Error()))}
+		return protocol.NewErrorRpcResult(
+			errors.New(fmt.Sprintf("failed to forking invoke provider %v, but no luck to perform the invocation. Last error is: %s", selected, err.Error())))
 	}
 	if len(rsps) == 0 {
-		return &protocol.RPCResult{Err: errors.New(fmt.Sprintf("failed to forking invoke provider %v, but no resp", selected))}
+		return protocol.NewErrorRpcResult(errors.New(fmt.Sprintf("failed to forking invoke provider %v, but no resp", selected)))
 	}
 	result, ok := rsps[0].(protocol.Result)
 	if !ok {
-		return &protocol.RPCResult{Err: errors.New(fmt.Sprintf("failed to forking invoke provider %v, but not legal resp", selected))}
+		return protocol.NewErrorRpcResult(errors.New(fmt.Sprintf("failed to forking invoke provider %v, but not legal resp", selected)))
 	}
 	return result
 }

--- a/cluster/cluster_impl/forking_cluster_test.go
+++ b/cluster/cluster_impl/forking_cluster_test.go
@@ -68,7 +68,7 @@ func Test_ForkingInvokeSuccess(t *testing.T) {
 
 	invokers := make([]*mock.MockInvoker, 0)
 
-	mockResult := &protocol.RPCResult{Rest: rest{tried: 0, success: true}}
+	mockResult := protocol.NewRpcResult(rest{tried: 0, success: true})
 	forkingUrl.AddParam(constant.FORKS_KEY, strconv.Itoa(3))
 	//forkingUrl.AddParam(constant.TIMEOUT_KEY, strconv.Itoa(constant.DEFAULT_TIMEOUT))
 
@@ -98,7 +98,7 @@ func Test_ForkingInvokeTimeout(t *testing.T) {
 
 	invokers := make([]*mock.MockInvoker, 0)
 
-	mockResult := &protocol.RPCResult{Rest: rest{tried: 0, success: true}}
+	mockResult := protocol.NewRpcResult(rest{tried: 0, success: true})
 	forkingUrl.AddParam(constant.FORKS_KEY, strconv.Itoa(3))
 
 	var wg sync.WaitGroup
@@ -129,7 +129,7 @@ func Test_ForkingInvokeHalfTimeout(t *testing.T) {
 
 	invokers := make([]*mock.MockInvoker, 0)
 
-	mockResult := &protocol.RPCResult{Rest: rest{tried: 0, success: true}}
+	mockResult := protocol.NewRpcResult(rest{tried: 0, success: true})
 	forkingUrl.AddParam(constant.FORKS_KEY, strconv.Itoa(3))
 
 	var wg sync.WaitGroup

--- a/cluster/router/condition_router.go
+++ b/cluster/router/condition_router.go
@@ -126,7 +126,7 @@ func (c *ConditionRouter) Route(invokers []protocol.Invoker, url common.URL, inv
 	if len(c.ThenCondition) == 0 {
 		return result
 	}
-	localIP, _ := utils.GetLocalIP()
+	localIP := utils.GetLocalIP()
 	for _, invoker := range invokers {
 		isMatchThen, err := c.MatchThen(invoker.GetUrl(), url)
 		if err != nil {

--- a/cluster/router/condition_router_test.go
+++ b/cluster/router/condition_router_test.go
@@ -146,7 +146,7 @@ func TestRoute_matchWhen(t *testing.T) {
 }
 
 func TestRoute_matchFilter(t *testing.T) {
-	localIP, _ := utils.GetLocalIP()
+	localIP := utils.GetLocalIP()
 	url1, _ := common.NewURL(context.TODO(), "dubbo://10.20.3.3:20880/com.foo.BarService?default.serialization=fastjson")
 	url2, _ := common.NewURL(context.TODO(), fmt.Sprintf("dubbo://%s:20880/com.foo.BarService", localIP))
 	url3, _ := common.NewURL(context.TODO(), fmt.Sprintf("dubbo://%s:20880/com.foo.BarService", localIP))
@@ -204,7 +204,7 @@ func TestRoute_methodRoute(t *testing.T) {
 
 func TestRoute_ReturnFalse(t *testing.T) {
 	url, _ := common.NewURL(context.TODO(), "")
-	localIP, _ := utils.GetLocalIP()
+	localIP := utils.GetLocalIP()
 	invokers := []protocol.Invoker{NewMockInvoker(url, 1), NewMockInvoker(url, 2), NewMockInvoker(url, 3)}
 	inv := &invocation.RPCInvocation{}
 	rule := base64.URLEncoding.EncodeToString([]byte("host = " + localIP + " => false"))
@@ -215,7 +215,7 @@ func TestRoute_ReturnFalse(t *testing.T) {
 }
 
 func TestRoute_ReturnEmpty(t *testing.T) {
-	localIP, _ := utils.GetLocalIP()
+	localIP := utils.GetLocalIP()
 	url, _ := common.NewURL(context.TODO(), "")
 	invokers := []protocol.Invoker{NewMockInvoker(url, 1), NewMockInvoker(url, 2), NewMockInvoker(url, 3)}
 	inv := &invocation.RPCInvocation{}
@@ -227,7 +227,7 @@ func TestRoute_ReturnEmpty(t *testing.T) {
 }
 
 func TestRoute_ReturnAll(t *testing.T) {
-	localIP, _ := utils.GetLocalIP()
+	localIP := utils.GetLocalIP()
 	invokers := []protocol.Invoker{&MockInvoker{}, &MockInvoker{}, &MockInvoker{}}
 	inv := &invocation.RPCInvocation{}
 	rule := base64.URLEncoding.EncodeToString([]byte("host = " + localIP + " => " + " host = " + localIP))
@@ -238,7 +238,7 @@ func TestRoute_ReturnAll(t *testing.T) {
 }
 
 func TestRoute_HostFilter(t *testing.T) {
-	localIP, _ := utils.GetLocalIP()
+	localIP := utils.GetLocalIP()
 	url1, _ := common.NewURL(context.TODO(), "dubbo://10.20.3.3:20880/com.foo.BarService")
 	url2, _ := common.NewURL(context.TODO(), fmt.Sprintf("dubbo://%s:20880/com.foo.BarService", localIP))
 	url3, _ := common.NewURL(context.TODO(), fmt.Sprintf("dubbo://%s:20880/com.foo.BarService", localIP))
@@ -257,7 +257,7 @@ func TestRoute_HostFilter(t *testing.T) {
 }
 
 func TestRoute_Empty_HostFilter(t *testing.T) {
-	localIP, _ := utils.GetLocalIP()
+	localIP := utils.GetLocalIP()
 	url1, _ := common.NewURL(context.TODO(), "dubbo://10.20.3.3:20880/com.foo.BarService")
 	url2, _ := common.NewURL(context.TODO(), fmt.Sprintf("dubbo://%s:20880/com.foo.BarService", localIP))
 	url3, _ := common.NewURL(context.TODO(), fmt.Sprintf("dubbo://%s:20880/com.foo.BarService", localIP))
@@ -276,7 +276,7 @@ func TestRoute_Empty_HostFilter(t *testing.T) {
 }
 
 func TestRoute_False_HostFilter(t *testing.T) {
-	localIP, _ := utils.GetLocalIP()
+	localIP := utils.GetLocalIP()
 	url1, _ := common.NewURL(context.TODO(), "dubbo://10.20.3.3:20880/com.foo.BarService")
 	url2, _ := common.NewURL(context.TODO(), fmt.Sprintf("dubbo://%s:20880/com.foo.BarService", localIP))
 	url3, _ := common.NewURL(context.TODO(), fmt.Sprintf("dubbo://%s:20880/com.foo.BarService", localIP))
@@ -295,7 +295,7 @@ func TestRoute_False_HostFilter(t *testing.T) {
 }
 
 func TestRoute_Placeholder(t *testing.T) {
-	localIP, _ := utils.GetLocalIP()
+	localIP := utils.GetLocalIP()
 	url1, _ := common.NewURL(context.TODO(), "dubbo://10.20.3.3:20880/com.foo.BarService")
 	url2, _ := common.NewURL(context.TODO(), fmt.Sprintf("dubbo://%s:20880/com.foo.BarService", localIP))
 	url3, _ := common.NewURL(context.TODO(), fmt.Sprintf("dubbo://%s:20880/com.foo.BarService", localIP))
@@ -314,7 +314,7 @@ func TestRoute_Placeholder(t *testing.T) {
 }
 
 func TestRoute_NoForce(t *testing.T) {
-	localIP, _ := utils.GetLocalIP()
+	localIP := utils.GetLocalIP()
 	url1, _ := common.NewURL(context.TODO(), "dubbo://10.20.3.3:20880/com.foo.BarService")
 	url2, _ := common.NewURL(context.TODO(), fmt.Sprintf("dubbo://%s:20880/com.foo.BarService", localIP))
 	url3, _ := common.NewURL(context.TODO(), fmt.Sprintf("dubbo://%s:20880/com.foo.BarService", localIP))
@@ -331,7 +331,7 @@ func TestRoute_NoForce(t *testing.T) {
 }
 
 func TestRoute_Force(t *testing.T) {
-	localIP, _ := utils.GetLocalIP()
+	localIP := utils.GetLocalIP()
 	url1, _ := common.NewURL(context.TODO(), "dubbo://10.20.3.3:20880/com.foo.BarService")
 	url2, _ := common.NewURL(context.TODO(), fmt.Sprintf("dubbo://%s:20880/com.foo.BarService", localIP))
 	url3, _ := common.NewURL(context.TODO(), fmt.Sprintf("dubbo://%s:20880/com.foo.BarService", localIP))

--- a/cluster/router/condition_router_test.go
+++ b/cluster/router/condition_router_test.go
@@ -102,7 +102,7 @@ func (bi *MockInvoker) Invoke(invocation protocol.Invocation) protocol.Result {
 	} else {
 		err = perrors.New("error")
 	}
-	result := &protocol.RPCResult{Err: err, Rest: rest{tried: count, success: success}}
+	result := protocol.NewRpcResult(rest{tried: count, success: success}).SetError(err)
 	return result
 }
 

--- a/common/utils/net.go
+++ b/common/utils/net.go
@@ -18,8 +18,11 @@
 package utils
 
 import (
-	"github.com/apache/dubbo-go/common/logger"
 	"net"
+)
+
+import (
+	"github.com/apache/dubbo-go/common/logger"
 )
 
 var localIp = ""

--- a/common/utils/net.go
+++ b/common/utils/net.go
@@ -31,7 +31,7 @@ func init() {
 func initLocalIp() {
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
-		logger.Error("init local error", err)
+		logger.Error("[utils][initLocalIp] error", err)
 	}
 
 	for _, addr := range addrs {
@@ -42,8 +42,8 @@ func initLocalIp() {
 		}
 	}
 
-	if localIp == "" {
-		logger.Error("can not get local IP")
+	if len(localIp) == 0 {
+		logger.Error("[utils][initLocalIp] can not get local IP")
 	}
 }
 

--- a/common/utils/net.go
+++ b/common/utils/net.go
@@ -18,11 +18,8 @@
 package utils
 
 import (
+	"github.com/apache/dubbo-go/common/logger"
 	"net"
-)
-
-import (
-	perrors "github.com/pkg/errors"
 )
 
 var localIp = ""
@@ -31,10 +28,10 @@ func init() {
 	initLocalIp()
 }
 
-func initLocalIp() (string, error) {
+func initLocalIp() {
 	addrs, err := net.InterfaceAddrs()
 	if err != nil {
-		return "", perrors.WithStack(err)
+		logger.Error("init local error", err)
 	}
 
 	for _, addr := range addrs {
@@ -46,12 +43,10 @@ func initLocalIp() (string, error) {
 	}
 
 	if localIp == "" {
-		return "", perrors.Errorf("can not get local IP")
+		logger.Error("can not get local IP")
 	}
-
-	return localIp, nil
 }
 
-func GetLocalIP() (string, error) {
-	return localIp, nil
+func GetLocalIP() string {
+	return localIp
 }

--- a/common/utils/net_test.go
+++ b/common/utils/net_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestGetLocalIP(t *testing.T) {
-	ip, err := GetLocalIP()
-	assert.NoError(t, err)
+	ip := GetLocalIP()
+	assert.NotEmpty(t, ip, "get local ip error")
 	t.Log(ip)
 }

--- a/filter/impl/echo_filter.go
+++ b/filter/impl/echo_filter.go
@@ -42,9 +42,7 @@ func (ef *EchoFilter) Invoke(invoker protocol.Invoker, invocation protocol.Invoc
 	logger.Infof("invoking echo filter.")
 	logger.Debugf("%v,%v", invocation.MethodName(), len(invocation.Arguments()))
 	if invocation.MethodName() == constant.ECHO && len(invocation.Arguments()) == 1 {
-		return &protocol.RPCResult{
-			Rest: invocation.Arguments()[0],
-		}
+		return protocol.NewRpcResult(invocation.Arguments()[0])
 	}
 
 	return invoker.Invoke(invocation)

--- a/filter/impl/hystrix_filter_test.go
+++ b/filter/impl/hystrix_filter_test.go
@@ -126,10 +126,7 @@ type testMockSuccessInvoker struct {
 }
 
 func (iv *testMockSuccessInvoker) Invoke(invocation protocol.Invocation) protocol.Result {
-	return &protocol.RPCResult{
-		Rest: "Sucess",
-		Err:  nil,
-	}
+	return protocol.NewRpcResult("Success").SetError(nil)
 }
 
 type testMockFailInvoker struct {
@@ -137,9 +134,7 @@ type testMockFailInvoker struct {
 }
 
 func (iv *testMockFailInvoker) Invoke(invocation protocol.Invocation) protocol.Result {
-	return &protocol.RPCResult{
-		Err: errors.Errorf("exception"),
-	}
+	return protocol.NewErrorRpcResult(errors.Errorf("exception"))
 }
 
 func TestHystrixFilter_Invoke_Success(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -47,3 +47,5 @@ require (
 	google.golang.org/grpc v1.22.1
 	gopkg.in/yaml.v2 v2.2.2
 )
+
+go 1.13

--- a/go.sum
+++ b/go.sum
@@ -26,10 +26,10 @@ github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6 h1:fLjPD/aNc3UIO
 github.com/StackExchange/wmi v0.0.0-20180116203802-5d049714c4a6/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/Workiva/go-datastructures v1.0.50 h1:slDmfW6KCHcC7U+LP3DDBbm4fqTwZGn1beOFPfGaLvo=
 github.com/Workiva/go-datastructures v1.0.50/go.mod h1:Z+F2Rca0qCsVYDS8z7bAGm8f3UkzuWYS/oBZz5a7VVA=
-github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5 h1:rFw4nCn9iMW+Vajsk51NtYIcwSTkXr+JGrMd36kTDJw=
-github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af h1:DBNMBMuMiWYu0b+8KMJuWmfCkcxl09JwdlqwDZZ6U14=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af/go.mod h1:5Jv4cbFiHJMsVxt52+i0Ha45fjshj6wxYr1r19tB9bw=
+github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5 h1:rFw4nCn9iMW+Vajsk51NtYIcwSTkXr+JGrMd36kTDJw=
+github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/aliyun/alibaba-cloud-sdk-go v0.0.0-20190802083043-4cd0c391755e h1:MSuLXx/mveDbpDNhVrcWTMeV4lbYWKcyO4rH+jAxmX0=

--- a/protocol/jsonrpc/jsonrpc_invoker.go
+++ b/protocol/jsonrpc/jsonrpc_invoker.go
@@ -59,7 +59,7 @@ func (ji *JsonrpcInvoker) Invoke(invocation protocol.Invocation) protocol.Result
 	error := ji.client.Call(ctx, url, req, inv.Reply())
 	if error == nil {
 		result.SetResult(inv.Reply())
-	}else {
+	} else {
 		result.SetError(error)
 	}
 	logger.Debugf("result.Err: %v, result.Rest: %v", result.Error(), result.Result())

--- a/protocol/jsonrpc/jsonrpc_invoker.go
+++ b/protocol/jsonrpc/jsonrpc_invoker.go
@@ -62,7 +62,7 @@ func (ji *JsonrpcInvoker) Invoke(invocation protocol.Invocation) protocol.Result
 	} else {
 		result.SetError(error)
 	}
-	logger.Debugf("result.Err: %v, result.Rest: %v", result.Error(), result.Result())
+	logger.Debugf("[JsonrpcInvoker][Invoke] result.Err: %v, result.Rest: %v", result.Error(), result.Result())
 
 	return &result
 }

--- a/protocol/jsonrpc/jsonrpc_invoker.go
+++ b/protocol/jsonrpc/jsonrpc_invoker.go
@@ -55,11 +55,14 @@ func (ji *JsonrpcInvoker) Invoke(invocation protocol.Invocation) protocol.Result
 		"X-Services": url.Path,
 		"X-Method":   inv.MethodName(),
 	})
-	result.Err = ji.client.Call(ctx, url, req, inv.Reply())
-	if result.Err == nil {
-		result.Rest = inv.Reply()
+
+	error := ji.client.Call(ctx, url, req, inv.Reply())
+	if error == nil {
+		result.SetResult(inv.Reply())
+	}else {
+		result.SetError(error)
 	}
-	logger.Debugf("result.Err: %v, result.Rest: %v", result.Err, result.Rest)
+	logger.Debugf("result.Err: %v, result.Rest: %v", result.Error(), result.Result())
 
 	return &result
 }

--- a/protocol/protocolwrapper/protocol_filter_wrapper_test.go
+++ b/protocol/protocolwrapper/protocol_filter_wrapper_test.go
@@ -71,9 +71,7 @@ func (ef *EchoFilterForTest) Invoke(invoker protocol.Invoker, invocation protoco
 	logger.Infof("invoking echo filter.")
 	logger.Debugf("%v,%v", invocation.MethodName(), len(invocation.Arguments()))
 	if invocation.MethodName() == constant.ECHO && len(invocation.Arguments()) == 1 {
-		return &protocol.RPCResult{
-			Rest: invocation.Arguments()[0],
-		}
+		return protocol.NewRpcResult(invocation.Arguments()[0])
 	}
 
 	return invoker.Invoke(invocation)

--- a/protocol/result.go
+++ b/protocol/result.go
@@ -18,13 +18,13 @@
 package protocol
 
 type Result interface {
-	SetError(error)
+	SetError(error) Result
 	Error() error
-	SetResult(interface{})
+	SetResult(interface{}) Result
 	Result() interface{}
-	SetAttachments(map[string]string)
+	SetAttachments(map[string]string) Result
 	Attachments() map[string]string
-	AddAttachment(string, string)
+	AddAttachment(string, string) Result
 	Attachment(string, string) string
 }
 
@@ -33,41 +33,57 @@ type Result interface {
 /////////////////////////////
 
 type RPCResult struct {
-	Attrs map[string]string
-	Err   error
-	Rest  interface{}
+	attrs map[string]string
+	err   error
+	rest  interface{}
 }
 
-func (r *RPCResult) SetError(err error) {
-	r.Err = err
+func NewErrorRpcResult(err error) *RPCResult {
+	result := &RPCResult{}
+	result.err = err
+	return result
+}
+
+func NewRpcResult(rest interface{}) *RPCResult {
+	result := &RPCResult{}
+	result.rest = rest
+	return result
+}
+
+func (r *RPCResult) SetError(err error) Result {
+	r.err = err
+	return r
 }
 
 func (r *RPCResult) Error() error {
-	return r.Err
+	return r.err
 }
 
-func (r *RPCResult) SetResult(rest interface{}) {
-	r.Rest = rest
+func (r *RPCResult) SetResult(rest interface{}) Result {
+	r.rest = rest
+	return r
 }
 
 func (r *RPCResult) Result() interface{} {
-	return r.Rest
+	return r.rest
 }
 
-func (r *RPCResult) SetAttachments(attr map[string]string) {
-	r.Attrs = attr
+func (r *RPCResult) SetAttachments(attr map[string]string) Result {
+	r.attrs = attr
+	return r
 }
 
 func (r *RPCResult) Attachments() map[string]string {
-	return r.Attrs
+	return r.attrs
 }
 
-func (r *RPCResult) AddAttachment(key, value string) {
-	r.Attrs[key] = value
+func (r *RPCResult) AddAttachment(key, value string) Result {
+	r.attrs[key] = value
+	return r
 }
 
 func (r *RPCResult) Attachment(key, defaultValue string) string {
-	v, ok := r.Attrs[key]
+	v, ok := r.attrs[key]
 	if !ok {
 		v = defaultValue
 	}

--- a/registry/consul/utils.go
+++ b/registry/consul/utils.go
@@ -48,7 +48,7 @@ func buildService(url common.URL) (*consul.AgentServiceRegistration, error) {
 
 	// address
 	if url.Ip == "" {
-		url.Ip, _ = utils.GetLocalIP()
+		url.Ip = utils.GetLocalIP()
 	}
 
 	// port

--- a/registry/etcdv3/registry.go
+++ b/registry/etcdv3/registry.go
@@ -34,7 +34,7 @@ const Name = "etcdv3"
 
 func init() {
 	processID = fmt.Sprintf("%d", os.Getpid())
-	localIP, _ = utils.GetLocalIP()
+	localIP = utils.GetLocalIP()
 	extension.SetRegistry(Name, newETCDV3Registry)
 }
 

--- a/registry/nacos/registry.go
+++ b/registry/nacos/registry.go
@@ -28,7 +28,7 @@ var (
 )
 
 func init() {
-	localIP, _ = utils.GetLocalIP()
+	localIP = utils.GetLocalIP()
 	extension.SetRegistry(constant.NACOS_KEY, newNacosRegistry)
 }
 

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -54,7 +54,7 @@ var (
 
 func init() {
 	processID = fmt.Sprintf("%d", os.Getpid())
-	localIP, _ = utils.GetLocalIP()
+	localIP = utils.GetLocalIP()
 	//plugins.PluggableRegistries["zookeeper"] = newZkRegistry
 	extension.SetRegistry("zookeeper", newZkRegistry)
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
#182 
**Which issue(s) this PR fixes**:
1. modify protocol/result.go member to private and provide two methods create result
2. remove common/utils/net.go filter private ip, and cache the localIp by global variable
3. use reflect.ValueOf(obj).MapKeys()  instead of MapRanges()  to compatible go1.11



<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```