### PR TITLE
Fix: issue #32

### DIFF
--- a/common/rpc_service.go
+++ b/common/rpc_service.go
@@ -274,7 +274,9 @@ func (sm *serviceMap) UnRegister(interfaceName, protocol, serviceId string) erro
 		}
 	}
 	delete(svcs, serviceId)
-	delete(sm.serviceMap, protocol)
+	if len(sm.serviceMap) == 0 {
+		delete(sm.serviceMap, protocol)
+	}
 
 	return nil
 }

--- a/config/reference_config.go
+++ b/config/reference_config.go
@@ -188,6 +188,7 @@ func (c *ReferenceConfig) getUrlMap() url.Values {
 	urlMap.Set(constant.VERSION_KEY, c.Version)
 	urlMap.Set(constant.GENERIC_KEY, strconv.FormatBool(c.Generic))
 	urlMap.Set(constant.ROLE_KEY, strconv.Itoa(common.CONSUMER))
+
 	urlMap.Set(constant.RELEASE_KEY, "dubbo-golang-"+constant.Version)
 	urlMap.Set(constant.SIDE_KEY, (common.RoleType(common.CONSUMER)).Role())
 

--- a/config_center/zookeeper/impl.go
+++ b/config_center/zookeeper/impl.go
@@ -74,7 +74,7 @@ func newZookeeperDynamicConfiguration(url *common.URL) (*zookeeperDynamicConfigu
 	c.cacheListener = NewCacheListener(c.rootPath)
 
 	err = c.client.Create(c.rootPath)
-	c.listener.ListenServiceEvent(c.rootPath, c.cacheListener)
+	c.listener.ListenServiceEvent(url, c.rootPath, c.cacheListener)
 	return c, err
 
 }
@@ -100,7 +100,7 @@ func newMockZookeeperDynamicConfiguration(url *common.URL, opts ...zookeeper.Opt
 	c.cacheListener = NewCacheListener(c.rootPath)
 
 	err = c.client.Create(c.rootPath)
-	go c.listener.ListenServiceEvent(c.rootPath, c.cacheListener)
+	go c.listener.ListenServiceEvent(url, c.rootPath, c.cacheListener)
 	return tc, c, err
 
 }

--- a/registry/base_registry.go
+++ b/registry/base_registry.go
@@ -178,7 +178,10 @@ func (r *BaseRegistry) RestartCallBack() bool {
 		}
 		logger.Infof("success to re-register service :%v", confIf.Key())
 	}
-	r.facadeBasedRegistry.InitListeners()
+
+	if flag {
+		r.facadeBasedRegistry.InitListeners()
+	}
 
 	return flag
 }

--- a/registry/base_registry.go
+++ b/registry/base_registry.go
@@ -117,14 +117,10 @@ func (r *BaseRegistry) GetUrl() common.URL {
 func (r *BaseRegistry) Destroy() {
 	//first step close registry's all listeners
 	r.facadeBasedRegistry.CloseListener()
-	logger.Info("1---")
 	// then close r.done to notify other program who listen to it
 	close(r.done)
-	logger.Info("2---")
-
 	// wait waitgroup done (wait listeners outside close over)
 	r.wg.Wait()
-	logger.Info("3---")
 
 	//close registry client
 	r.closeRegisters()

--- a/registry/base_registry.go
+++ b/registry/base_registry.go
@@ -117,10 +117,15 @@ func (r *BaseRegistry) GetUrl() common.URL {
 func (r *BaseRegistry) Destroy() {
 	//first step close registry's all listeners
 	r.facadeBasedRegistry.CloseListener()
+	logger.Info("1---")
 	// then close r.done to notify other program who listen to it
 	close(r.done)
+	logger.Info("2---")
+
 	// wait waitgroup done (wait listeners outside close over)
 	r.wg.Wait()
+	logger.Info("3---")
+
 	//close registry client
 	r.closeRegisters()
 }

--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -44,7 +44,8 @@ import (
 )
 
 var (
-	regProtocol = newRegistryProtocol()
+	regProtocol *registryProtocol
+	once sync.Once
 )
 
 type registryProtocol struct {
@@ -348,6 +349,9 @@ func setProviderUrl(regURL *common.URL, providerURL *common.URL) {
 
 // GetProtocol ...
 func GetProtocol() protocol.Protocol {
+	once.Do(func() {
+		regProtocol = newRegistryProtocol()
+	})
 	return regProtocol
 }
 

--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -347,7 +347,7 @@ func setProviderUrl(regURL *common.URL, providerURL *common.URL) {
 	regURL.SubURL = providerURL
 }
 
-// GetProtocol ...
+// GetProtocol return the singleton RegistryProtocol
 func GetProtocol() protocol.Protocol {
 	once.Do(func() {
 		regProtocol = newRegistryProtocol()

--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -45,7 +45,7 @@ import (
 
 var (
 	regProtocol *registryProtocol
-	once sync.Once
+	once        sync.Once
 )
 
 type registryProtocol struct {

--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -44,7 +44,7 @@ import (
 )
 
 var (
-	regProtocol *registryProtocol
+	regProtocol = newRegistryProtocol()
 )
 
 type registryProtocol struct {
@@ -348,10 +348,7 @@ func setProviderUrl(regURL *common.URL, providerURL *common.URL) {
 
 // GetProtocol ...
 func GetProtocol() protocol.Protocol {
-	if regProtocol != nil {
-		return regProtocol
-	}
-	return newRegistryProtocol()
+	return regProtocol
 }
 
 type wrappedInvoker struct {

--- a/registry/zookeeper/listener.go
+++ b/registry/zookeeper/listener.go
@@ -38,7 +38,6 @@ import (
 // RegistryDataListener ...
 type RegistryDataListener struct {
 	subscribed map[*common.URL]config_center.ConfigurationListener
-	listener   config_center.ConfigurationListener
 	mutex      sync.Mutex
 	closed     bool
 }

--- a/registry/zookeeper/listener.go
+++ b/registry/zookeeper/listener.go
@@ -155,6 +155,7 @@ func (l *RegistryConfigurationListener) Close() {
 		l.registry.WaitGroup().Done()
 	})
 }
+
 // valid return the true if the client conn isn't nil
 func (l *RegistryConfigurationListener) valid() bool {
 	return l.client.ZkConnValid()

--- a/registry/zookeeper/listener.go
+++ b/registry/zookeeper/listener.go
@@ -81,7 +81,7 @@ func (l *RegistryDataListener) DataChange(eventType remoting.Event) bool {
 	return false
 }
 
-func (l *RegistryDataListener) Close(){
+func (l *RegistryDataListener) Close() {
 	for _, listener := range l.subscribed {
 		listener.(*RegistryConfigurationListener).Close()
 	}

--- a/registry/zookeeper/listener_test.go
+++ b/registry/zookeeper/listener_test.go
@@ -32,15 +32,15 @@ import (
 )
 
 func Test_DataChange(t *testing.T) {
-	listener := NewRegistryDataListener(&MockDataListener{})
+	listener := NewRegistryDataListener()
 	url, _ := common.NewURL("jsonrpc%3A%2F%2F127.0.0.1%3A20001%2Fcom.ikurento.user.UserProvider%3Fanyhost%3Dtrue%26app.version%3D0.0.1%26application%3DBDTService%26category%3Dproviders%26cluster%3Dfailover%26dubbo%3Ddubbo-provider-golang-1.3.0%26environment%3Ddev%26group%3D%26interface%3Dcom.ikurento.user.UserProvider%26ip%3D10.32.20.124%26loadbalance%3Drandom%26methods.GetUser.loadbalance%3Drandom%26methods.GetUser.retries%3D1%26methods.GetUser.weight%3D0%26module%3Ddubbogo%2Buser-info%2Bserver%26name%3DBDTService%26organization%3Dikurento.com%26owner%3DZX%26pid%3D74500%26retries%3D0%26service.filter%3Decho%26side%3Dprovider%26timestamp%3D1560155407%26version%3D%26warmup%3D100")
-	listener.AddInterestedURL(&url)
+	listener.SubscribeURL(&url, &MockConfigurationListener{})
 	int := listener.DataChange(remoting.Event{Path: "/dubbo/com.ikurento.user.UserProvider/providers/jsonrpc%3A%2F%2F127.0.0.1%3A20001%2Fcom.ikurento.user.UserProvider%3Fanyhost%3Dtrue%26app.version%3D0.0.1%26application%3DBDTService%26category%3Dproviders%26cluster%3Dfailover%26dubbo%3Ddubbo-provider-golang-1.3.0%26environment%3Ddev%26group%3D%26interface%3Dcom.ikurento.user.UserProvider%26ip%3D10.32.20.124%26loadbalance%3Drandom%26methods.GetUser.loadbalance%3Drandom%26methods.GetUser.retries%3D1%26methods.GetUser.weight%3D0%26module%3Ddubbogo%2Buser-info%2Bserver%26name%3DBDTService%26organization%3Dikurento.com%26owner%3DZX%26pid%3D74500%26retries%3D0%26service.filter%3Decho%26side%3Dprovider%26timestamp%3D1560155407%26version%3D%26warmup%3D100"})
 	assert.Equal(t, true, int)
 }
 
-type MockDataListener struct {
+type MockConfigurationListener struct {
 }
 
-func (*MockDataListener) Process(configType *config_center.ConfigChangeEvent) {
+func (*MockConfigurationListener) Process(configType *config_center.ConfigChangeEvent) {
 }

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -120,10 +120,16 @@ func newMockZkRegistry(url *common.URL, opts ...zookeeper.Option) (*zk.TestClust
 
 func (r *zkRegistry) InitListeners() {
 	r.listener = zookeeper.NewZkEventListener(r.client)
-	recoverd := r.dataListener.subscribed
 	newDataListener := NewRegistryDataListener()
-	for url, _ := range recoverd {
-		newDataListener.SubscribeURL(url, NewRegistryConfigurationListener(r.client, r))
+	// should recover if dataListener isn't nil before
+	if r.dataListener != nil {
+		recoverd := r.dataListener.subscribed
+		if recoverd != nil && len(recoverd) > 0 {
+			// recover all subscribed url
+			for url, _ := range recoverd {
+				newDataListener.SubscribeURL(url, NewRegistryConfigurationListener(r.client, r))
+			}
+		}
 	}
 	r.dataListener = newDataListener
 }

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -20,7 +20,6 @@ package zookeeper
 import (
 	"fmt"
 	"net/url"
-	"strings"
 	"sync"
 	"time"
 )

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -186,7 +186,17 @@ func (r *zkRegistry) registerTempZookeeperNode(root string, node string) error {
 }
 
 func (r *zkRegistry) getListener(conf *common.URL) (*RegistryConfigurationListener, error) {
-	zkListener := NewRegistryConfigurationListener(r.client, r)
+
+	var zkListener *RegistryConfigurationListener
+	if r.dataListener.subscribed[conf] != nil {
+
+		zkListener, err := r.dataListener.subscribed[conf].(*RegistryConfigurationListener)
+		if err != nil && zkListener.isClosed {
+			return nil, perrors.New("zk connection broken")
+		}
+	}
+
+	zkListener = NewRegistryConfigurationListener(r.client, r)
 	if r.listener == nil {
 		r.cltLock.Lock()
 		client := r.client

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -232,6 +232,5 @@ func (r *zkRegistry) getListener(conf *common.URL) (*RegistryConfigurationListen
 
 	go r.listener.ListenServiceEvent(fmt.Sprintf("/dubbo/%s/"+constant.DEFAULT_CATEGORY, url.QueryEscape(conf.Service())), r.dataListener)
 
-
 	return zkListener, nil
 }

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -120,6 +120,7 @@ func newMockZkRegistry(url *common.URL, opts ...zookeeper.Option) (*zk.TestClust
 
 func (r *zkRegistry) InitListeners() {
 	r.listener = zookeeper.NewZkEventListener(r.client)
+
 	r.dataListener = NewRegistryDataListener()
 }
 

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -154,7 +154,6 @@ func (r *zkRegistry) DoSubscribe(conf *common.URL) (registry.Listener, error) {
 }
 
 func (r *zkRegistry) CloseAndNilClient() {
-	logger.Info("c")
 	r.client.Close()
 	r.client = nil
 }

--- a/remoting/zookeeper/client.go
+++ b/remoting/zookeeper/client.go
@@ -157,7 +157,7 @@ func ValidateZookeeperClient(container zkClientFacade, opts ...Option) error {
 	}
 
 	if connected {
-		logger.Info("sdsds")
+		logger.Info("Connect to zookeeper successfully, name{%s}, zk address{%v}", opions.zkName, url.Location)
 		container.WaitGroup().Add(1) //zk client start successful, then registry wg +1
 	}
 

--- a/remoting/zookeeper/facade.go
+++ b/remoting/zookeeper/facade.go
@@ -48,11 +48,11 @@ func HandleClientRestart(r zkClientFacade) {
 		failTimes int
 	)
 
-	defer r.WaitGroup().Done()
 LOOP:
 	for {
 		select {
 		case <-r.Done():
+			r.WaitGroup().Done() // dec the wg when registry is closed
 			logger.Warnf("(ZkProviderRegistry)reconnectZkRegistry goroutine exit now...")
 			break LOOP
 			// re-register all services
@@ -63,12 +63,14 @@ LOOP:
 			zkAddress := r.ZkClient().ZkAddrs
 			r.SetZkClient(nil)
 			r.ZkClientLock().Unlock()
+			r.WaitGroup().Done() // dec the wg when zk client is closed
 
 			// Connect zk until success.
 			failTimes = 0
 			for {
 				select {
 				case <-r.Done():
+					r.WaitGroup().Done() // dec the wg when registry is closed
 					logger.Warnf("(ZkProviderRegistry)reconnectZkRegistry goroutine exit now...")
 					break LOOP
 				case <-getty.GetTimeWheel().After(timeSecondDuration(failTimes * ConnDelay)): // Prevent crazy reconnection zk.

--- a/remoting/zookeeper/facade_test.go
+++ b/remoting/zookeeper/facade_test.go
@@ -38,6 +38,16 @@ type mockFacade struct {
 	done    chan struct{}
 }
 
+func newMockFacade(client *ZookeeperClient, url *common.URL) zkClientFacade {
+	mock := &mockFacade{
+		client: client,
+		URL:    url,
+	}
+
+	mock.wg.Add(1)
+	return mock
+}
+
 func (r *mockFacade) ZkClient() *ZookeeperClient {
 	return r.client
 }
@@ -80,7 +90,7 @@ func Test_Facade(t *testing.T) {
 	assert.NoError(t, err)
 	defer ts.Stop()
 	url, _ := common.NewURL("mock://127.0.0.1")
-	mock := &mockFacade{client: z, URL: &url}
+	mock := newMockFacade(z, &url)
 	go HandleClientRestart(mock)
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")

--- a/remoting/zookeeper/listener.go
+++ b/remoting/zookeeper/listener.go
@@ -18,6 +18,7 @@
 package zookeeper
 
 import (
+	"github.com/apache/dubbo-go/common"
 	"path"
 	"strings"
 	"sync"
@@ -173,7 +174,7 @@ func (l *ZkEventListener) handleZkNodeEvent(zkPath string, children []string, li
 	}
 }
 
-func (l *ZkEventListener) listenDirEvent(zkPath string, listener remoting.DataListener) {
+func (l *ZkEventListener) listenDirEvent(conf *common.URL, zkPath string, listener remoting.DataListener) {
 	defer l.wg.Done()
 
 	var (
@@ -224,7 +225,16 @@ func (l *ZkEventListener) listenDirEvent(zkPath string, listener remoting.DataLi
 		}
 		failTimes = 0
 		for _, c := range children {
-			// listen l service node
+
+			// Only need to compare Path when subscribing to provider
+			if strings.LastIndex(zkPath, constant.PROVIDER_CATEGORY) != -1 {
+				provider, _ := common.NewURL(c)
+				if provider.Path != conf.Path {
+					continue
+				}
+			}
+
+			//listen l service node
 			dubboPath := path.Join(zkPath, c)
 
 			//Save the path to avoid listen repeatedly
@@ -232,7 +242,7 @@ func (l *ZkEventListener) listenDirEvent(zkPath string, listener remoting.DataLi
 			_, ok := l.pathMap[dubboPath]
 			l.pathMapLock.Unlock()
 			if ok {
-				logger.Warnf("@zkPath %s has already been listened.", zkPath)
+				logger.Warnf("@zkPath %s has already been listened.", dubboPath)
 				continue
 			}
 
@@ -263,7 +273,7 @@ func (l *ZkEventListener) listenDirEvent(zkPath string, listener remoting.DataLi
 				strings.LastIndex(zkPath, constant.CONSUMER_CATEGORY) == -1 {
 				l.wg.Add(1)
 				go func(zkPath string, listener remoting.DataListener) {
-					l.listenDirEvent(zkPath, listener)
+					l.listenDirEvent(conf, zkPath, listener)
 					logger.Warnf("listenDirEvent(zkPath{%s}) goroutine exit now", zkPath)
 				}(dubboPath, listener)
 			}
@@ -291,11 +301,11 @@ func timeSecondDuration(sec int) time.Duration {
 // registry.go:Listen -> listenServiceEvent -> listenDirEvent -> ListenServiceNodeEvent
 //                            |
 //                            --------> ListenServiceNodeEvent
-func (l *ZkEventListener) ListenServiceEvent(zkPath string, listener remoting.DataListener) {
+func (l *ZkEventListener) ListenServiceEvent(conf *common.URL, zkPath string, listener remoting.DataListener) {
 	logger.Infof("listen dubbo path{%s}", zkPath)
 	l.wg.Add(1)
 	go func(zkPath string, listener remoting.DataListener) {
-		l.listenDirEvent(zkPath, listener)
+		l.listenDirEvent(conf, zkPath, listener)
 		logger.Warnf("listenDirEvent(zkPath{%s}) goroutine exit now", zkPath)
 	}(zkPath, listener)
 }

--- a/remoting/zookeeper/listener_test.go
+++ b/remoting/zookeeper/listener_test.go
@@ -97,7 +97,7 @@ func TestListener(t *testing.T) {
 	go client.HandleZkEvent(event)
 	listener := NewZkEventListener(client)
 	dataListener := &mockDataListener{client: client, changedData: changedData, wait: &wait}
-	listener.ListenServiceEvent("/dubbo", dataListener)
+	listener.ListenServiceEvent(nil, "/dubbo", dataListener)
 	time.Sleep(1 * time.Second)
 	_, err := client.Conn.Set("/dubbo/dubbo.properties", []byte(changedData), 1)
 	assert.NoError(t, err)


### PR DESCRIPTION
1. modify registryProtocol as a singleton to fix graceful shutdown can't delete the provider url
2. fix notification confusion caused by multiple references sharing the same zk listener


