### PR TITLE
Fix: Revert the registryProtocol.GetProtocol() to its original codes

### DIFF
--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -338,10 +338,10 @@ func setProviderUrl(regURL *common.URL, providerURL *common.URL) {
 }
 
 func GetProtocol() protocol.Protocol {
-	if regProtocol == nil {
-		regProtocol = newRegistryProtocol()
+	if regProtocol != nil {
+		return regProtocol
 	}
-	return regProtocol
+	return newRegistryProtocol()
 }
 
 type wrappedInvoker struct {

--- a/registry/protocol/protocol_test.go
+++ b/registry/protocol/protocol_test.go
@@ -291,8 +291,3 @@ func TestExportWithApplicationConfig(t *testing.T) {
 	v2, _ := regProtocol.bounds.Load(getCacheKey(newUrl))
 	assert.NotNil(t, v2)
 }
-
-func TestGetProtocol(t *testing.T) {
-	singleton := GetProtocol()
-	assert.True(t, singleton == GetProtocol())
-}


### PR DESCRIPTION
It seems that we can not change the registryProtocol to be a singleton. If we do that, the listen, especially zk registry listener, doesn't work well.

<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```