### PR TITLE
fix: zkRegistry.Destroy() -- negative Waitgroup counter

### DIFF
--- a/filter/impl/tps/impl/tps_limiter_method_service_test.go
+++ b/filter/impl/tps/impl/tps_limiter_method_service_test.go
@@ -50,7 +50,7 @@ func TestMethodServiceTpsLimiterImpl_IsAllowable_Only_Service_Level(t *testing.T
 	mockStrategyImpl.EXPECT().IsAllowable().Return(true).Times(1)
 
 	extension.SetTpsLimitStrategy(constant.DEFAULT_KEY, &mockStrategyCreator{
-		rate:     40,
+		rate:     20,
 		interval: 60000,
 		t:        t,
 		strategy: mockStrategyImpl,

--- a/registry/zookeeper/listener.go
+++ b/registry/zookeeper/listener.go
@@ -20,6 +20,7 @@ package zookeeper
 import (
 	"context"
 	"strings"
+	"sync"
 )
 
 import (
@@ -71,10 +72,11 @@ func (l *RegistryDataListener) DataChange(eventType remoting.Event) bool {
 }
 
 type RegistryConfigurationListener struct {
-	client   *zk.ZookeeperClient
-	registry *zkRegistry
-	events   chan *config_center.ConfigChangeEvent
-	isClosed bool
+	client    *zk.ZookeeperClient
+	registry  *zkRegistry
+	events    chan *config_center.ConfigChangeEvent
+	isClosed  bool
+	closeOnce sync.Once
 }
 
 func NewRegistryConfigurationListener(client *zk.ZookeeperClient, reg *zkRegistry) *RegistryConfigurationListener {
@@ -110,14 +112,11 @@ func (l *RegistryConfigurationListener) Next() (*registry.ServiceEvent, error) {
 	}
 }
 func (l *RegistryConfigurationListener) Close() {
-	if l.registry.IsAvailable() {
-		/**
-		 * if the registry is not available, it means that the registry has been destroy
-		 * so we don't need to call Done(), or it will cause the negative count panic for registry.wg
-		 */
+	// ensure that the listener will be closed at most once.
+	l.closeOnce.Do(func() {
 		l.isClosed = true
 		l.registry.wg.Done()
-	}
+	})
 }
 
 func (l *RegistryConfigurationListener) valid() bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
Last time I try to fix #252 but the solution has a problem that in a concurrent environment the listener will be closed twice too. So I add a closeOncy to ensure it should be closed at most once.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #252 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```