### PR TITLE
Fix: The registryProtocol should be singleton

### DIFF
--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -338,10 +338,10 @@ func setProviderUrl(regURL *common.URL, providerURL *common.URL) {
 }
 
 func GetProtocol() protocol.Protocol {
-	if regProtocol != nil {
-		return regProtocol
+	if regProtocol == nil {
+		regProtocol = newRegistryProtocol()
 	}
-	return newRegistryProtocol()
+	return regProtocol
 }
 
 type wrappedInvoker struct {

--- a/registry/protocol/protocol_test.go
+++ b/registry/protocol/protocol_test.go
@@ -291,3 +291,8 @@ func TestExportWithApplicationConfig(t *testing.T) {
 	v2, _ := regProtocol.bounds.Load(getCacheKey(newUrl))
 	assert.NotNil(t, v2)
 }
+
+func TestGetProtocol(t *testing.T) {
+	singleton := GetProtocol()
+	assert.True(t, singleton == GetProtocol())
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
It seems that the registryProtocol should be a singleton. The method GetProtocol doesn't set the value after it creates an instance of registryProtocol. So every time we invoke extension.GetProtocol("registry"), we will get different instances.

But the registryProtocol mantains all the instances of Registry, it should be a singleton.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```