### PR TITLE
Rem:remove zk restart code

### DIFF
--- a/config_center/zookeeper/impl.go
+++ b/config_center/zookeeper/impl.go
@@ -67,8 +67,6 @@ func newZookeeperDynamicConfiguration(url *common.URL) (*zookeeperDynamicConfigu
 		logger.Errorf("zookeeper client start error ,error message is %v", err)
 		return nil, err
 	}
-	c.wg.Add(1)
-	go zookeeper.HandleClientRestart(c)
 
 	c.listener = zookeeper.NewZkEventListener(c.client)
 	c.cacheListener = NewCacheListener(c.rootPath)
@@ -93,8 +91,6 @@ func newMockZookeeperDynamicConfiguration(url *common.URL, opts ...zookeeper.Opt
 		logger.Errorf("mock zookeeper client start error ,error message is %v", err)
 		return tc, c, err
 	}
-	c.wg.Add(1)
-	go zookeeper.HandleClientRestart(c)
 
 	c.listener = zookeeper.NewZkEventListener(c.client)
 	c.cacheListener = NewCacheListener(c.rootPath)

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -78,10 +78,6 @@ func newZkRegistry(url *common.URL) (registry.Registry, error) {
 	if err != nil {
 		return nil, err
 	}
-	r.WaitGroup().Add(1) //zk client start successful, then wg +1
-
-	go zookeeper.HandleClientRestart(r)
-
 	r.listener = zookeeper.NewZkEventListener(r.client)
 	r.configListener = NewRegistryConfigurationListener(r.client, r)
 	r.dataListener = NewRegistryDataListener(r.configListener)
@@ -113,8 +109,7 @@ func newMockZkRegistry(url *common.URL, opts ...zookeeper.Option) (*zk.TestClust
 	if err != nil {
 		return nil, nil, err
 	}
-	r.WaitGroup().Add(1) //zk client start successful, then wg +1
-	go zookeeper.HandleClientRestart(r)
+
 	r.InitListeners()
 	return c, r, nil
 }

--- a/remoting/zookeeper/client.go
+++ b/remoting/zookeeper/client.go
@@ -258,17 +258,7 @@ LOOP:
 				z.name, event.Type, event.Server, event.Path, event.State, StateToString(event.State), event.Err)
 			switch (int)(event.State) {
 			case (int)(zk.StateDisconnected):
-				logger.Warnf("zk{addr:%s} state is StateDisconnected, so close the zk client{name:%s}.", z.ZkAddrs, z.name)
-				z.stop()
-				z.Lock()
-				conn := z.Conn
-				z.Conn = nil
-				z.Unlock()
-				if conn != nil {
-					conn.Close()
-				}
-
-				break LOOP
+				logger.Errorf("zk{addr:%s} state is StateDisconnected, zk client{name:%s}.", z.ZkAddrs, z.name)
 			case (int)(zk.EventNodeDataChanged), (int)(zk.EventNodeChildrenChanged):
 				logger.Infof("zkClient{%s} get zk node changed event{path:%s}", z.name, event.Path)
 				z.Lock()

--- a/remoting/zookeeper/facade.go
+++ b/remoting/zookeeper/facade.go
@@ -20,14 +20,9 @@ package zookeeper
 import (
 	"sync"
 )
-import (
-	"github.com/dubbogo/getty"
-	perrors "github.com/pkg/errors"
-)
 
 import (
 	"github.com/apache/dubbo-go/common"
-	"github.com/apache/dubbo-go/common/logger"
 )
 
 type zkClientFacade interface {
@@ -38,54 +33,4 @@ type zkClientFacade interface {
 	Done() chan struct{}        //for zk client control
 	RestartCallBack() bool
 	common.Node
-}
-
-// HandleClientRestart ...
-func HandleClientRestart(r zkClientFacade) {
-	var (
-		err error
-
-		failTimes int
-	)
-
-	defer r.WaitGroup().Done()
-LOOP:
-	for {
-		select {
-		case <-r.Done():
-			logger.Warnf("(ZkProviderRegistry)reconnectZkRegistry goroutine exit now...")
-			break LOOP
-			// re-register all services
-		case <-r.ZkClient().Done():
-			r.ZkClientLock().Lock()
-			r.ZkClient().Close()
-			zkName := r.ZkClient().name
-			zkAddress := r.ZkClient().ZkAddrs
-			r.SetZkClient(nil)
-			r.ZkClientLock().Unlock()
-
-			// Connect zk until success.
-			failTimes = 0
-			for {
-				select {
-				case <-r.Done():
-					logger.Warnf("(ZkProviderRegistry)reconnectZkRegistry goroutine exit now...")
-					break LOOP
-				case <-getty.GetTimeWheel().After(timeSecondDuration(failTimes * ConnDelay)): // Prevent crazy reconnection zk.
-				}
-				err = ValidateZookeeperClient(r, WithZkName(zkName))
-				logger.Infof("ZkProviderRegistry.validateZookeeperClient(zkAddr{%s}) = error{%#v}",
-					zkAddress, perrors.WithStack(err))
-				if err == nil {
-					if r.RestartCallBack() {
-						break
-					}
-				}
-				failTimes++
-				if MaxFailTimes <= failTimes {
-					failTimes = MaxFailTimes
-				}
-			}
-		}
-	}
 }

--- a/remoting/zookeeper/facade_test.go
+++ b/remoting/zookeeper/facade_test.go
@@ -79,9 +79,6 @@ func Test_Facade(t *testing.T) {
 	ts, z, event, err := NewMockZookeeperClient("test", 15*time.Second)
 	assert.NoError(t, err)
 	defer ts.Stop()
-	url, _ := common.NewURL("mock://127.0.0.1")
-	mock := &mockFacade{client: z, URL: &url}
-	go HandleClientRestart(mock)
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
 	z.Close()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

The zookeeper library has the ability to reconnect, so restart code is unnecessary

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```