### PR TITLE
fix(etcdv3/test): cleanup etcd config directory in ut

### DIFF
--- a/registry/etcdv3/listener_test.go
+++ b/registry/etcdv3/listener_test.go
@@ -18,6 +18,7 @@
 package etcdv3
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -47,6 +48,11 @@ func (suite *RegistryTestSuite) SetupSuite() {
 
 	cfg := embed.NewConfig()
 	cfg.Dir = "/tmp/default.etcd"
+
+	if _, err := os.Stat(cfg.Dir); err == nil {
+		os.RemoveAll(cfg.Dir)
+	}
+
 	e, err := embed.StartEtcd(cfg)
 	if err != nil {
 		t.Fatal(err)

--- a/remoting/etcdv3/client_test.go
+++ b/remoting/etcdv3/client_test.go
@@ -20,6 +20,7 @@ package etcdv3
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"path"
 	"reflect"
 	"strings"
@@ -92,6 +93,11 @@ func (suite *ClientTestSuite) SetupSuite() {
 	cfg.LPUrls = []url.URL{*lpurl}
 	cfg.LCUrls = []url.URL{*lcurl}
 	cfg.Dir = "/tmp/default.etcd"
+
+	if _, err := os.Stat(cfg.Dir); err == nil {
+		os.RemoveAll(cfg.Dir)
+	}
+
 	e, err := embed.StartEtcd(cfg)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
if the ut process accidentally give up their hands during the halfway, we may encounter a duplicate directory creation exception as below when the next time we run ut, so a proper way to address this issue is to make sure every time the directory is not there when need to create it.

```
2020/02/24 05:33:54 [InitLog] warn: log configure file name is nil
2020-02-24 05:33:54.751824 I | embed: listening for peers on http://localhost:2382
2020-02-24 05:33:54.752323 I | embed: listening for client requests on localhost:2381
2020-02-24 05:33:57.686223 I | etcdserver: name = default
2020-02-24 05:33:57.686240 I | etcdserver: data dir = /tmp/default.etcd
2020-02-24 05:33:57.686247 I | etcdserver: member dir = /tmp/default.etcd/member
2020-02-24 05:33:57.686251 I | etcdserver: heartbeat = 100ms
2020-02-24 05:33:57.686255 I | etcdserver: election = 1000ms
2020-02-24 05:33:57.686259 I | etcdserver: snapshot count = 100000
2020-02-24 05:33:57.686271 I | etcdserver: advertise client URLs = http://localhost:2379
2020-02-24 05:33:57.686276 I | etcdserver: initial advertise peer URLs = http://localhost:2380
2020-02-24 05:33:57.686286 I | etcdserver: initial cluster = default=http://localhost:2380
2020-02-24 05:33:57.686414 C | etcdserver: create wal error: file already exists
--- FAIL: TestClientSuite (2.94s)
    suite.go:62: test panicked: create wal error: file already exists
        goroutine 114 [running]:
        runtime/debug.Stack(0xc0001fc5f8, 0x1a09140, 0xc0001887c0)
        	/usr/local/Cellar/go/1.13.7/libexec/src/runtime/debug/stack.go:24 +0x9d
        github.com/stretchr/testify/suite.failOnPanic(0xc00024e300)
        	/Users/jihuizheng/go/pkg/mod/github.com/stretchr/testify@v1.4.0/suite/suite.go:62 +0x57
        panic(0x1a09140, 0xc0001887c0)
        	/usr/local/Cellar/go/1.13.7/libexec/src/runtime/panic.go:679 +0x1b2
        github.com/coreos/pkg/capnslog.(*PackageLogger).Panicf(0xc0001a5d00, 0x1bcb87e, 0x14, 0xc0001fc7f0, 0x1, 0x1)
        	/Users/jihuizheng/go/pkg/mod/github.com/coreos/pkg@v0.0.0-20180928190104-399ea9e2e55f/capnslog/pkg_logger.go:83 +0x135
        github.com/coreos/etcd/etcdserver.startNode(0x1bc06ab, 0x7, 0x0, 0x0, 0x0, 0x0, 0xc00028f080, 0x1, 0x1, 0xc00028f000, ...)
        	/Users/jihuizheng/go/pkg/mod/github.com/coreos/etcd@v3.3.13+incompatible/etcdserver/raft.go:406 +0x1a7
        github.com/coreos/etcd/etcdserver.NewServer(0x1bc06ab, 0x7, 0x0, 0x0, 0x0, 0x0, 0xc00028f080, 0x1, 0x1, 0xc00028f000, ...)
        	/Users/jihuizheng/go/pkg/mod/github.com/coreos/etcd@v3.3.13+incompatible/etcdserver/server.go:363 +0x2cd0
        go.etcd.io/etcd/embed.StartEtcd(0xc00009a400, 0xc000258480, 0x0, 0x0)
        	/Users/jihuizheng/go/pkg/mod/go.etcd.io/etcd@v3.3.13+incompatible/embed/etcd.go:179 +0x7ef
        github.com/apache/dubbo-go/remoting/etcdv3.(*ClientTestSuite).SetupSuite(0xc00019cf60)
        	/Users/jihuizheng/Documents/dubbo-go/remoting/etcdv3/client_test.go:95 +0x195
        github.com/stretchr/testify/suite.Run(0xc00024e300, 0x1d2af60, 0xc00019cf60)
        	/Users/jihuizheng/go/pkg/mod/github.com/stretchr/testify@v1.4.0/suite/suite.go:102 +0x4ff
        github.com/apache/dubbo-go/remoting/etcdv3.TestClientSuite(0xc00024e300)
        	/Users/jihuizheng/Documents/dubbo-go/remoting/etcdv3/client_test.go:370 +0xdf
        testing.tRunner(0xc00024e300, 0x1c05be0)
        	/usr/local/Cellar/go/1.13.7/libexec/src/testing/testing.go:909 +0xc9
        created by testing.(*T).Run
        	/usr/local/Cellar/go/1.13.7/libexec/src/testing/testing.go:960 +0x350
FAIL
coverage: 0.0% of statements
FAIL	github.com/apache/dubbo-go/remoting/etcdv3	2.962s
``` 