### PR TITLE
Fix: registry simplified ignore user params

### DIFF
--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -59,6 +59,7 @@ const (
 )
 
 const (
+	USER_DEFINED                           = "user-defined."
 	TIMESTAMP_KEY                          = "timestamp"
 	REMOTE_TIMESTAMP_KEY                   = "remote.timestamp"
 	CLUSTER_KEY                            = "cluster"

--- a/config/service_config.go
+++ b/config/service_config.go
@@ -60,7 +60,7 @@ type ServiceConfig struct {
 	Warmup                      string            `yaml:"warmup"  json:"warmup,omitempty"  property:"warmup"`
 	Retries                     string            `yaml:"retries"  json:"retries,omitempty" property:"retries"`
 	Serialization               string            `yaml:"serialization" json:"serialization" property:"serialization"`
-	Params                      map[string]string `yaml:"params"  json:"params,omitempty" property:"params"`
+	Params                      map[string]string `default:"{}" yaml:"params"  json:"params,omitempty" property:"params"`
 	Token                       string            `yaml:"token" json:"token,omitempty" property:"token"`
 	AccessLog                   string            `yaml:"accesslog" json:"accesslog,omitempty" property:"accesslog"`
 	TpsLimiter                  string            `yaml:"tps.limiter" json:"tps.limiter,omitempty" property:"tps.limiter"`
@@ -269,9 +269,14 @@ func (c *ServiceConfig) Implement(s common.RPCService) {
 func (c *ServiceConfig) getUrlMap() url.Values {
 	urlMap := url.Values{}
 	// first set user params
+	simplified := providerConfig.Registries[c.Registry].Simplified
 	for k, v := range c.Params {
+		if simplified {
+			k = constant.USER_DEFINED + k
+		}
 		urlMap.Set(k, v)
 	}
+
 	urlMap.Set(constant.INTERFACE_KEY, c.InterfaceName)
 	urlMap.Set(constant.TIMESTAMP_KEY, strconv.FormatInt(time.Now().Unix(), 10))
 	urlMap.Set(constant.CLUSTER_KEY, c.Cluster)

--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -100,14 +100,14 @@ func getUrlToRegistry(providerUrl *common.URL, registryUrl *common.URL) *common.
 }
 
 func filterSimplifiedKey(url *common.URL) *common.URL {
-	params := url.CloneWithParams(reserveParams)
+	newUrl := url.CloneWithParams(reserveParams)
 	for k := range url.GetParams() {
 		if !strings.HasPrefix(k, constant.USER_DEFINED) {
 			continue
 		}
-		params.SetParam(strings.TrimPrefix(k, constant.USER_DEFINED), url.GetParam(k, ""))
+		newUrl.SetParam(strings.TrimPrefix(k, constant.USER_DEFINED), url.GetParam(k, ""))
 	}
-	return params
+	return newUrl
 }
 
 // filterHideKey filter the parameters that do not need to be output in url(Starting with .)

--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -100,6 +100,7 @@ func getUrlToRegistry(providerUrl *common.URL, registryUrl *common.URL) *common.
 }
 
 func filterSimplifiedKey(url *common.URL) *common.URL {
+	// get url with reserve params
 	newUrl := url.CloneWithParams(reserveParams)
 	for k := range url.GetParams() {
 		if !strings.HasPrefix(k, constant.USER_DEFINED) {

--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -93,10 +93,21 @@ func getRegistry(regUrl *common.URL) registry.Registry {
 
 func getUrlToRegistry(providerUrl *common.URL, registryUrl *common.URL) *common.URL {
 	if registryUrl.GetParamBool("simplified", false) {
-		return providerUrl.CloneWithParams(reserveParams)
+		return filterSimplifiedKey(providerUrl)
 	} else {
 		return filterHideKey(providerUrl)
 	}
+}
+
+func filterSimplifiedKey(url *common.URL) *common.URL {
+	params := url.CloneWithParams(reserveParams)
+	for k := range url.GetParams() {
+		if !strings.HasPrefix(k, constant.USER_DEFINED) {
+			continue
+		}
+		params.SetParam(strings.TrimPrefix(k, constant.USER_DEFINED), url.GetParam(k, ""))
+	}
+	return params
 }
 
 // filterHideKey filter the parameters that do not need to be output in url(Starting with .)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/contributing.md before commit pull request. 
-->

**What this PR does**:
Fix: registry simplified ignore user params

**Does this PR introduce a user-facing change?**:
需要在service加一个自定义参数，但是consul会默认simplified=true，会忽略自己的自定义参数.