### PR TITLE
fix lock panic

### DIFF
--- a/registry/base_registry.go
+++ b/registry/base_registry.go
@@ -77,8 +77,6 @@ type FacadeBasedRegistry interface {
 	// DoSubscribe actually subscribe the URL
 	DoSubscribe(conf *common.URL) (Listener, error)
 	// CloseAndNilClient close the client and then reset the client in registry to nil
-	// you should notice that this method will be invoked inside a lock.
-	// So you should implement this method as light weighted as you can.
 	CloseAndNilClient()
 	// CloseListener close listeners
 	CloseListener()
@@ -367,11 +365,11 @@ func (r *BaseRegistry) Subscribe(url *common.URL, notifyListener NotifyListener)
 func (r *BaseRegistry) closeRegisters() {
 	logger.Infof("begin to close provider client")
 	r.cltLock.Lock()
-	defer r.cltLock.Unlock()
-	// Close and remove(set to nil) the registry client
-	r.facadeBasedRegistry.CloseAndNilClient()
 	// reset the services map
 	r.services = nil
+	r.cltLock.Unlock()
+	// Close and remove(set to nil) the registry client
+	r.facadeBasedRegistry.CloseAndNilClient()
 }
 
 // IsAvailable judge to is registry not closed by chan r.done

--- a/registry/etcdv3/registry.go
+++ b/registry/etcdv3/registry.go
@@ -115,8 +115,11 @@ func (r *etcdV3Registry) DoRegister(root string, node string) error {
 }
 
 func (r *etcdV3Registry) CloseAndNilClient() {
-	r.client.Close()
+	r.cltLock.Lock()
+	defer r.cltLock.Unlock()
+	client := r.client
 	r.client = nil
+	go client.Close()
 }
 
 func (r *etcdV3Registry) CloseListener() {

--- a/registry/kubernetes/registry.go
+++ b/registry/kubernetes/registry.go
@@ -82,8 +82,11 @@ func (r *kubernetesRegistry) SetClient(client *kubernetes.Client) {
 }
 
 func (r *kubernetesRegistry) CloseAndNilClient() {
-	r.client.Close()
+	r.cltLock.Lock()
+	defer r.cltLock.Unlock()
+	client := r.client
 	r.client = nil
+	go client.Close()
 }
 
 func (r *kubernetesRegistry) CloseListener() {

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -138,8 +138,11 @@ func (r *zkRegistry) DoSubscribe(conf *common.URL) (registry.Listener, error) {
 }
 
 func (r *zkRegistry) CloseAndNilClient() {
-	r.client.Close()
+	r.cltLock.Lock()
+	defer r.cltLock.Unlock()
+	client := r.client
 	r.client = nil
+	go client.Close()
 }
 
 func (r *zkRegistry) ZkClient() *zookeeper.ZookeeperClient {

--- a/remoting/zookeeper/client.go
+++ b/remoting/zookeeper/client.go
@@ -375,10 +375,6 @@ func (z *ZookeeperClient) ZkConnValid() bool {
 
 // Close ...
 func (z *ZookeeperClient) Close() {
-	if z == nil {
-		return
-	}
-
 	z.stop()
 	z.Wait.Wait()
 	z.Lock()


### PR DESCRIPTION
try to fix the lock panic. 

goroutine 3284 [running]:
sync.(*Mutex).Lock(...)
	/usr/local/go/src/sync/mutex.go:74
github.com/apache/dubbo-go/remoting/zookeeper.(*ZookeeperClient).RegisterTemp(0x0, 0x0, 0x0, 0x0, 0x0, 0x39, 0xc030b46300, 0xc0, 0xc0)
	/home/docker/go/pkg/mod/github.com/wenxuwan/dubbo-go@v1.4.2-0.20201117104708-2e3dcf6cc4cd/remoting/zookeeper/client.go:455 +0x114
github.com/apache/dubbo-go/registry/zookeeper.(*zkRegistry).registerTempZookeeperNode(0xc02fea7050, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/docker/go/pkg/mod/github.com/wenxuwan/dubbo-go@v1.4.2-0.20201117104708-2e3dcf6cc4cd/registry/zookeeper/registry.go:176 +0x387
github.com/apache/dubbo-go/registry/zookeeper.(*zkRegistry).DoRegister(0xc02fea7050, 0x0, 0x0, 0x0, 0x0, 0x3, 0xffffffffffffffff)
	/home/docker/go/pkg/mod/github.com/wenxuwan/dubbo-go@v1.4.2-0.20201117104708-2e3dcf6cc4cd/registry/zookeeper/registry.go:133 +0x53
github.com/apache/dubbo-go/registry.(*BaseRegistry).register(0xc02fea7050, 0xd8a023, 0x5, 0xd889fe, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/docker/go/pkg/mod/github.com/wenxuwan/dubbo-go@v1.4.2-0.20201117104708-2e3dcf6cc4cd/registry/base_registry.go:220 +0x434
github.com/apache/dubbo-go/registry.(*BaseRegistry).Register(0xc02fea7050, 0xd8a023, 0x5, 0xd889fe, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/home/docker/go/pkg/mod/github.com/wenxuwan/dubbo-go@v1.4.2-0.20201117104708-2e3dcf6cc4cd/registry/base_registry.go:143 +0x1d0
github.com/apache/dubbo-go/registry/protocol.(*registryProtocol).Refer(0xc0004d9540, 0xc0309b08c0, 0x8, 0xc0003f2600, 0x5b, 0xc0309b08cb, 0xc, 0xc0309b08d8, 0x4, 0x0, ...)
	/home/docker/go/pkg/mod/github.com/wenxuwan/dubbo-go@v1.4.2-0.20201117104708-2e3dcf6cc4cd/registry/protocol/protocol.go:122 +0x412
github.com/apache/dubbo-go/config.(*ReferenceConfig).Refer(0xc00cb83e08, 0xc6aa80, 0xc0309be3a0)
	/home/docker/go/pkg/mod/github.com/wenxuwan/dubbo-go@v1.4.2-0.20201117104708-2e3dcf6cc4cd/config/reference_config.go:134 +0xb69
github.com/apache/dubbo-go/config.(*ReferenceConfig).GenericLoad(0xc00cb83e08, 0xc0309ae2c0, 0x39)
	/home/docker/go/pkg/mod/github.com/wenxuwan/dubbo-go@v1.4.2-0.20201117104708-2e3dcf6cc4cd/config/reference_config.go:228 +0x113
gitlab.com/TuyaBE/highway-proxy/protocol/dubbo.(*DubboClientStu).Create(0x14b2ca0, 0xc0309ae2c0, 0x39, 0x0, 0x0, 0x0)
	/home/docker/highway-proxy/protocol/dubbo/dubbo.go:88 +0x286
gitlab.com/TuyaBE/highway-proxy/protocol/dubbo.(*DubboClientStu).initInterface(0x14b2ca0, 0xc0309ae2c0, 0x39, 0x0, 0x0)
	/home/docker/highway-proxy/protocol/dubbo/init.go:36 +0x198
created by gitlab.com/TuyaBE/highway-proxy/protocol/dubbo.(*DubboClientStu).loadProviderInterface
	/home/docker/highway-proxy/protocol/dubbo/init.go:51 +0x34f