### PR TITLE
Ftr: Replace func(int, int) with TpsLimitStrategyCreator interface

### DIFF
--- a/common/extension/tps_limit.go
+++ b/common/extension/tps_limit.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	tpsLimitStrategy = make(map[string]func(rate int, interval int) tps.TpsLimitStrategy)
+	tpsLimitStrategy = make(map[string]tps.TpsLimitStrategyCreator)
 	tpsLimiter       = make(map[string]func() tps.TpsLimiter)
 )
 
@@ -39,11 +39,11 @@ func GetTpsLimiter(name string) tps.TpsLimiter {
 	return creator()
 }
 
-func SetTpsLimitStrategy(name string, creator func(rate int, interval int) tps.TpsLimitStrategy) {
+func SetTpsLimitStrategy(name string, creator tps.TpsLimitStrategyCreator) {
 	tpsLimitStrategy[name] = creator
 }
 
-func GetTpsLimitStrategyCreator(name string) func(rate int, interval int) tps.TpsLimitStrategy {
+func GetTpsLimitStrategyCreator(name string) tps.TpsLimitStrategyCreator {
 	creator, ok := tpsLimitStrategy[name]
 	if !ok {
 		panic("TpsLimitStrategy for " + name + " is not existing, make sure you have import the package " +

--- a/filter/impl/tps/impl/tps_limit_fix_window_strategy.go
+++ b/filter/impl/tps/impl/tps_limit_fix_window_strategy.go
@@ -33,8 +33,9 @@ const (
 )
 
 func init() {
-	extension.SetTpsLimitStrategy(FixedWindowKey, NewFixedWindowTpsLimitStrategyImpl)
-	extension.SetTpsLimitStrategy(constant.DEFAULT_KEY, NewFixedWindowTpsLimitStrategyImpl)
+	creator := &fixedWindowStrategyCreator{}
+	extension.SetTpsLimitStrategy(FixedWindowKey, creator)
+	extension.SetTpsLimitStrategy(constant.DEFAULT_KEY, creator)
 }
 
 /**
@@ -76,7 +77,9 @@ func (impl *FixedWindowTpsLimitStrategyImpl) IsAllowable() bool {
 	return atomic.AddInt32(&impl.count, 1) <= impl.rate
 }
 
-func NewFixedWindowTpsLimitStrategyImpl(rate int, interval int) tps.TpsLimitStrategy {
+type fixedWindowStrategyCreator struct{}
+
+func (creator *fixedWindowStrategyCreator) Create(rate int, interval int) tps.TpsLimitStrategy {
 	return &FixedWindowTpsLimitStrategyImpl{
 		rate:      int32(rate),
 		interval:  int64(interval) * int64(time.Millisecond), // convert to ns

--- a/filter/impl/tps/impl/tps_limit_fix_window_strategy_test.go
+++ b/filter/impl/tps/impl/tps_limit_fix_window_strategy_test.go
@@ -27,12 +27,13 @@ import (
 )
 
 func TestFixedWindowTpsLimitStrategyImpl_IsAllowable(t *testing.T) {
-	strategy := NewFixedWindowTpsLimitStrategyImpl(2, 60000)
+	creator := &fixedWindowStrategyCreator{}
+	strategy := creator.Create(2, 60000)
 	assert.True(t, strategy.IsAllowable())
 	assert.True(t, strategy.IsAllowable())
 	assert.False(t, strategy.IsAllowable())
 
-	strategy = NewFixedWindowTpsLimitStrategyImpl(2, 2000)
+	strategy = creator.Create(2, 2000)
 	assert.True(t, strategy.IsAllowable())
 	assert.True(t, strategy.IsAllowable())
 	assert.False(t, strategy.IsAllowable())

--- a/filter/impl/tps/impl/tps_limit_sliding_window_strategy.go
+++ b/filter/impl/tps/impl/tps_limit_sliding_window_strategy.go
@@ -29,7 +29,7 @@ import (
 )
 
 func init() {
-	extension.SetTpsLimitStrategy("slidingWindow", NewSlidingWindowTpsLimitStrategyImpl)
+	extension.SetTpsLimitStrategy("slidingWindow", &slidingWindowStrategyCreator{})
 }
 
 /**
@@ -80,7 +80,9 @@ func (impl *SlidingWindowTpsLimitStrategyImpl) IsAllowable() bool {
 	return false
 }
 
-func NewSlidingWindowTpsLimitStrategyImpl(rate int, interval int) tps.TpsLimitStrategy {
+type slidingWindowStrategyCreator struct{}
+
+func (creator *slidingWindowStrategyCreator) Create(rate int, interval int) tps.TpsLimitStrategy {
 	return &SlidingWindowTpsLimitStrategyImpl{
 		rate:     rate,
 		interval: int64(interval) * int64(time.Millisecond),

--- a/filter/impl/tps/impl/tps_limit_sliding_window_strategy_test.go
+++ b/filter/impl/tps/impl/tps_limit_sliding_window_strategy_test.go
@@ -27,14 +27,15 @@ import (
 )
 
 func TestSlidingWindowTpsLimitStrategyImpl_IsAllowable(t *testing.T) {
-	strategy := NewSlidingWindowTpsLimitStrategyImpl(2, 60000)
+	creator := &slidingWindowStrategyCreator{}
+	strategy := creator.Create(2, 60000)
 	assert.True(t, strategy.IsAllowable())
 	assert.True(t, strategy.IsAllowable())
 	assert.False(t, strategy.IsAllowable())
 	time.Sleep(2100 * time.Millisecond)
 	assert.False(t, strategy.IsAllowable())
 
-	strategy = NewSlidingWindowTpsLimitStrategyImpl(2, 2000)
+	strategy = creator.Create(2, 2000)
 	assert.True(t, strategy.IsAllowable())
 	assert.True(t, strategy.IsAllowable())
 	assert.False(t, strategy.IsAllowable())

--- a/filter/impl/tps/impl/tps_limit_thread_safe_fix_window_strategy.go
+++ b/filter/impl/tps/impl/tps_limit_thread_safe_fix_window_strategy.go
@@ -27,7 +27,9 @@ import (
 )
 
 func init() {
-	extension.SetTpsLimitStrategy("threadSafeFixedWindow", NewThreadSafeFixedWindowTpsLimitStrategyImpl)
+	extension.SetTpsLimitStrategy("threadSafeFixedWindow", &threadSafeFixedWindowStrategyCreator{
+		fixedWindowStrategyCreator: &fixedWindowStrategyCreator{},
+	})
 }
 
 /**
@@ -56,8 +58,12 @@ func (impl *ThreadSafeFixedWindowTpsLimitStrategyImpl) IsAllowable() bool {
 	return impl.fixedWindow.IsAllowable()
 }
 
-func NewThreadSafeFixedWindowTpsLimitStrategyImpl(rate int, interval int) tps.TpsLimitStrategy {
-	fixedWindowStrategy := NewFixedWindowTpsLimitStrategyImpl(rate, interval).(*FixedWindowTpsLimitStrategyImpl)
+type threadSafeFixedWindowStrategyCreator struct {
+	fixedWindowStrategyCreator *fixedWindowStrategyCreator
+}
+
+func (creator *threadSafeFixedWindowStrategyCreator) Create(rate int, interval int) tps.TpsLimitStrategy {
+	fixedWindowStrategy := creator.fixedWindowStrategyCreator.Create(rate, interval).(*FixedWindowTpsLimitStrategyImpl)
 	return &ThreadSafeFixedWindowTpsLimitStrategyImpl{
 		fixedWindow: fixedWindowStrategy,
 		mutex:       &sync.Mutex{},

--- a/filter/impl/tps/impl/tps_limit_thread_safe_fix_window_strategy_test.go
+++ b/filter/impl/tps/impl/tps_limit_thread_safe_fix_window_strategy_test.go
@@ -27,12 +27,13 @@ import (
 )
 
 func TestThreadSafeFixedWindowTpsLimitStrategyImpl_IsAllowable(t *testing.T) {
-	strategy := NewThreadSafeFixedWindowTpsLimitStrategyImpl(2, 60000)
+	creator := &threadSafeFixedWindowStrategyCreator{}
+	strategy := creator.Create(2, 60000)
 	assert.True(t, strategy.IsAllowable())
 	assert.True(t, strategy.IsAllowable())
 	assert.False(t, strategy.IsAllowable())
 
-	strategy = NewThreadSafeFixedWindowTpsLimitStrategyImpl(2, 2000)
+	strategy = creator.Create(2, 2000)
 	assert.True(t, strategy.IsAllowable())
 	assert.True(t, strategy.IsAllowable())
 	assert.False(t, strategy.IsAllowable())

--- a/filter/impl/tps/impl/tps_limiter_method_service.go
+++ b/filter/impl/tps/impl/tps_limiter_method_service.go
@@ -148,7 +148,7 @@ func (limiter MethodServiceTpsLimiterImpl) IsAllowable(url common.URL, invocatio
 	limitStrategyConfig := url.GetParam(methodConfigPrefix+constant.TPS_LIMIT_STRATEGY_KEY,
 		url.GetParam(constant.TPS_LIMIT_STRATEGY_KEY, constant.DEFAULT_KEY))
 	limitStateCreator := extension.GetTpsLimitStrategyCreator(limitStrategyConfig)
-	limitState, _ = limiter.tpsState.LoadOrStore(limitTarget, limitStateCreator(int(limitRate), int(limitInterval)))
+	limitState, _ = limiter.tpsState.LoadOrStore(limitTarget, limitStateCreator.Create(int(limitRate), int(limitInterval)))
 	return limitState.(tps.TpsLimitStrategy).IsAllowable()
 }
 

--- a/filter/impl/tps/tps_limit_strategy.go
+++ b/filter/impl/tps/tps_limit_strategy.go
@@ -34,3 +34,7 @@ package tps
 type TpsLimitStrategy interface {
 	IsAllowable() bool
 }
+
+type TpsLimitStrategyCreator interface {
+	Create(rate int, interval int) TpsLimitStrategy
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

Now, the tps-limit's extension accepts `func(rate int, interval int)tps.TpsLimitStrategy` as the creator of TpsLimitStrategy.

It's bad-smell code. So this PR define the TpsStrategyCreator interface to replace them.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```