### PR TITLE
远程调用次数变量读取未使用原子操作

### DIFF
--- a/protocol/dubbo/dubbo_invoker.go
+++ b/protocol/dubbo/dubbo_invoker.go
@@ -87,7 +87,7 @@ func (di *DubboInvoker) Invoke(ctx context.Context, invocation protocol.Invocati
 		err    error
 		result protocol.RPCResult
 	)
-	if di.reqNum < 0 {
+	if atomic.LoadInt64(&di.reqNum) < 0 {
 		// Generally, the case will not happen, because the invoker has been removed
 		// from the invoker list before destroy,so no new request will enter the destroyed invoker
 		logger.Warnf("this dubboInvoker is destroyed")


### PR DESCRIPTION
远程调用次数变量读取未使用原子操作

What this PR does:
修订远程调用次数读未使用原子操作
Which issue(s) this PR fixes:

Fixes #1025


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note

```