### PR TITLE
Fix map iteration order

### DIFF
--- a/config/config_api_test.go
+++ b/config/config_api_test.go
@@ -161,11 +161,11 @@ func TestNewProviderConfig(t *testing.T) {
 	}
 	assert.NotNil(t, testProviderConfig.Registries)
 
-	if registry ,ok := testProviderConfig.Registries["demoConsul"];ok {
+	if registry, ok := testProviderConfig.Registries["demoConsul"]; ok {
 		assert.Equal(t, registry, defaultConsulRegistry)
 	}
 
-	if registry ,ok := testProviderConfig.Registries["demoNacos"];ok {
+	if registry, ok := testProviderConfig.Registries["demoNacos"]; ok {
 		assert.Equal(t, registry, defaultNacosRegistry)
 	}
 

--- a/config/config_api_test.go
+++ b/config/config_api_test.go
@@ -160,16 +160,13 @@ func TestNewProviderConfig(t *testing.T) {
 		assert.Equal(t, v, serviceConfig)
 	}
 	assert.NotNil(t, testProviderConfig.Registries)
-	i := 0
-	for k, v := range testProviderConfig.Registries {
-		if i == 0 {
-			assert.Equal(t, k, "demoConsul")
-			assert.Equal(t, v, defaultConsulRegistry)
-			i++
-		} else {
-			assert.Equal(t, k, "demoNacos")
-			assert.Equal(t, v, defaultNacosRegistry)
-		}
+
+	if registry ,ok := testProviderConfig.Registries["demoConsul"];ok {
+		assert.Equal(t, registry, defaultConsulRegistry)
+	}
+
+	if registry ,ok := testProviderConfig.Registries["demoNacos"];ok {
+		assert.Equal(t, registry, defaultNacosRegistry)
 	}
 
 	assert.NotNil(t, testProviderConfig.Protocols)

--- a/registry/nacos/registry_test.go
+++ b/registry/nacos/registry_test.go
@@ -69,7 +69,7 @@ func TestNacosRegistry_Register(t *testing.T) {
 	service, _ := nacosReg.namingClient.GetService(vo.GetServiceParam{ServiceName: "providers:com.ikurento.user.UserProvider:1.0.0:guangzhou-idc"})
 	data, _ := json.Marshal(service)
 	t.Logf(string(data))
-	//assert.Equal(t, 1, len(service.Hosts))
+	assert.Equal(t, 1, len(service.Hosts))
 }
 
 func TestNacosRegistry_Subscribe(t *testing.T) {
@@ -107,14 +107,14 @@ func TestNacosRegistry_Subscribe(t *testing.T) {
 		return
 	}
 
-	//serviceEvent, _ := listener.Next()
-	//assert.NoError(t, err)
-	//if err != nil {
-	//	t.Errorf("listener error:%s \n", err.Error())
-	//	return
-	//}
-	//t.Logf("serviceEvent:%+v \n", serviceEvent)
-	//assert.Regexp(t, ".*ServiceEvent{Action{add}.*", serviceEvent.String())
+	serviceEvent, _ := listener.Next()
+	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("listener error:%s \n", err.Error())
+		return
+	}
+	t.Logf("serviceEvent:%+v \n", serviceEvent)
+	assert.Regexp(t, ".*ServiceEvent{Action{add}.*", serviceEvent.String())
 
 }
 

--- a/registry/nacos/registry_test.go
+++ b/registry/nacos/registry_test.go
@@ -69,7 +69,7 @@ func TestNacosRegistry_Register(t *testing.T) {
 	service, _ := nacosReg.namingClient.GetService(vo.GetServiceParam{ServiceName: "providers:com.ikurento.user.UserProvider:1.0.0:guangzhou-idc"})
 	data, _ := json.Marshal(service)
 	t.Logf(string(data))
-	assert.Equal(t, 1, len(service.Hosts))
+	//assert.Equal(t, 1, len(service.Hosts))
 }
 
 func TestNacosRegistry_Subscribe(t *testing.T) {
@@ -100,20 +100,21 @@ func TestNacosRegistry_Subscribe(t *testing.T) {
 
 	regurl.SetParam(constant.ROLE_KEY, strconv.Itoa(common.CONSUMER))
 	reg2, _ := newNacosRegistry(regurl)
-	listener, err := reg2.(*nacosRegistry).subscribe(testUrl)
+	_, err = reg2.(*nacosRegistry).subscribe(testUrl)
 	assert.Nil(t, err)
 	if err != nil {
 		t.Errorf("subscribe error:%s \n", err.Error())
 		return
 	}
-	serviceEvent, _ := listener.Next()
-	assert.NoError(t, err)
-	if err != nil {
-		t.Errorf("listener error:%s \n", err.Error())
-		return
-	}
-	t.Logf("serviceEvent:%+v \n", serviceEvent)
-	assert.Regexp(t, ".*ServiceEvent{Action{add}.*", serviceEvent.String())
+
+	//serviceEvent, _ := listener.Next()
+	//assert.NoError(t, err)
+	//if err != nil {
+	//	t.Errorf("listener error:%s \n", err.Error())
+	//	return
+	//}
+	//t.Logf("serviceEvent:%+v \n", serviceEvent)
+	//assert.Regexp(t, ".*ServiceEvent{Action{add}.*", serviceEvent.String())
 
 }
 


### PR DESCRIPTION
go map在迭代的时候添加顺序和遍历顺序是不能保证一致的，因此修改了测试用例