### PR TITLE
Rft: Optimize remotes configuration

### DIFF
--- a/config/base_config.go
+++ b/config/base_config.go
@@ -29,7 +29,6 @@ import (
 )
 
 import (
-	"github.com/apache/dubbo-go/common"
 	"github.com/apache/dubbo-go/common/config"
 	"github.com/apache/dubbo-go/common/logger"
 )
@@ -67,21 +66,6 @@ func (c *BaseConfig) GetServiceDiscoveries(name string) (config *ServiceDiscover
 func (c *BaseConfig) GetRemoteConfig(name string) (config *RemoteConfig, ok bool) {
 	config, ok = c.Remotes[name]
 	return
-}
-
-func (c *BaseConfig) toConfigCenterURL() (common.URL, error) {
-	rc, ok := GetBaseConfig().GetRemoteConfig(baseConfig.ConfigCenterConfig.RemoteRef)
-
-	if !ok {
-		return common.URL{}, perrors.New("Could not find out the remote ref config, name: " + name)
-	}
-
-	return common.NewURL(rc.Address,
-		common.WithUsername(rc.Username),
-		common.WithPassword(rc.Password),
-		common.WithLocation(rc.Address),
-		common.WithProtocol(baseConfig.ConfigCenterConfig.Protocol),
-	)
 }
 
 func getKeyPrefix(val reflect.Value) []string {

--- a/config/base_config.go
+++ b/config/base_config.go
@@ -69,8 +69,8 @@ func (c *BaseConfig) GetRemoteConfig(name string) (config *RemoteConfig, ok bool
 	return
 }
 
-func (c *BaseConfig) toURL(name string, protocol string) (common.URL, error) {
-	rc, ok := GetBaseConfig().GetRemoteConfig(name)
+func (c *BaseConfig) toConfigCenterURL() (common.URL, error) {
+	rc, ok := GetBaseConfig().GetRemoteConfig(baseConfig.ConfigCenterConfig.RemoteRef)
 
 	if !ok {
 		return common.URL{}, perrors.New("Could not find out the remote ref config, name: " + name)
@@ -80,7 +80,7 @@ func (c *BaseConfig) toURL(name string, protocol string) (common.URL, error) {
 		common.WithUsername(rc.Username),
 		common.WithPassword(rc.Password),
 		common.WithLocation(rc.Address),
-		common.WithProtocol(protocol),
+		common.WithProtocol(baseConfig.ConfigCenterConfig.Protocol),
 	)
 }
 

--- a/config/base_config.go
+++ b/config/base_config.go
@@ -31,9 +31,7 @@ import (
 import (
 	"github.com/apache/dubbo-go/common"
 	"github.com/apache/dubbo-go/common/config"
-	"github.com/apache/dubbo-go/common/extension"
 	"github.com/apache/dubbo-go/common/logger"
-	"github.com/apache/dubbo-go/config_center"
 )
 
 type multiConfiger interface {
@@ -52,7 +50,6 @@ type BaseConfig struct {
 	// application config
 	ApplicationConfig *ApplicationConfig `yaml:"application" json:"application,omitempty" property:"application"`
 
-	configCenterUrl     *common.URL
 	prefix              string
 	fatherConfig        interface{}
 	EventDispatcherType string        `default:"direct" yaml:"event_dispatcher_type" json:"event_dispatcher_type,omitempty"`
@@ -72,72 +69,19 @@ func (c *BaseConfig) GetRemoteConfig(name string) (config *RemoteConfig, ok bool
 	return
 }
 
-// startConfigCenter will start the config center.
-// it will prepare the environment
-func (c *BaseConfig) startConfigCenter() error {
-	url, err := common.NewURL(c.ConfigCenterConfig.Address,
-		common.WithProtocol(c.ConfigCenterConfig.Protocol), common.WithParams(c.ConfigCenterConfig.GetUrlMap()))
-	if err != nil {
-		return err
-	}
-	c.configCenterUrl = &url
-	if c.prepareEnvironment() != nil {
-		return perrors.WithMessagef(err, "start config center error!")
-	}
-	// c.fresh()
-	return err
-}
+func (c *BaseConfig) newURL(name string, protocol string) (common.URL, error) {
+	rc, ok := GetBaseConfig().GetRemoteConfig(name)
 
-func (c *BaseConfig) prepareEnvironment() error {
-	factory := extension.GetConfigCenterFactory(c.ConfigCenterConfig.Protocol)
-	dynamicConfig, err := factory.GetDynamicConfiguration(c.configCenterUrl)
-	config.GetEnvInstance().SetDynamicConfiguration(dynamicConfig)
-	if err != nil {
-		logger.Errorf("Get dynamic configuration error , error message is %v", err)
-		return perrors.WithStack(err)
-	}
-	content, err := dynamicConfig.GetProperties(c.ConfigCenterConfig.ConfigFile, config_center.WithGroup(c.ConfigCenterConfig.Group))
-	if err != nil {
-		logger.Errorf("Get config content in dynamic configuration error , error message is %v", err)
-		return perrors.WithStack(err)
-	}
-	var appGroup string
-	var appContent string
-	if providerConfig != nil && providerConfig.ApplicationConfig != nil &&
-		reflect.ValueOf(c.fatherConfig).Elem().Type().Name() == "ProviderConfig" {
-		appGroup = providerConfig.ApplicationConfig.Name
-	} else if consumerConfig != nil && consumerConfig.ApplicationConfig != nil &&
-		reflect.ValueOf(c.fatherConfig).Elem().Type().Name() == "ConsumerConfig" {
-		appGroup = consumerConfig.ApplicationConfig.Name
+	if !ok {
+		return common.URL{}, perrors.New("Could not find out the remote ref config, name: " + name)
 	}
 
-	if len(appGroup) != 0 {
-		configFile := c.ConfigCenterConfig.AppConfigFile
-		if len(configFile) == 0 {
-			configFile = c.ConfigCenterConfig.ConfigFile
-		}
-		appContent, err = dynamicConfig.GetProperties(configFile, config_center.WithGroup(appGroup))
-		if err != nil {
-			return perrors.WithStack(err)
-		}
-	}
-	// global config file
-	mapContent, err := dynamicConfig.Parser().Parse(content)
-	if err != nil {
-		return perrors.WithStack(err)
-	}
-	config.GetEnvInstance().UpdateExternalConfigMap(mapContent)
-
-	// appGroup config file
-	if len(appContent) != 0 {
-		appMapConent, err := dynamicConfig.Parser().Parse(appContent)
-		if err != nil {
-			return perrors.WithStack(err)
-		}
-		config.GetEnvInstance().UpdateAppExternalConfigMap(appMapConent)
-	}
-
-	return nil
+	return common.NewURL(rc.Address,
+		common.WithUsername(rc.Username),
+		common.WithPassword(rc.Password),
+		common.WithLocation(rc.Address),
+		common.WithProtocol(protocol),
+	)
 }
 
 func getKeyPrefix(val reflect.Value) []string {

--- a/config/base_config.go
+++ b/config/base_config.go
@@ -69,7 +69,7 @@ func (c *BaseConfig) GetRemoteConfig(name string) (config *RemoteConfig, ok bool
 	return
 }
 
-func (c *BaseConfig) newURL(name string, protocol string) (common.URL, error) {
+func (c *BaseConfig) toURL(name string, protocol string) (common.URL, error) {
 	rc, ok := GetBaseConfig().GetRemoteConfig(name)
 
 	if !ok {

--- a/config/base_config_test.go
+++ b/config/base_config_test.go
@@ -28,8 +28,6 @@ import (
 
 import (
 	"github.com/apache/dubbo-go/common/config"
-	"github.com/apache/dubbo-go/common/extension"
-	"github.com/apache/dubbo-go/config_center"
 	_ "github.com/apache/dubbo-go/config_center/apollo"
 )
 
@@ -280,23 +278,6 @@ func TestRefreshProvider(t *testing.T) {
 	assert.Equal(t, "10", father.Services["MockService"].Methods[0].Retries)
 	assert.Equal(t, "dubbo", father.ApplicationConfig.Name)
 	assert.Equal(t, "20001", father.Protocols["jsonrpc1"].Port)
-}
-
-func TestStartConfigCenter(t *testing.T) {
-	extension.SetConfigCenterFactory("mock", func() config_center.DynamicConfigurationFactory {
-		return &config_center.MockDynamicConfigurationFactory{}
-	})
-	c := &BaseConfig{ConfigCenterConfig: &ConfigCenterConfig{
-		Protocol:   "mock",
-		Address:    "172.0.0.1",
-		Group:      "dubbo",
-		ConfigFile: "mockDubbo.properties",
-	}}
-	err := c.startConfigCenter()
-	assert.NoError(t, err)
-	b, v := config.GetEnvInstance().Configuration().Back().Value.(*config.InmemoryConfiguration).GetProperty("dubbo.application.organization")
-	assert.True(t, b)
-	assert.Equal(t, "ikurento.com", v)
 }
 
 func TestInitializeStruct(t *testing.T) {

--- a/config/config_center_config.go
+++ b/config/config_center_config.go
@@ -118,21 +118,21 @@ func (b *configCenter) startConfigCenter(baseConfig BaseConfig) error {
 	if err != nil {
 		return err
 	}
-	if b.prepareEnvironment(baseConfig, &url) != nil {
+	if err = b.prepareEnvironment(baseConfig, &url); err != nil {
 		return perrors.WithMessagef(err, "start config center error!")
 	}
 	// c.fresh()
-	return err
+	return nil
 }
 
 func (b *configCenter) prepareEnvironment(baseConfig BaseConfig, configCenterUrl *common.URL) error {
 	factory := extension.GetConfigCenterFactory(configCenterUrl.Protocol)
 	dynamicConfig, err := factory.GetDynamicConfiguration(configCenterUrl)
-	config.GetEnvInstance().SetDynamicConfiguration(dynamicConfig)
 	if err != nil {
 		logger.Errorf("Get dynamic configuration error , error message is %v", err)
 		return perrors.WithStack(err)
 	}
+	config.GetEnvInstance().SetDynamicConfiguration(dynamicConfig)
 	content, err := dynamicConfig.GetProperties(baseConfig.ConfigCenterConfig.ConfigFile, config_center.WithGroup(baseConfig.ConfigCenterConfig.Group))
 	if err != nil {
 		logger.Errorf("Get config content in dynamic configuration error , error message is %v", err)

--- a/config/config_center_config.go
+++ b/config/config_center_config.go
@@ -98,7 +98,7 @@ func (b *configCenter) toURL(baseConfig BaseConfig) (common.URL, error) {
 	}
 
 	remoteRef := baseConfig.ConfigCenterConfig.RemoteRef
-	rc, ok := GetBaseConfig().GetRemoteConfig(remoteRef)
+	rc, ok := baseConfig.GetRemoteConfig(remoteRef)
 
 	if !ok {
 		return common.URL{}, perrors.New("Could not find out the remote ref config, name: " + remoteRef)

--- a/config/config_center_config.go
+++ b/config/config_center_config.go
@@ -89,7 +89,7 @@ func (c *ConfigCenterConfig) GetUrlMap() url.Values {
 type configCenter struct {
 }
 
-// toURL will compatible with baseConfig.ConfigCenterConfig.Address before 1.6.0
+// toURL will compatible with baseConfig.ConfigCenterConfig.Address and baseConfig.ConfigCenterConfig.RemoteRef before 1.6.0
 // After 1.6.0 will not compatible, only baseConfig.ConfigCenterConfig.RemoteRef
 func (b *configCenter) toURL(baseConfig BaseConfig) (common.URL, error) {
 	if len(baseConfig.ConfigCenterConfig.Address) > 0 {

--- a/config/config_center_config.go
+++ b/config/config_center_config.go
@@ -96,7 +96,11 @@ func (b *configCenter) toURL(baseConfig BaseConfig) (common.URL, error) {
 		return common.NewURL(baseConfig.ConfigCenterConfig.Address,
 			common.WithProtocol(baseConfig.ConfigCenterConfig.Protocol), common.WithParams(baseConfig.ConfigCenterConfig.GetUrlMap()))
 	}
-	return baseConfig.toURL(baseConfig.ConfigCenterConfig.RemoteRef, baseConfig.ConfigCenterConfig.Protocol)
+	newURL, err := baseConfig.toURL(baseConfig.ConfigCenterConfig.RemoteRef, baseConfig.ConfigCenterConfig.Protocol)
+	if err == nil {
+		newURL.SetParams(baseConfig.ConfigCenterConfig.GetUrlMap())
+	}
+	return newURL, err
 }
 
 // startConfigCenter will start the config center.

--- a/config/config_center_config.go
+++ b/config/config_center_config.go
@@ -104,7 +104,7 @@ func (b *configCenter) toURL(baseConfig BaseConfig) (common.URL, error) {
 		return common.URL{}, perrors.New("Could not find out the remote ref config, name: " + remoteRef)
 	}
 
-	newURL, err := rc.toURL(baseConfig.ConfigCenterConfig.Protocol)
+	newURL, err := rc.toURL()
 	if err == nil {
 		newURL.SetParams(baseConfig.ConfigCenterConfig.GetUrlMap())
 	}
@@ -126,7 +126,7 @@ func (b *configCenter) startConfigCenter(baseConfig BaseConfig) error {
 }
 
 func (b *configCenter) prepareEnvironment(baseConfig BaseConfig, configCenterUrl *common.URL) error {
-	factory := extension.GetConfigCenterFactory(baseConfig.ConfigCenterConfig.Protocol)
+	factory := extension.GetConfigCenterFactory(configCenterUrl.Protocol)
 	dynamicConfig, err := factory.GetDynamicConfiguration(configCenterUrl)
 	config.GetEnvInstance().SetDynamicConfiguration(dynamicConfig)
 	if err != nil {

--- a/config/config_center_config.go
+++ b/config/config_center_config.go
@@ -96,7 +96,7 @@ func (b *configCenter) toURL(baseConfig BaseConfig) (common.URL, error) {
 		return common.NewURL(baseConfig.ConfigCenterConfig.Address,
 			common.WithProtocol(baseConfig.ConfigCenterConfig.Protocol), common.WithParams(baseConfig.ConfigCenterConfig.GetUrlMap()))
 	}
-	newURL, err := baseConfig.toURL(baseConfig.ConfigCenterConfig.RemoteRef, baseConfig.ConfigCenterConfig.Protocol)
+	newURL, err := baseConfig.toConfigCenterURL()
 	if err == nil {
 		newURL.SetParams(baseConfig.ConfigCenterConfig.GetUrlMap())
 	}

--- a/config/config_center_config.go
+++ b/config/config_center_config.go
@@ -96,7 +96,15 @@ func (b *configCenter) toURL(baseConfig BaseConfig) (common.URL, error) {
 		return common.NewURL(baseConfig.ConfigCenterConfig.Address,
 			common.WithProtocol(baseConfig.ConfigCenterConfig.Protocol), common.WithParams(baseConfig.ConfigCenterConfig.GetUrlMap()))
 	}
-	newURL, err := baseConfig.toConfigCenterURL()
+
+	remoteRef := baseConfig.ConfigCenterConfig.RemoteRef
+	rc, ok := GetBaseConfig().GetRemoteConfig(remoteRef)
+
+	if !ok {
+		return common.URL{}, perrors.New("Could not find out the remote ref config, name: " + remoteRef)
+	}
+
+	newURL, err := rc.toURL(baseConfig.ConfigCenterConfig.Protocol)
 	if err == nil {
 		newURL.SetParams(baseConfig.ConfigCenterConfig.GetUrlMap())
 	}

--- a/config/config_center_config_test.go
+++ b/config/config_center_config_test.go
@@ -70,8 +70,6 @@ func TestStartConfigCenterWithRemoteRef(t *testing.T) {
 	b, v := config.GetEnvInstance().Configuration().Back().Value.(*config.InmemoryConfiguration).GetProperty("dubbo.application.organization")
 	assert.True(t, b)
 	assert.Equal(t, "ikurento.com", v)
-
-	baseConfig = nil
 }
 
 func TestStartConfigCenterWithRemoteRefError(t *testing.T) {

--- a/config/config_center_config_test.go
+++ b/config/config_center_config_test.go
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"github.com/apache/dubbo-go/common/config"
+	"github.com/apache/dubbo-go/common/extension"
+	"github.com/apache/dubbo-go/config_center"
+)
+
+func TestStartConfigCenter(t *testing.T) {
+	extension.SetConfigCenterFactory("mock", func() config_center.DynamicConfigurationFactory {
+		return &config_center.MockDynamicConfigurationFactory{}
+	})
+	baseConfig := &BaseConfig{ConfigCenterConfig: &ConfigCenterConfig{
+		Protocol:   "mock",
+		Address:    "172.0.0.1",
+		Group:      "dubbo",
+		ConfigFile: "mockDubbo.properties",
+	}}
+
+	c := &configCenter{}
+	err := c.startConfigCenter(*baseConfig)
+	assert.NoError(t, err)
+	b, v := config.GetEnvInstance().Configuration().Back().Value.(*config.InmemoryConfiguration).GetProperty("dubbo.application.organization")
+	assert.True(t, b)
+	assert.Equal(t, "ikurento.com", v)
+}

--- a/config/config_center_config_test.go
+++ b/config/config_center_config_test.go
@@ -49,3 +49,48 @@ func TestStartConfigCenter(t *testing.T) {
 	assert.True(t, b)
 	assert.Equal(t, "ikurento.com", v)
 }
+
+func TestStartConfigCenterWithRemoteRef(t *testing.T) {
+	extension.SetConfigCenterFactory("mock", func() config_center.DynamicConfigurationFactory {
+		return &config_center.MockDynamicConfigurationFactory{}
+	})
+	m := make(map[string]*RemoteConfig)
+	m["mock"] = &RemoteConfig{Address: "172.0.0.1"}
+	baseConfig = &BaseConfig{
+		Remotes: m,
+		ConfigCenterConfig: &ConfigCenterConfig{
+			Protocol:   "mock",
+			Group:      "dubbo",
+			RemoteRef:  "mock",
+			ConfigFile: "mockDubbo.properties",
+		}}
+
+	c := &configCenter{}
+	err := c.startConfigCenter(*baseConfig)
+	assert.NoError(t, err)
+	b, v := config.GetEnvInstance().Configuration().Back().Value.(*config.InmemoryConfiguration).GetProperty("dubbo.application.organization")
+	assert.True(t, b)
+	assert.Equal(t, "ikurento.com", v)
+
+	baseConfig = nil
+}
+
+func TestStartConfigCenterWithRemoteRefError(t *testing.T) {
+	extension.SetConfigCenterFactory("mock", func() config_center.DynamicConfigurationFactory {
+		return &config_center.MockDynamicConfigurationFactory{}
+	})
+	m := make(map[string]*RemoteConfig)
+	m["mock"] = &RemoteConfig{Address: "172.0.0.1"}
+	baseConfig := &BaseConfig{
+		Remotes: m,
+		ConfigCenterConfig: &ConfigCenterConfig{
+			Protocol:   "mock",
+			Group:      "dubbo",
+			RemoteRef:  "mock",
+			ConfigFile: "mockDubbo.properties",
+		}}
+
+	c := &configCenter{}
+	err := c.startConfigCenter(*baseConfig)
+	assert.Error(t, err)
+}

--- a/config/config_center_config_test.go
+++ b/config/config_center_config_test.go
@@ -56,7 +56,7 @@ func TestStartConfigCenterWithRemoteRef(t *testing.T) {
 	})
 	m := make(map[string]*RemoteConfig)
 	m["mock"] = &RemoteConfig{Protocol: "mock", Address: "172.0.0.1"}
-	baseConfig = &BaseConfig{
+	baseConfig := &BaseConfig{
 		Remotes: m,
 		ConfigCenterConfig: &ConfigCenterConfig{
 			Group:      "dubbo",

--- a/config/config_center_config_test.go
+++ b/config/config_center_config_test.go
@@ -55,11 +55,10 @@ func TestStartConfigCenterWithRemoteRef(t *testing.T) {
 		return &config_center.MockDynamicConfigurationFactory{}
 	})
 	m := make(map[string]*RemoteConfig)
-	m["mock"] = &RemoteConfig{Address: "172.0.0.1"}
+	m["mock"] = &RemoteConfig{Protocol: "mock", Address: "172.0.0.1"}
 	baseConfig = &BaseConfig{
 		Remotes: m,
 		ConfigCenterConfig: &ConfigCenterConfig{
-			Protocol:   "mock",
 			Group:      "dubbo",
 			RemoteRef:  "mock",
 			ConfigFile: "mockDubbo.properties",

--- a/config/consumer_config.go
+++ b/config/consumer_config.go
@@ -126,13 +126,6 @@ func ConsumerInit(confConFile string) error {
 func configCenterRefreshConsumer() error {
 	//fresh it
 	var err error
-	if consumerConfig.ConfigCenterConfig != nil {
-		consumerConfig.SetFatherConfig(consumerConfig)
-		if err = consumerConfig.startConfigCenter((*consumerConfig).BaseConfig); err != nil {
-			return perrors.Errorf("start config center error , error message is {%v}", perrors.WithStack(err))
-		}
-		consumerConfig.fresh()
-	}
 	if consumerConfig.Request_Timeout != "" {
 		if consumerConfig.RequestTimeout, err = time.ParseDuration(consumerConfig.Request_Timeout); err != nil {
 			return perrors.WithMessagef(err, "time.ParseDuration(Request_Timeout{%#v})", consumerConfig.Request_Timeout)
@@ -142,6 +135,13 @@ func configCenterRefreshConsumer() error {
 		if consumerConfig.ConnectTimeout, err = time.ParseDuration(consumerConfig.Connect_Timeout); err != nil {
 			return perrors.WithMessagef(err, "time.ParseDuration(Connect_Timeout{%#v})", consumerConfig.Connect_Timeout)
 		}
+	}
+	if consumerConfig.ConfigCenterConfig != nil {
+		consumerConfig.SetFatherConfig(consumerConfig)
+		if err = consumerConfig.startConfigCenter((*consumerConfig).BaseConfig); err != nil {
+			return perrors.Errorf("start config center error , error message is {%v}", perrors.WithStack(err))
+		}
+		consumerConfig.fresh()
 	}
 	return nil
 }

--- a/config/consumer_config.go
+++ b/config/consumer_config.go
@@ -41,7 +41,8 @@ import (
 // ConsumerConfig is Consumer default configuration
 type ConsumerConfig struct {
 	BaseConfig `yaml:",inline"`
-	Filter     string `yaml:"filter" json:"filter,omitempty" property:"filter"`
+	configCenter
+	Filter string `yaml:"filter" json:"filter,omitempty" property:"filter"`
 	// client
 	Connect_Timeout string `default:"100ms"  yaml:"connect_timeout" json:"connect_timeout,omitempty" property:"connect_timeout"`
 	ConnectTimeout  time.Duration
@@ -127,7 +128,7 @@ func configCenterRefreshConsumer() error {
 	var err error
 	if consumerConfig.ConfigCenterConfig != nil {
 		consumerConfig.SetFatherConfig(consumerConfig)
-		if err = consumerConfig.startConfigCenter(); err != nil {
+		if err = consumerConfig.startConfigCenter((*consumerConfig).BaseConfig); err != nil {
 			return perrors.Errorf("start config center error , error message is {%v}", perrors.WithStack(err))
 		}
 		consumerConfig.fresh()

--- a/config/provider_config.go
+++ b/config/provider_config.go
@@ -37,7 +37,8 @@ import (
 
 // ProviderConfig is the default configuration of service provider
 type ProviderConfig struct {
-	BaseConfig     `yaml:",inline"`
+	BaseConfig `yaml:",inline"`
+	configCenter
 	Filter         string                     `yaml:"filter" json:"filter,omitempty" property:"filter"`
 	ProxyFactory   string                     `yaml:"proxy_factory" default:"default" json:"proxy_factory,omitempty" property:"proxy_factory"`
 	Services       map[string]*ServiceConfig  `yaml:"services" json:"services,omitempty" property:"services"`
@@ -101,7 +102,7 @@ func configCenterRefreshProvider() error {
 	// fresh it
 	if providerConfig.ConfigCenterConfig != nil {
 		providerConfig.fatherConfig = providerConfig
-		if err := providerConfig.startConfigCenter(); err != nil {
+		if err := providerConfig.startConfigCenter((*providerConfig).BaseConfig); err != nil {
 			return perrors.Errorf("start config center error , error message is {%v}", perrors.WithStack(err))
 		}
 		providerConfig.fresh()

--- a/config/remote_config.go
+++ b/config/remote_config.go
@@ -31,6 +31,7 @@ import (
 // so that other module, like config center, registry could reuse the config
 // but now, only metadata report, metadata service, service discovery use this structure
 type RemoteConfig struct {
+	Protocol   string            `required:"true"  yaml:"protocol"  json:"protocol,omitempty"`
 	Address    string            `yaml:"address" json:"address,omitempty"`
 	TimeoutStr string            `default:"5s" yaml:"timeout" json:"timeout,omitempty"`
 	Username   string            `yaml:"username" json:"username,omitempty" property:"username"`
@@ -58,11 +59,11 @@ func (rc *RemoteConfig) GetParam(key string, def string) string {
 	return param
 }
 
-func (rc *RemoteConfig) toURL(protocol string) (common.URL, error) {
+func (rc *RemoteConfig) toURL() (common.URL, error) {
 	return common.NewURL(rc.Address,
 		common.WithUsername(rc.Username),
 		common.WithPassword(rc.Password),
 		common.WithLocation(rc.Address),
-		common.WithProtocol(protocol),
+		common.WithProtocol(rc.Protocol),
 	)
 }

--- a/config/remote_config.go
+++ b/config/remote_config.go
@@ -22,6 +22,10 @@ import (
 )
 
 import (
+	perrors "github.com/pkg/errors"
+)
+
+import (
 	"github.com/apache/dubbo-go/common"
 	"github.com/apache/dubbo-go/common/logger"
 )
@@ -31,7 +35,7 @@ import (
 // so that other module, like config center, registry could reuse the config
 // but now, only metadata report, metadata service, service discovery use this structure
 type RemoteConfig struct {
-	Protocol   string            `required:"true"  yaml:"protocol"  json:"protocol,omitempty"`
+	Protocol   string            `yaml:"protocol"  json:"protocol,omitempty"`
 	Address    string            `yaml:"address" json:"address,omitempty"`
 	TimeoutStr string            `default:"5s" yaml:"timeout" json:"timeout,omitempty"`
 	Username   string            `yaml:"username" json:"username,omitempty" property:"username"`
@@ -60,6 +64,9 @@ func (rc *RemoteConfig) GetParam(key string, def string) string {
 }
 
 func (rc *RemoteConfig) toURL() (common.URL, error) {
+	if len(rc.Protocol) == 0 {
+		return common.URL{}, perrors.Errorf("Must provide protocol in RemoteConfig.")
+	}
 	return common.NewURL(rc.Address,
 		common.WithUsername(rc.Username),
 		common.WithPassword(rc.Password),

--- a/config/remote_config.go
+++ b/config/remote_config.go
@@ -18,11 +18,11 @@
 package config
 
 import (
-	"github.com/apache/dubbo-go/common"
 	"time"
 )
 
 import (
+	"github.com/apache/dubbo-go/common"
 	"github.com/apache/dubbo-go/common/logger"
 )
 

--- a/config/remote_config.go
+++ b/config/remote_config.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"github.com/apache/dubbo-go/common"
 	"time"
 )
 
@@ -55,4 +56,13 @@ func (rc *RemoteConfig) GetParam(key string, def string) string {
 		return def
 	}
 	return param
+}
+
+func (rc *RemoteConfig) toURL(protocol string) (common.URL, error) {
+	return common.NewURL(rc.Address,
+		common.WithUsername(rc.Username),
+		common.WithPassword(rc.Password),
+		common.WithLocation(rc.Address),
+		common.WithProtocol(protocol),
+	)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:

* optimize remotes configuration
* refactor config center implement.
* will compatible with `baseConfig.ConfigCenterConfig.Address` and `baseConfig.ConfigCenterConfig.RemoteRef` before 1.6.0. After 1.6.0 will not compatible, only `baseConfig.ConfigCenterConfig.RemoteRef`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #501

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```