### PR TITLE
Fix: client read timeout caused by default request timeout is 0

### DIFF
--- a/protocol/dubbo/dubbo_invoker.go
+++ b/protocol/dubbo/dubbo_invoker.go
@@ -73,6 +73,9 @@ func NewDubboInvoker(url common.URL, client *remoting.ExchangeClient) *DubboInvo
 	if t, err := time.ParseDuration(requestTimeoutStr); err == nil {
 		requestTimeout = t
 	}
+	if requestTimeout == 0 {
+		requestTimeout = time.Second * 3
+	}
 	return &DubboInvoker{
 		BaseInvoker: *protocol.NewBaseInvoker(url),
 		client:      client,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/contributing.md before commit pull request. 
-->

**What this PR does**:
修复默认request timeout为0导致的错误(client read timeout)

**Which issue(s) this PR fixes**:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:
如果用户未设置timeout值，在NewDubboInvoker()方法中做了兜底
此修改可以解决问题，但未必是最好的修复方式

**Does this PR introduce a user-facing change?**:
None
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```