### PR TITLE
fix: fix consulRegister not unregister when destory bug

### DIFF
--- a/registry/consul/registry.go
+++ b/registry/consul/registry.go
@@ -187,5 +187,10 @@ func (r *consulRegistry) IsAvailable() bool {
 
 // Destroy consul registry center
 func (r *consulRegistry) Destroy() {
+	if r.URL != nil{
+		if err := r.UnRegister(*r.URL); err != nil{
+			logger.Errorf("consul registry unregister with err: %s", err.Error())
+		}
+	}
 	close(r.done)
 }

--- a/registry/consul/registry_test.go
+++ b/registry/consul/registry_test.go
@@ -55,3 +55,19 @@ func (suite *consulRegistryTestSuite) testSubscribe() {
 	assert.NoError(suite.t, err)
 	suite.listener = listener
 }
+
+func (suite *consulRegistryTestSuite) testDestroy(){
+	consumerRegistryUrl := newConsumerRegistryUrl(registryHost, registryPort)
+	consumerRegistry, _ := newConsulRegistry(consumerRegistryUrl)
+	consulRegistryImp := consumerRegistry.(*consulRegistry)
+	assert.True(suite.t, consulRegistryImp.IsAvailable())
+	consulRegistryImp.Destroy()
+	assert.False(suite.t, consulRegistryImp.IsAvailable())
+
+	consumerRegistry, _ = newConsulRegistry(consumerRegistryUrl)
+	consulRegistryImp = consumerRegistry.(*consulRegistry)
+	consulRegistryImp.URL = nil
+	assert.True(suite.t, consulRegistryImp.IsAvailable())
+	consulRegistryImp.Destroy()
+	assert.False(suite.t, consulRegistryImp.IsAvailable())
+}

--- a/registry/consul/utils_test.go
+++ b/registry/consul/utils_test.go
@@ -163,6 +163,7 @@ func test1(t *testing.T) {
 	suite.testListener(remoting.EventTypeAdd)
 	suite.testUnregister()
 	suite.testListener(remoting.EventTypeDel)
+	suite.testDestroy()
 }
 
 // subscribe -> register -> unregister
@@ -183,7 +184,10 @@ func test2(t *testing.T) {
 	suite.testListener(remoting.EventTypeAdd)
 	suite.testUnregister()
 	suite.testListener(remoting.EventTypeDel)
+	suite.testDestroy()
 }
+
+
 
 func TestConsulRegistry(t *testing.T) {
 	t.Run("test1", test1)


### PR DESCRIPTION
**What this PR does**:
修复consul Registry 在interrupt后不会立刻从注册中心消失的bug

**Which issue(s) this PR fixes**:
Fixes #749

**Special notes for your reviewer**:
修复consul Registry 在interrupt后不会立刻从注册中心消失的bug，在consulRegistry的Destory函数中增加对Unregister函数的调用。从而从注册中心反注册。

**Does this PR introduce a user-facing change?**:
NONE

```release-note
修复consul Registry 在interrupt后不会立刻从注册中心消失的bug
```