### PR TITLE
Refactor Proxy with ImplementFunc to allow override impl

### DIFF
--- a/common/proxy/proxy.go
+++ b/common/proxy/proxy.go
@@ -48,7 +48,6 @@ type Proxy struct {
 
 type (
 	// ProxyOption a function to init Proxy with options
-	// nolint
 	ProxyOption func(p *Proxy)
 	// ImplementFunc function for proxy impl of RPCService functions
 	ImplementFunc func(p *Proxy, v common.RPCService)
@@ -60,12 +59,12 @@ var (
 
 // NewProxy create service proxy.
 func NewProxy(invoke protocol.Invoker, callback interface{}, attachments map[string]string) *Proxy {
-	return NewProxyWith(invoke, callback, attachments,
+	return NewProxyWithOptions(invoke, callback, attachments,
 		WithProxyImplementFunc(DefaultProxyImplementFunc))
 }
 
 // NewProxy create service proxy.
-func NewProxyWith(invoke protocol.Invoker, callback interface{}, attachments map[string]string, opts ...ProxyOption) *Proxy {
+func NewProxyWithOptions(invoke protocol.Invoker, callback interface{}, attachments map[string]string, opts ...ProxyOption) *Proxy {
 	p := &Proxy{
 		invoke:      invoke,
 		callback:    callback,
@@ -94,7 +93,6 @@ func (p *Proxy) Implement(v common.RPCService) {
 		p.implement(p, v)
 		p.rpc = v
 	})
-
 }
 
 // Get gets rpc service instance.

--- a/common/proxy/proxy.go
+++ b/common/proxy/proxy.go
@@ -63,7 +63,7 @@ func NewProxy(invoke protocol.Invoker, callback interface{}, attachments map[str
 		WithProxyImplementFunc(DefaultProxyImplementFunc))
 }
 
-// NewProxy create service proxy.
+// NewProxyWithOptions create service proxy with options.
 func NewProxyWithOptions(invoke protocol.Invoker, callback interface{}, attachments map[string]string, opts ...ProxyOption) *Proxy {
 	p := &Proxy{
 		invoke:      invoke,
@@ -76,6 +76,7 @@ func NewProxyWithOptions(invoke protocol.Invoker, callback interface{}, attachme
 	return p
 }
 
+// WithProxyImplementFunc an option function to setup proxy.ImplementFunc
 func WithProxyImplementFunc(f ImplementFunc) ProxyOption {
 	return func(p *Proxy) {
 		p.implement = f
@@ -110,6 +111,7 @@ func (p *Proxy) GetInvoker() protocol.Invoker {
 	return p.invoke
 }
 
+// DefaultProxyImplementFunc the default function for proxy impl
 func DefaultProxyImplementFunc(p *Proxy, v common.RPCService) {
 	// check parameters, incoming interface must be a elem's pointer.
 	valueOf := reflect.ValueOf(v)

--- a/common/proxy/proxy.go
+++ b/common/proxy/proxy.go
@@ -40,22 +40,46 @@ import (
 type Proxy struct {
 	rpc         common.RPCService
 	invoke      protocol.Invoker
-	callBack    interface{}
+	callback    interface{}
 	attachments map[string]string
-
-	once sync.Once
+	implement   ImplementFunc
+	once        sync.Once
 }
+
+type (
+	// ProxyOption a function to init Proxy with options
+	// nolint
+	ProxyOption func(p *Proxy)
+	// ImplementFunc function for proxy impl of RPCService functions
+	ImplementFunc func(p *Proxy, v common.RPCService)
+)
 
 var (
 	typError = reflect.Zero(reflect.TypeOf((*error)(nil)).Elem()).Type()
 )
 
 // NewProxy create service proxy.
-func NewProxy(invoke protocol.Invoker, callBack interface{}, attachments map[string]string) *Proxy {
-	return &Proxy{
+func NewProxy(invoke protocol.Invoker, callback interface{}, attachments map[string]string) *Proxy {
+	return NewProxyWith(invoke, callback, attachments,
+		WithProxyImplementFunc(DefaultProxyImplementFunc))
+}
+
+// NewProxy create service proxy.
+func NewProxyWith(invoke protocol.Invoker, callback interface{}, attachments map[string]string, opts ...ProxyOption) *Proxy {
+	p := &Proxy{
 		invoke:      invoke,
-		callBack:    callBack,
+		callback:    callback,
 		attachments: attachments,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+func WithProxyImplementFunc(f ImplementFunc) ProxyOption {
+	return func(p *Proxy) {
+		p.implement = f
 	}
 }
 
@@ -66,6 +90,29 @@ func NewProxy(invoke protocol.Invoker, callBack interface{}, attachments map[str
 //  		Yyy func(ctx context.Context, args []interface{}, rsp *Zzz) error
 // 		}
 func (p *Proxy) Implement(v common.RPCService) {
+	p.once.Do(func() {
+		p.implement(p, v)
+		p.rpc = v
+	})
+
+}
+
+// Get gets rpc service instance.
+func (p *Proxy) Get() common.RPCService {
+	return p.rpc
+}
+
+// GetCallback gets callback.
+func (p *Proxy) GetCallback() interface{} {
+	return p.callback
+}
+
+// GetInvoker gets Invoker.
+func (p *Proxy) GetInvoker() protocol.Invoker {
+	return p.invoke
+}
+
+func DefaultProxyImplementFunc(p *Proxy, v common.RPCService) {
 	// check parameters, incoming interface must be a elem's pointer.
 	valueOf := reflect.ValueOf(v)
 	logger.Debugf("[Implement] reflect.TypeOf: %s", valueOf.String())
@@ -138,7 +185,7 @@ func (p *Proxy) Implement(v common.RPCService) {
 
 			inv = invocation_impl.NewRPCInvocationWithOptions(invocation_impl.WithMethodName(methodName),
 				invocation_impl.WithArguments(inIArr), invocation_impl.WithReply(reply.Interface()),
-				invocation_impl.WithCallBack(p.callBack), invocation_impl.WithParameterValues(inVArr))
+				invocation_impl.WithCallBack(p.callback), invocation_impl.WithParameterValues(inVArr))
 
 			for k, value := range p.attachments {
 				inv.SetAttachments(k, value)
@@ -215,23 +262,4 @@ func (p *Proxy) Implement(v common.RPCService) {
 		}
 	}
 
-	p.once.Do(func() {
-		p.rpc = v
-	})
-
-}
-
-// Get gets rpc service instance.
-func (p *Proxy) Get() common.RPCService {
-	return p.rpc
-}
-
-// GetCallback gets callback.
-func (p *Proxy) GetCallback() interface{} {
-	return p.callBack
-}
-
-// GetInvoker gets Invoker.
-func (p *Proxy) GetInvoker() protocol.Invoker {
-	return p.invoke
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/contributing.md before commit pull request. 
-->

**What this PR does**:

Ftr: Add Prox ImplementFunc to allow override impl 

重构Proxy，添加ImplementFunc函数，允许项目对Proxy的代理实现进行重新实现。

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

在网关泛调用场景下，当前GenericService实现需要修改对返回数据的处理逻辑。
目前ProxyFactory允许自定义注册，但其创建的proxy.Proxy无法重新实现。

```release-note
Ftr: Add Proxy ImplementFunc to allow override impl 
```