### PR TITLE
fix(apollo/ut): ignore apollo property file which generated by ut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ remoting/zookeeper/zookeeper-4unittest/
 config_center/zookeeper/zookeeper-4unittest/
 registry/zookeeper/zookeeper-4unittest/
 registry/consul/agent*
+config_center/apollo/mockDubbog.properties.json


### PR DESCRIPTION
Even base on `develop` branch, the temp JSON file is still on the fly after the ut process finished

```
On branch develop
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	config_center/apollo/mockDubbog.properties.json

nothing added to commit but untracked files present (use "git add" to track)
```

One possible reason is that the [100ms](https://github.com/apache/dubbo-go/blob/master/config_center/apollo/impl_test.go#L271) is not long enough to wait until the JSON file creation process done from another goroutine.