### PR TITLE
Fix BUG:  The generic filter and default reference filters lack ','

### DIFF
--- a/config/reference_config.go
+++ b/config/reference_config.go
@@ -183,7 +183,7 @@ func (refconfig *ReferenceConfig) getUrlMap() url.Values {
 	//filter
 	var defaultReferenceFilter = constant.DEFAULT_REFERENCE_FILTERS
 	if refconfig.Generic {
-		defaultReferenceFilter = constant.GENERIC_REFERENCE_FILTERS + defaultReferenceFilter
+		defaultReferenceFilter = constant.GENERIC_REFERENCE_FILTERS + "," + defaultReferenceFilter
 	}
 	urlMap.Set(constant.REFERENCE_FILTER_KEY, mergeValue(consumerConfig.Filter, refconfig.Filter, defaultReferenceFilter))
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
The lack of ',' between generic filter and default reference filters
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```