### PR TITLE
Add attribute method into Invocation and RpcInvocation

### DIFF
--- a/protocol/invocation.go
+++ b/protocol/invocation.go
@@ -30,5 +30,8 @@ type Invocation interface {
 	Reply() interface{}
 	Attachments() map[string]string
 	AttachmentsByKey(string, string) string
+	// Refer to dubbo 2.7.6.  It is different from attachment. It is used in internal process.
+	Attributes() map[string]interface{}
+	AttributeByKey(string, interface{}) interface{}
 	Invoker() Invoker
 }

--- a/protocol/invocation/rpcinvocation.go
+++ b/protocol/invocation/rpcinvocation.go
@@ -40,8 +40,10 @@ type RPCInvocation struct {
 	reply           interface{}
 	callBack        interface{}
 	attachments     map[string]string
-	invoker         protocol.Invoker
-	lock            sync.RWMutex
+	// Refer to dubbo 2.7.6.  It is different from attachment. It is used in internal process.
+	attributes map[string]interface{}
+	invoker    protocol.Invoker
+	lock       sync.RWMutex
 }
 
 // NewRPCInvocation ...
@@ -105,6 +107,25 @@ func (r *RPCInvocation) AttachmentsByKey(key string, defaultValue string) string
 		return defaultValue
 	}
 	value, ok := r.attachments[key]
+	if ok {
+		return value
+	}
+	return defaultValue
+}
+
+// get attributes
+func (r *RPCInvocation) Attributes() map[string]interface{} {
+	return r.attributes
+}
+
+// get attribute by key. If it is not exist, it will return default value
+func (r *RPCInvocation) AttributeByKey(key string, defaultValue interface{}) interface{} {
+	r.lock.RLock()
+	defer r.lock.RUnlock()
+	if r.attributes == nil {
+		return defaultValue
+	}
+	value, ok := r.attributes[key]
 	if ok {
 		return value
 	}

--- a/protocol/invocation/rpcinvocation.go
+++ b/protocol/invocation/rpcinvocation.go
@@ -52,6 +52,7 @@ func NewRPCInvocation(methodName string, arguments []interface{}, attachments ma
 		methodName:  methodName,
 		arguments:   arguments,
 		attachments: attachments,
+		attributes:  make(map[string]interface{}, 8),
 	}
 }
 
@@ -142,6 +143,16 @@ func (r *RPCInvocation) SetAttachments(key string, value string) {
 	r.attachments[key] = value
 }
 
+// SetAttribute. If Attributes is nil, it will be inited.
+func (r *RPCInvocation) SetAttribute(key string, value interface{}) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	if r.attributes == nil {
+		r.attributes = make(map[string]interface{})
+	}
+	r.attributes[key] = value
+}
+
 // Invoker ...
 func (r *RPCInvocation) Invoker() protocol.Invoker {
 	return r.invoker
@@ -214,6 +225,12 @@ func WithCallBack(callBack interface{}) option {
 func WithAttachments(attachments map[string]string) option {
 	return func(invo *RPCInvocation) {
 		invo.attachments = attachments
+	}
+}
+
+func WithAttributes(attributes map[string]interface{}) option {
+	return func(invo *RPCInvocation) {
+		invo.attributes = attributes
 	}
 }
 

--- a/protocol/invocation/rpcinvocation.go
+++ b/protocol/invocation/rpcinvocation.go
@@ -62,6 +62,9 @@ func NewRPCInvocationWithOptions(opts ...option) *RPCInvocation {
 	for _, opt := range opts {
 		opt(invo)
 	}
+	if invo.attributes == nil {
+		invo.attributes = make(map[string]interface{})
+	}
 	return invo
 }
 
@@ -123,9 +126,6 @@ func (r *RPCInvocation) Attributes() map[string]interface{} {
 func (r *RPCInvocation) AttributeByKey(key string, defaultValue interface{}) interface{} {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
-	if r.attributes == nil {
-		return defaultValue
-	}
 	value, ok := r.attributes[key]
 	if ok {
 		return value
@@ -147,9 +147,6 @@ func (r *RPCInvocation) SetAttachments(key string, value string) {
 func (r *RPCInvocation) SetAttribute(key string, value interface{}) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
-	if r.attributes == nil {
-		r.attributes = make(map[string]interface{})
-	}
 	r.attributes[key] = value
 }
 
@@ -225,12 +222,6 @@ func WithCallBack(callBack interface{}) option {
 func WithAttachments(attachments map[string]string) option {
 	return func(invo *RPCInvocation) {
 		invo.attachments = attachments
-	}
-}
-
-func WithAttributes(attributes map[string]interface{}) option {
-	return func(invo *RPCInvocation) {
-		invo.attributes = attributes
 	}
 }
 


### PR DESCRIPTION
Some parameter need to be used in the internal process.  For example we need calculate the serialize type and store into attribute. If we don't store it and this serialize value is used by some function or method , we must calculate it in every function.

