### PR TITLE
enhancement: custom registry report ip and ports

### DIFF
--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -325,3 +325,9 @@ const (
 	// SERVICE_DISCOVERY_KEY indicate which service discovery instance will be used
 	SERVICE_DISCOVERY_KEY = "service_discovery"
 )
+
+//custom registry ip and port
+const (
+	DUBBOGO_IP_TO_REGISTRY   = "DUBBOGO_IP_TO_REGISTRY"
+	DUBBOGO_PORT_TO_REGISTRY = "DUBBOGO_PORT_TO_REGISTRY"
+)

--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -19,6 +19,7 @@ package protocol
 
 import (
 	"context"
+	"os"
 	"strings"
 	"sync"
 )
@@ -194,6 +195,16 @@ func (proto *registryProtocol) Export(invoker protocol.Invoker) protocol.Exporte
 	}
 
 	registeredProviderUrl := getUrlToRegistry(providerUrl, registryUrl)
+
+	// custom registry report ip and ports
+	customIp := os.Getenv(constant.DUBBOGO_IP_TO_REGISTRY)
+	if len(customIp) > 0 {
+		registeredProviderUrl.Ip = customIp
+	}
+	customPort := os.Getenv(constant.DUBBOGO_PORT_TO_REGISTRY)
+	if len(customPort) > 0 {
+		registeredProviderUrl.Port = customPort
+	}
 	err := reg.Register(*registeredProviderUrl)
 	if err != nil {
 		logger.Errorf("provider service %v register registry %v error, error message is %s",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/contributing.md before commit pull request. 
-->

**What this PR does**:
support custom report to registry ip and port from environment variables. like apache/dubbo

**Which issue(s) this PR fixes**:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:
the code is simple. please the code style is right?

**Does this PR introduce a user-facing change?**:
Now the user can specify  the IP and port what report to registry  by set environment variables.

DUBBOGO_IP_TO_REGISTRY -> custom IP
DUBBOGO_PORT_TO_REGISTRY -> custom port
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```