### PR TITLE
Fix: add etcdv3 lease to defeat provider register info left in the registry when provider app  panic

### DIFF
--- a/registry/etcdv3/registry.go
+++ b/registry/etcdv3/registry.go
@@ -112,8 +112,9 @@ func (r *etcdV3Registry) InitListeners() {
 }
 
 // DoRegister actually do the register job in the registry center of etcd
+// for lease
 func (r *etcdV3Registry) DoRegister(root string, node string) error {
-	return r.client.Create(path.Join(root, node), "")
+	return r.client.RegisterTemp(path.Join(root, node), "")
 }
 
 // nolint

--- a/remoting/etcdv3/client.go
+++ b/remoting/etcdv3/client.go
@@ -408,7 +408,8 @@ func (c *Client) keepAliveKV(k string, v string) error {
 		return ErrNilETCDV3Client
 	}
 
-	lease, err := c.rawClient.Grant(c.ctx, int64(time.Second.Seconds()))
+	// make lease time longer, since 1 second is too short
+	lease, err := c.rawClient.Grant(c.ctx, int64(30*time.Second.Seconds()))
 	if err != nil {
 		return perrors.WithMessage(err, "grant lease")
 	}


### PR DESCRIPTION

**What this PR does**:
 etcdv3 registry lease
