### PR TITLE
Imp: Zk client

### DIFF
--- a/remoting/zookeeper/client.go
+++ b/remoting/zookeeper/client.go
@@ -384,11 +384,11 @@ func (z *ZookeeperClient) Close() {
 	z.Conn = nil
 	z.Unlock()
 	if conn != nil {
-		logger.Warnf("zkClient Conn{name:%s, zk addr:%s} exit now.", z.name, conn.SessionID())
+		logger.Infof("zkClient Conn{name:%s, zk addr:%d} exit now.", z.name, conn.SessionID())
 		conn.Close()
 	}
 
-	logger.Warnf("zkClient{name:%s, zk addr:%s} exit now.", z.name, z.ZkAddrs)
+	logger.Infof("zkClient{name:%s, zk addr:%s} exit now.", z.name, z.ZkAddrs)
 }
 
 // Create will create the node recursively, which means that if the parent node is absent,
@@ -419,9 +419,9 @@ func (z *ZookeeperClient) CreateWithValue(basePath string, value []byte) error {
 
 		if err != nil {
 			if err == zk.ErrNodeExists {
-				logger.Debugf("zk.create(\"%s\") exists\n", tmpPath)
+				logger.Debugf("zk.create(\"%s\") exists", tmpPath)
 			} else {
-				logger.Errorf("zk.create(\"%s\") error(%v)\n", tmpPath, perrors.WithStack(err))
+				logger.Errorf("zk.create(\"%s\") error(%v)", tmpPath, perrors.WithStack(err))
 				return perrors.WithMessagef(err, "zk.Create(path:%s)", basePath)
 			}
 		}
@@ -457,10 +457,10 @@ func (z *ZookeeperClient) RegisterTemp(basePath string, node string) (string, er
 	}
 
 	if err != nil {
-		logger.Warnf("conn.Create(\"%s\", zk.FlagEphemeral) = error(%v)\n", zkPath, perrors.WithStack(err))
+		logger.Warnf("conn.Create(\"%s\", zk.FlagEphemeral) = error(%v)", zkPath, perrors.WithStack(err))
 		return zkPath, perrors.WithStack(err)
 	}
-	logger.Debugf("zkClient{%s} create a temp zookeeper node:%s\n", z.name, tmpPath)
+	logger.Debugf("zkClient{%s} create a temp zookeeper node:%s", z.name, tmpPath)
 
 	return tmpPath, nil
 }
@@ -485,11 +485,11 @@ func (z *ZookeeperClient) RegisterTempSeq(basePath string, data []byte) (string,
 
 	logger.Debugf("zookeeperClient.RegisterTempSeq(basePath{%s}) = tempPath{%s}", basePath, tmpPath)
 	if err != nil && err != zk.ErrNodeExists {
-		logger.Errorf("zkClient{%s} conn.Create(\"%s\", \"%s\", zk.FlagEphemeral|zk.FlagSequence) error(%v)\n",
+		logger.Errorf("zkClient{%s} conn.Create(\"%s\", \"%s\", zk.FlagEphemeral|zk.FlagSequence) error(%v)",
 			z.name, basePath, string(data), err)
 		return "", perrors.WithStack(err)
 	}
-	logger.Debugf("zkClient{%s} create a temp zookeeper node:%s\n", z.name, tmpPath)
+	logger.Debugf("zkClient{%s} create a temp zookeeper node:%s", z.name, tmpPath)
 
 	return tmpPath, nil
 }

--- a/remoting/zookeeper/client.go
+++ b/remoting/zookeeper/client.go
@@ -302,12 +302,11 @@ func (z *ZookeeperClient) RegisterEvent(zkPath string, event *chan struct{}) {
 	}
 
 	z.Lock()
+	defer z.Unlock()
 	a := z.eventRegistry[zkPath]
 	a = append(a, event)
-
 	z.eventRegistry[zkPath] = a
 	logger.Debugf("zkClient{%s} register event{path:%s, ptr:%p}", z.name, zkPath, event)
-	z.Unlock()
 }
 
 // UnregisterEvent ...
@@ -323,8 +322,7 @@ func (z *ZookeeperClient) UnregisterEvent(zkPath string, event *chan struct{}) {
 	}
 	for i, e := range infoList {
 		if e == event {
-			arr := infoList
-			infoList = append(arr[:i], arr[i+1:]...)
+			infoList = append(infoList[:i], infoList[i+1:]...)
 			logger.Infof("zkClient{%s} unregister event{path:%s, event:%p}", z.name, zkPath, event)
 		}
 	}

--- a/remoting/zookeeper/client.go
+++ b/remoting/zookeeper/client.go
@@ -445,7 +445,6 @@ func (z *ZookeeperClient) Delete(basePath string) error {
 func (z *ZookeeperClient) RegisterTemp(basePath string, node string) (string, error) {
 	var (
 		err     error
-		data    []byte
 		zkPath  string
 		tmpPath string
 	)

--- a/remoting/zookeeper/client_test.go
+++ b/remoting/zookeeper/client_test.go
@@ -111,7 +111,7 @@ func TestCreateDelete(t *testing.T) {
 	require.NoError(t, err)
 	err = z.Delete("/test1/test2/test3/test4")
 	require.NoError(t, err)
-	//verifyEventOrder(t, event, []zk.EventType{zk.EventNodeCreated}, "event channel")
+	// verifyEventOrder(t, event, []zk.EventType{zk.EventNodeCreated}, "event channel")
 }
 
 func TestRegisterTemp(t *testing.T) {

--- a/remoting/zookeeper/client_test.go
+++ b/remoting/zookeeper/client_test.go
@@ -18,7 +18,6 @@
 package zookeeper
 
 import (
-	"fmt"
 	"testing"
 	"time"
 )
@@ -28,6 +27,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+import (
+	"github.com/apache/dubbo-go/common/logger"
+)
+
 func verifyEventStateOrder(t *testing.T, c <-chan zk.Event, expectedStates []zk.State, source string) {
 	for _, state := range expectedStates {
 		for {
@@ -35,7 +38,7 @@ func verifyEventStateOrder(t *testing.T, c <-chan zk.Event, expectedStates []zk.
 			if !ok {
 				t.Fatalf("unexpected channel close for %s", source)
 			}
-			fmt.Println(event)
+			logger.Debug(event)
 			if event.Type != zk.EventSession {
 				continue
 			}

--- a/remoting/zookeeper/client_test.go
+++ b/remoting/zookeeper/client_test.go
@@ -24,7 +24,7 @@ import (
 
 import (
 	"github.com/dubbogo/go-zookeeper/zk"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 import (
@@ -80,7 +80,7 @@ func verifyEventStateOrder(t *testing.T, c <-chan zk.Event, expectedStates []zk.
 
 func Test_newMockZookeeperClient(t *testing.T) {
 	ts, z, event, err := NewMockZookeeperClient("test", 15*time.Second)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer ts.Stop()
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
@@ -90,49 +90,53 @@ func Test_newMockZookeeperClient(t *testing.T) {
 }
 
 func TestCreate(t *testing.T) {
-	ts, z, event, _ := NewMockZookeeperClient("test", 15*time.Second)
+	ts, z, event, err := NewMockZookeeperClient("test", 15*time.Second)
+	require.NoError(t, err)
 	defer ts.Stop()
-	err := z.Create("test1/test2/test3/test4")
-	assert.NoError(t, err)
+	err = z.Create("test1/test2/test3/test4")
+	require.NoError(t, err)
 
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
 }
 
 func TestCreateDelete(t *testing.T) {
-	ts, z, event, _ := NewMockZookeeperClient("test", 15*time.Second)
+	ts, z, event, err := NewMockZookeeperClient("test", 15*time.Second)
+	require.NoError(t, err)
 	defer ts.Stop()
 
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
-	err := z.Create("/test1/test2/test3/test4")
-	assert.NoError(t, err)
-	err2 := z.Delete("/test1/test2/test3/test4")
-	assert.NoError(t, err2)
+	err = z.Create("/test1/test2/test3/test4")
+	require.NoError(t, err)
+	err = z.Delete("/test1/test2/test3/test4")
+	require.NoError(t, err)
 	//verifyEventOrder(t, event, []zk.EventType{zk.EventNodeCreated}, "event channel")
 }
 
 func TestRegisterTemp(t *testing.T) {
-	ts, z, event, _ := NewMockZookeeperClient("test", 15*time.Second)
+	ts, z, event, err := NewMockZookeeperClient("test", 15*time.Second)
+	require.NoError(t, err)
 	defer ts.Stop()
-	err := z.Create("/test1/test2/test3")
-	assert.NoError(t, err)
+	err = z.Create("/test1/test2/test3")
+	require.NoError(t, err)
 
 	tmpath, err := z.RegisterTemp("/test1/test2/test3", "test4")
-	assert.NoError(t, err)
-	assert.Equal(t, "/test1/test2/test3/test4", tmpath)
+	require.NoError(t, err)
+	require.Equal(t, "/test1/test2/test3/test4", tmpath)
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
 }
 
 func TestRegisterTempSeq(t *testing.T) {
-	ts, z, event, _ := NewMockZookeeperClient("test", 15*time.Second)
+	ts, z, event, err := NewMockZookeeperClient("test", 15*time.Second)
+	require.NoError(t, err)
 	defer ts.Stop()
-	err := z.Create("/test1/test2/test3")
-	assert.NoError(t, err)
+	err = z.Create("/test1/test2/test3")
+	require.NoError(t, err)
 	tmpath, err := z.RegisterTempSeq("/test1/test2/test3", []byte("test"))
-	assert.NoError(t, err)
-	assert.Equal(t, "/test1/test2/test3/0000000000", tmpath)
+	require.NoError(t, err)
+	require.Equal(t, "/test1/test2/test3/0000000000", tmpath)
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
 }

--- a/remoting/zookeeper/client_test.go
+++ b/remoting/zookeeper/client_test.go
@@ -24,7 +24,7 @@ import (
 
 import (
 	"github.com/dubbogo/go-zookeeper/zk"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 import (
@@ -80,7 +80,7 @@ func verifyEventStateOrder(t *testing.T, c <-chan zk.Event, expectedStates []zk.
 
 func Test_newMockZookeeperClient(t *testing.T) {
 	ts, z, event, err := NewMockZookeeperClient("test", 15*time.Second)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	defer ts.Stop()
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
@@ -91,10 +91,10 @@ func Test_newMockZookeeperClient(t *testing.T) {
 
 func TestCreate(t *testing.T) {
 	ts, z, event, err := NewMockZookeeperClient("test", 15*time.Second)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	defer ts.Stop()
 	err = z.Create("test1/test2/test3/test4")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
@@ -102,41 +102,41 @@ func TestCreate(t *testing.T) {
 
 func TestCreateDelete(t *testing.T) {
 	ts, z, event, err := NewMockZookeeperClient("test", 15*time.Second)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	defer ts.Stop()
 
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
 	err = z.Create("/test1/test2/test3/test4")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	err = z.Delete("/test1/test2/test3/test4")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	// verifyEventOrder(t, event, []zk.EventType{zk.EventNodeCreated}, "event channel")
 }
 
 func TestRegisterTemp(t *testing.T) {
 	ts, z, event, err := NewMockZookeeperClient("test", 15*time.Second)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	defer ts.Stop()
 	err = z.Create("/test1/test2/test3")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	tmpath, err := z.RegisterTemp("/test1/test2/test3", "test4")
-	require.NoError(t, err)
-	require.Equal(t, "/test1/test2/test3/test4", tmpath)
+	assert.NoError(t, err)
+	assert.Equal(t, "/test1/test2/test3/test4", tmpath)
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
 }
 
 func TestRegisterTempSeq(t *testing.T) {
 	ts, z, event, err := NewMockZookeeperClient("test", 15*time.Second)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	defer ts.Stop()
 	err = z.Create("/test1/test2/test3")
-	require.NoError(t, err)
+	assert.NoError(t, err)
 	tmpath, err := z.RegisterTempSeq("/test1/test2/test3", []byte("test"))
-	require.NoError(t, err)
-	require.Equal(t, "/test1/test2/test3/0000000000", tmpath)
+	assert.NoError(t, err)
+	assert.Equal(t, "/test1/test2/test3/0000000000", tmpath)
 	states := []zk.State{zk.StateConnecting, zk.StateConnected, zk.StateHasSession}
 	verifyEventStateOrder(t, event, states, "event channel")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

- add lock for `eventRegistry` in `ZookeeperClient ` to avoid concurrent read and write in map
- replace `github.com/stretchr/testify/assert` with `github.com/stretchr/testify/require`  in test to fail test case immediately when test meet an error
- fix type and remove `\n` in log

**Special notes for your reviewer**:

- NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```