### PR TITLE
Improve: add more ci environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: go
 
+os:
+  - linux
+  - osx
+
 go:
   - "1.12"
+  - "1.13"
 
 env:
   - GO111MODULE=on


### PR DESCRIPTION
Add more CI jobs to cover both `go1.12` and `go1.13` for `osx` and `linux`.

![image](https://user-images.githubusercontent.com/6234553/75462758-b3e55c00-59bf-11ea-8e09-75b5f613b590.png)
