### PR TITLE
avoid initint the log twice 

### DIFF
--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -60,6 +60,10 @@ type Logger interface {
 }
 
 func init() {
+	// forbidden to executing twice.
+	if logger != nil {
+		return
+	}
 	logConfFile := os.Getenv(constant.APP_LOG_CONF_FILE)
 	err := InitLog(logConfFile)
 	if err != nil {


### PR DESCRIPTION
避免日志被初始化两次。
方便自定义自己的日志，默认的框架中的日志没有集成日志分文件，文件大小限制等。