### PR TITLE
ProxyInvoker cannot be extended 

### DIFF
--- a/common/proxy/proxy_factory/default.go
+++ b/common/proxy/proxy_factory/default.go
@@ -89,6 +89,8 @@ func (pi *ProxyInvoker) Invoke(ctx context.Context, invocation protocol.Invocati
 	result.SetAttachments(invocation.Attachments())
 
 	url := pi.GetUrl()
+	//get providerUrl. The origin url may be is registry URL.
+	url = *getProviderURL(&url)
 
 	methodName := invocation.MethodName()
 	proto := url.Protocol
@@ -158,4 +160,11 @@ func (pi *ProxyInvoker) Invoke(ctx context.Context, invocation protocol.Invocati
 		}
 	}
 	return result
+}
+
+func getProviderURL(url *common.URL) *common.URL {
+	if url.SubURL == nil {
+		return url
+	}
+	return url.SubURL
 }

--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -32,7 +32,6 @@ import (
 	"github.com/apache/dubbo-go/common/constant"
 	"github.com/apache/dubbo-go/common/extension"
 	"github.com/apache/dubbo-go/common/logger"
-	"github.com/apache/dubbo-go/common/proxy/proxy_factory"
 	"github.com/apache/dubbo-go/config"
 	"github.com/apache/dubbo-go/config_center"
 	_ "github.com/apache/dubbo-go/config_center/configurator"
@@ -408,8 +407,6 @@ func newWrappedInvoker(invoker protocol.Invoker, url *common.URL) *wrappedInvoke
 
 // Invoke remote service base on URL of wrappedInvoker
 func (ivk *wrappedInvoker) Invoke(ctx context.Context, invocation protocol.Invocation) protocol.Result {
-	// get right url
-	ivk.invoker.(*proxy_factory.ProxyInvoker).BaseInvoker = *protocol.NewBaseInvoker(ivk.GetUrl())
 	return ivk.invoker.Invoke(ctx, invocation)
 }
 


### PR DESCRIPTION


In the code, it is a conversion 
```
ivk.invoker.(*proxy_factory.ProxyInvoker).BaseInvoker
```
If I want to extend the ProxyInvoker, some error happend.