### PR TITLE
重构网络模块

### DIFF
--- a/protocol/dubbo/dubbo_codec.go
+++ b/protocol/dubbo/dubbo_codec.go
@@ -1,0 +1,297 @@
+package dubbo
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	hessian "github.com/apache/dubbo-go-hessian2"
+	"github.com/apache/dubbo-go/common/constant"
+	"github.com/apache/dubbo-go/common/logger"
+	"github.com/apache/dubbo-go/protocol"
+	"github.com/apache/dubbo-go/protocol/invocation"
+	"github.com/apache/dubbo-go/remoting"
+	perrors "github.com/pkg/errors"
+	"strconv"
+	"time"
+)
+
+//SerialID serial ID
+type SerialID byte
+type SequenceType int64
+
+const (
+	// S_Dubbo dubbo serial id
+	S_Dubbo SerialID = 2
+)
+
+// DubboPackage ...
+type DubboPackage struct {
+	Header  hessian.DubboHeader
+	Service hessian.Service
+	Body    interface{}
+	Err     error
+}
+
+func (p DubboPackage) String() string {
+	return fmt.Sprintf("DubboPackage: Header-%v, Path-%v, Body-%v", p.Header, p.Service, p.Body)
+}
+
+//
+//// Marshal ...
+//func (p *DubboPackage) Marshal() (*bytes.Buffer, error) {
+//	codec := hessian.NewHessianCodec(nil)
+//
+//	pkg, err := codec.Write(p.Service, p.Header, p.Body)
+//	if err != nil {
+//		return nil, perrors.WithStack(err)
+//	}
+//
+//	return bytes.NewBuffer(pkg), nil
+//}
+//
+// Unmarshal ...
+func (p *DubboPackage) Unmarshal(buf *bytes.Buffer, resp *remoting.Response) error {
+	// fix issue https://github.com/apache/dubbo-go/issues/380
+	bufLen := buf.Len()
+	if bufLen < hessian.HEADER_LENGTH {
+		return perrors.WithStack(hessian.ErrHeaderNotEnough)
+	}
+
+	codec := hessian.NewHessianCodec(bufio.NewReaderSize(buf, bufLen))
+
+	// read header
+	err := codec.ReadHeader(&p.Header)
+	if err != nil {
+		return perrors.WithStack(err)
+	}
+
+	if resp != nil { // for client
+		if p.Header.Type&hessian.PackageRequest != 0x00 {
+			// size of this array must be '7'
+			// https://github.com/apache/dubbo-go-hessian2/blob/master/request.go#L272
+			p.Body = make([]interface{}, 7)
+		} else {
+			//pendingRsp, ok := client.pendingResponses.Load(SequenceType(p.Header.ID))
+			//if !ok {
+			//	return perrors.Errorf("client.GetPendingResponse(%v) = nil", p.Header.ID)
+			//}
+			p.Body = &hessian.Response{RspObj: resp.Reply}
+		}
+	}
+
+	// read body
+	err = codec.ReadBody(p.Body)
+	return perrors.WithStack(err)
+}
+
+/////////////////////////////////////////
+/////////////////////////////////////////
+
+type DubboCodec struct {
+}
+
+func (c *DubboCodec) EncodeRequest(request remoting.Request) (*bytes.Buffer, error) {
+	invocation := request.Data.(invocation.RPCInvocation)
+
+	p := &DubboPackage{}
+	p.Service.Path = invocation.AttachmentsByKey(constant.PATH_KEY, "")
+	p.Service.Interface = invocation.AttachmentsByKey(constant.INTERFACE_KEY, "")
+	p.Service.Version = invocation.AttachmentsByKey(constant.VERSION_KEY, "")
+	p.Service.Group = invocation.AttachmentsByKey(constant.GROUP_KEY, "")
+	p.Service.Method = invocation.MethodName()
+
+	timeout, err := strconv.Atoi(invocation.AttachmentsByKey(constant.TIMEOUT_KEY, "3000"))
+	if err != nil {
+		panic(err)
+	}
+	p.Service.Timeout = time.Duration(timeout)
+	//var timeout = request.svcUrl.GetParam(strings.Join([]string{constant.METHOD_KEYS, request.method + constant.RETRIES_KEY}, "."), "")
+	//if len(timeout) != 0 {
+	//	if t, err := time.ParseDuration(timeout); err == nil {
+	//		p.Service.Timeout = t
+	//	}
+	//}
+
+	p.Header.SerialID = byte(S_Dubbo)
+	p.Header.ID = request.Id
+	if request.TwoWay {
+		p.Header.Type = hessian.PackageRequest_TwoWay
+	} else {
+		p.Header.Type = hessian.PackageRequest
+	}
+
+	p.Body = hessian.NewRequest(invocation.Arguments(), invocation.Attachments())
+
+	codec := hessian.NewHessianCodec(nil)
+
+	pkg, err := codec.Write(p.Service, p.Header, p.Body)
+	if err != nil {
+		return nil, perrors.WithStack(err)
+	}
+
+	return bytes.NewBuffer(pkg), nil
+}
+func (c *DubboCodec) EncodeResponse(response remoting.Response) (*bytes.Buffer, error) {
+	var ptype hessian.PackageType = hessian.PackageResponse
+	if response.IsHeartbeat() {
+		ptype = hessian.PackageHeartbeat
+	}
+	resp := &DubboPackage{
+		Header: hessian.DubboHeader{
+			SerialID:       response.SerialID,
+			Type:           ptype,
+			ID:             response.Id,
+			ResponseStatus: response.Status,
+		},
+	}
+	resp.Body = response.Result
+	//if response.Header.Type&hessian.PackageRequest != 0x00 {
+	//	resp.Body = req.Body
+	//} else {
+	//	resp.Body = nil
+	//}
+	codec := hessian.NewHessianCodec(nil)
+
+	pkg, err := codec.Write(resp.Service, resp.Header, resp.Body)
+	if err != nil {
+		return nil, perrors.WithStack(err)
+	}
+
+	return bytes.NewBuffer(pkg), nil
+}
+func (c *DubboCodec) DecodeRequest(data []byte) (*remoting.Request, error) {
+	pkg := &DubboPackage{
+		Body: make([]interface{}, 7),
+	}
+	var request *remoting.Request = nil
+	buf := bytes.NewBuffer(data)
+	err := pkg.Unmarshal(buf, nil)
+	if err != nil {
+		originErr := perrors.Cause(err)
+		if originErr == hessian.ErrHeaderNotEnough || originErr == hessian.ErrBodyNotEnough {
+			return request, nil
+		}
+		logger.Errorf("pkg.Unmarshal(len(@data):%d) = error:%+v", buf.Len(), err)
+
+		return request, perrors.WithStack(err)
+	}
+	request = &remoting.Request{
+		Id:       pkg.Header.ID,
+		SerialID: pkg.Header.SerialID,
+		TwoWay:   false,
+	}
+	if pkg.Header.Type&hessian.PackageHeartbeat == 0x00 {
+		// convert params of request
+		req := pkg.Body.([]interface{}) // length of body should be 7
+		if len(req) > 0 {
+			//invocation := request.Data.(*invocation.RPCInvocation)
+			var methodName string
+			var args []interface{}
+			var attachments map[string]string = make(map[string]string)
+			if req[0] != nil {
+				//dubbo version
+				request.Version = req[0].(string)
+			}
+			if req[1] != nil {
+				//path
+				attachments[constant.PATH_KEY] = req[1].(string)
+			}
+			if req[2] != nil {
+				//version
+				attachments[constant.VERSION_KEY] = req[2].(string)
+			}
+			if req[3] != nil {
+				//method
+				methodName = req[3].(string)
+			}
+			if req[4] != nil {
+				//argsType
+				//invocation.ParameterTypes(constant., req[1].(string))
+				//argsTypes = req[4].(string)
+			}
+			if req[5] != nil {
+				args = req[5].([]interface{})
+			}
+			if req[6] != nil {
+				attachments = req[6].(map[string]string)
+			}
+			if pkg.Service.Path == "" && len(attachments[constant.PATH_KEY]) > 0 {
+				pkg.Service.Path = attachments[constant.PATH_KEY]
+			}
+			if _, ok := attachments[constant.INTERFACE_KEY]; ok {
+				pkg.Service.Interface = attachments[constant.INTERFACE_KEY]
+			} else {
+				pkg.Service.Interface = pkg.Service.Path
+			}
+			if len(attachments[constant.GROUP_KEY]) > 0 {
+				pkg.Service.Group = attachments[constant.GROUP_KEY]
+			}
+			invoc := invocation.NewRPCInvocationWithOptions(invocation.WithAttachments(attachments),
+				invocation.WithArguments(args), invocation.WithMethodName(methodName))
+			request.Data = invoc
+			//pkg.Body = map[string]interface{}{
+			//	"dubboVersion": dubboVersion,
+			//	"argsTypes":    argsTypes,
+			//	"args":         args,
+			//	"service":      common.ServiceMap.GetService("dubbo", pkg.Service.Path), // path as a key
+			//	"attachments":  attachments,
+			//}
+		}
+	}
+	return request, nil
+}
+func (c *DubboCodec) DecodeResponse(data []byte) (*remoting.Response, error) {
+	pkg := &DubboPackage{}
+	buf := bytes.NewBuffer(data)
+	var response *remoting.Response
+	err := pkg.Unmarshal(buf, response)
+	if err != nil {
+		originErr := perrors.Cause(err)
+		if originErr == hessian.ErrHeaderNotEnough || originErr == hessian.ErrBodyNotEnough {
+			return response, nil
+		}
+		logger.Errorf("pkg.Unmarshal(len(@data):%d) = error:%+v", buf.Len(), err)
+
+		return response, perrors.WithStack(err)
+	}
+	response = &remoting.Response{
+		Id: pkg.Header.ID,
+		//Version:  pkg.Header.,
+		SerialID: pkg.Header.SerialID,
+		Status:   pkg.Header.ResponseStatus,
+		Event:    (pkg.Header.Type | hessian.PackageHeartbeat) != 0,
+	}
+	var error error
+	if pkg.Header.Type&hessian.PackageHeartbeat != 0x00 {
+		if pkg.Header.Type&hessian.PackageResponse != 0x00 {
+			logger.Debugf("get rpc heartbeat response{header: %#v, body: %#v}", pkg.Header, pkg.Body)
+			if pkg.Err != nil {
+				logger.Errorf("rpc heartbeat response{error: %#v}", pkg.Err)
+				error = pkg.Err
+			}
+		} else {
+			logger.Debugf("get rpc heartbeat request{header: %#v, service: %#v, body: %#v}", pkg.Header, pkg.Service, pkg.Body)
+			response.Status = hessian.Response_OK
+			//reply(session, p, hessian.PackageHeartbeat)
+		}
+		return response, error
+	}
+	logger.Debugf("get rpc response{header: %#v, body: %#v}", pkg.Header, pkg.Body)
+	rpcResult := &protocol.RPCResult{}
+	if pkg.Header.Type&hessian.PackageRequest == 0x00 {
+		if pkg.Err != nil {
+			rpcResult.Err = pkg.Err
+		}
+		rpcResult.Attrs = pkg.Body.(*hessian.Response).Attachments
+		rpcResult.Rest = pkg.Body.(*hessian.Response).RspObj
+	}
+
+	//h.conn.updateSession(session)
+	//pendingResponse := h.conn.pool.rpcClient.removePendingResponse(SequenceType(p.Header.ID))
+	//if pendingResponse == nil {
+	//	logger.Errorf("failed to get pending response context for response package %s", *p)
+	//	return
+	//}
+
+	return response, nil
+}

--- a/protocol/dubbo/dubbo_invoker.go
+++ b/protocol/dubbo/dubbo_invoker.go
@@ -19,6 +19,7 @@ package dubbo
 
 import (
 	"context"
+	"github.com/apache/dubbo-go/remoting/getty"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -51,14 +52,14 @@ var (
 // DubboInvoker ...
 type DubboInvoker struct {
 	protocol.BaseInvoker
-	client   *Client
+	client   *getty.Client
 	quitOnce sync.Once
 	// Used to record the number of requests. -1 represent this DubboInvoker is destroyed
 	reqNum int64
 }
 
 // NewDubboInvoker ...
-func NewDubboInvoker(url common.URL, client *Client) *DubboInvoker {
+func NewDubboInvoker(url common.URL, client *getty.Client) *DubboInvoker {
 	return &DubboInvoker{
 		BaseInvoker: *protocol.NewBaseInvoker(url),
 		client:      client,
@@ -99,18 +100,18 @@ func (di *DubboInvoker) Invoke(ctx context.Context, invocation protocol.Invocati
 		logger.Errorf("ParseBool - error: %v", err)
 		async = false
 	}
-	response := NewResponse(inv.Reply(), nil)
+	response := getty.NewResponse(inv.Reply(), nil)
 	if async {
 		if callBack, ok := inv.CallBack().(func(response common.CallbackResponse)); ok {
-			result.Err = di.client.AsyncCall(NewRequest(url.Location, url, inv.MethodName(), inv.Arguments(), inv.Attachments()), callBack, response)
+			result.Err = di.client.AsyncCall(getty.NewRequest(url.Location, url, inv.MethodName(), inv.Arguments(), inv.Attachments()), callBack, response)
 		} else {
-			result.Err = di.client.CallOneway(NewRequest(url.Location, url, inv.MethodName(), inv.Arguments(), inv.Attachments()))
+			result.Err = di.client.CallOneway(getty.NewRequest(url.Location, url, inv.MethodName(), inv.Arguments(), inv.Attachments()))
 		}
 	} else {
 		if inv.Reply() == nil {
 			result.Err = ErrNoReply
 		} else {
-			result.Err = di.client.Call(NewRequest(url.Location, url, inv.MethodName(), inv.Arguments(), inv.Attachments()), response)
+			result.Err = di.client.Call(getty.NewRequest(url.Location, url, inv.MethodName(), inv.Arguments(), inv.Attachments()), response)
 		}
 	}
 	if result.Err == nil {

--- a/protocol/dubbo/dubbo_protocol_test.go
+++ b/protocol/dubbo/dubbo_protocol_test.go
@@ -34,7 +34,7 @@ import (
 func TestDubboProtocol_Export(t *testing.T) {
 	// Export
 	proto := GetProtocol()
-	srvConf = &ServerConfig{}
+	//getty.srvConf = &getty.ServerConfig{}
 	url, err := common.NewURL("dubbo://127.0.0.1:20000/com.ikurento.user.UserProvider?anyhost=true&" +
 		"application=BDTService&category=providers&default.timeout=10000&dubbo=dubbo-provider-golang-1.0.0&" +
 		"environment=dev&interface=com.ikurento.user.UserProvider&ip=192.168.56.1&methods=GetUser%2C&" +
@@ -83,7 +83,7 @@ func TestDubboProtocol_Refer(t *testing.T) {
 		"module=dubbogo+user-info+server&org=ikurento.com&owner=ZX&pid=1447&revision=0.0.1&" +
 		"side=provider&timeout=3000&timestamp=1556509797245")
 	assert.NoError(t, err)
-	clientConf = &ClientConfig{}
+	//getty.clientConf = &getty.ClientConfig{}
 	invoker := proto.Refer(url)
 
 	// make sure url

--- a/remoting/codec.go
+++ b/remoting/codec.go
@@ -1,0 +1,12 @@
+package remoting
+
+import (
+	"bytes"
+)
+
+type Codec interface {
+	EncodeRequest(request Request) (*bytes.Buffer, error)
+	EncodeResponse(response Response) (*bytes.Buffer, error)
+	DecodeRequest(*bytes.Buffer) (*Request, error)
+	DecodeResponse(*bytes.Buffer) (*Response, error)
+}

--- a/remoting/exchange.go
+++ b/remoting/exchange.go
@@ -1,0 +1,134 @@
+package remoting
+
+import (
+	"github.com/apache/dubbo-go/common"
+	"time"
+)
+
+//// Request ...
+//type Request struct {
+//	addr   string
+//	svcUrl common.URL
+//	method string
+//	args   interface{}
+//	atta   map[string]string
+//}
+//
+//// NewRequest ...
+//func NewRequest(addr string, svcUrl common.URL, method string, args interface{}, atta map[string]string) *Request {
+//	return &Request{
+//		addr:   addr,
+//		svcUrl: svcUrl,
+//		method: method,
+//		args:   args,
+//		atta:   atta,
+//	}
+//}
+//
+//// Response ...
+//type Response struct {
+//	reply interface{}
+//	atta  map[string]string
+//}
+//
+//// NewResponse ...
+//func NewResponse(reply interface{}, atta map[string]string) *Response {
+//	return &Response{
+//		reply: reply,
+//		atta:  atta,
+//	}
+//}
+// Request ...
+type Request struct {
+	Id       int64
+	Version  string
+	SerialID byte
+	Data     interface{}
+	TwoWay   bool
+	event    bool
+	broken   bool
+}
+
+// NewRequest ...
+func NewRequest(id int64, version string) *Request {
+	return &Request{
+		Id:      id,
+		Version: version,
+	}
+}
+
+func (request *Request) SetHeartbeat(isHeartbeat bool) {
+	if isHeartbeat {
+
+	}
+}
+
+// Response ...
+type Response struct {
+	Id       int64
+	Version  string
+	SerialID byte
+	Status   uint8
+	Event    bool
+	Error    error
+	Result   interface{}
+	Reply    interface{}
+}
+
+// NewResponse ...
+func NewResponse(id int64, version string) *Response {
+	return &Response{
+		Id:      id,
+		Version: version,
+	}
+}
+
+func (response *Response) IsHeartbeat() bool {
+	return response.Event && response.Result == nil
+}
+
+type Options struct {
+	// connect timeout
+	ConnectTimeout time.Duration
+	// request timeout
+	//RequestTimeout time.Duration
+}
+
+//AsyncCallbackResponse async response for dubbo
+type AsyncCallbackResponse struct {
+	common.CallbackResponse
+	Opts      Options
+	Cause     error
+	Start     time.Time // invoke(call) start time == write start time
+	ReadStart time.Time // read start time, write duration = ReadStart - Start
+	Reply     interface{}
+}
+
+type PendingResponse struct {
+	seq       uint64
+	err       error
+	start     time.Time
+	readStart time.Time
+	callback  common.AsyncCallback
+	response  *Response
+	done      chan struct{}
+}
+
+// NewPendingResponse ...
+func NewPendingResponse() *PendingResponse {
+	return &PendingResponse{
+		start:    time.Now(),
+		response: &Response{},
+		done:     make(chan struct{}),
+	}
+}
+
+// GetCallResponse ...
+func (r PendingResponse) GetCallResponse() common.CallbackResponse {
+	return AsyncCallbackResponse{
+		Cause:     r.err,
+		Start:     r.start,
+		ReadStart: r.readStart,
+		Reply:     r.response,
+	}
+}

--- a/remoting/exchange_client.go
+++ b/remoting/exchange_client.go
@@ -1,0 +1,35 @@
+package remoting
+
+import (
+	"github.com/apache/dubbo-go/common"
+	"github.com/apache/dubbo-go/protocol"
+	"time"
+)
+
+type ExchangeClient struct {
+	ConnectTimeout time.Duration
+	address        string
+}
+
+func newExchangeClient(url common.URL, ConnectTimeout time.Duration, ) *ExchangeClient {
+	exchangeClient := &ExchangeClient{
+		ConnectTimeout: ConnectTimeout,
+		address:        url.Ip + ":" + url.Port,
+	}
+
+	return exchangeClient
+}
+
+func (client *ExchangeClient) request(invocation *protocol.Invocation, url common.URL, timeout time.Duration,
+	result *protocol.RPCResult) error {
+
+}
+
+func (client *ExchangeClient) asyncRequest(invocation *protocol.Invocation, url common.URL, timeout time.Duration,
+	callback common.AsyncCallback, result *protocol.RPCResult) error {
+
+}
+
+func (client *ExchangeClient) send(invocation *protocol.Invocation, timeout time.Duration) error {
+
+}

--- a/remoting/getty/client.go
+++ b/remoting/getty/client.go
@@ -1,0 +1,368 @@
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one or more
+// * contributor license agreements.  See the NOTICE file distributed with
+// * this work for additional information regarding copyright ownership.
+// * The ASF licenses this file to You under the Apache License, Version 2.0
+// * (the "License"); you may not use this file except in compliance with
+// * the License.  You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package getty
+//
+//import (
+//	"github.com/apache/dubbo-go/remoting"
+//	"math/rand"
+//	"strings"
+//	"sync"
+//	"time"
+//)
+//
+//import (
+//	hessian "github.com/apache/dubbo-go-hessian2"
+//	"github.com/dubbogo/getty"
+//	gxsync "github.com/dubbogo/gost/sync"
+//	perrors "github.com/pkg/errors"
+//	"go.uber.org/atomic"
+//	"gopkg.in/yaml.v2"
+//)
+//
+//import (
+//	"github.com/apache/dubbo-go/common"
+//	"github.com/apache/dubbo-go/common/constant"
+//	"github.com/apache/dubbo-go/common/logger"
+//	"github.com/apache/dubbo-go/config"
+//)
+//
+//var (
+//	errInvalidCodecType  = perrors.New("illegal CodecType")
+//	errInvalidAddress    = perrors.New("remote address invalid or empty")
+//	errSessionNotExist   = perrors.New("session not exist")
+//	errClientClosed      = perrors.New("client closed")
+//	errClientReadTimeout = perrors.New("client read timeout")
+//
+//	clientConf   *ClientConfig
+//	clientGrpool *gxsync.TaskPool
+//)
+//
+//func Init(protocol string) {
+//
+//	// load clientconfig from consumer_config
+//	// default use dubbo
+//	consumerConfig := config.GetConsumerConfig()
+//	if consumerConfig.ApplicationConfig == nil {
+//		return
+//	}
+//	protocolConf := config.GetConsumerConfig().ProtocolConf
+//	defaultClientConfig := GetDefaultClientConfig()
+//	if protocolConf == nil {
+//		logger.Info("protocol_conf default use dubbo config")
+//	} else {
+//		dubboConf := protocolConf.(map[interface{}]interface{})[protocol]
+//		if dubboConf == nil {
+//			logger.Warnf("dubboConf is nil")
+//			return
+//		}
+//		dubboConfByte, err := yaml.Marshal(dubboConf)
+//		if err != nil {
+//			panic(err)
+//		}
+//		err = yaml.Unmarshal(dubboConfByte, &defaultClientConfig)
+//		if err != nil {
+//			panic(err)
+//		}
+//	}
+//	clientConf = &defaultClientConfig
+//	if err := clientConf.CheckValidity(); err != nil {
+//		logger.Warnf("[CheckValidity] error: %v", err)
+//		return
+//	}
+//	setClientGrpool()
+//
+//	rand.Seed(time.Now().UnixNano())
+//}
+//
+//// SetClientConf ...
+//func SetClientConf(c ClientConfig) {
+//	clientConf = &c
+//	err := clientConf.CheckValidity()
+//	if err != nil {
+//		logger.Warnf("[ClientConfig CheckValidity] error: %v", err)
+//		return
+//	}
+//	setClientGrpool()
+//}
+//
+//// GetClientConf ...
+//func GetClientConf() ClientConfig {
+//	return *clientConf
+//}
+//
+//func setClientGrpool() {
+//	if clientConf.GrPoolSize > 1 {
+//		clientGrpool = gxsync.NewTaskPool(gxsync.WithTaskPoolTaskPoolSize(clientConf.GrPoolSize), gxsync.WithTaskPoolTaskQueueLength(clientConf.QueueLen),
+//			gxsync.WithTaskPoolTaskQueueNumber(clientConf.QueueNumber))
+//	}
+//}
+//
+//// Options ...
+//type Options struct {
+//	// connect timeout
+//	ConnectTimeout time.Duration
+//	// request timeout
+//	//RequestTimeout time.Duration
+//}
+//
+////AsyncCallbackResponse async response for dubbo
+//type AsyncCallbackResponse struct {
+//	common.CallbackResponse
+//	Opts      Options
+//	Cause     error
+//	Start     time.Time // invoke(call) start time == write start time
+//	ReadStart time.Time // read start time, write duration = ReadStart - Start
+//	Reply     interface{}
+//}
+//
+//// Client ...
+//type Client struct {
+//	opts     Options
+//	conf     ClientConfig
+//	pool     *gettyRPCClientPool
+//	sequence atomic.Uint64
+//
+//	pendingResponses *sync.Map
+//}
+//
+//// NewClient ...
+//func NewClient(opt Options) *Client {
+//
+//	switch {
+//	case opt.ConnectTimeout == 0:
+//		opt.ConnectTimeout = 3 * time.Second
+//		//fallthrough
+//		//case opt.RequestTimeout == 0:
+//		//	opt.RequestTimeout = 3 * time.Second
+//	}
+//
+//	// make sure that client request sequence is an odd number
+//	initSequence := uint64(rand.Int63n(time.Now().UnixNano()))
+//	if initSequence%2 == 0 {
+//		initSequence++
+//	}
+//
+//	c := &Client{
+//		opts:             opt,
+//		pendingResponses: new(sync.Map),
+//		conf:             *clientConf,
+//	}
+//	c.sequence.Store(initSequence)
+//	c.pool = newGettyRPCClientConnPool(c, clientConf.PoolSize, time.Duration(int(time.Second)*clientConf.PoolTTL))
+//
+//	return c
+//}
+//
+////
+////// Request ...
+////type Request struct {
+////	addr   string
+////	svcUrl common.URL
+////	method string
+////	args   interface{}
+////	atta   map[string]string
+////}
+////
+////// NewRequest ...
+////func NewRequest(addr string, svcUrl common.URL, method string, args interface{}, atta map[string]string) *Request {
+////	return &Request{
+////		addr:   addr,
+////		svcUrl: svcUrl,
+////		method: method,
+////		args:   args,
+////		atta:   atta,
+////	}
+////}
+////
+////// Response ...
+////type Response struct {
+////	reply interface{}
+////	atta  map[string]string
+////}
+////
+////// NewResponse ...
+////func NewResponse(reply interface{}, atta map[string]string) *Response {
+////	return &Response{
+////		reply: reply,
+////		atta:  atta,
+////	}
+////}
+//
+//// CallOneway call one way
+//func (c *Client) CallOneway(request *remoting.Request, timeout time.Duration) error {
+//
+//	return perrors.WithStack(c.call(CT_OneWay, request, remoting.NewResponse(request.Id, request.Version), nil))
+//}
+//
+//// Call if @response is nil, the transport layer will get the response without notify the invoker.
+//func (c *Client) Call(request *remoting.Request, response *remoting.Response, timeout time.Duration) error {
+//
+//	ct := CT_TwoWay
+//	if response.reply == nil {
+//		ct = CT_OneWay
+//	}
+//
+//	return perrors.WithStack(c.call(ct, request, response, nil))
+//}
+//
+//// AsyncCall ...
+//func (c *Client) AsyncCall(request *remoting.Request, callback common.AsyncCallback, response *remoting.Response, timeout time.Duration) error {
+//
+//	return perrors.WithStack(c.call(CT_TwoWay, request, response, callback, timeout))
+//}
+//
+//func (c *Client) call(ct CallType, request *remoting.Request, response *remoting.Response, callback common.AsyncCallback, timeout time.Duration) error {
+//
+//	p := &DubboPackage{}
+//	p.Service.Path = strings.TrimPrefix(request.svcUrl.Path, "/")
+//	p.Service.Interface = request.svcUrl.GetParam(constant.INTERFACE_KEY, "")
+//	p.Service.Version = request.svcUrl.GetParam(constant.VERSION_KEY, "")
+//	p.Service.Group = request.svcUrl.GetParam(constant.GROUP_KEY, "")
+//	p.Service.Method = request.method
+//
+//	p.Service.Timeout = timeout
+//	//var timeout = request.svcUrl.GetParam(strings.Join([]string{constant.METHOD_KEYS, request.method + constant.RETRIES_KEY}, "."), "")
+//	//if len(timeout) != 0 {
+//	//	if t, err := time.ParseDuration(timeout); err == nil {
+//	//		p.Service.Timeout = t
+//	//	}
+//	//}
+//
+//	p.Header.SerialID = byte(S_Dubbo)
+//	p.Body = hessian.NewRequest(request.args, request.atta)
+//
+//	var rsp *PendingResponse
+//	if ct != CT_OneWay {
+//		p.Header.Type = hessian.PackageRequest_TwoWay
+//		rsp = NewPendingResponse()
+//		rsp.response = response
+//		rsp.callback = callback
+//	} else {
+//		p.Header.Type = hessian.PackageRequest
+//	}
+//
+//	var (
+//		err     error
+//		session getty.Session
+//		conn    *gettyRPCClient
+//	)
+//	conn, session, err = c.selectSession(request.addr)
+//	if err != nil {
+//		return perrors.WithStack(err)
+//	}
+//	if session == nil {
+//		return errSessionNotExist
+//	}
+//	defer func() {
+//		if err == nil {
+//			c.pool.put(conn)
+//			return
+//		}
+//		conn.close()
+//	}()
+//
+//	if err = c.transfer(session, p, rsp); err != nil {
+//		return perrors.WithStack(err)
+//	}
+//
+//	if ct == CT_OneWay || callback != nil {
+//		return nil
+//	}
+//
+//	select {
+//	case <-getty.GetTimeWheel().After(c.opts.RequestTimeout):
+//		c.removePendingResponse(SequenceType(rsp.seq))
+//		return perrors.WithStack(errClientReadTimeout)
+//	case <-rsp.done:
+//		err = rsp.err
+//	}
+//
+//	return perrors.WithStack(err)
+//}
+//
+//// Close ...
+//func (c *Client) Close() {
+//	if c.pool != nil {
+//		c.pool.close()
+//	}
+//	c.pool = nil
+//}
+//
+//func (c *Client) selectSession(addr string) (*gettyRPCClient, getty.Session, error) {
+//	rpcClient, err := c.pool.getGettyRpcClient(addr)
+//	if err != nil {
+//		return nil, nil, perrors.WithStack(err)
+//	}
+//	return rpcClient, rpcClient.selectSession(), nil
+//}
+//
+//func (c *Client) heartbeat(session getty.Session) error {
+//	return c.transfer(session, nil, NewPendingResponse())
+//}
+//
+//func (c *Client) transfer(session getty.Session, pkg *DubboPackage,
+//	rsp *PendingResponse) error {
+//
+//	var (
+//		sequence uint64
+//		err      error
+//	)
+//
+//	sequence = c.sequence.Add(1)
+//
+//	if pkg == nil {
+//		pkg = &DubboPackage{}
+//		pkg.Body = hessian.NewRequest([]interface{}{}, nil)
+//		pkg.Body = []interface{}{}
+//		pkg.Header.Type = hessian.PackageHeartbeat
+//		pkg.Header.SerialID = byte(S_Dubbo)
+//	}
+//	pkg.Header.ID = int64(sequence)
+//
+//	// cond1
+//	if rsp != nil {
+//		rsp.seq = sequence
+//		c.addPendingResponse(rsp)
+//	}
+//
+//	err = session.WritePkg(pkg, c.opts.RequestTimeout)
+//	if err != nil {
+//		c.removePendingResponse(SequenceType(rsp.seq))
+//	} else if rsp != nil { // cond2
+//		// cond2 should not merged with cond1. cause the response package may be returned very
+//		// soon and it will be handled by other goroutine.
+//		rsp.readStart = time.Now()
+//	}
+//
+//	return perrors.WithStack(err)
+//}
+//
+//func (c *Client) addPendingResponse(pr *PendingResponse) {
+//	c.pendingResponses.Store(SequenceType(pr.seq), pr)
+//}
+//
+//func (c *Client) removePendingResponse(seq SequenceType) *PendingResponse {
+//	if c.pendingResponses == nil {
+//		return nil
+//	}
+//	if presp, ok := c.pendingResponses.Load(seq); ok {
+//		c.pendingResponses.Delete(seq)
+//		return presp.(*PendingResponse)
+//	}
+//	return nil
+//}

--- a/remoting/getty/client_test.go
+++ b/remoting/getty/client_test.go
@@ -15,11 +15,12 @@
  * limitations under the License.
  */
 
-package dubbo
+package getty
 
 import (
 	"bytes"
 	"context"
+	"github.com/apache/dubbo-go/protocol/dubbo"
 	"sync"
 	"testing"
 	"time"
@@ -209,7 +210,7 @@ func InitTest(t *testing.T) (protocol.Protocol, common.URL) {
 	assert.NoError(t, srvConf.CheckValidity())
 
 	// Export
-	proto := GetProtocol()
+	proto := dubbo.GetProtocol()
 	url, err := common.NewURL("dubbo://127.0.0.1:20000/UserProvider?anyhost=true&" +
 		"application=BDTService&category=providers&default.timeout=10000&dubbo=dubbo-provider-golang-1.0.0&" +
 		"environment=dev&interface=com.ikurento.user.UserProvider&ip=192.168.56.1&methods=GetUser%2C&" +

--- a/remoting/getty/codec.go
+++ b/remoting/getty/codec.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package dubbo
+package getty
 
 import (
 	"bufio"
@@ -126,31 +126,31 @@ func (p *DubboPackage) Unmarshal(buf *bytes.Buffer, opts ...interface{}) error {
 ////////////////////////////////////////////
 
 // PendingResponse ...
-type PendingResponse struct {
-	seq       uint64
-	err       error
-	start     time.Time
-	readStart time.Time
-	callback  common.AsyncCallback
-	response  *Response
-	done      chan struct{}
-}
-
-// NewPendingResponse ...
-func NewPendingResponse() *PendingResponse {
-	return &PendingResponse{
-		start:    time.Now(),
-		response: &Response{},
-		done:     make(chan struct{}),
-	}
-}
-
-// GetCallResponse ...
-func (r PendingResponse) GetCallResponse() common.CallbackResponse {
-	return AsyncCallbackResponse{
-		Cause:     r.err,
-		Start:     r.start,
-		ReadStart: r.readStart,
-		Reply:     r.response,
-	}
-}
+//type PendingResponse struct {
+//	seq       uint64
+//	err       error
+//	start     time.Time
+//	readStart time.Time
+//	callback  common.AsyncCallback
+//	response  *Response
+//	done      chan struct{}
+//}
+//
+//// NewPendingResponse ...
+//func NewPendingResponse() *PendingResponse {
+//	return &PendingResponse{
+//		start:    time.Now(),
+//		response: &Response{},
+//		done:     make(chan struct{}),
+//	}
+//}
+//
+//// GetCallResponse ...
+//func (r PendingResponse) GetCallResponse() common.CallbackResponse {
+//	return AsyncCallbackResponse{
+//		Cause:     r.err,
+//		Start:     r.start,
+//		ReadStart: r.readStart,
+//		Reply:     r.response,
+//	}
+//}

--- a/remoting/getty/codec_test.go
+++ b/remoting/getty/codec_test.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package dubbo
+package getty
 
 import (
 	"bytes"

--- a/remoting/getty/config.go
+++ b/remoting/getty/config.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package dubbo
+package getty
 
 import (
 	"time"

--- a/remoting/getty/listener_test.go
+++ b/remoting/getty/listener_test.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package dubbo
+package getty
 
 import (
 	"testing"

--- a/remoting/getty/pool.go
+++ b/remoting/getty/pool.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package dubbo
+package getty
 
 import (
 	"fmt"
@@ -37,7 +37,7 @@ import (
 
 type gettyRPCClient struct {
 	once     sync.Once
-	protocol string
+	//protocol string
 	addr     string
 	active   int64 // zero, not create or be destroyed
 
@@ -52,9 +52,9 @@ var (
 	errClientPoolClosed = perrors.New("client pool closed")
 )
 
-func newGettyRPCClientConn(pool *gettyRPCClientPool, protocol, addr string) (*gettyRPCClient, error) {
+func newGettyRPCClientConn(pool *gettyRPCClientPool, addr string) (*gettyRPCClient, error) {
 	c := &gettyRPCClient{
-		protocol: protocol,
+		//protocol: protocol,
 		addr:     addr,
 		pool:     pool,
 		gettyClient: getty.NewTCPClient(
@@ -315,11 +315,11 @@ func (p *gettyRPCClientPool) close() {
 	}
 }
 
-func (p *gettyRPCClientPool) getGettyRpcClient(protocol, addr string) (*gettyRPCClient, error) {
+func (p *gettyRPCClientPool) getGettyRpcClient(addr string) (*gettyRPCClient, error) {
 	conn, err := p.get()
 	if err == nil && conn == nil {
 		// create new conn
-		rpcClientConn, err := newGettyRPCClientConn(p, protocol, addr)
+		rpcClientConn, err := newGettyRPCClientConn(p, addr)
 		return rpcClientConn, perrors.WithStack(err)
 	}
 	return conn, perrors.WithStack(err)

--- a/remoting/getty/readwriter.go
+++ b/remoting/getty/readwriter.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package dubbo
+package getty
 
 import (
 	"bytes"
@@ -160,7 +160,7 @@ func (p *RpcServerPackageHandler) Read(ss getty.Session, data []byte) (interface
 				"dubboVersion": dubboVersion,
 				"argsTypes":    argsTypes,
 				"args":         args,
-				"service":      common.ServiceMap.GetService(DUBBO, pkg.Service.Path), // path as a key
+				"service":      common.ServiceMap.GetService("dubbo", pkg.Service.Path), // path as a key
 				"attachments":  attachments,
 			}
 		}

--- a/remoting/getty/readwriter2.go
+++ b/remoting/getty/readwriter2.go
@@ -1,0 +1,186 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package getty
+
+import (
+	"bytes"
+	"reflect"
+)
+
+import (
+	"github.com/apache/dubbo-go-hessian2"
+	"github.com/dubbogo/getty"
+	perrors "github.com/pkg/errors"
+)
+
+import (
+	"github.com/apache/dubbo-go/common"
+	"github.com/apache/dubbo-go/common/constant"
+	"github.com/apache/dubbo-go/common/logger"
+)
+
+////////////////////////////////////////////
+// RpcClientPackageHandler
+////////////////////////////////////////////
+
+// RpcClientPackageHandler ...
+type RpcClientPackageHandler struct {
+	client *Client
+}
+
+// NewRpcClientPackageHandler ...
+func NewRpcClientPackageHandler(client *Client) *RpcClientPackageHandler {
+	return &RpcClientPackageHandler{client: client}
+}
+
+func (p *RpcClientPackageHandler) Read(ss getty.Session, data []byte) (interface{}, int, error) {
+	pkg := &DubboPackage{}
+
+	buf := bytes.NewBuffer(data)
+	err := pkg.Unmarshal(buf, p.client)
+	if err != nil {
+		originErr := perrors.Cause(err)
+		if originErr == hessian.ErrHeaderNotEnough || originErr == hessian.ErrBodyNotEnough {
+			return nil, 0, nil
+		}
+
+		logger.Errorf("pkg.Unmarshal(ss:%+v, len(@data):%d) = error:%+v", ss, len(data), err)
+
+		return nil, 0, perrors.WithStack(err)
+	}
+
+	if pkg.Header.Type&hessian.PackageRequest == 0x00 {
+		pkg.Err = pkg.Body.(*hessian.Response).Exception
+		pkg.Body = NewResponse(pkg.Body.(*hessian.Response).RspObj, pkg.Body.(*hessian.Response).Attachments)
+	}
+
+	return pkg, hessian.HEADER_LENGTH + pkg.Header.BodyLen, nil
+}
+
+func (p *RpcClientPackageHandler) Write(ss getty.Session, pkg interface{}) ([]byte, error) {
+	req, ok := pkg.(*DubboPackage)
+	if !ok {
+		logger.Errorf("illegal pkg:%+v\n", pkg)
+		return nil, perrors.New("invalid rpc request")
+	}
+
+	buf, err := req.Marshal()
+	if err != nil {
+		logger.Warnf("binary.Write(req{%#v}) = err{%#v}", req, perrors.WithStack(err))
+		return nil, perrors.WithStack(err)
+	}
+
+	return buf.Bytes(), nil
+}
+
+////////////////////////////////////////////
+// RpcServerPackageHandler
+////////////////////////////////////////////
+
+var (
+	rpcServerPkgHandler = &RpcServerPackageHandler{}
+)
+
+// RpcServerPackageHandler ...
+type RpcServerPackageHandler struct{}
+
+func (p *RpcServerPackageHandler) Read(ss getty.Session, data []byte) (interface{}, int, error) {
+	pkg := &DubboPackage{
+		Body: make([]interface{}, 7),
+	}
+
+	buf := bytes.NewBuffer(data)
+	err := pkg.Unmarshal(buf)
+	if err != nil {
+		originErr := perrors.Cause(err)
+		if originErr == hessian.ErrHeaderNotEnough || originErr == hessian.ErrBodyNotEnough {
+			return nil, 0, nil
+		}
+
+		logger.Errorf("pkg.Unmarshal(ss:%+v, len(@data):%d) = error:%+v", ss, len(data), err)
+
+		return nil, 0, perrors.WithStack(err)
+	}
+
+	if pkg.Header.Type&hessian.PackageHeartbeat == 0x00 {
+		// convert params of request
+		req := pkg.Body.([]interface{}) // length of body should be 7
+		if len(req) > 0 {
+			var dubboVersion, argsTypes string
+			var args []interface{}
+			var attachments map[string]string
+			if req[0] != nil {
+				dubboVersion = req[0].(string)
+			}
+			if req[1] != nil {
+				pkg.Service.Path = req[1].(string)
+			}
+			if req[2] != nil {
+				pkg.Service.Version = req[2].(string)
+			}
+			if req[3] != nil {
+				pkg.Service.Method = req[3].(string)
+			}
+			if req[4] != nil {
+				argsTypes = req[4].(string)
+			}
+			if req[5] != nil {
+				args = req[5].([]interface{})
+			}
+			if req[6] != nil {
+				attachments = req[6].(map[string]string)
+			}
+			if pkg.Service.Path == "" && len(attachments[constant.PATH_KEY]) > 0 {
+				pkg.Service.Path = attachments[constant.PATH_KEY]
+			}
+			if _, ok := attachments[constant.INTERFACE_KEY]; ok {
+				pkg.Service.Interface = attachments[constant.INTERFACE_KEY]
+			} else {
+				pkg.Service.Interface = pkg.Service.Path
+			}
+			if len(attachments[constant.GROUP_KEY]) > 0 {
+				pkg.Service.Group = attachments[constant.GROUP_KEY]
+			}
+			pkg.Body = map[string]interface{}{
+				"dubboVersion": dubboVersion,
+				"argsTypes":    argsTypes,
+				"args":         args,
+				"service":      common.ServiceMap.GetService("dubbo", pkg.Service.Path), // path as a key
+				"attachments":  attachments,
+			}
+		}
+	}
+
+	return pkg, hessian.HEADER_LENGTH + pkg.Header.BodyLen, nil
+}
+
+func (p *RpcServerPackageHandler) Write(ss getty.Session, pkg interface{}) ([]byte, error) {
+	res, ok := pkg.(*DubboPackage)
+	if !ok {
+		logger.Errorf("illegal pkg:%+v\n, it is %+v", pkg, reflect.TypeOf(pkg))
+		return nil, perrors.New("invalid rpc response")
+	}
+
+	buf, err := res.Marshal()
+	if err != nil {
+		logger.Warnf("binary.Write(res{%#v}) = err{%#v}", res, perrors.WithStack(err))
+		return nil, perrors.WithStack(err)
+	}
+
+	return buf.Bytes(), nil
+}

--- a/remoting/getty/server.go
+++ b/remoting/getty/server.go
@@ -15,10 +15,12 @@
  * limitations under the License.
  */
 
-package dubbo
+package getty
 
 import (
 	"fmt"
+	"github.com/apache/dubbo-go/protocol"
+	"github.com/apache/dubbo-go/protocol/dubbo"
 	"net"
 )
 
@@ -52,7 +54,7 @@ func init() {
 	if protocolConf == nil {
 		logger.Info("protocol_conf default use dubbo config")
 	} else {
-		dubboConf := protocolConf.(map[interface{}]interface{})[DUBBO]
+		dubboConf := protocolConf.(map[interface{}]interface{})[dubbo.DUBBO]
 		if dubboConf == nil {
 			logger.Warnf("dubboConf is nil")
 			return
@@ -106,13 +108,13 @@ type Server struct {
 }
 
 // NewServer ...
-func NewServer() *Server {
+func NewServer(serverHandler func(url *common.URL, invocation protocol.Invocation) protocol.Result) *Server {
 
 	s := &Server{
 		conf: *srvConf,
 	}
 
-	s.rpcHandler = NewRpcServerHandler(s.conf.SessionNumber, s.conf.sessionTimeout)
+	s.rpcHandler = NewRpcServerHandler(s.conf.SessionNumber, s.conf.sessionTimeout, serverHandler)
 
 	return s
 }

--- a/remoting/getty/server2.go
+++ b/remoting/getty/server2.go
@@ -1,0 +1,1 @@
+package getty


### PR DESCRIPTION
现在dubbo和getty耦合度很高，所以先进行第一轮抽象，部分逻辑后续待优化。
做的改动：
1. 增加exchange层做中转，连接dubbo协议和网络交互。exchange入参出参是invocation和result， 网络层入参出参是request和response
2. 在dubbo_protocol中增加共用相同连接（客户端访问server，当ip和端口相同，就共用exchange）
3. 将getty相关的逻辑移到remoting/getty下， 将addr和requestTimeout删除，getty服务管理连接，每个请求的超时，都是请求的入口传入，方便前面提到的连接共享
4. 抽象codec接口
5.requestId变成全局，PendingResponse也变成全局



待优化的小的功能点：
1. codec和remoting.client下后续可以抽象成扩展。现在还是编码形式存在。
2. codec中的hessian编解码，期望能对hessian进行抽象
3. getty中的逻辑尽量保持了和原来的逻辑一直，没有做调整，后续看下getty和remoting/getty之间的api层是否可以抽象。

-----
代码主干流程完成，部分异常和分支流程待完善，单元测试待完善。 先提交给大家看下