### PR TITLE
optimize get url with pointer type

### DIFF
--- a/cluster/cluster_impl/available_cluster_invoker_test.go
+++ b/cluster/cluster_impl/available_cluster_invoker_test.go
@@ -51,7 +51,7 @@ func registerAvailable(invoker *mock.MockInvoker) protocol.Invoker {
 
 	invokers := []protocol.Invoker{}
 	invokers = append(invokers, invoker)
-	invoker.EXPECT().GetUrl().Return(availableUrl)
+	invoker.EXPECT().GetUrl().Return(&availableUrl)
 
 	staticDir := directory.NewStaticDirectory(invokers)
 	clusterInvoker := availableCluster.Join(staticDir)

--- a/cluster/cluster_impl/base_cluster_invoker.go
+++ b/cluster/cluster_impl/base_cluster_invoker.go
@@ -50,7 +50,7 @@ func newBaseClusterInvoker(directory cluster.Directory) baseClusterInvoker {
 	}
 }
 
-func (invoker *baseClusterInvoker) GetUrl() common.URL {
+func (invoker *baseClusterInvoker) GetUrl() *common.URL {
 	return invoker.directory.GetUrl()
 }
 

--- a/cluster/cluster_impl/broadcast_cluster_invoker_test.go
+++ b/cluster/cluster_impl/broadcast_cluster_invoker_test.go
@@ -52,7 +52,7 @@ func registerBroadcast(mockInvokers ...*mock.MockInvoker) protocol.Invoker {
 	for i, ivk := range mockInvokers {
 		invokers = append(invokers, ivk)
 		if i == 0 {
-			ivk.EXPECT().GetUrl().Return(broadcastUrl)
+			ivk.EXPECT().GetUrl().Return(&broadcastUrl)
 		}
 	}
 	staticDir := directory.NewStaticDirectory(invokers)

--- a/cluster/cluster_impl/failback_cluster_test.go
+++ b/cluster/cluster_impl/failback_cluster_test.go
@@ -55,7 +55,7 @@ func registerFailback(invoker *mock.MockInvoker) protocol.Invoker {
 	invokers := []protocol.Invoker{}
 	invokers = append(invokers, invoker)
 
-	invoker.EXPECT().GetUrl().Return(failbackUrl)
+	invoker.EXPECT().GetUrl().Return(&failbackUrl)
 
 	staticDir := directory.NewStaticDirectory(invokers)
 	clusterInvoker := failbackCluster.Join(staticDir)
@@ -70,7 +70,7 @@ func TestFailbackSuceess(t *testing.T) {
 	invoker := mock.NewMockInvoker(ctrl)
 	clusterInvoker := registerFailback(invoker).(*failbackClusterInvoker)
 
-	invoker.EXPECT().GetUrl().Return(failbackUrl).AnyTimes()
+	invoker.EXPECT().GetUrl().Return(&failbackUrl).AnyTimes()
 
 	mockResult := &protocol.RPCResult{Rest: rest{tried: 0, success: true}}
 	invoker.EXPECT().Invoke(gomock.Any()).Return(mockResult)
@@ -87,7 +87,7 @@ func TestFailbackRetryOneSuccess(t *testing.T) {
 	invoker := mock.NewMockInvoker(ctrl)
 	clusterInvoker := registerFailback(invoker).(*failbackClusterInvoker)
 
-	invoker.EXPECT().GetUrl().Return(failbackUrl).AnyTimes()
+	invoker.EXPECT().GetUrl().Return(&failbackUrl).AnyTimes()
 
 	// failed at first
 	mockFailedResult := &protocol.RPCResult{Err: perrors.New("error")}
@@ -130,7 +130,7 @@ func TestFailbackRetryFailed(t *testing.T) {
 	invoker := mock.NewMockInvoker(ctrl)
 	clusterInvoker := registerFailback(invoker).(*failbackClusterInvoker)
 
-	invoker.EXPECT().GetUrl().Return(failbackUrl).AnyTimes()
+	invoker.EXPECT().GetUrl().Return(&failbackUrl).AnyTimes()
 
 	mockFailedResult := &protocol.RPCResult{Err: perrors.New("error")}
 	invoker.EXPECT().Invoke(gomock.Any()).Return(mockFailedResult)
@@ -177,7 +177,7 @@ func TestFailbackRetryFailed10Times(t *testing.T) {
 	clusterInvoker := registerFailback(invoker).(*failbackClusterInvoker)
 	clusterInvoker.maxRetries = 10
 
-	invoker.EXPECT().GetUrl().Return(failbackUrl).AnyTimes()
+	invoker.EXPECT().GetUrl().Return(&failbackUrl).AnyTimes()
 
 	// 10 task should failed firstly.
 	mockFailedResult := &protocol.RPCResult{Err: perrors.New("error")}
@@ -219,7 +219,7 @@ func TestFailbackOutOfLimit(t *testing.T) {
 	clusterInvoker := registerFailback(invoker).(*failbackClusterInvoker)
 	clusterInvoker.failbackTasks = 1
 
-	invoker.EXPECT().GetUrl().Return(failbackUrl).AnyTimes()
+	invoker.EXPECT().GetUrl().Return(&failbackUrl).AnyTimes()
 
 	mockFailedResult := &protocol.RPCResult{Err: perrors.New("error")}
 	invoker.EXPECT().Invoke(gomock.Any()).Return(mockFailedResult).Times(11)

--- a/cluster/cluster_impl/failfast_cluster_test.go
+++ b/cluster/cluster_impl/failfast_cluster_test.go
@@ -53,7 +53,7 @@ func registerFailfast(invoker *mock.MockInvoker) protocol.Invoker {
 	invokers := []protocol.Invoker{}
 	invokers = append(invokers, invoker)
 
-	invoker.EXPECT().GetUrl().Return(failfastUrl)
+	invoker.EXPECT().GetUrl().Return(&failfastUrl)
 
 	staticDir := directory.NewStaticDirectory(invokers)
 	clusterInvoker := failfastCluster.Join(staticDir)
@@ -67,7 +67,7 @@ func TestFailfastInvokeSuccess(t *testing.T) {
 	invoker := mock.NewMockInvoker(ctrl)
 	clusterInvoker := registerFailfast(invoker)
 
-	invoker.EXPECT().GetUrl().Return(failfastUrl).AnyTimes()
+	invoker.EXPECT().GetUrl().Return(&failfastUrl).AnyTimes()
 
 	mockResult := &protocol.RPCResult{Rest: rest{tried: 0, success: true}}
 
@@ -87,7 +87,7 @@ func TestFailfastInvokeFail(t *testing.T) {
 	invoker := mock.NewMockInvoker(ctrl)
 	clusterInvoker := registerFailfast(invoker)
 
-	invoker.EXPECT().GetUrl().Return(failfastUrl).AnyTimes()
+	invoker.EXPECT().GetUrl().Return(&failfastUrl).AnyTimes()
 
 	mockResult := &protocol.RPCResult{Err: perrors.New("error")}
 

--- a/cluster/cluster_impl/failover_cluster_test.go
+++ b/cluster/cluster_impl/failover_cluster_test.go
@@ -45,7 +45,7 @@ import (
 
 // nolint
 type MockInvoker struct {
-	url       common.URL
+	url       *common.URL
 	available bool
 	destroyed bool
 
@@ -55,7 +55,7 @@ type MockInvoker struct {
 // nolint
 func NewMockInvoker(url common.URL, successCount int) *MockInvoker {
 	return &MockInvoker{
-		url:          url,
+		url:          &url,
 		available:    true,
 		destroyed:    false,
 		successCount: successCount,
@@ -63,7 +63,7 @@ func NewMockInvoker(url common.URL, successCount int) *MockInvoker {
 }
 
 // nolint
-func (bi *MockInvoker) GetUrl() common.URL {
+func (bi *MockInvoker) GetUrl() *common.URL {
 	return bi.url
 }
 

--- a/cluster/cluster_impl/failsafe_cluster_test.go
+++ b/cluster/cluster_impl/failsafe_cluster_test.go
@@ -53,7 +53,7 @@ func registerFailsafe(invoker *mock.MockInvoker) protocol.Invoker {
 	invokers := []protocol.Invoker{}
 	invokers = append(invokers, invoker)
 
-	invoker.EXPECT().GetUrl().Return(failbackUrl)
+	invoker.EXPECT().GetUrl().Return(&failbackUrl)
 
 	staticDir := directory.NewStaticDirectory(invokers)
 	clusterInvoker := failsafeCluster.Join(staticDir)
@@ -67,7 +67,7 @@ func TestFailSafeInvokeSuccess(t *testing.T) {
 	invoker := mock.NewMockInvoker(ctrl)
 	clusterInvoker := registerFailsafe(invoker)
 
-	invoker.EXPECT().GetUrl().Return(failsafeUrl).AnyTimes()
+	invoker.EXPECT().GetUrl().Return(&failsafeUrl).AnyTimes()
 
 	mockResult := &protocol.RPCResult{Rest: rest{tried: 0, success: true}}
 
@@ -86,7 +86,7 @@ func TestFailSafeInvokeFail(t *testing.T) {
 	invoker := mock.NewMockInvoker(ctrl)
 	clusterInvoker := registerFailsafe(invoker)
 
-	invoker.EXPECT().GetUrl().Return(failsafeUrl).AnyTimes()
+	invoker.EXPECT().GetUrl().Return(&failsafeUrl).AnyTimes()
 
 	mockResult := &protocol.RPCResult{Err: perrors.New("error")}
 

--- a/cluster/cluster_impl/forking_cluster_test.go
+++ b/cluster/cluster_impl/forking_cluster_test.go
@@ -54,7 +54,7 @@ func registerForking(mockInvokers ...*mock.MockInvoker) protocol.Invoker {
 	for i, ivk := range mockInvokers {
 		invokers = append(invokers, ivk)
 		if i == 0 {
-			ivk.EXPECT().GetUrl().Return(forkingUrl)
+			ivk.EXPECT().GetUrl().Return(&forkingUrl)
 		}
 	}
 	staticDir := directory.NewStaticDirectory(invokers)

--- a/cluster/cluster_impl/zone_aware_cluster_invoker_test.go
+++ b/cluster/cluster_impl/zone_aware_cluster_invoker_test.go
@@ -52,7 +52,7 @@ func TestZoneWareInvokerWithPreferredSuccess(t *testing.T) {
 		url, _ := common.NewURL(fmt.Sprintf("dubbo://192.168.1.%v:20000/com.ikurento.user.UserProvider", i))
 		invoker := mock.NewMockInvoker(ctrl)
 		invoker.EXPECT().IsAvailable().Return(true).AnyTimes()
-		invoker.EXPECT().GetUrl().Return(url).AnyTimes()
+		invoker.EXPECT().GetUrl().Return(&url).AnyTimes()
 		if 0 == i {
 			url.SetParam(constant.REGISTRY_KEY+"."+constant.PREFERRED_KEY, "true")
 			invoker.EXPECT().Invoke(gomock.Any()).DoAndReturn(
@@ -92,7 +92,7 @@ func TestZoneWareInvokerWithWeightSuccess(t *testing.T) {
 		url, _ := common.NewURL(fmt.Sprintf("dubbo://192.168.1.%v:20000/com.ikurento.user.UserProvider", i))
 		invoker := mock.NewMockInvoker(ctrl)
 		invoker.EXPECT().IsAvailable().Return(true).AnyTimes()
-		invoker.EXPECT().GetUrl().Return(url).AnyTimes()
+		invoker.EXPECT().GetUrl().Return(&url).AnyTimes()
 		url.SetParam(constant.REGISTRY_KEY+"."+constant.REGISTRY_LABEL_KEY, "true")
 		if 1 == i {
 			url.SetParam(constant.REGISTRY_KEY+"."+constant.WEIGHT_KEY, w1)
@@ -150,7 +150,7 @@ func TestZoneWareInvokerWithZoneSuccess(t *testing.T) {
 
 		invoker := mock.NewMockInvoker(ctrl)
 		invoker.EXPECT().IsAvailable().Return(true).AnyTimes()
-		invoker.EXPECT().GetUrl().Return(url).AnyTimes()
+		invoker.EXPECT().GetUrl().Return(&url).AnyTimes()
 		invoker.EXPECT().Invoke(gomock.Any()).DoAndReturn(
 			func(invocation protocol.Invocation) protocol.Result {
 				return &protocol.RPCResult{
@@ -186,7 +186,7 @@ func TestZoneWareInvokerWithZoneForceFail(t *testing.T) {
 
 		invoker := mock.NewMockInvoker(ctrl)
 		invoker.EXPECT().IsAvailable().Return(true).AnyTimes()
-		invoker.EXPECT().GetUrl().Return(url).AnyTimes()
+		invoker.EXPECT().GetUrl().Return(&url).AnyTimes()
 		invokers = append(invokers, invoker)
 	}
 

--- a/cluster/directory/base_directory.go
+++ b/cluster/directory/base_directory.go
@@ -65,8 +65,8 @@ func (dir *BaseDirectory) SetRouterChain(routerChain router.Chain) {
 }
 
 // GetUrl Get URL
-func (dir *BaseDirectory) GetUrl() common.URL {
-	return *dir.url
+func (dir *BaseDirectory) GetUrl() *common.URL {
+	return dir.url
 }
 
 // GetDirectoryUrl Get URL instance

--- a/cluster/directory/base_directory_test.go
+++ b/cluster/directory/base_directory_test.go
@@ -42,7 +42,7 @@ var (
 func TestNewBaseDirectory(t *testing.T) {
 	directory := NewBaseDirectory(&url)
 	assert.NotNil(t, directory)
-	assert.Equal(t, url, directory.GetUrl())
+	assert.Equal(t, url, *directory.GetUrl())
 	assert.Equal(t, &url, directory.GetDirectoryUrl())
 }
 

--- a/cluster/directory/static_directory.go
+++ b/cluster/directory/static_directory.go
@@ -34,13 +34,13 @@ type staticDirectory struct {
 
 // NewStaticDirectory Create a new staticDirectory with invokers
 func NewStaticDirectory(invokers []protocol.Invoker) *staticDirectory {
-	var url common.URL
+	var url *common.URL
 
 	if len(invokers) > 0 {
 		url = invokers[0].GetUrl()
 	}
 	dir := &staticDirectory{
-		BaseDirectory: NewBaseDirectory(&url),
+		BaseDirectory: NewBaseDirectory(url),
 		invokers:      invokers,
 	}
 
@@ -72,7 +72,7 @@ func (dir *staticDirectory) List(invocation protocol.Invocation) []protocol.Invo
 		return invokers
 	}
 	dirUrl := dir.GetUrl()
-	return routerChain.Route(&dirUrl, invocation)
+	return routerChain.Route(dirUrl, invocation)
 }
 
 // Destroy Destroy
@@ -91,7 +91,7 @@ func (dir *staticDirectory) BuildRouterChain(invokers []protocol.Invoker) error 
 		return perrors.Errorf("invokers == null")
 	}
 	url := invokers[0].GetUrl()
-	routerChain, e := chain.NewRouterChain(&url)
+	routerChain, e := chain.NewRouterChain(url)
 	if e != nil {
 		return e
 	}

--- a/cluster/directory/static_directory_test.go
+++ b/cluster/directory/static_directory_test.go
@@ -36,7 +36,7 @@ func TestStaticDirList(t *testing.T) {
 	invokers := []protocol.Invoker{}
 	for i := 0; i < 10; i++ {
 		url, _ := common.NewURL(fmt.Sprintf("dubbo://192.168.1.%v:20000/com.ikurento.user.UserProvider", i))
-		invokers = append(invokers, protocol.NewBaseInvoker(url))
+		invokers = append(invokers, protocol.NewBaseInvoker(&url))
 	}
 
 	staticDir := NewStaticDirectory(invokers)
@@ -49,7 +49,7 @@ func TestStaticDirDestroy(t *testing.T) {
 	invokers := []protocol.Invoker{}
 	for i := 0; i < 10; i++ {
 		url, _ := common.NewURL(fmt.Sprintf("dubbo://192.168.1.%v:20000/com.ikurento.user.UserProvider", i))
-		invokers = append(invokers, protocol.NewBaseInvoker(url))
+		invokers = append(invokers, protocol.NewBaseInvoker(&url))
 	}
 
 	staticDir := NewStaticDirectory(invokers)

--- a/cluster/loadbalance/consistent_hash_test.go
+++ b/cluster/loadbalance/consistent_hash_test.go
@@ -58,7 +58,7 @@ type consistentHashSelectorSuite struct {
 func (s *consistentHashSelectorSuite) SetupTest() {
 	var invokers []protocol.Invoker
 	url, _ := common.NewURL(url20000)
-	invokers = append(invokers, protocol.NewBaseInvoker(url))
+	invokers = append(invokers, protocol.NewBaseInvoker(&url))
 	s.selector = newConsistentHashSelector(invokers, "echo", 999944)
 }
 
@@ -71,8 +71,8 @@ func (s *consistentHashSelectorSuite) TestSelectForKey() {
 	url1, _ := common.NewURL(url8080Short)
 	url2, _ := common.NewURL(url8081Short)
 	s.selector.virtualInvokers = make(map[uint32]protocol.Invoker)
-	s.selector.virtualInvokers[99874] = protocol.NewBaseInvoker(url1)
-	s.selector.virtualInvokers[9999945] = protocol.NewBaseInvoker(url2)
+	s.selector.virtualInvokers[99874] = protocol.NewBaseInvoker(&url1)
+	s.selector.virtualInvokers[9999945] = protocol.NewBaseInvoker(&url2)
 	s.selector.keys = []uint32{99874, 9999945}
 	result := s.selector.selectForKey(9999944)
 	s.Equal(result.GetUrl().String(), url8081Short+"?")
@@ -103,9 +103,9 @@ func (s *consistentHashLoadBalanceSuite) SetupTest() {
 	s.url3, err = common.NewURL(url8082)
 	s.NoError(err)
 
-	s.invoker1 = protocol.NewBaseInvoker(s.url1)
-	s.invoker2 = protocol.NewBaseInvoker(s.url2)
-	s.invoker3 = protocol.NewBaseInvoker(s.url3)
+	s.invoker1 = protocol.NewBaseInvoker(&s.url1)
+	s.invoker2 = protocol.NewBaseInvoker(&s.url2)
+	s.invoker3 = protocol.NewBaseInvoker(&s.url3)
 
 	s.invokers = append(s.invokers, s.invoker1, s.invoker2, s.invoker3)
 	s.lb = NewConsistentHashLoadBalance()

--- a/cluster/loadbalance/least_active_test.go
+++ b/cluster/loadbalance/least_active_test.go
@@ -39,13 +39,13 @@ func TestLeastActiveSelect(t *testing.T) {
 	var invokers []protocol.Invoker
 
 	url, _ := common.NewURL(fmt.Sprintf("dubbo://%s:%d/org.apache.demo.HelloService", constant.LOCAL_HOST_VALUE, constant.DEFAULT_PORT))
-	invokers = append(invokers, protocol.NewBaseInvoker(url))
+	invokers = append(invokers, protocol.NewBaseInvoker(&url))
 	i := loadBalance.Select(invokers, &invocation.RPCInvocation{})
 	assert.True(t, i.GetUrl().URLEqual(url))
 
 	for i := 1; i < 10; i++ {
 		url, _ := common.NewURL(fmt.Sprintf("dubbo://192.168.1.%v:20000/org.apache.demo.HelloService", i))
-		invokers = append(invokers, protocol.NewBaseInvoker(url))
+		invokers = append(invokers, protocol.NewBaseInvoker(&url))
 	}
 	loadBalance.Select(invokers, &invocation.RPCInvocation{})
 }
@@ -57,7 +57,7 @@ func TestLeastActiveByWeight(t *testing.T) {
 	loop := 3
 	for i := 1; i <= loop; i++ {
 		url, _ := common.NewURL(fmt.Sprintf("test%v://192.168.1.%v:20000/org.apache.demo.HelloService?weight=%v", i, i, i))
-		invokers = append(invokers, protocol.NewBaseInvoker(url))
+		invokers = append(invokers, protocol.NewBaseInvoker(&url))
 	}
 
 	inv := invocation.NewRPCInvocationWithOptions(invocation.WithMethodName("test"))

--- a/cluster/loadbalance/random_test.go
+++ b/cluster/loadbalance/random_test.go
@@ -48,13 +48,13 @@ func TestRandomlbSelect(t *testing.T) {
 	invokers := []protocol.Invoker{}
 
 	url, _ := common.NewURL(fmt.Sprintf(tmpUrlFormat, 0))
-	invokers = append(invokers, protocol.NewBaseInvoker(url))
+	invokers = append(invokers, protocol.NewBaseInvoker(&url))
 	i := randomlb.Select(invokers, &invocation.RPCInvocation{})
 	assert.True(t, i.GetUrl().URLEqual(url))
 
 	for i := 1; i < 10; i++ {
 		url, _ := common.NewURL(fmt.Sprintf(tmpUrlFormat, i))
-		invokers = append(invokers, protocol.NewBaseInvoker(url))
+		invokers = append(invokers, protocol.NewBaseInvoker(&url))
 	}
 	randomlb.Select(invokers, &invocation.RPCInvocation{})
 }
@@ -65,13 +65,13 @@ func TestRandomlbSelectWeight(t *testing.T) {
 	invokers := []protocol.Invoker{}
 	for i := 0; i < 10; i++ {
 		url, _ := common.NewURL(fmt.Sprintf(tmpUrlFormat, i))
-		invokers = append(invokers, protocol.NewBaseInvoker(url))
+		invokers = append(invokers, protocol.NewBaseInvoker(&url))
 	}
 
 	urlParams := url.Values{}
 	urlParams.Set("methods.test."+constant.WEIGHT_KEY, "10000000000000")
 	urll, _ := common.NewURL(tmpUrl, common.WithParams(urlParams))
-	invokers = append(invokers, protocol.NewBaseInvoker(urll))
+	invokers = append(invokers, protocol.NewBaseInvoker(&urll))
 	ivc := invocation.NewRPCInvocationWithOptions(invocation.WithMethodName("test"))
 
 	var selectedInvoker []protocol.Invoker
@@ -96,13 +96,13 @@ func TestRandomlbSelectWarmup(t *testing.T) {
 	invokers := []protocol.Invoker{}
 	for i := 0; i < 10; i++ {
 		url, _ := common.NewURL(fmt.Sprintf(tmpUrlFormat, i))
-		invokers = append(invokers, protocol.NewBaseInvoker(url))
+		invokers = append(invokers, protocol.NewBaseInvoker(&url))
 	}
 
 	urlParams := url.Values{}
 	urlParams.Set(constant.REMOTE_TIMESTAMP_KEY, strconv.FormatInt(time.Now().Add(time.Minute*(-9)).Unix(), 10))
 	urll, _ := common.NewURL(tmpUrl, common.WithParams(urlParams))
-	invokers = append(invokers, protocol.NewBaseInvoker(urll))
+	invokers = append(invokers, protocol.NewBaseInvoker(&urll))
 	ivc := invocation.NewRPCInvocationWithOptions(invocation.WithMethodName("test"))
 
 	var selectedInvoker []protocol.Invoker

--- a/cluster/loadbalance/round_robin_test.go
+++ b/cluster/loadbalance/round_robin_test.go
@@ -41,13 +41,13 @@ func TestRoundRobinSelect(t *testing.T) {
 
 	url, _ := common.NewURL(fmt.Sprintf("dubbo://%s:%d/org.apache.demo.HelloService",
 		constant.LOCAL_HOST_VALUE, constant.DEFAULT_PORT))
-	invokers = append(invokers, protocol.NewBaseInvoker(url))
+	invokers = append(invokers, protocol.NewBaseInvoker(&url))
 	i := loadBalance.Select(invokers, &invocation.RPCInvocation{})
 	assert.True(t, i.GetUrl().URLEqual(url))
 
 	for i := 1; i < 10; i++ {
 		url, _ := common.NewURL(fmt.Sprintf("dubbo://192.168.1.%v:20000/org.apache.demo.HelloService", i))
-		invokers = append(invokers, protocol.NewBaseInvoker(url))
+		invokers = append(invokers, protocol.NewBaseInvoker(&url))
 	}
 	loadBalance.Select(invokers, &invocation.RPCInvocation{})
 }
@@ -59,7 +59,7 @@ func TestRoundRobinByWeight(t *testing.T) {
 	loop := 10
 	for i := 1; i <= loop; i++ {
 		url, _ := common.NewURL(fmt.Sprintf("dubbo://192.168.1.%v:20000/org.apache.demo.HelloService?weight=%v", i, i))
-		invokers = append(invokers, protocol.NewBaseInvoker(url))
+		invokers = append(invokers, protocol.NewBaseInvoker(&url))
 	}
 
 	loop = (1 + loop) * loop / 2

--- a/cluster/router/chain/chain_test.go
+++ b/cluster/router/chain/chain_test.go
@@ -171,7 +171,7 @@ func TestRouterChainRoute(t *testing.T) {
 
 	invokers := []protocol.Invoker{}
 	dubboURL, _ := common.NewURL(fmt.Sprintf(dubboForamt, test1234IP, port20000))
-	invokers = append(invokers, protocol.NewBaseInvoker(dubboURL))
+	invokers = append(invokers, protocol.NewBaseInvoker(&dubboURL))
 	chain.SetInvokers(invokers)
 	chain.buildCache()
 
@@ -212,7 +212,7 @@ conditions:
 
 	invokers := []protocol.Invoker{}
 	dubboURL, _ := common.NewURL(fmt.Sprintf(dubboForamt, test1234IP, port20000))
-	invokers = append(invokers, protocol.NewBaseInvoker(dubboURL))
+	invokers = append(invokers, protocol.NewBaseInvoker(&dubboURL))
 	chain.SetInvokers(invokers)
 	chain.buildCache()
 
@@ -241,7 +241,7 @@ func TestRouterChainRouteNoRoute(t *testing.T) {
 
 	invokers := []protocol.Invoker{}
 	dubboURL, _ := common.NewURL(fmt.Sprintf(dubboForamt, test1234IP, port20000))
-	invokers = append(invokers, protocol.NewBaseInvoker(dubboURL))
+	invokers = append(invokers, protocol.NewBaseInvoker(&dubboURL))
 	chain.SetInvokers(invokers)
 	chain.buildCache()
 

--- a/cluster/router/condition/factory_test.go
+++ b/cluster/router/condition/factory_test.go
@@ -52,7 +52,7 @@ const (
 )
 
 type MockInvoker struct {
-	url          common.URL
+	url          *common.URL
 	available    bool
 	destroyed    bool
 	successCount int
@@ -60,14 +60,14 @@ type MockInvoker struct {
 
 func NewMockInvoker(url common.URL, successCount int) *MockInvoker {
 	return &MockInvoker{
-		url:          url,
+		url:          &url,
 		available:    true,
 		destroyed:    false,
 		successCount: successCount,
 	}
 }
 
-func (bi *MockInvoker) GetUrl() common.URL {
+func (bi *MockInvoker) GetUrl() *common.URL {
 	return bi.url
 }
 

--- a/cluster/router/condition/router.go
+++ b/cluster/router/condition/router.go
@@ -173,7 +173,7 @@ func (c *ConditionRouter) Route(invokers *roaring.Bitmap, cache router.Cache, ur
 		index := iter.Next()
 		invoker := cache.GetInvokers()[index]
 		invokerUrl := invoker.GetUrl()
-		isMatchThen := c.MatchThen(&invokerUrl, url)
+		isMatchThen := c.MatchThen(invokerUrl, url)
 		if isMatchThen {
 			result.Add(index)
 		}

--- a/cluster/router/healthcheck/factory_test.go
+++ b/cluster/router/healthcheck/factory_test.go
@@ -33,18 +33,18 @@ import (
 
 // nolint
 type MockInvoker struct {
-	url common.URL
+	url *common.URL
 }
 
 // nolint
-func NewMockInvoker(url common.URL) *MockInvoker {
+func NewMockInvoker(url *common.URL) *MockInvoker {
 	return &MockInvoker{
 		url: url,
 	}
 }
 
 // nolint
-func (bi *MockInvoker) GetUrl() common.URL {
+func (bi *MockInvoker) GetUrl() *common.URL {
 	return bi.url
 }
 

--- a/cluster/router/healthcheck/health_check_route_test.go
+++ b/cluster/router/healthcheck/health_check_route_test.go
@@ -57,9 +57,9 @@ func TestHealthCheckRouterRoute(t *testing.T) {
 	hcr, _ := NewHealthCheckRouter(&consumerURL)
 
 	var invokers []protocol.Invoker
-	invoker1 := NewMockInvoker(url1)
-	invoker2 := NewMockInvoker(url2)
-	invoker3 := NewMockInvoker(url3)
+	invoker1 := NewMockInvoker(&url1)
+	invoker2 := NewMockInvoker(&url2)
+	invoker3 := NewMockInvoker(&url3)
 	invokers = append(invokers, invoker1, invoker2, invoker3)
 	inv := invocation.NewRPCInvocation(healthCheckRouteMethodNameTest, nil, nil)
 	res := hcr.Route(utils.ToBitmap(invokers), setUpAddrCache(hcr.(*HealthCheckRouter), invokers), &consumerURL, inv)
@@ -67,15 +67,15 @@ func TestHealthCheckRouterRoute(t *testing.T) {
 	assert.True(t, len(res.ToArray()) == len(invokers))
 
 	for i := 0; i < 10; i++ {
-		request(url1, healthCheckRouteMethodNameTest, 0, false, false)
+		request(&url1, healthCheckRouteMethodNameTest, 0, false, false)
 	}
 	res = hcr.Route(utils.ToBitmap(invokers), setUpAddrCache(hcr.(*HealthCheckRouter), invokers), &consumerURL, inv)
 	// invokers1  is unhealthy now
 	assert.True(t, len(res.ToArray()) == 2 && !res.Contains(0))
 
 	for i := 0; i < 10; i++ {
-		request(url1, healthCheckRouteMethodNameTest, 0, false, false)
-		request(url2, healthCheckRouteMethodNameTest, 0, false, false)
+		request(&url1, healthCheckRouteMethodNameTest, 0, false, false)
+		request(&url2, healthCheckRouteMethodNameTest, 0, false, false)
 	}
 
 	res = hcr.Route(utils.ToBitmap(invokers), setUpAddrCache(hcr.(*HealthCheckRouter), invokers), &consumerURL, inv)
@@ -83,9 +83,9 @@ func TestHealthCheckRouterRoute(t *testing.T) {
 	assert.True(t, len(res.ToArray()) == 1 && !res.Contains(0) && !res.Contains(1))
 
 	for i := 0; i < 10; i++ {
-		request(url1, healthCheckRouteMethodNameTest, 0, false, false)
-		request(url2, healthCheckRouteMethodNameTest, 0, false, false)
-		request(url3, healthCheckRouteMethodNameTest, 0, false, false)
+		request(&url1, healthCheckRouteMethodNameTest, 0, false, false)
+		request(&url2, healthCheckRouteMethodNameTest, 0, false, false)
+		request(&url3, healthCheckRouteMethodNameTest, 0, false, false)
 	}
 
 	res = hcr.Route(utils.ToBitmap(invokers), setUpAddrCache(hcr.(*HealthCheckRouter), invokers), &consumerURL, inv)
@@ -93,12 +93,12 @@ func TestHealthCheckRouterRoute(t *testing.T) {
 	assert.True(t, len(res.ToArray()) == 3)
 
 	// reset the invoker1 successive failed count, so invoker1 go to healthy
-	request(url1, healthCheckRouteMethodNameTest, 0, false, true)
+	request(&url1, healthCheckRouteMethodNameTest, 0, false, true)
 	res = hcr.Route(utils.ToBitmap(invokers), setUpAddrCache(hcr.(*HealthCheckRouter), invokers), &consumerURL, inv)
 	assert.True(t, res.Contains(0))
 
 	for i := 0; i < 6; i++ {
-		request(url1, healthCheckRouteMethodNameTest, 0, false, false)
+		request(&url1, healthCheckRouteMethodNameTest, 0, false, false)
 	}
 	// now all invokers are unhealthy, so downgraded to all again
 	res = hcr.Route(utils.ToBitmap(invokers), setUpAddrCache(hcr.(*HealthCheckRouter), invokers), &consumerURL, inv)

--- a/cluster/router/tag/tag_router_test.go
+++ b/cluster/router/tag/tag_router_test.go
@@ -79,7 +79,7 @@ var (
 
 // MockInvoker is only mock the Invoker to support test tagRouter
 type MockInvoker struct {
-	url          common.URL
+	url          *common.URL
 	available    bool
 	destroyed    bool
 	successCount int
@@ -87,14 +87,14 @@ type MockInvoker struct {
 
 func NewMockInvoker(url common.URL) *MockInvoker {
 	return &MockInvoker{
-		url:          url,
+		url:          &url,
 		available:    true,
 		destroyed:    false,
 		successCount: 0,
 	}
 }
 
-func (bi *MockInvoker) GetUrl() common.URL {
+func (bi *MockInvoker) GetUrl() *common.URL {
 	return bi.url
 }
 

--- a/common/node.go
+++ b/common/node.go
@@ -19,7 +19,7 @@ package common
 
 // Node use for process dubbo node
 type Node interface {
-	GetUrl() URL
+	GetUrl() *URL
 	IsAvailable() bool
 	Destroy()
 }

--- a/common/proxy/proxy_factory/default.go
+++ b/common/proxy/proxy_factory/default.go
@@ -74,7 +74,7 @@ func (factory *DefaultProxyFactory) GetAsyncProxy(invoker protocol.Invoker, call
 // GetInvoker gets a invoker
 func (factory *DefaultProxyFactory) GetInvoker(url common.URL) protocol.Invoker {
 	return &ProxyInvoker{
-		BaseInvoker: *protocol.NewBaseInvoker(url),
+		BaseInvoker: *protocol.NewBaseInvoker(&url),
 	}
 }
 
@@ -90,7 +90,7 @@ func (pi *ProxyInvoker) Invoke(ctx context.Context, invocation protocol.Invocati
 
 	url := pi.GetUrl()
 	//get providerUrl. The origin url may be is registry URL.
-	url = *getProviderURL(&url)
+	url = getProviderURL(url)
 
 	methodName := invocation.MethodName()
 	proto := url.Protocol

--- a/common/proxy/proxy_factory/default_test.go
+++ b/common/proxy/proxy_factory/default_test.go
@@ -34,7 +34,7 @@ import (
 func TestGetProxy(t *testing.T) {
 	proxyFactory := NewDefaultProxyFactory()
 	url := common.NewURLWithOptions()
-	proxy := proxyFactory.GetProxy(protocol.NewBaseInvoker(*url), url)
+	proxy := proxyFactory.GetProxy(protocol.NewBaseInvoker(url), url)
 	assert.NotNil(t, proxy)
 }
 
@@ -49,7 +49,7 @@ func TestGetAsyncProxy(t *testing.T) {
 	proxyFactory := NewDefaultProxyFactory()
 	url := common.NewURLWithOptions()
 	async := &TestAsync{}
-	proxy := proxyFactory.GetAsyncProxy(protocol.NewBaseInvoker(*url), async.CallBack, url)
+	proxy := proxyFactory.GetAsyncProxy(protocol.NewBaseInvoker(url), async.CallBack, url)
 	assert.NotNil(t, proxy)
 }
 

--- a/common/proxy/proxy_test.go
+++ b/common/proxy/proxy_test.go
@@ -58,7 +58,7 @@ func (s *TestServiceInt) Reference() string {
 
 func TestProxyImplement(t *testing.T) {
 
-	invoker := protocol.NewBaseInvoker(common.URL{})
+	invoker := protocol.NewBaseInvoker(&common.URL{})
 	p := NewProxy(invoker, nil, map[string]string{constant.ASYNC_KEY: "false"})
 	s := &TestService{}
 	p.Implement(s)
@@ -126,7 +126,7 @@ func TestProxyImplement(t *testing.T) {
 
 func TestProxyImplementForContext(t *testing.T) {
 	invoker := &TestProxyInvoker{
-		BaseInvoker: *protocol.NewBaseInvoker(common.URL{}),
+		BaseInvoker: *protocol.NewBaseInvoker(&common.URL{}),
 	}
 	p := NewProxy(invoker, nil, map[string]string{constant.ASYNC_KEY: "false"})
 	s := &TestService{}

--- a/common/url.go
+++ b/common/url.go
@@ -664,7 +664,7 @@ func (c *URL) CloneWithParams(reserveParams []string) *URL {
 }
 
 // IsEquals compares if two URLs equals with each other. Excludes are all parameter keys which should ignored.
-func IsEquals(left URL, right URL, excludes ...string) bool {
+func IsEquals(left *URL, right *URL, excludes ...string) bool {
 	if left.Ip != right.Ip || left.Port != right.Port {
 		return false
 	}

--- a/config/config_loader_test.go
+++ b/config/config_loader_test.go
@@ -464,7 +464,7 @@ func (c Comparator) Compare(comp cm.Comparator) int {
 type mockServiceDiscoveryRegistry struct {
 }
 
-func (mr *mockServiceDiscoveryRegistry) GetUrl() common.URL {
+func (mr *mockServiceDiscoveryRegistry) GetUrl() *common.URL {
 	panic("implement me")
 }
 

--- a/config/reference_config_test.go
+++ b/config/reference_config_test.go
@@ -335,7 +335,7 @@ func newRegistryProtocol() protocol.Protocol {
 type mockRegistryProtocol struct{}
 
 func (*mockRegistryProtocol) Refer(url common.URL) protocol.Invoker {
-	return protocol.NewBaseInvoker(url)
+	return protocol.NewBaseInvoker(&url)
 }
 
 func (*mockRegistryProtocol) Export(invoker protocol.Invoker) protocol.Exporter {
@@ -367,7 +367,7 @@ func getRegistryUrl(invoker protocol.Invoker) *common.URL {
 		protocol := url.GetParam(constant.REGISTRY_KEY, "")
 		url.Protocol = protocol
 	}
-	return &url
+	return url
 }
 
 func (p *mockRegistryProtocol) GetRegistries() []registry.Registry {

--- a/config/service_config.go
+++ b/config/service_config.go
@@ -325,7 +325,7 @@ func (c *ServiceConfig) GetExportedUrls() []*common.URL {
 		var urls []*common.URL
 		for _, exporter := range c.exporters {
 			url := exporter.GetInvoker().GetUrl()
-			urls = append(urls, &url)
+			urls = append(urls, url)
 		}
 		return urls
 	}

--- a/config_center/nacos/client.go
+++ b/config_center/nacos/client.go
@@ -99,7 +99,7 @@ func ValidateNacosClient(container nacosClientFacade, opts ...option) error {
 	nacosAddresses := strings.Split(url.Location, ",")
 	if container.NacosClient() == nil {
 		//in dubbo ,every registry only connect one node ,so this is []string{r.Address}
-		newClient, err := newNacosClient(os.nacosName, nacosAddresses, timeout, url)
+		newClient, err := newNacosClient(os.nacosName, nacosAddresses, timeout, *url)
 		if err != nil {
 			logger.Errorf("newNacosClient(name{%s}, nacos address{%v}, timeout{%d}) = error{%v}",
 				os.nacosName, url.Location, timeout.String(), err)
@@ -109,7 +109,7 @@ func ValidateNacosClient(container nacosClientFacade, opts ...option) error {
 	}
 
 	if container.NacosClient().Client() == nil {
-		configClient, err := initNacosConfigClient(nacosAddresses, timeout, url)
+		configClient, err := initNacosConfigClient(nacosAddresses, timeout, *url)
 		if err != nil {
 			logger.Errorf("initNacosConfigClient(addr:%+v,timeout:%v,url:%v) = err %+v",
 				nacosAddresses, timeout.String(), url, err)

--- a/config_center/nacos/impl.go
+++ b/config_center/nacos/impl.go
@@ -186,8 +186,8 @@ func (n *nacosDynamicConfiguration) GetDone() chan struct{} {
 }
 
 // GetUrl Get Url
-func (n *nacosDynamicConfiguration) GetUrl() common.URL {
-	return *n.url
+func (n *nacosDynamicConfiguration) GetUrl() *common.URL {
+	return n.url
 }
 
 // Destroy Destroy configuration instance

--- a/config_center/zookeeper/impl.go
+++ b/config_center/zookeeper/impl.go
@@ -183,8 +183,8 @@ func (c *zookeeperDynamicConfiguration) Done() chan struct{} {
 	return c.done
 }
 
-func (c *zookeeperDynamicConfiguration) GetUrl() common.URL {
-	return *c.url
+func (c *zookeeperDynamicConfiguration) GetUrl() *common.URL {
+	return c.url
 }
 
 func (c *zookeeperDynamicConfiguration) Destroy() {

--- a/config_center/zookeeper/impl_test.go
+++ b/config_center/zookeeper/impl_test.go
@@ -55,7 +55,7 @@ func initZkData(group string, t *testing.T) (*zk.TestCluster, *zookeeperDynamicC
 	assert.True(t, ok)
 	assert.NoError(t, err)
 	assert.True(t, zreg.IsAvailable())
-	assert.Equal(t, zreg.GetUrl(), regurl)
+	assert.Equal(t, *zreg.GetUrl(), regurl)
 	assert.True(t, zreg.RestartCallBack())
 	zreg.SetParser(&parser.DefaultConfigurationParser{})
 

--- a/filter/filter_impl/access_log_filter_test.go
+++ b/filter/filter_impl/access_log_filter_test.go
@@ -43,7 +43,7 @@ func TestAccessLogFilter_Invoke_Not_Config(t *testing.T) {
 			"loadbalance=random&methods.GetUser.retries=1&methods.GetUser.weight=0&module=dubbogo+user-info+server&name=" +
 			"BDTService&organization=ikurento.com&owner=ZX&registry.role=3&retries=&" +
 			"service.filter=echo%2Ctoken%2Caccesslog&timestamp=1569153406&token=934804bf-b007-4174-94eb-96e3e1d60cc7&version=&warmup=100")
-	invoker := protocol.NewBaseInvoker(url)
+	invoker := protocol.NewBaseInvoker(&url)
 
 	attach := make(map[string]interface{}, 10)
 	inv := invocation.NewRPCInvocation("MethodName", []interface{}{"OK", "Hello"}, attach)
@@ -62,7 +62,7 @@ func TestAccessLogFilterInvokeDefaultConfig(t *testing.T) {
 			"loadbalance=random&methods.GetUser.retries=1&methods.GetUser.weight=0&module=dubbogo+user-info+server&name=" +
 			"BDTService&organization=ikurento.com&owner=ZX&registry.role=3&retries=&" +
 			"service.filter=echo%2Ctoken%2Caccesslog&timestamp=1569153406&token=934804bf-b007-4174-94eb-96e3e1d60cc7&version=&warmup=100")
-	invoker := protocol.NewBaseInvoker(url)
+	invoker := protocol.NewBaseInvoker(&url)
 
 	attach := make(map[string]interface{}, 10)
 	attach[constant.VERSION_KEY] = "1.0"

--- a/filter/filter_impl/active_filter_test.go
+++ b/filter/filter_impl/active_filter_test.go
@@ -44,7 +44,7 @@ func TestActiveFilterInvoke(t *testing.T) {
 	defer ctrl.Finish()
 	invoker := mock.NewMockInvoker(ctrl)
 	invoker.EXPECT().Invoke(gomock.Any()).Return(nil)
-	invoker.EXPECT().GetUrl().Return(url).Times(1)
+	invoker.EXPECT().GetUrl().Return(&url).Times(1)
 	filter.Invoke(context.Background(), invoker, invoc)
 	assert.True(t, invoc.AttachmentsByKey(dubboInvokeStartTime, "") != "")
 
@@ -61,13 +61,13 @@ func TestActiveFilterOnResponse(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	invoker := mock.NewMockInvoker(ctrl)
-	invoker.EXPECT().GetUrl().Return(url).Times(1)
+	invoker.EXPECT().GetUrl().Return(&url).Times(1)
 	result := &protocol.RPCResult{
 		Err: errors.New("test"),
 	}
 	filter.OnResponse(nil, result, invoker, invoc)
-	methodStatus := protocol.GetMethodStatus(url, "test")
-	urlStatus := protocol.GetURLStatus(url)
+	methodStatus := protocol.GetMethodStatus(&url, "test")
+	urlStatus := protocol.GetURLStatus(&url)
 
 	assert.Equal(t, int32(1), methodStatus.GetTotal())
 	assert.Equal(t, int32(1), urlStatus.GetTotal())

--- a/filter/filter_impl/auth/consumer_sign.go
+++ b/filter/filter_impl/auth/consumer_sign.go
@@ -42,8 +42,8 @@ func (csf *ConsumerSignFilter) Invoke(ctx context.Context, invoker protocol.Invo
 	logger.Infof("invoking ConsumerSign filter.")
 	url := invoker.GetUrl()
 
-	err := doAuthWork(&url, func(authenticator filter.Authenticator) error {
-		return authenticator.Sign(invocation, &url)
+	err := doAuthWork(url, func(authenticator filter.Authenticator) error {
+		return authenticator.Sign(invocation, url)
 	})
 	if err != nil {
 		panic(fmt.Sprintf("Sign for invocation %s # %s failed", url.ServiceKey(), invocation.MethodName()))

--- a/filter/filter_impl/auth/consumer_sign_test.go
+++ b/filter/filter_impl/auth/consumer_sign_test.go
@@ -46,7 +46,7 @@ func TestConsumerSignFilter_Invoke(t *testing.T) {
 	invoker := mock.NewMockInvoker(ctrl)
 	result := &protocol.RPCResult{}
 	invoker.EXPECT().Invoke(inv).Return(result).Times(2)
-	invoker.EXPECT().GetUrl().Return(url).Times(2)
+	invoker.EXPECT().GetUrl().Return(&url).Times(2)
 	assert.Equal(t, result, filter.Invoke(context.Background(), invoker, inv))
 
 	url.SetParam(constant.SERVICE_AUTH_KEY, "true")

--- a/filter/filter_impl/auth/provider_auth.go
+++ b/filter/filter_impl/auth/provider_auth.go
@@ -42,8 +42,8 @@ func (paf *ProviderAuthFilter) Invoke(ctx context.Context, invoker protocol.Invo
 	logger.Infof("invoking providerAuth filter.")
 	url := invoker.GetUrl()
 
-	err := doAuthWork(&url, func(authenticator filter.Authenticator) error {
-		return authenticator.Authenticate(invocation, &url)
+	err := doAuthWork(url, func(authenticator filter.Authenticator) error {
+		return authenticator.Authenticate(invocation, url)
 	})
 	if err != nil {
 		logger.Infof("auth the request: %v occur exception, cause: %s", invocation, err.Error())

--- a/filter/filter_impl/auth/provider_auth_test.go
+++ b/filter/filter_impl/auth/provider_auth_test.go
@@ -66,7 +66,7 @@ func TestProviderAuthFilter_Invoke(t *testing.T) {
 	invoker := mock.NewMockInvoker(ctrl)
 	result := &protocol.RPCResult{}
 	invoker.EXPECT().Invoke(inv).Return(result).Times(2)
-	invoker.EXPECT().GetUrl().Return(url).Times(2)
+	invoker.EXPECT().GetUrl().Return(&url).Times(2)
 	assert.Equal(t, result, filter.Invoke(context.Background(), invoker, inv))
 	url.SetParam(constant.SERVICE_AUTH_KEY, "true")
 	assert.Equal(t, result, filter.Invoke(context.Background(), invoker, inv))

--- a/filter/filter_impl/echo_filter_test.go
+++ b/filter/filter_impl/echo_filter_test.go
@@ -34,10 +34,10 @@ import (
 
 func TestEchoFilterInvoke(t *testing.T) {
 	filter := GetFilter()
-	result := filter.Invoke(context.Background(), protocol.NewBaseInvoker(common.URL{}), invocation.NewRPCInvocation("$echo", []interface{}{"OK"}, nil))
+	result := filter.Invoke(context.Background(), protocol.NewBaseInvoker(&common.URL{}), invocation.NewRPCInvocation("$echo", []interface{}{"OK"}, nil))
 	assert.Equal(t, "OK", result.Result())
 
-	result = filter.Invoke(context.Background(), protocol.NewBaseInvoker(common.URL{}), invocation.NewRPCInvocation("MethodName", []interface{}{"OK"}, nil))
+	result = filter.Invoke(context.Background(), protocol.NewBaseInvoker(&common.URL{}), invocation.NewRPCInvocation("MethodName", []interface{}{"OK"}, nil))
 	assert.Nil(t, result.Error())
 	assert.Nil(t, result.Result())
 }

--- a/filter/filter_impl/execute_limit_filter_test.go
+++ b/filter/filter_impl/execute_limit_filter_test.go
@@ -44,7 +44,7 @@ func TestExecuteLimitFilterInvokeIgnored(t *testing.T) {
 
 	limitFilter := GetExecuteLimitFilter()
 
-	result := limitFilter.Invoke(context.Background(), protocol.NewBaseInvoker(*invokeUrl), invoc)
+	result := limitFilter.Invoke(context.Background(), protocol.NewBaseInvoker(invokeUrl), invoc)
 	assert.NotNil(t, result)
 	assert.Nil(t, result.Error())
 }
@@ -61,7 +61,7 @@ func TestExecuteLimitFilterInvokeConfigureError(t *testing.T) {
 
 	limitFilter := GetExecuteLimitFilter()
 
-	result := limitFilter.Invoke(context.Background(), protocol.NewBaseInvoker(*invokeUrl), invoc)
+	result := limitFilter.Invoke(context.Background(), protocol.NewBaseInvoker(invokeUrl), invoc)
 	assert.NotNil(t, result)
 	assert.Nil(t, result.Error())
 }
@@ -78,7 +78,7 @@ func TestExecuteLimitFilterInvoke(t *testing.T) {
 
 	limitFilter := GetExecuteLimitFilter()
 
-	result := limitFilter.Invoke(context.Background(), protocol.NewBaseInvoker(*invokeUrl), invoc)
+	result := limitFilter.Invoke(context.Background(), protocol.NewBaseInvoker(invokeUrl), invoc)
 	assert.NotNil(t, result)
 	assert.Nil(t, result.Error())
 }

--- a/filter/filter_impl/generic_service_filter_test.go
+++ b/filter/filter_impl/generic_service_filter_test.go
@@ -100,7 +100,7 @@ func TestGenericServiceFilterInvoke(t *testing.T) {
 	rpcInvocation := invocation.NewRPCInvocation(methodName, aurguments, nil)
 	filter := GetGenericServiceFilter()
 	url, _ := common.NewURL("testprotocol://127.0.0.1:20000/com.test.Path")
-	result := filter.Invoke(context.Background(), &proxy_factory.ProxyInvoker{BaseInvoker: *protocol.NewBaseInvoker(url)}, rpcInvocation)
+	result := filter.Invoke(context.Background(), &proxy_factory.ProxyInvoker{BaseInvoker: *protocol.NewBaseInvoker(&url)}, rpcInvocation)
 	assert.NotNil(t, result)
 	assert.Nil(t, result.Error())
 }

--- a/filter/filter_impl/graceful_shutdown_filter_test.go
+++ b/filter/filter_impl/graceful_shutdown_filter_test.go
@@ -54,7 +54,7 @@ func TestGenericFilterInvoke(t *testing.T) {
 	assert.Equal(t, extension.GetRejectedExecutionHandler(constant.DEFAULT_KEY),
 		shutdownFilter.getRejectHandler())
 
-	result := shutdownFilter.Invoke(context.Background(), protocol.NewBaseInvoker(*invokeUrl), invoc)
+	result := shutdownFilter.Invoke(context.Background(), protocol.NewBaseInvoker(invokeUrl), invoc)
 	assert.NotNil(t, result)
 	assert.Nil(t, result.Error())
 
@@ -65,7 +65,7 @@ func TestGenericFilterInvoke(t *testing.T) {
 	shutdownFilter.shutdownConfig = providerConfig.ShutdownConfig
 
 	assert.True(t, shutdownFilter.rejectNewRequest())
-	result = shutdownFilter.OnResponse(nil, nil, protocol.NewBaseInvoker(*invokeUrl), invoc)
+	result = shutdownFilter.OnResponse(nil, nil, protocol.NewBaseInvoker(invokeUrl), invoc)
 
 	rejectHandler := &common2.OnlyLogRejectedExecutionHandler{}
 	extension.SetRejectedExecutionHandler("mock", func() filter.RejectedExecutionHandler {

--- a/filter/filter_impl/hystrix_filter.go
+++ b/filter/filter_impl/hystrix_filter.go
@@ -130,6 +130,9 @@ type HystrixFilter struct {
 
 // Invoke is an implementation of filter, provides Hystrix pattern latency and fault tolerance
 func (hf *HystrixFilter) Invoke(ctx context.Context, invoker protocol.Invoker, invocation protocol.Invocation) protocol.Result {
+	if invoker.GetUrl() == nil {
+		return invoker.Invoke(ctx, invocation)
+	}
 	cmdName := fmt.Sprintf("%s&method=%s", invoker.GetUrl().Key(), invocation.MethodName())
 
 	// Do the configuration if the circuit breaker is created for the first time

--- a/filter/filter_impl/metrics_filter_test.go
+++ b/filter/filter_impl/metrics_filter_test.go
@@ -55,7 +55,7 @@ func TestMetricsFilterInvoke(t *testing.T) {
 			"loadbalance=random&methods.GetUser.retries=1&methods.GetUser.weight=0&module=dubbogo+user-info+server&name=" +
 			"BDTService&organization=ikurento.com&owner=ZX&registry.role=3&retries=&" +
 			"service.filter=echo%2Ctoken%2Caccesslog&timestamp=1569153406&token=934804bf-b007-4174-94eb-96e3e1d60cc7&version=&warmup=100")
-	invoker := protocol.NewBaseInvoker(url)
+	invoker := protocol.NewBaseInvoker(&url)
 
 	attach := make(map[string]interface{}, 10)
 	inv := invocation.NewRPCInvocation("MethodName", []interface{}{"OK", "Hello"}, attach)

--- a/filter/filter_impl/sentinel_filter.go
+++ b/filter/filter_impl/sentinel_filter.go
@@ -229,7 +229,7 @@ func getInterfaceGroupAndVersionEnabled() bool {
 	return true
 }
 
-func getColonSeparatedKey(url common.URL) string {
+func getColonSeparatedKey(url *common.URL) string {
 	return fmt.Sprintf("%s:%s:%s",
 		url.Service(),
 		url.GetParam(constant.GROUP_KEY, ""),

--- a/filter/filter_impl/sentinel_filter_test.go
+++ b/filter/filter_impl/sentinel_filter_test.go
@@ -43,7 +43,7 @@ func TestSentinelFilter_QPS(t *testing.T) {
 		"module=dubbogo+user-info+server&org=ikurento.com&owner=ZX&pid=1447&revision=0.0.1&" +
 		"side=provider&timeout=3000&timestamp=1556509797245&bean.name=UserProvider")
 	assert.NoError(t, err)
-	mockInvoker := protocol.NewBaseInvoker(url)
+	mockInvoker := protocol.NewBaseInvoker(&url)
 	interfaceResourceName, _ := getResourceName(mockInvoker,
 		invocation.NewRPCInvocation("hello", []interface{}{"OK"}, make(map[string]interface{})), "prefix_")
 	mockInvocation := invocation.NewRPCInvocation("hello", []interface{}{"OK"}, make(map[string]interface{}))
@@ -91,7 +91,7 @@ func TestConsumerFilter_Invoke(t *testing.T) {
 		"module=dubbogo+user-info+server&org=ikurento.com&owner=ZX&pid=1447&revision=0.0.1&" +
 		"side=provider&timeout=3000&timestamp=1556509797245&bean.name=UserProvider")
 	assert.NoError(t, err)
-	mockInvoker := protocol.NewBaseInvoker(url)
+	mockInvoker := protocol.NewBaseInvoker(&url)
 	mockInvocation := invocation.NewRPCInvocation("hello", []interface{}{"OK"}, make(map[string]interface{}))
 	result := f.Invoke(context.TODO(), mockInvoker, mockInvocation)
 	assert.NoError(t, result.Error())
@@ -105,7 +105,7 @@ func TestProviderFilter_Invoke(t *testing.T) {
 		"module=dubbogo+user-info+server&org=ikurento.com&owner=ZX&pid=1447&revision=0.0.1&" +
 		"side=provider&timeout=3000&timestamp=1556509797245&bean.name=UserProvider")
 	assert.NoError(t, err)
-	mockInvoker := protocol.NewBaseInvoker(url)
+	mockInvoker := protocol.NewBaseInvoker(&url)
 	mockInvocation := invocation.NewRPCInvocation("hello", []interface{}{"OK"}, make(map[string]interface{}))
 	result := f.Invoke(context.TODO(), mockInvoker, mockInvocation)
 	assert.NoError(t, result.Error())
@@ -119,7 +119,7 @@ func TestGetResourceName(t *testing.T) {
 		"module=dubbogo+user-info+server&org=ikurento.com&owner=ZX&pid=1447&revision=0.0.1&" +
 		"side=provider&timeout=3000&timestamp=1556509797245&bean.name=UserProvider")
 	assert.NoError(t, err)
-	mockInvoker := protocol.NewBaseInvoker(url)
+	mockInvoker := protocol.NewBaseInvoker(&url)
 	interfaceResourceName, methodResourceName := getResourceName(mockInvoker,
 		invocation.NewRPCInvocation("hello", []interface{}{"OK"}, make(map[string]interface{})), "prefix_")
 	assert.Equal(t, "com.ikurento.user.UserProvider:myGroup:1.0.0", interfaceResourceName)

--- a/filter/filter_impl/token_filter_test.go
+++ b/filter/filter_impl/token_filter_test.go
@@ -43,7 +43,7 @@ func TestTokenFilterInvoke(t *testing.T) {
 	attch := make(map[string]interface{}, 0)
 	attch[constant.TOKEN_KEY] = "ori_key"
 	result := filter.Invoke(context.Background(),
-		protocol.NewBaseInvoker(*url),
+		protocol.NewBaseInvoker(url),
 		invocation.NewRPCInvocation("MethodName",
 			[]interface{}{"OK"}, attch))
 	assert.Nil(t, result.Error())
@@ -56,7 +56,7 @@ func TestTokenFilterInvokeEmptyToken(t *testing.T) {
 	testUrl := common.URL{}
 	attch := make(map[string]interface{}, 0)
 	attch[constant.TOKEN_KEY] = "ori_key"
-	result := filter.Invoke(context.Background(), protocol.NewBaseInvoker(testUrl), invocation.NewRPCInvocation("MethodName", []interface{}{"OK"}, attch))
+	result := filter.Invoke(context.Background(), protocol.NewBaseInvoker(&testUrl), invocation.NewRPCInvocation("MethodName", []interface{}{"OK"}, attch))
 	assert.Nil(t, result.Error())
 	assert.Nil(t, result.Result())
 }
@@ -68,7 +68,7 @@ func TestTokenFilterInvokeEmptyAttach(t *testing.T) {
 		common.WithParams(url.Values{}),
 		common.WithParamsValue(constant.TOKEN_KEY, "ori_key"))
 	attch := make(map[string]interface{}, 0)
-	result := filter.Invoke(context.Background(), protocol.NewBaseInvoker(*testUrl), invocation.NewRPCInvocation("MethodName", []interface{}{"OK"}, attch))
+	result := filter.Invoke(context.Background(), protocol.NewBaseInvoker(testUrl), invocation.NewRPCInvocation("MethodName", []interface{}{"OK"}, attch))
 	assert.NotNil(t, result.Error())
 }
 
@@ -81,6 +81,6 @@ func TestTokenFilterInvokeNotEqual(t *testing.T) {
 	attch := make(map[string]interface{}, 0)
 	attch[constant.TOKEN_KEY] = "err_key"
 	result := filter.Invoke(context.Background(),
-		protocol.NewBaseInvoker(*testUrl), invocation.NewRPCInvocation("MethodName", []interface{}{"OK"}, attch))
+		protocol.NewBaseInvoker(testUrl), invocation.NewRPCInvocation("MethodName", []interface{}{"OK"}, attch))
 	assert.NotNil(t, result.Error())
 }

--- a/filter/filter_impl/tps/tps_limiter_method_service.go
+++ b/filter/filter_impl/tps/tps_limiter_method_service.go
@@ -120,7 +120,7 @@ type MethodServiceTpsLimiterImpl struct {
 // The key point is how to keep thread-safe
 // This implementation use concurrent map + loadOrStore to make implementation thread-safe
 // You can image that even multiple threads create limiter, but only one could store the limiter into tpsState
-func (limiter MethodServiceTpsLimiterImpl) IsAllowable(url common.URL, invocation protocol.Invocation) bool {
+func (limiter MethodServiceTpsLimiterImpl) IsAllowable(url *common.URL, invocation protocol.Invocation) bool {
 
 	methodConfigPrefix := "methods." + invocation.MethodName() + "."
 
@@ -176,7 +176,7 @@ func (limiter MethodServiceTpsLimiterImpl) IsAllowable(url common.URL, invocatio
 // If we can convert the methodLevelConfig to int64, return;
 // Or, we will try to look up server-level configuration and then convert it to int64
 func getLimitConfig(methodLevelConfig string,
-	url common.URL,
+	url *common.URL,
 	invocation protocol.Invocation,
 	configKey string,
 	defaultVal string) int64 {

--- a/filter/filter_impl/tps/tps_limiter_method_service_test.go
+++ b/filter/filter_impl/tps/tps_limiter_method_service_test.go
@@ -57,7 +57,7 @@ func TestMethodServiceTpsLimiterImplIsAllowableOnlyServiceLevel(t *testing.T) {
 	})
 
 	limiter := GetMethodServiceTpsLimiter()
-	result := limiter.IsAllowable(*invokeUrl, invoc)
+	result := limiter.IsAllowable(invokeUrl, invoc)
 	assert.True(t, result)
 }
 
@@ -73,7 +73,7 @@ func TestMethodServiceTpsLimiterImplIsAllowableNoConfig(t *testing.T) {
 		common.WithParamsValue(constant.TPS_LIMIT_RATE_KEY, ""))
 
 	limiter := GetMethodServiceTpsLimiter()
-	result := limiter.IsAllowable(*invokeUrl, invoc)
+	result := limiter.IsAllowable(invokeUrl, invoc)
 	assert.True(t, result)
 }
 
@@ -106,7 +106,7 @@ func TestMethodServiceTpsLimiterImplIsAllowableMethodLevelOverride(t *testing.T)
 	})
 
 	limiter := GetMethodServiceTpsLimiter()
-	result := limiter.IsAllowable(*invokeUrl, invoc)
+	result := limiter.IsAllowable(invokeUrl, invoc)
 	assert.True(t, result)
 }
 
@@ -136,7 +136,7 @@ func TestMethodServiceTpsLimiterImplIsAllowableBothMethodAndService(t *testing.T
 	})
 
 	limiter := GetMethodServiceTpsLimiter()
-	result := limiter.IsAllowable(*invokeUrl, invoc)
+	result := limiter.IsAllowable(invokeUrl, invoc)
 	assert.True(t, result)
 }
 

--- a/filter/filter_impl/tps/tps_limiter_mock.go
+++ b/filter/filter_impl/tps/tps_limiter_mock.go
@@ -58,7 +58,7 @@ func (m *MockTpsLimiter) EXPECT() *MockTpsLimiterMockRecorder {
 }
 
 // IsAllowable mocks base method
-func (m *MockTpsLimiter) IsAllowable(arg0 common.URL, arg1 protocol.Invocation) bool {
+func (m *MockTpsLimiter) IsAllowable(arg0 *common.URL, arg1 protocol.Invocation) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsAllowable", arg0, arg1)
 	ret0, _ := ret[0].(bool)

--- a/filter/filter_impl/tps_limit_filter_test.go
+++ b/filter/filter_impl/tps_limit_filter_test.go
@@ -47,7 +47,7 @@ func TestTpsLimitFilterInvokeWithNoTpsLimiter(t *testing.T) {
 	attch := make(map[string]interface{}, 0)
 
 	result := tpsFilter.Invoke(context.Background(),
-		protocol.NewBaseInvoker(*invokeUrl),
+		protocol.NewBaseInvoker(invokeUrl),
 		invocation.NewRPCInvocation("MethodName",
 			[]interface{}{"OK"}, attch))
 	assert.Nil(t, result.Error())
@@ -71,7 +71,7 @@ func TestGenericFilterInvokeWithDefaultTpsLimiter(t *testing.T) {
 	attch := make(map[string]interface{}, 0)
 
 	result := tpsFilter.Invoke(context.Background(),
-		protocol.NewBaseInvoker(*invokeUrl),
+		protocol.NewBaseInvoker(invokeUrl),
 		invocation.NewRPCInvocation("MethodName",
 			[]interface{}{"OK"}, attch))
 	assert.Nil(t, result.Error())
@@ -102,7 +102,7 @@ func TestGenericFilterInvokeWithDefaultTpsLimiterNotAllow(t *testing.T) {
 	attch := make(map[string]interface{}, 0)
 
 	result := tpsFilter.Invoke(context.Background(),
-		protocol.NewBaseInvoker(*invokeUrl), invocation.NewRPCInvocation("MethodName", []interface{}{"OK"}, attch))
+		protocol.NewBaseInvoker(invokeUrl), invocation.NewRPCInvocation("MethodName", []interface{}{"OK"}, attch))
 	assert.Nil(t, result.Error())
 	assert.Nil(t, result.Result())
 }

--- a/filter/filter_impl/tracing_filter_test.go
+++ b/filter/filter_impl/tracing_filter_test.go
@@ -40,7 +40,7 @@ func TestTracingFilterInvoke(t *testing.T) {
 			"loadbalance=random&methods.GetUser.retries=1&methods.GetUser.weight=0&module=dubbogo+user-info+server&name=" +
 			"BDTService&organization=ikurento.com&owner=ZX&registry.role=3&retries=&" +
 			"service.filter=echo%2Ctoken%2Caccesslog&timestamp=1569153406&token=934804bf-b007-4174-94eb-96e3e1d60cc7&version=&warmup=100")
-	invoker := protocol.NewBaseInvoker(url)
+	invoker := protocol.NewBaseInvoker(&url)
 
 	attach := make(map[string]interface{}, 10)
 	inv := invocation.NewRPCInvocation("MethodName", []interface{}{"OK", "Hello"}, attach)

--- a/filter/handler/rejected_execution_handler_mock.go
+++ b/filter/handler/rejected_execution_handler_mock.go
@@ -58,7 +58,7 @@ func (m *MockRejectedExecutionHandler) EXPECT() *MockRejectedExecutionHandlerMoc
 }
 
 // RejectedExecution mocks base method
-func (m *MockRejectedExecutionHandler) RejectedExecution(url common.URL, invocation protocol.Invocation) protocol.Result {
+func (m *MockRejectedExecutionHandler) RejectedExecution(url *common.URL, invocation protocol.Invocation) protocol.Result {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RejectedExecution", url, invocation)
 	ret0, _ := ret[0].(protocol.Result)

--- a/filter/handler/rejected_execution_handler_only_log.go
+++ b/filter/handler/rejected_execution_handler_only_log.go
@@ -63,7 +63,7 @@ type OnlyLogRejectedExecutionHandler struct {
 }
 
 // RejectedExecution will do nothing, it only log the invocation.
-func (handler *OnlyLogRejectedExecutionHandler) RejectedExecution(url common.URL,
+func (handler *OnlyLogRejectedExecutionHandler) RejectedExecution(url *common.URL,
 	_ protocol.Invocation) protocol.Result {
 
 	logger.Errorf("The invocation was rejected. url: %s", url.String())

--- a/filter/handler/rejected_execution_handler_only_log_test.go
+++ b/filter/handler/rejected_execution_handler_only_log_test.go
@@ -31,5 +31,5 @@ func TestOnlyLogRejectedExecutionHandler_RejectedExecution(t *testing.T) {
 	invokeUrl := common.NewURLWithOptions(
 		common.WithParams(url.Values{}),
 		common.WithParamsValue(constant.INTERFACE_KEY, "methodName"))
-	handler.RejectedExecution(*invokeUrl, nil)
+	handler.RejectedExecution(invokeUrl, nil)
 }

--- a/filter/rejected_execution_handler.go
+++ b/filter/rejected_execution_handler.go
@@ -33,5 +33,5 @@ import (
 type RejectedExecutionHandler interface {
 
 	// RejectedExecution will be called if the invocation was rejected by some component.
-	RejectedExecution(url common.URL, invocation protocol.Invocation) protocol.Result
+	RejectedExecution(url *common.URL, invocation protocol.Invocation) protocol.Result
 }

--- a/filter/tps_limiter.go
+++ b/filter/tps_limiter.go
@@ -35,5 +35,5 @@ import (
  */
 type TpsLimiter interface {
 	// IsAllowable will check whether this invocation should be enabled for further process
-	IsAllowable(common.URL, protocol.Invocation) bool
+	IsAllowable(*common.URL, protocol.Invocation) bool
 }

--- a/metadata/service/inmemory/metadata_service_proxy_factory_test.go
+++ b/metadata/service/inmemory/metadata_service_proxy_factory_test.go
@@ -81,7 +81,7 @@ func (m mockProtocol) Destroy() {
 type mockInvoker struct {
 }
 
-func (m *mockInvoker) GetUrl() common.URL {
+func (m *mockInvoker) GetUrl() *common.URL {
 	panic("implement me")
 }
 

--- a/metrics/prometheus/reporter.go
+++ b/metrics/prometheus/reporter.go
@@ -130,13 +130,13 @@ func newHistogramVec(side string) *prometheus.HistogramVec {
 }
 
 // whether this url represents the application received the request as server
-func isProvider(url common.URL) bool {
+func isProvider(url *common.URL) bool {
 	role := url.GetParam(constant.ROLE_KEY, "")
 	return strings.EqualFold(role, strconv.Itoa(common.PROVIDER))
 }
 
 // whether this url represents the application sent then request as client
-func isConsumer(url common.URL) bool {
+func isConsumer(url *common.URL) bool {
 	role := url.GetParam(constant.ROLE_KEY, "")
 	return strings.EqualFold(role, strconv.Itoa(common.CONSUMER))
 }

--- a/metrics/prometheus/reporter_test.go
+++ b/metrics/prometheus/reporter_test.go
@@ -41,12 +41,12 @@ func TestPrometheusReporter_Report(t *testing.T) {
 			"loadbalance=random&methods.GetUser.retries=1&methods.GetUser.weight=0&module=dubbogo+user-info+server&name=" +
 			"BDTService&organization=ikurento.com&owner=ZX&registry.role=3&retries=&" +
 			"service.filter=echo%2Ctoken%2Caccesslog&timestamp=1569153406&token=934804bf-b007-4174-94eb-96e3e1d60cc7&version=&warmup=100")
-	invoker := protocol.NewBaseInvoker(url)
+	invoker := protocol.NewBaseInvoker(&url)
 
 	attach := make(map[string]interface{}, 10)
 	inv := invocation.NewRPCInvocation("MethodName", []interface{}{"OK", "Hello"}, attach)
 
-	assert.False(t, isConsumer(url))
+	assert.False(t, isConsumer(&url))
 	ctx := context.Background()
 	reporter.Report(ctx, invoker, inv, 100*time.Millisecond, nil)
 
@@ -57,7 +57,7 @@ func TestPrometheusReporter_Report(t *testing.T) {
 			"loadbalance=random&methods.GetUser.retries=1&methods.GetUser.weight=0&module=dubbogo+user-info+server&name=" +
 			"BDTService&organization=ikurento.com&owner=ZX&registry.role=0&retries=&" +
 			"service.filter=echo%2Ctoken%2Caccesslog&timestamp=1569153406&token=934804bf-b007-4174-94eb-96e3e1d60cc7&version=&warmup=100")
-	invoker = protocol.NewBaseInvoker(url)
+	invoker = protocol.NewBaseInvoker(&url)
 	reporter.Report(ctx, invoker, inv, 100*time.Millisecond, nil)
 
 	// invalid role
@@ -67,6 +67,6 @@ func TestPrometheusReporter_Report(t *testing.T) {
 			"loadbalance=random&methods.GetUser.retries=1&methods.GetUser.weight=0&module=dubbogo+user-info+server&name=" +
 			"BDTService&organization=ikurento.com&owner=ZX&registry.role=9&retries=&" +
 			"service.filter=echo%2Ctoken%2Caccesslog&timestamp=1569153406&token=934804bf-b007-4174-94eb-96e3e1d60cc7&version=&warmup=100")
-	invoker = protocol.NewBaseInvoker(url)
+	invoker = protocol.NewBaseInvoker(&url)
 	reporter.Report(ctx, invoker, inv, 100*time.Millisecond, nil)
 }

--- a/protocol/dubbo/dubbo_invoker.go
+++ b/protocol/dubbo/dubbo_invoker.go
@@ -74,7 +74,7 @@ func NewDubboInvoker(url common.URL, client *remoting.ExchangeClient) *DubboInvo
 		requestTimeout = t
 	}
 	return &DubboInvoker{
-		BaseInvoker: *protocol.NewBaseInvoker(url),
+		BaseInvoker: *protocol.NewBaseInvoker(&url),
 		client:      client,
 		reqNum:      0,
 		timeout:     requestTimeout,
@@ -126,15 +126,15 @@ func (di *DubboInvoker) Invoke(ctx context.Context, invocation protocol.Invocati
 	if async {
 		if callBack, ok := inv.CallBack().(func(response common.CallbackResponse)); ok {
 			//result.Err = di.client.AsyncCall(NewRequest(url.Location, url, inv.MethodName(), inv.Arguments(), inv.Attachments()), callBack, response)
-			result.Err = di.client.AsyncRequest(&invocation, url, timeout, callBack, rest)
+			result.Err = di.client.AsyncRequest(&invocation, *url, timeout, callBack, rest)
 		} else {
-			result.Err = di.client.Send(&invocation, url, timeout)
+			result.Err = di.client.Send(&invocation, *url, timeout)
 		}
 	} else {
 		if inv.Reply() == nil {
 			result.Err = ErrNoReply
 		} else {
-			result.Err = di.client.Request(&invocation, url, timeout, rest)
+			result.Err = di.client.Request(&invocation, *url, timeout, rest)
 		}
 	}
 	if result.Err == nil {

--- a/protocol/dubbo/dubbo_invoker_test.go
+++ b/protocol/dubbo/dubbo_invoker_test.go
@@ -150,7 +150,7 @@ func InitTest(t *testing.T) (protocol.Protocol, common.URL) {
 		"side=provider&timeout=3000&timestamp=1556509797245&bean.name=UserProvider")
 	assert.NoError(t, err)
 	proto.Export(&proxy_factory.ProxyInvoker{
-		BaseInvoker: *protocol.NewBaseInvoker(url),
+		BaseInvoker: *protocol.NewBaseInvoker(&url),
 	})
 
 	time.Sleep(time.Second * 2)

--- a/protocol/dubbo/dubbo_protocol.go
+++ b/protocol/dubbo/dubbo_protocol.go
@@ -85,7 +85,7 @@ func (dp *DubboProtocol) Export(invoker protocol.Invoker) protocol.Exporter {
 	dp.SetExporterMap(serviceKey, exporter)
 	logger.Infof("Export service: %s", url.String())
 	// start server
-	dp.openServer(url)
+	dp.openServer(*url)
 	return exporter
 }
 

--- a/protocol/dubbo/dubbo_protocol_test.go
+++ b/protocol/dubbo/dubbo_protocol_test.go
@@ -90,7 +90,7 @@ func TestDubboProtocol_Export(t *testing.T) {
 	proto := GetProtocol()
 	url, err := common.NewURL(mockCommonUrl)
 	assert.NoError(t, err)
-	exporter := proto.Export(protocol.NewBaseInvoker(url))
+	exporter := proto.Export(protocol.NewBaseInvoker(&url))
 	// make sure url
 	eq := exporter.GetInvoker().GetUrl().URLEqual(url)
 	assert.True(t, eq)
@@ -98,7 +98,7 @@ func TestDubboProtocol_Export(t *testing.T) {
 	// second service: the same path and the different version
 	url2, err := common.NewURL(mockCommonUrl, common.WithParamsValue(constant.VERSION_KEY, "v1.1"))
 	assert.NoError(t, err)
-	exporter2 := proto.Export(protocol.NewBaseInvoker(url2))
+	exporter2 := proto.Export(protocol.NewBaseInvoker(&url2))
 	// make sure url
 	eq2 := exporter2.GetInvoker().GetUrl().URLEqual(url2)
 	assert.True(t, eq2)
@@ -137,7 +137,7 @@ func TestDubboProtocol_Refer(t *testing.T) {
 
 	url, err := common.NewURL(mockCommonUrl)
 	proto.Export(&proxy_factory.ProxyInvoker{
-		BaseInvoker: *protocol.NewBaseInvoker(url),
+		BaseInvoker: *protocol.NewBaseInvoker(&url),
 	})
 	assert.NoError(t, err)
 	invoker := proto.Refer(url)

--- a/protocol/grpc/grpc_invoker.go
+++ b/protocol/grpc/grpc_invoker.go
@@ -47,7 +47,7 @@ type GrpcInvoker struct {
 // NewGrpcInvoker returns a Grpc invoker instance
 func NewGrpcInvoker(url common.URL, client *Client) *GrpcInvoker {
 	return &GrpcInvoker{
-		BaseInvoker: *protocol.NewBaseInvoker(url),
+		BaseInvoker: *protocol.NewBaseInvoker(&url),
 		client:      client,
 	}
 }

--- a/protocol/grpc/grpc_protocol.go
+++ b/protocol/grpc/grpc_protocol.go
@@ -61,7 +61,7 @@ func (gp *GrpcProtocol) Export(invoker protocol.Invoker) protocol.Exporter {
 	exporter := NewGrpcExporter(serviceKey, invoker, gp.ExporterMap())
 	gp.SetExporterMap(serviceKey, exporter)
 	logger.Infof("Export service: %s", url.String())
-	gp.openServer(url)
+	gp.openServer(*url)
 	return exporter
 }
 

--- a/protocol/grpc/grpc_protocol_test.go
+++ b/protocol/grpc/grpc_protocol_test.go
@@ -39,7 +39,7 @@ func TestGrpcProtocolExport(t *testing.T) {
 	proto := GetProtocol()
 	url, err := common.NewURL(mockGrpcCommonUrl)
 	assert.NoError(t, err)
-	exporter := proto.Export(protocol.NewBaseInvoker(url))
+	exporter := proto.Export(protocol.NewBaseInvoker(&url))
 	time.Sleep(time.Second)
 
 	// make sure url

--- a/protocol/invoker.go
+++ b/protocol/invoker.go
@@ -41,13 +41,13 @@ type Invoker interface {
 
 // BaseInvoker provides default invoker implement
 type BaseInvoker struct {
-	url       common.URL
+	url       *common.URL
 	available bool
 	destroyed bool
 }
 
 // NewBaseInvoker creates a new BaseInvoker
-func NewBaseInvoker(url common.URL) *BaseInvoker {
+func NewBaseInvoker(url *common.URL) *BaseInvoker {
 	return &BaseInvoker{
 		url:       url,
 		available: true,
@@ -56,7 +56,7 @@ func NewBaseInvoker(url common.URL) *BaseInvoker {
 }
 
 // GetUrl gets base invoker URL
-func (bi *BaseInvoker) GetUrl() common.URL {
+func (bi *BaseInvoker) GetUrl() *common.URL {
 	return bi.url
 }
 

--- a/protocol/jsonrpc/http_test.go
+++ b/protocol/jsonrpc/http_test.go
@@ -67,7 +67,7 @@ func TestHTTPClientCall(t *testing.T) {
 	url, err := common.NewURL(mockJsonCommonUrl)
 	assert.NoError(t, err)
 	proto.Export(&proxy_factory.ProxyInvoker{
-		BaseInvoker: *protocol.NewBaseInvoker(url),
+		BaseInvoker: *protocol.NewBaseInvoker(&url),
 	})
 	time.Sleep(time.Second * 2)
 

--- a/protocol/jsonrpc/jsonrpc_invoker.go
+++ b/protocol/jsonrpc/jsonrpc_invoker.go
@@ -38,7 +38,7 @@ type JsonrpcInvoker struct {
 // NewJsonrpcInvoker creates JSON RPC invoker with @url and @client
 func NewJsonrpcInvoker(url common.URL, client *HTTPClient) *JsonrpcInvoker {
 	return &JsonrpcInvoker{
-		BaseInvoker: *protocol.NewBaseInvoker(url),
+		BaseInvoker: *protocol.NewBaseInvoker(&url),
 		client:      client,
 	}
 }
@@ -52,13 +52,13 @@ func (ji *JsonrpcInvoker) Invoke(ctx context.Context, invocation protocol.Invoca
 
 	inv := invocation.(*invocation_impl.RPCInvocation)
 	url := ji.GetUrl()
-	req := ji.client.NewRequest(url, inv.MethodName(), inv.Arguments())
+	req := ji.client.NewRequest(*url, inv.MethodName(), inv.Arguments())
 	ctxNew := context.WithValue(ctx, constant.DUBBOGO_CTX_KEY, map[string]string{
 		"X-Proxy-Id": "dubbogo",
 		"X-Services": url.Path,
 		"X-Method":   inv.MethodName(),
 	})
-	result.Err = ji.client.Call(ctxNew, url, req, inv.Reply())
+	result.Err = ji.client.Call(ctxNew, *url, req, inv.Reply())
 	if result.Err == nil {
 		result.Rest = inv.Reply()
 	}

--- a/protocol/jsonrpc/jsonrpc_invoker_test.go
+++ b/protocol/jsonrpc/jsonrpc_invoker_test.go
@@ -49,7 +49,7 @@ func TestJsonrpcInvokerInvoke(t *testing.T) {
 		"side=provider&timeout=3000&timestamp=1556509797245&bean.name=UserProvider")
 	assert.NoError(t, err)
 	proto.Export(&proxy_factory.ProxyInvoker{
-		BaseInvoker: *protocol.NewBaseInvoker(url),
+		BaseInvoker: *protocol.NewBaseInvoker(&url),
 	})
 	time.Sleep(time.Second * 2)
 

--- a/protocol/jsonrpc/jsonrpc_protocol.go
+++ b/protocol/jsonrpc/jsonrpc_protocol.go
@@ -69,7 +69,7 @@ func (jp *JsonrpcProtocol) Export(invoker protocol.Invoker) protocol.Exporter {
 	logger.Infof("Export service: %s", url.String())
 
 	// start server
-	jp.openServer(url)
+	jp.openServer(*url)
 
 	return exporter
 }

--- a/protocol/jsonrpc/jsonrpc_protocol_test.go
+++ b/protocol/jsonrpc/jsonrpc_protocol_test.go
@@ -43,7 +43,7 @@ func TestJsonrpcProtocolExport(t *testing.T) {
 		"module=dubbogo+user-info+server&org=ikurento.com&owner=ZX&pid=1447&revision=0.0.1&" +
 		"side=provider&timeout=3000&timestamp=1556509797245")
 	assert.NoError(t, err)
-	exporter := proto.Export(protocol.NewBaseInvoker(url))
+	exporter := proto.Export(protocol.NewBaseInvoker(&url))
 
 	// make sure url
 	eq := exporter.GetInvoker().GetUrl().URLEqual(url)

--- a/protocol/mock/mock_invoker.go
+++ b/protocol/mock/mock_invoker.go
@@ -59,9 +59,9 @@ func (m *MockInvoker) EXPECT() *MockInvokerMockRecorder {
 }
 
 // GetUrl mocks base method
-func (m *MockInvoker) GetUrl() common.URL {
+func (m *MockInvoker) GetUrl() *common.URL {
 	ret := m.ctrl.Call(m, "GetUrl")
-	ret0, _ := ret[0].(common.URL)
+	ret0, _ := ret[0].(*common.URL)
 	return ret0
 }
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -90,7 +90,7 @@ func (bp *BaseProtocol) Export(invoker Invoker) Exporter {
 
 // Refer is default refer implement.
 func (bp *BaseProtocol) Refer(url common.URL) Invoker {
-	return NewBaseInvoker(url)
+	return NewBaseInvoker(&url)
 }
 
 // Destroy will destroy all invoker and exporter, so it only is called once.

--- a/protocol/protocolwrapper/mock_protocol_filter.go
+++ b/protocol/protocolwrapper/mock_protocol_filter.go
@@ -40,7 +40,7 @@ func (pfw *mockProtocolFilter) Export(invoker protocol.Invoker) protocol.Exporte
 
 // Refer a mock remote service
 func (pfw *mockProtocolFilter) Refer(url common.URL) protocol.Invoker {
-	return protocol.NewBaseInvoker(url)
+	return protocol.NewBaseInvoker(&url)
 }
 
 // Destroy will do nothing

--- a/protocol/protocolwrapper/protocol_filter_wrapper.go
+++ b/protocol/protocolwrapper/protocol_filter_wrapper.go
@@ -101,7 +101,7 @@ type FilterInvoker struct {
 }
 
 // GetUrl is used to get url from FilterInvoker
-func (fi *FilterInvoker) GetUrl() common.URL {
+func (fi *FilterInvoker) GetUrl() *common.URL {
 	return fi.invoker.GetUrl()
 }
 

--- a/protocol/protocolwrapper/protocol_filter_wrapper_test.go
+++ b/protocol/protocolwrapper/protocol_filter_wrapper_test.go
@@ -43,7 +43,7 @@ func TestProtocolFilterWrapperExport(t *testing.T) {
 	u := common.NewURLWithOptions(
 		common.WithParams(url.Values{}),
 		common.WithParamsValue(constant.SERVICE_FILTER_KEY, "echo"))
-	exporter := filtProto.Export(protocol.NewBaseInvoker(*u))
+	exporter := filtProto.Export(protocol.NewBaseInvoker(u))
 	_, ok := exporter.GetInvoker().(*FilterInvoker)
 	assert.True(t, ok)
 }

--- a/protocol/rest/rest_invoker.go
+++ b/protocol/rest/rest_invoker.go
@@ -45,7 +45,7 @@ type RestInvoker struct {
 // NewRestInvoker returns a RestInvoker
 func NewRestInvoker(url common.URL, client *client.RestClient, restMethodConfig map[string]*config.RestMethodConfig) *RestInvoker {
 	return &RestInvoker{
-		BaseInvoker:         *protocol.NewBaseInvoker(url),
+		BaseInvoker:         *protocol.NewBaseInvoker(&url),
 		client:              *client,
 		restMethodConfigMap: restMethodConfig,
 	}

--- a/protocol/rest/rest_protocol.go
+++ b/protocol/rest/rest_protocol.go
@@ -78,7 +78,7 @@ func (rp *RestProtocol) Export(invoker protocol.Invoker) protocol.Exporter {
 		return nil
 	}
 	rp.SetExporterMap(serviceKey, exporter)
-	restServer := rp.getServer(url, restServiceConfig.Server)
+	restServer := rp.getServer(*url, restServiceConfig.Server)
 	for _, methodConfig := range restServiceConfig.RestMethodConfigsMap {
 		restServer.Deploy(methodConfig, server.GetRouteFunc(invoker, methodConfig))
 	}

--- a/protocol/rpc_status.go
+++ b/protocol/rpc_status.go
@@ -97,7 +97,7 @@ func (rpc *RPCStatus) GetSuccessiveRequestFailureCount() int32 {
 }
 
 // GetURLStatus get URL RPC status.
-func GetURLStatus(url common.URL) *RPCStatus {
+func GetURLStatus(url *common.URL) *RPCStatus {
 	rpcStatus, found := serviceStatistic.Load(url.Key())
 	if !found {
 		rpcStatus, _ = serviceStatistic.LoadOrStore(url.Key(), &RPCStatus{})
@@ -106,7 +106,7 @@ func GetURLStatus(url common.URL) *RPCStatus {
 }
 
 // GetMethodStatus get method RPC status.
-func GetMethodStatus(url common.URL, methodName string) *RPCStatus {
+func GetMethodStatus(url *common.URL, methodName string) *RPCStatus {
 	identifier := url.Key()
 	methodMap, found := methodStatistics.Load(identifier)
 	if !found {
@@ -124,13 +124,13 @@ func GetMethodStatus(url common.URL, methodName string) *RPCStatus {
 }
 
 // BeginCount gets begin count.
-func BeginCount(url common.URL, methodName string) {
+func BeginCount(url *common.URL, methodName string) {
 	beginCount0(GetURLStatus(url))
 	beginCount0(GetMethodStatus(url, methodName))
 }
 
 // EndCount gets end count.
-func EndCount(url common.URL, methodName string, elapsed int64, succeeded bool) {
+func EndCount(url *common.URL, methodName string, elapsed int64, succeeded bool) {
 	endCount0(GetURLStatus(url), elapsed, succeeded)
 	endCount0(GetMethodStatus(url, methodName), elapsed, succeeded)
 }

--- a/protocol/rpc_status_test.go
+++ b/protocol/rpc_status_test.go
@@ -37,7 +37,8 @@ const (
 func TestBeginCount(t *testing.T) {
 	defer CleanAllStatus()
 
-	url, _ := common.NewURL(mockCommonDubboUrl)
+	urlTmp, _ := common.NewURL(mockCommonDubboUrl)
+	url := &urlTmp
 	BeginCount(url, "test")
 	urlStatus := GetURLStatus(url)
 	methodStatus := GetMethodStatus(url, "test")
@@ -51,7 +52,8 @@ func TestBeginCount(t *testing.T) {
 func TestEndCount(t *testing.T) {
 	defer CleanAllStatus()
 
-	url, _ := common.NewURL(mockCommonDubboUrl)
+	urlTmp, _ := common.NewURL(mockCommonDubboUrl)
+	url := &urlTmp
 	EndCount(url, "test", 100, true)
 	urlStatus := GetURLStatus(url)
 	methodStatus := GetMethodStatus(url, "test")
@@ -65,7 +67,7 @@ func TestGetMethodStatus(t *testing.T) {
 	defer CleanAllStatus()
 
 	url, _ := common.NewURL(mockCommonDubboUrl)
-	status := GetMethodStatus(url, "test")
+	status := GetMethodStatus(&url, "test")
 	assert.NotNil(t, status)
 	assert.Equal(t, int32(0), status.total)
 }
@@ -74,7 +76,7 @@ func TestGetUrlStatus(t *testing.T) {
 	defer CleanAllStatus()
 
 	url, _ := common.NewURL(mockCommonDubboUrl)
-	status := GetURLStatus(url)
+	status := GetURLStatus(&url)
 	assert.NotNil(t, status)
 	assert.Equal(t, int32(0), status.total)
 }
@@ -83,7 +85,7 @@ func TestbeginCount0(t *testing.T) {
 	defer CleanAllStatus()
 
 	url, _ := common.NewURL(mockCommonDubboUrl)
-	status := GetURLStatus(url)
+	status := GetURLStatus(&url)
 	beginCount0(status)
 	assert.Equal(t, int32(1), status.active)
 }
@@ -91,7 +93,8 @@ func TestbeginCount0(t *testing.T) {
 func TestAll(t *testing.T) {
 	defer CleanAllStatus()
 
-	url, _ := common.NewURL(mockCommonDubboUrl)
+	urlTmp, _ := common.NewURL(mockCommonDubboUrl)
+	url := &urlTmp
 	request(url, "test", 100, false, true)
 	urlStatus := GetURLStatus(url)
 	methodStatus := GetMethodStatus(url, "test")
@@ -142,7 +145,7 @@ func TestAll(t *testing.T) {
 
 }
 
-func request(url common.URL, method string, elapsed int64, active, succeeded bool) {
+func request(url *common.URL, method string, elapsed int64, active, succeeded bool) {
 	BeginCount(url, method)
 	if !active {
 		EndCount(url, method, elapsed, succeeded)

--- a/registry/base_registry.go
+++ b/registry/base_registry.go
@@ -114,8 +114,8 @@ func (r *BaseRegistry) InitBaseRegistry(url *common.URL, facadeRegistry FacadeBa
 }
 
 // GetUrl for get registry's url
-func (r *BaseRegistry) GetUrl() common.URL {
-	return *r.URL
+func (r *BaseRegistry) GetUrl() *common.URL {
+	return r.URL
 }
 
 // Destroy for graceful down

--- a/registry/consul/registry.go
+++ b/registry/consul/registry.go
@@ -172,8 +172,8 @@ func (r *consulRegistry) getListener(url common.URL) (registry.Listener, error) 
 }
 
 // GetUrl get registry URL of consul registry center
-func (r *consulRegistry) GetUrl() common.URL {
-	return *r.URL
+func (r *consulRegistry) GetUrl() *common.URL {
+	return r.URL
 }
 
 // IsAvailable checks consul registry center whether is available

--- a/registry/directory/directory.go
+++ b/registry/directory/directory.go
@@ -303,7 +303,7 @@ func (dir *RegistryDirectory) cacheInvoker(url *common.URL) protocol.Invoker {
 		} else {
 			// if cached invoker has the same URL with the new URL, then no need to re-refer, and no need to destroy
 			// the old invoker.
-			if common.IsEquals(*newUrl, cacheInvoker.(protocol.Invoker).GetUrl()) {
+			if common.IsEquals(newUrl, cacheInvoker.(protocol.Invoker).GetUrl()) {
 				return nil
 			}
 

--- a/registry/directory/directory_test.go
+++ b/registry/directory/directory_test.go
@@ -183,7 +183,7 @@ func Test_toGroupInvokers(t *testing.T) {
 	defer ctrl.Finish()
 	invoker := mock.NewMockInvoker(ctrl)
 	newUrl, _ := common.NewURL("dubbo://192.168.1.1:20000/com.ikurento.user.UserProvider")
-	invoker.EXPECT().GetUrl().Return(newUrl).AnyTimes()
+	invoker.EXPECT().GetUrl().Return(&newUrl).AnyTimes()
 
 	registryDirectory.cacheInvokersMap.Store("group1", invoker)
 	registryDirectory.cacheInvokersMap.Store("group2", invoker)

--- a/registry/mock_registry.go
+++ b/registry/mock_registry.go
@@ -68,8 +68,8 @@ func (r *MockRegistry) IsAvailable() bool {
 }
 
 // nolint
-func (r *MockRegistry) GetUrl() common.URL {
-	return common.URL{}
+func (r *MockRegistry) GetUrl() *common.URL {
+	return &common.URL{}
 }
 
 func (r *MockRegistry) subscribe(*common.URL) (Listener, error) {

--- a/registry/nacos/registry.go
+++ b/registry/nacos/registry.go
@@ -211,8 +211,8 @@ func (nr *nacosRegistry) UnSubscribe(url *common.URL, notifyListener registry.No
 }
 
 // GetUrl gets its registration URL
-func (nr *nacosRegistry) GetUrl() common.URL {
-	return *nr.URL
+func (nr *nacosRegistry) GetUrl() *common.URL {
+	return nr.URL
 }
 
 // IsAvailable determines nacos registry center whether it is available

--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -275,9 +275,9 @@ func (nl *overrideSubscribeListener) doOverrideIfNecessary() {
 		}
 
 		if currentUrl.String() != providerUrl.String() {
-			newRegUrl := nl.originInvoker.GetUrl()
-			setProviderUrl(&newRegUrl, providerUrl)
-			nl.protocol.reExport(nl.originInvoker, &newRegUrl)
+			newRegUrl := nl.originInvoker.GetUrl().Clone()
+			setProviderUrl(newRegUrl, providerUrl)
+			nl.protocol.reExport(nl.originInvoker, newRegUrl)
 		}
 	}
 }
@@ -372,7 +372,7 @@ func getRegistryUrl(invoker protocol.Invoker) *common.URL {
 		protocol := url.GetParam(constant.REGISTRY_KEY, "")
 		url.Protocol = protocol
 	}
-	return &url
+	return url
 }
 
 func getProviderUrl(invoker protocol.Invoker) *common.URL {
@@ -401,7 +401,7 @@ type wrappedInvoker struct {
 func newWrappedInvoker(invoker protocol.Invoker, url *common.URL) *wrappedInvoker {
 	return &wrappedInvoker{
 		invoker:     invoker,
-		BaseInvoker: *protocol.NewBaseInvoker(*url),
+		BaseInvoker: *protocol.NewBaseInvoker(url),
 	}
 }
 

--- a/registry/protocol/protocol_test.go
+++ b/registry/protocol/protocol_test.go
@@ -129,7 +129,7 @@ func exporterNormal(t *testing.T, regProtocol *registryProtocol) *common.URL {
 	)
 
 	url.SubURL = &suburl
-	invoker := protocol.NewBaseInvoker(url)
+	invoker := protocol.NewBaseInvoker(&url)
 	exporter := regProtocol.Export(invoker)
 
 	assert.IsType(t, &protocol.BaseExporter{}, exporter)
@@ -154,7 +154,7 @@ func TestMultiRegAndMultiProtoExporter(t *testing.T) {
 	)
 
 	url2.SubURL = &suburl2
-	invoker2 := protocol.NewBaseInvoker(url2)
+	invoker2 := protocol.NewBaseInvoker(&url2)
 	regProtocol.Export(invoker2)
 
 	var count int
@@ -185,7 +185,7 @@ func TestOneRegAndProtoExporter(t *testing.T) {
 	)
 
 	url2.SubURL = &suburl2
-	invoker2 := protocol.NewBaseInvoker(url2)
+	invoker2 := protocol.NewBaseInvoker(&url2)
 	regProtocol.Export(invoker2)
 
 	var count int

--- a/registry/servicediscovery/service_discovery_registry.go
+++ b/registry/servicediscovery/service_discovery_registry.go
@@ -145,8 +145,8 @@ func (s *serviceDiscoveryRegistry) GetServiceDiscovery() registry.ServiceDiscove
 	return s.serviceDiscovery
 }
 
-func (s *serviceDiscoveryRegistry) GetUrl() common.URL {
-	return *s.url
+func (s *serviceDiscoveryRegistry) GetUrl() *common.URL {
+	return s.url
 }
 
 func (s *serviceDiscoveryRegistry) IsAvailable() bool {

--- a/registry/zookeeper/service_discovery.go
+++ b/registry/zookeeper/service_discovery.go
@@ -154,8 +154,8 @@ func (zksd *zookeeperServiceDiscovery) RestartCallBack() bool {
 }
 
 // nolint
-func (zksd *zookeeperServiceDiscovery) GetUrl() common.URL {
-	return *zksd.url
+func (zksd *zookeeperServiceDiscovery) GetUrl() *common.URL {
+	return zksd.url
 }
 
 // nolint

--- a/remoting/getty/getty_client_test.go
+++ b/remoting/getty/getty_client_test.go
@@ -397,7 +397,7 @@ func InitTest(t *testing.T) (*Server, common.URL) {
 	userProvider := &UserProvider{}
 	common.ServiceMap.Register("", url.Protocol, userProvider)
 	invoker := &proxy_factory.ProxyInvoker{
-		BaseInvoker: *protocol.NewBaseInvoker(url),
+		BaseInvoker: *protocol.NewBaseInvoker(&url),
 	}
 	handler := func(invocation *invocation.RPCInvocation) protocol.RPCResult {
 		//result := protocol.RPCResult{}

--- a/remoting/kubernetes/client.go
+++ b/remoting/kubernetes/client.go
@@ -173,7 +173,7 @@ func ValidateClient(container clientFacade) error {
 	// new Client
 	if client == nil || client.Valid() {
 
-		newClient, err := newClient(container.GetUrl())
+		newClient, err := newClient(*container.GetUrl())
 		if err != nil {
 			logger.Warnf("new kubernetes client: %v)", err)
 			return perrors.WithMessage(err, "new kubernetes client")

--- a/remoting/kubernetes/facade_test.go
+++ b/remoting/kubernetes/facade_test.go
@@ -43,8 +43,8 @@ func (r *mockFacade) SetClient(client *Client) {
 	r.client = client
 }
 
-func (r *mockFacade) GetUrl() common.URL {
-	return *r.URL
+func (r *mockFacade) GetUrl() *common.URL {
+	return r.URL
 }
 
 func (r *mockFacade) Destroy() {

--- a/remoting/zookeeper/facade.go
+++ b/remoting/zookeeper/facade.go
@@ -37,7 +37,7 @@ type ZkClientFacade interface {
 	WaitGroup() *sync.WaitGroup // for wait group control, zk client listener & zk client container
 	Done() chan struct{}        // for zk client control
 	RestartCallBack() bool
-	GetUrl() common.URL
+	GetUrl() *common.URL
 }
 
 // HandleClientRestart keeps the connection between client and server

--- a/remoting/zookeeper/facade_test.go
+++ b/remoting/zookeeper/facade_test.go
@@ -68,8 +68,8 @@ func (r *mockFacade) Done() chan struct{} {
 	return r.done
 }
 
-func (r *mockFacade) GetUrl() common.URL {
-	return *r.URL
+func (r *mockFacade) GetUrl() *common.URL {
+	return r.URL
 }
 
 func (r *mockFacade) Destroy() {


### PR DESCRIPTION
In Node Interface:
```
GetUrl() URL
```
it will use value copy, and it will be invoked so many times that it is very busy.  Refer to : https://github.com/apache/dubbo-go/issues/814

We should use the Pointer , and I think it will work better.

```
GetUrl() *URL
```

