### PR TITLE
add read configuration from the command line when start

### DIFF
--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -64,7 +64,7 @@ func init() {
 	fs := flag.NewFlagSet("log_config", flag.ContinueOnError)
 	logConfFile := fs.String("logConf", "", "default log config path")
 	fs.Parse(os.Args[1:])
-	for len(fs.Args()) != 0{
+	for len(fs.Args()) != 0 {
 		fs.Parse(fs.Args()[1:])
 	}
 	err := InitLog(*logConfFile)

--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -18,6 +18,7 @@
 package logger
 
 import (
+	"flag"
 	"io/ioutil"
 	"log"
 	"os"
@@ -30,10 +31,6 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"gopkg.in/yaml.v2"
-)
-
-import (
-	"github.com/apache/dubbo-go/common/constant"
 )
 
 var (
@@ -64,8 +61,13 @@ func init() {
 	if logger != nil {
 		return
 	}
-	logConfFile := os.Getenv(constant.APP_LOG_CONF_FILE)
-	err := InitLog(logConfFile)
+	fs := flag.NewFlagSet("log_config", flag.ContinueOnError)
+	logConfFile := fs.String("logConf", "", "default log config path")
+	fs.Parse(os.Args[1:])
+	for len(fs.Args()) != 0{
+		fs.Parse(fs.Args()[1:])
+	}
+	err := InitLog(*logConfFile)
 	if err != nil {
 		log.Printf("[InitLog] warn: %v", err)
 	}

--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -33,6 +33,10 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+import (
+	"github.com/apache/dubbo-go/common/constant"
+)
+
 var (
 	logger Logger
 )
@@ -61,8 +65,9 @@ func init() {
 	if logger != nil {
 		return
 	}
-	fs := flag.NewFlagSet("log_config", flag.ContinueOnError)
-	logConfFile := fs.String("logConf", "", "default log config path")
+
+	fs := flag.NewFlagSet("log", flag.ContinueOnError)
+	logConfFile := fs.String("logConf", os.Getenv(constant.APP_LOG_CONF_FILE), "default log config path")
 	fs.Parse(os.Args[1:])
 	for len(fs.Args()) != 0 {
 		fs.Parse(fs.Args()[1:])

--- a/config/config_loader.go
+++ b/config/config_loader.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -63,9 +64,14 @@ func init() {
 		confProFile string
 	)
 
-	confConFile = os.Getenv(constant.CONF_CONSUMER_FILE_PATH)
-	confProFile = os.Getenv(constant.CONF_PROVIDER_FILE_PATH)
-	confRouterFile = os.Getenv(constant.CONF_ROUTER_FILE_PATH)
+	fs := flag.NewFlagSet("config_loader", flag.ContinueOnError)
+	fs.StringVar(&confConFile, "conConf", "", "default client config path")
+	fs.StringVar(&confProFile, "proConf", "", "default server config path")
+	fs.StringVar(&confRouterFile, "rouConf", "", "default router config path")
+	fs.Parse(os.Args[1:])
+	for len(fs.Args()) != 0{
+		fs.Parse(fs.Args()[1:])
+	}
 
 	if errCon := ConsumerInit(confConFile); errCon != nil {
 		log.Printf("[consumerInit] %#v", errCon)

--- a/config/config_loader.go
+++ b/config/config_loader.go
@@ -69,7 +69,7 @@ func init() {
 	fs.StringVar(&confProFile, "proConf", "", "default server config path")
 	fs.StringVar(&confRouterFile, "rouConf", "", "default router config path")
 	fs.Parse(os.Args[1:])
-	for len(fs.Args()) != 0{
+	for len(fs.Args()) != 0 {
 		fs.Parse(fs.Args()[1:])
 	}
 

--- a/config/config_loader.go
+++ b/config/config_loader.go
@@ -64,10 +64,10 @@ func init() {
 		confProFile string
 	)
 
-	fs := flag.NewFlagSet("config_loader", flag.ContinueOnError)
-	fs.StringVar(&confConFile, "conConf", "", "default client config path")
-	fs.StringVar(&confProFile, "proConf", "", "default server config path")
-	fs.StringVar(&confRouterFile, "rouConf", "", "default router config path")
+	fs := flag.NewFlagSet("config", flag.ContinueOnError)
+	fs.StringVar(&confConFile, "conConf", os.Getenv(constant.CONF_CONSUMER_FILE_PATH), "default client config path")
+	fs.StringVar(&confProFile, "proConf", os.Getenv(constant.CONF_PROVIDER_FILE_PATH), "default server config path")
+	fs.StringVar(&confRouterFile, "rouConf", os.Getenv(constant.CONF_ROUTER_FILE_PATH), "default router config path")
 	fs.Parse(os.Args[1:])
 	for len(fs.Args()) != 0 {
 		fs.Parse(fs.Args()[1:])


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/contributing.md before commit pull request. 
-->

**What this PR does**:
Add feature :
Developers can add command line parameters when starting the program to set the location of log, provider, consumer and router configuration files.
If no parameters are added at startup, it will be read from the default environment variables **same as before**.
If you set environment variables and add parameters at startup, it will run according to the startup parameters.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
+ In https://github.com/dubbogo/dubbo-samples/dubbo-samples/golang/helloworld/dubbo/go-server/app
   You can start server width out setting environment variables, like this:
   ```shell
   go run . -proConf ../profiles/dev/server.yml -logConf ../profiles/dev/log.yml
   ```
   In https://github.com/dubbogo/dubbo-samples/dubbo-samples/golang/helloworld/dubbo/go-client/app
   You can start client like this:
   ```shell
   go run . -conConf ../profiles/dev/client.yml -logConf ../profiles/dev/log.yml
   ```
+ If you don’t want to start in this way, you can set the environment variables in go-server/app like this:
   ```shell
   export CONF_PROVIDER_FILE_PATH="../profiles/dev/server.yml"
   export APP_LOG_CONF_FILE="../profiles/dev/log.yml"
   ```
   then start the server
   ```shell
   go run .
   ```
+ if you set environment variables and parameters like this:
   ```shell
   export CONF_PROVIDER_FILE_PATH="../profiles/dev/server.yml"
   export APP_LOG_CONF_FILE="../profiles/dev/log.yml"
   go run . -conConf ../profiles/dev/client_new.yml
   ```
   under this circumstance “../profiles/dev/client_new.yml” is valid
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```