### PR TITLE
Fix: Nacos client logDir path seperator

### DIFF
--- a/before_ut.bat
+++ b/before_ut.bat
@@ -20,7 +20,7 @@ set zkJarPath=remoting/zookeeper/zookeeper-4unittest/contrib/fatjar
 set zkJar=%zkJarPath%/%zkJarName%
 
 if not exist "%zkJar%" (
-   md %zkJarPath%
+   md "%zkJarPath%"
    curl -L %remoteJarUrl% -o %zkJar%
 )
 

--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -119,6 +119,7 @@ const (
 	CONFIG_CLUSTER_KEY    = "config.cluster"
 	CONFIG_CHECK_KEY      = "config.check"
 	CONFIG_TIMEOUT_KET    = "config.timeout"
+	CONFIG_LOG_DIR_KEY    = "config.logDir"
 	CONFIG_VERSION_KEY    = "configVersion"
 	COMPATIBLE_CONFIG_KEY = "compatible_config"
 )

--- a/config/config_center_config.go
+++ b/config/config_center_config.go
@@ -46,6 +46,7 @@ type ConfigCenterConfig struct {
 	Group         string `default:"dubbo" yaml:"group" json:"group,omitempty"`
 	Username      string `yaml:"username" json:"username,omitempty"`
 	Password      string `yaml:"password" json:"password,omitempty"`
+	LogDir        string `yaml:"log_dir" json:"log_dir,omitempty"`
 	ConfigFile    string `default:"dubbo.properties" yaml:"config_file"  json:"config_file,omitempty"`
 	Namespace     string `default:"dubbo" yaml:"namespace"  json:"namespace,omitempty"`
 	AppConfigFile string `default:"dubbo.properties" yaml:"app_config_file"  json:"app_config_file,omitempty"`
@@ -73,5 +74,6 @@ func (c *ConfigCenterConfig) GetUrlMap() url.Values {
 	urlMap.Set(constant.CONFIG_GROUP_KEY, c.Group)
 	urlMap.Set(constant.CONFIG_CLUSTER_KEY, c.Cluster)
 	urlMap.Set(constant.CONFIG_APP_ID_KEY, c.AppId)
+	urlMap.Set(constant.CONFIG_LOG_DIR_KEY, c.LogDir)
 	return urlMap
 }

--- a/config_center/nacos/client.go
+++ b/config_center/nacos/client.go
@@ -18,7 +18,7 @@
 package nacos
 
 import (
-	"runtime"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -37,7 +37,8 @@ import (
 	"github.com/apache/dubbo-go/common/logger"
 )
 
-var logDir string
+// Nacos Log dir, it can be override when creating client by config_center.log_dir
+var logDir = filepath.Join("logs", "nacos", "log")
 
 // NacosClient Nacos client
 type NacosClient struct {
@@ -49,16 +50,6 @@ type NacosClient struct {
 	Timeout    time.Duration
 	once       sync.Once
 	onceClose  func()
-}
-
-// init default Nacos Log dir, it can be override when create client
-func init() {
-	switch runtime.GOOS {
-	case "windows":
-		logDir = "logs\\nacos\\log"
-	default:
-		logDir = "logs/nacos/log"
-	}
 }
 
 // Client Get Client

--- a/config_center/nacos/client.go
+++ b/config_center/nacos/client.go
@@ -51,6 +51,7 @@ type NacosClient struct {
 	onceClose  func()
 }
 
+// init default Nacos Log dir, it can be override when create client
 func init() {
 	switch runtime.GOOS {
 	case "windows":
@@ -97,6 +98,7 @@ func ValidateNacosClient(container nacosClientFacade, opts ...option) error {
 	}
 
 	url := container.GetUrl()
+	logDir = url.GetParam(constant.CONFIG_LOG_DIR_KEY, logDir)
 
 	if container.NacosClient() == nil {
 		//in dubbo ,every registry only connect one node ,so this is []string{r.Address}

--- a/config_center/nacos/client.go
+++ b/config_center/nacos/client.go
@@ -18,6 +18,7 @@
 package nacos
 
 import (
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -36,7 +37,7 @@ import (
 	"github.com/apache/dubbo-go/common/logger"
 )
 
-const logDir = "logs/nacos/log"
+var logDir string
 
 // NacosClient Nacos client
 type NacosClient struct {
@@ -48,6 +49,15 @@ type NacosClient struct {
 	Timeout    time.Duration
 	once       sync.Once
 	onceClose  func()
+}
+
+func init() {
+	switch runtime.GOOS {
+	case "windows":
+		logDir = "logs\\nacos\\log"
+	default:
+		logDir = "logs/nacos/log"
+	}
 }
 
 // Client Get Client


### PR DESCRIPTION
**What this PR does**:

- fix logDir path seperator in Windows
- fix unit test prepare script for Windows

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
no