### PR TITLE
Fix: url.params fatal error: concurrent map read and map write

### DIFF
--- a/common/url.go
+++ b/common/url.go
@@ -78,10 +78,10 @@ func (t RoleType) Role() string {
 }
 
 type baseUrl struct {
-	Protocol     string
-	Location     string // ip+port
-	Ip           string
-	Port         string
+	Protocol string
+	Location string // ip+port
+	Ip       string
+	Port     string
 	//url.Values is not safe map, add to avoid concurrent map read and map write error
 	paramsLock   sync.RWMutex
 	params       url.Values

--- a/common/url.go
+++ b/common/url.go
@@ -421,27 +421,12 @@ func (c *URL) SetParam(key string, value string) {
 
 // RangeParams will iterate the params
 func (c *URL) RangeParams(f func(key, value string) bool) {
-	var (
-		flag  bool
-		key   string
-		value string
-	)
-
-	func() {
-		c.paramsLock.RLock()
-		defer c.paramsLock.RUnlock()
-		for k, v := range c.params {
-			if !f(k, v[0]) {
-				key = k
-				value = v[0]
-				flag = true
-				break
-			}
+	c.paramsLock.RLock()
+	defer c.paramsLock.RUnlock()
+	for k, v := range c.params {
+		if !f(k, v[0]) {
+			break
 		}
-	}()
-
-	if flag {
-		f(key, value)
 	}
 }
 

--- a/common/url.go
+++ b/common/url.go
@@ -422,8 +422,8 @@ func (c *URL) SetParam(key string, value string) {
 // RangeParams will iterate the params
 func (c *URL) RangeParams(f func(key, value string) bool) {
 	var (
-		flag bool
-		key string
+		flag  bool
+		key   string
 		value string
 	)
 

--- a/common/url.go
+++ b/common/url.go
@@ -404,11 +404,13 @@ func (c *URL) AddParam(key string, value string) {
 
 // AddParamAvoidNil will add key-value pair
 func (c *URL) AddParamAvoidNil(key string, value string) {
+	c.paramsLock.Lock()
+	defer c.paramsLock.Unlock()
 	if c.params == nil {
 		c.params = url.Values{}
 	}
 
-	c.AddParam(key, value)
+	c.params.Add(key, value)
 }
 
 // SetParam will put the key-value pair into url


### PR DESCRIPTION
**What this PR does**:
fix url.params fatal error: concurrent map read and map write
**Which issue(s) this PR fixes**:
https://github.com/apache/dubbo-go/issues/772
