### PR TITLE
1.5

### DIFF
--- a/config/base_config.go
+++ b/config/base_config.go
@@ -19,6 +19,7 @@ package config
 
 import (
 	"bytes"
+	"github.com/apache/dubbo-go/common/yaml"
 	"reflect"
 	"strconv"
 	"strings"
@@ -53,6 +54,19 @@ type BaseConfig struct {
 
 	// cache file used to store the current used configurations.
 	CacheFile string `yaml:"cache_file" json:"cache_file,omitempty" property:"cache_file"`
+}
+
+func BaseInit(confBaseFile string) error {
+	if confBaseFile == "" {
+		return perrors.Errorf("application configure(base) file name is nil")
+	}
+	baseConfig = &BaseConfig{}
+	fileStream, err := yaml.UnmarshalYMLConfig(confBaseFile, baseConfig)
+	if err != nil {
+		return perrors.Errorf("unmarshalYmlConfig error %v", perrors.WithStack(err))
+	}
+	baseConfig.fileStream = bytes.NewBuffer(fileStream)
+	return nil
 }
 
 // nolint

--- a/config/config_loader.go
+++ b/config/config_loader.go
@@ -56,6 +56,7 @@ var (
 
 	maxWait        = 3
 	confRouterFile string
+	confBaseFile   string
 )
 
 // loaded consumer & provider config from xxx.yml, and log config from xxx.xml
@@ -75,7 +76,7 @@ func DefaultInit() []LoaderInitOption {
 		fs.Parse(fs.Args()[1:])
 	}
 
-	return []LoaderInitOption{RouterInitOption(confRouterFile), ConsumerInitOption(confConFile), ProviderInitOption(confProFile)}
+	return []LoaderInitOption{RouterInitOption(confRouterFile), BaseInitOption(""), ConsumerInitOption(confConFile), ProviderInitOption(confProFile)}
 }
 
 func checkRegistries(registries map[string]*RegistryConfig, singleRegistry *RegistryConfig) {
@@ -328,17 +329,11 @@ func Load() {
 func LoadWithOptions(options ...LoaderInitOption) {
 
 	for _, option := range options {
+		option.init()
+	}
+	for _, option := range options {
 		option.apply()
 	}
-	// init the global event dispatcher
-	extension.SetAndInitGlobalDispatcher(GetBaseConfig().EventDispatcherType)
-
-	// start the metadata report if config set
-	if err := startMetadataReport(GetApplicationConfig().MetadataType, GetBaseConfig().MetadataReportConfig); err != nil {
-		logger.Errorf("Provider starts metadata report error, and the error is {%#v}", err)
-		return
-	}
-
 	// init the shutdown callback
 	GracefulShutdownInit()
 }

--- a/config/config_loader.go
+++ b/config/config_loader.go
@@ -60,7 +60,7 @@ var (
 
 // loaded consumer & provider config from xxx.yml, and log config from xxx.xml
 // Namely: dubbo.consumer.xml & dubbo.provider.xml in java dubbo
-func DefaultInit() (routerInitOption, consumerInitOption, providerInitOption LoaderInitOption) {
+func DefaultInit() []LoaderInitOption {
 	var (
 		confConFile string
 		confProFile string
@@ -75,7 +75,7 @@ func DefaultInit() (routerInitOption, consumerInitOption, providerInitOption Loa
 		fs.Parse(fs.Args()[1:])
 	}
 
-	return RouterInitOption(confRouterFile), ConsumerInitOption(confConFile), ProviderInitOption(confProFile)
+	return []LoaderInitOption{RouterInitOption(confRouterFile), ConsumerInitOption(confConFile), ProviderInitOption(confProFile)}
 }
 
 func checkRegistries(registries map[string]*RegistryConfig, singleRegistry *RegistryConfig) {
@@ -321,14 +321,11 @@ func initRouter() {
 
 // Load Dubbo Init
 func Load() {
-	routerInitOption, consumerInitOption, providerInitOption := DefaultInit()
-	LoadWithOptions(routerInitOption, consumerInitOption, providerInitOption)
+	options := DefaultInit()
+	LoadWithOptions(options...)
 }
 
-func LoadWithOptions(routerInitOption, consumerInitOption, providerInitOption LoaderInitOption) {
-	if routerInitOption != nil {
-		routerInitOption.apply()
-	}
+func LoadWithOptions(options ...LoaderInitOption) {
 
 	// init the global event dispatcher
 	extension.SetAndInitGlobalDispatcher(GetBaseConfig().EventDispatcherType)
@@ -339,12 +336,8 @@ func LoadWithOptions(routerInitOption, consumerInitOption, providerInitOption Lo
 		return
 	}
 
-	if consumerInitOption != nil {
-		consumerInitOption.apply()
-	}
-
-	if providerInitOption != nil {
-		providerInitOption.apply()
+	for _, option := range options {
+		option.apply()
 	}
 
 	// init the shutdown callback

--- a/config/config_loader.go
+++ b/config/config_loader.go
@@ -327,6 +327,9 @@ func Load() {
 
 func LoadWithOptions(options ...LoaderInitOption) {
 
+	for _, option := range options {
+		option.apply()
+	}
 	// init the global event dispatcher
 	extension.SetAndInitGlobalDispatcher(GetBaseConfig().EventDispatcherType)
 
@@ -334,10 +337,6 @@ func LoadWithOptions(options ...LoaderInitOption) {
 	if err := startMetadataReport(GetApplicationConfig().MetadataType, GetBaseConfig().MetadataReportConfig); err != nil {
 		logger.Errorf("Provider starts metadata report error, and the error is {%#v}", err)
 		return
-	}
-
-	for _, option := range options {
-		option.apply()
 	}
 
 	// init the shutdown callback

--- a/config/config_loader_options.go
+++ b/config/config_loader_options.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package config
 
 import (

--- a/config/config_loader_options.go
+++ b/config/config_loader_options.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"log"
+)
+
+type LoaderInitOption interface {
+	apply()
+}
+
+type optionFunc func()
+
+func (f optionFunc) apply() {
+	f()
+}
+
+func ConsumerInitOption(confConFile string) LoaderInitOption {
+	return optionFunc(func() {
+		if errCon := ConsumerInit(confConFile); errCon != nil {
+			log.Printf("[consumerInit] %#v", errCon)
+			consumerConfig = nil
+		} else {
+			// Even though baseConfig has been initialized, we override it
+			// because we think read from config file is correct config
+			baseConfig = &consumerConfig.BaseConfig
+		}
+		loadConsumerConfig()
+	})
+}
+
+func ProviderInitOption(confProFile string) LoaderInitOption {
+	return optionFunc(func() {
+		if errPro := ProviderInit(confProFile); errPro != nil {
+			log.Printf("[providerInit] %#v", errPro)
+			providerConfig = nil
+		} else {
+			// Even though baseConfig has been initialized, we override it
+			// because we think read from config file is correct config
+			baseConfig = &providerConfig.BaseConfig
+		}
+		loadProviderConfig()
+	})
+}
+
+func RouterInitOption(crf string) LoaderInitOption {
+	return optionFunc(func() {
+		confRouterFile = crf
+		initRouter()
+	})
+}

--- a/config/config_loader_options.go
+++ b/config/config_loader_options.go
@@ -1,50 +1,97 @@
 package config
 
 import (
+	"github.com/apache/dubbo-go/common/extension"
+	"github.com/apache/dubbo-go/common/logger"
 	"log"
 )
 
 type LoaderInitOption interface {
+	init()
 	apply()
 }
 
-type optionFunc func()
+type optionFunc struct {
+	initFunc  func()
+	applyFunc func()
+}
 
-func (f optionFunc) apply() {
-	f()
+func (f *optionFunc) init() {
+	f.initFunc()
+}
+
+func (f *optionFunc) apply() {
+	f.applyFunc()
 }
 
 func ConsumerInitOption(confConFile string) LoaderInitOption {
-	return optionFunc(func() {
-		if errCon := ConsumerInit(confConFile); errCon != nil {
-			log.Printf("[consumerInit] %#v", errCon)
-			consumerConfig = nil
-		} else {
-			// Even though baseConfig has been initialized, we override it
-			// because we think read from config file is correct config
-			baseConfig = &consumerConfig.BaseConfig
-		}
-		loadConsumerConfig()
-	})
+	return &optionFunc{
+		func() {
+			if errCon := ConsumerInit(confConFile); errCon != nil {
+				log.Printf("[consumerInit] %#v", errCon)
+				consumerConfig = nil
+			} else if confBaseFile == "" {
+				// Even though baseConfig has been initialized, we override it
+				// because we think read from config file is correct config
+				baseConfig = &consumerConfig.BaseConfig
+			}
+		},
+		func() {
+			loadConsumerConfig()
+		},
+	}
 }
 
 func ProviderInitOption(confProFile string) LoaderInitOption {
-	return optionFunc(func() {
-		if errPro := ProviderInit(confProFile); errPro != nil {
-			log.Printf("[providerInit] %#v", errPro)
-			providerConfig = nil
-		} else {
-			// Even though baseConfig has been initialized, we override it
-			// because we think read from config file is correct config
-			baseConfig = &providerConfig.BaseConfig
-		}
-		loadProviderConfig()
-	})
+	return &optionFunc{
+		func() {
+			if errPro := ProviderInit(confProFile); errPro != nil {
+				log.Printf("[providerInit] %#v", errPro)
+				providerConfig = nil
+			} else if confBaseFile == "" {
+				// Even though baseConfig has been initialized, we override it
+				// because we think read from config file is correct config
+				baseConfig = &providerConfig.BaseConfig
+			}
+		},
+		func() {
+			loadProviderConfig()
+		},
+	}
 }
 
 func RouterInitOption(crf string) LoaderInitOption {
-	return optionFunc(func() {
-		confRouterFile = crf
-		initRouter()
-	})
+	return &optionFunc{
+		func() {
+			confRouterFile = crf
+		},
+		func() {
+			initRouter()
+		},
+	}
+}
+
+func BaseInitOption(cbf string) LoaderInitOption {
+	return &optionFunc{
+		func() {
+			if cbf == "" {
+				return
+			}
+			confBaseFile = cbf
+			if err := BaseInit(cbf); err != nil {
+				log.Printf("[BaseInit] %#v", err)
+				baseConfig = nil
+			}
+		},
+		func() {
+			// init the global event dispatcher
+			extension.SetAndInitGlobalDispatcher(GetBaseConfig().EventDispatcherType)
+
+			// start the metadata report if config set
+			if err := startMetadataReport(GetApplicationConfig().MetadataType, GetBaseConfig().MetadataReportConfig); err != nil {
+				logger.Errorf("Provider starts metadata report error, and the error is {%#v}", err)
+				return
+			}
+		},
+	}
 }

--- a/config/config_loader_test.go
+++ b/config/config_loader_test.go
@@ -45,6 +45,12 @@ import (
 	"github.com/apache/dubbo-go/registry"
 )
 
+func init() {
+	for _, option := range DefaultInit() {
+		option.init()
+	}
+}
+
 const mockConsumerConfigPath = "./testdata/consumer_config.yml"
 const mockProviderConfigPath = "./testdata/provider_config.yml"
 


### PR DESCRIPTION
解决问题：
1、默认使用init初始化，灵活性欠佳，集成进例如cobra这样的框架不够方便，参数存在冲突。
2、原初始化后如果baseconf没有生成，没有相应的set方法重新设置
3、增加baseconf配置文件，优先使用配置文件加载，如不使用配置文件则按原先得方式加载
//保留原初始化方式，把原来的init()中的处理逻辑集成进Load()函数，使用方式不变。
`config.Load()`
//config_loader 增加option 功能，实现按需初始化。
`
//保留原初始化方式，把原来的init()中的处理逻辑集成进Load()函数，使用方式不变。
config.Load()
//新的初始化方式（按需初始化）
config.LoadWithOptions(config.BaseInitOption(""),config.ConsumerInitOption(confConFile))
//目前转化成四个初始化选项：
//RouterInitOption、ConsumerInitOption、ProviderInitOption、BaseInitOption
