### PR TITLE
Fix: Consumer panic when restart provider 

### DIFF
--- a/remoting/exchange_client.go
+++ b/remoting/exchange_client.go
@@ -180,6 +180,8 @@ func (client *ExchangeClient) Send(invocation *protocol.Invocation, url common.U
 // close client
 func (client *ExchangeClient) Close() {
 	client.client.Close()
+	// for reinit client
+	client.init = false
 }
 
 // handle the response from server


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/contributing.md before commit pull request. 
-->

**What this PR does**:

* The reason as below :
When delete provider node will close getty_client and set getty_pool to nil. 
https://github.com/apache/dubbo-go/blob/1268a960bc7bdcd9457edca29f498e0ca42d0072/remoting/exchange_client.go#L182

However ExchangeClient.init is false cause getty_pool will not re-init when re-request.
https://github.com/apache/dubbo-go/blob/1268a960bc7bdcd9457edca29f498e0ca42d0072/remoting/exchange_client.go#L61

Then getty_pool is nil when re-request, detail as below

![image](https://user-images.githubusercontent.com/3828072/97127649-2e47c500-1775-11eb-822c-762e9c1687e0.png)

Solution：
* Change  a flag for re-init getty_pool

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```