### PR TITLE
no travis notification in fork

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,3 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
-
-notifications:
-  webhooks: https://oapi.dingtalk.com/robot/send?access_token=f5d6237f2c79db584e75604f7f88db1ce1673c8c0e98451217b28fde791e1d4f

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,8 @@ script:
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+
+notifications:
+  webhooks:
+    urls: https://oapi.dingtalk.com/robot/send?access_token=f5d6237f2c79db584e75604f7f88db1ce1673c8c0e98451217b28fde791e1d4f
+    if: fork = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,4 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 notifications:
-  webhooks:
-    urls: https://oapi.dingtalk.com/robot/send?access_token=f5d6237f2c79db584e75604f7f88db1ce1673c8c0e98451217b28fde791e1d4f
-    if: fork = false
+  webhooks: https://oapi.dingtalk.com/robot/send?access_token=f5d6237f2c79db584e75604f7f88db1ce1673c8c0e98451217b28fde791e1d4f

--- a/common/logger/log.yml
+++ b/common/logger/log.yml
@@ -1,6 +1,5 @@
-
 level: "debug"
-development: true
+development: false
 disableCaller: false
 disableStacktrace: false
 sampling:

--- a/registry/nacos/service_discovery_test.go
+++ b/registry/nacos/service_discovery_test.go
@@ -136,9 +136,6 @@ func TestNacosServiceDiscovery_CRUD(t *testing.T) {
 	err = serviceDiscovery.Update(instance)
 	assert.Nil(t, err)
 
-	//sometimes nacos may be failed to push update of instance,
-	//so it need 10s to pull, we sleep 10 second to make sure instance has been update
-	time.Sleep(11 * time.Second)
 	pageMap := serviceDiscovery.GetRequestInstances([]string{serviceName}, 0, 1)
 	assert.Equal(t, 1, len(pageMap))
 

--- a/registry/nacos/service_discovery_test.go
+++ b/registry/nacos/service_discovery_test.go
@@ -136,8 +136,6 @@ func TestNacosServiceDiscovery_CRUD(t *testing.T) {
 	err = serviceDiscovery.Update(instance)
 	assert.Nil(t, err)
 
-	//sometimes nacos may be failed to push update of instance,
-	//so it need 10s to pull, we sleep 10 second to make sure instance has been update
 	time.Sleep(5 * time.Second)
 	pageMap := serviceDiscovery.GetRequestInstances([]string{serviceName}, 0, 1)
 	assert.Equal(t, 1, len(pageMap))

--- a/registry/nacos/service_discovery_test.go
+++ b/registry/nacos/service_discovery_test.go
@@ -136,6 +136,9 @@ func TestNacosServiceDiscovery_CRUD(t *testing.T) {
 	err = serviceDiscovery.Update(instance)
 	assert.Nil(t, err)
 
+	//sometimes nacos may be failed to push update of instance,
+	//so it need 10s to pull, we sleep 10 second to make sure instance has been update
+	time.Sleep(5 * time.Second)
 	pageMap := serviceDiscovery.GetRequestInstances([]string{serviceName}, 0, 1)
 	assert.Equal(t, 1, len(pageMap))
 

--- a/registry/nacos/service_discovery_test.go
+++ b/registry/nacos/service_discovery_test.go
@@ -118,9 +118,6 @@ func TestNacosServiceDiscovery_CRUD(t *testing.T) {
 	err = serviceDiscovery.Register(instance)
 	assert.Nil(t, err)
 
-	//sometimes nacos may be failed to push update of instance,
-	//so it need 10s to pull, we sleep 10 second to make sure instance has been update
-	time.Sleep(11 * time.Second)
 	page := serviceDiscovery.GetHealthyInstancesByPage(serviceName, 0, 10, true)
 	assert.NotNil(t, page)
 	assert.Equal(t, 0, page.GetOffset())

--- a/test/integrate/dubbo/go-client/log.yml
+++ b/test/integrate/dubbo/go-client/log.yml
@@ -1,6 +1,5 @@
-
 level: "debug"
-development: true
+development: false
 disableCaller: false
 disableStacktrace: false
 sampling:

--- a/test/integrate/dubbo/go-server/log.yml
+++ b/test/integrate/dubbo/go-server/log.yml
@@ -1,6 +1,5 @@
-
 level: "debug"
-development: true
+development: false
 disableCaller: false
 disableStacktrace: false
 sampling:


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

- 在fork的仓库里面，不触发travis的notification，这样就可以偷偷摸摸的干活了
- 把nacos service discovery测试的等待时间调小一点试试

**Special notes for your reviewer**:

- NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```