### PR TITLE
introduce a export flag to decide if a service should be export 

### DIFF
--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -127,6 +127,7 @@ const (
 	TAG_ROUTE_PROTOCOL       = "tag"
 	PROVIDERS_CATEGORY       = "providers"
 	ROUTER_KEY               = "router"
+	EXPORT_KEY               = "export"
 )
 
 const (

--- a/config/service_config.go
+++ b/config/service_config.go
@@ -103,6 +103,7 @@ func (c *ServiceConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 	c.exported = atomic.NewBool(false)
 	c.unexported = atomic.NewBool(false)
+	c.export = true
 	return nil
 }
 


### PR DESCRIPTION
it is particularly useful with a config-post-processor

<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/contributing.md before commit pull request. 
-->

**What this PR does**:

Introduce a export flag to align with java implementation. It is particularly useful when a config post processor decides to break the exporting process.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```