### PR TITLE
Fix/ignore apollo prop file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ remoting/zookeeper/zookeeper-4unittest/
 config_center/zookeeper/zookeeper-4unittest/
 registry/zookeeper/zookeeper-4unittest/
 registry/consul/agent*
+config_center/apollo/mockDubbog.properties.json


### PR DESCRIPTION
after ut, apollo will generate a trivial config file.

```
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	config_center/apollo/mockDubbog.properties.json
```