### PR TITLE
Fix: application router get application name from dir.url and dir.url.suburl

### DIFF
--- a/cluster/directory/base_directory.go
+++ b/cluster/directory/base_directory.go
@@ -112,11 +112,15 @@ func (dir *BaseDirectory) SetRouters(urls []*common.URL) {
 
 func (dir *BaseDirectory) isProperRouter(url *common.URL) bool {
 	app := url.GetParam(constant.APPLICATION_KEY, "")
+	dirApp := dir.GetUrl().GetParam(constant.APPLICATION_KEY, "")
+	if len(dirApp) == 0 && dir.GetUrl().SubURL != nil {
+		dirApp = dir.GetUrl().SubURL.GetParam(constant.APPLICATION_KEY, "")
+	}
 	serviceKey := dir.GetUrl().ServiceKey()
-	if serviceKey == "" {
+	if len(serviceKey) == 0 {
 		serviceKey = dir.GetUrl().SubURL.ServiceKey()
 	}
-	if len(app) > 0 && app == dir.GetUrl().GetParam(constant.APPLICATION_KEY, "") {
+	if len(app) > 0 && app == dirApp {
 		return true
 	}
 	if url.ServiceKey() == serviceKey {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! 
-->

**What this PR does**:
Retrieve the directory's services' application name from suburl.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```