### PR TITLE
Fix: when provider restart,  somtimes consumer  can not discover the new service  

### DIFF
--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -79,6 +79,7 @@ func newZkRegistry(url *common.URL) (registry.Registry, error) {
 		return nil, err
 	}
 
+	r.WaitGroup().Add(1) //zk client start successful, then wg +1
 	go zookeeper.HandleClientRestart(r)
 
 	r.listener = zookeeper.NewZkEventListener(r.client)

--- a/remoting/zookeeper/listener.go
+++ b/remoting/zookeeper/listener.go
@@ -182,7 +182,7 @@ func (l *ZkEventListener) handleZkNodeEvent(zkPath string, children []string, li
 				logger.Warnf("delete zkNode{%s}", node)
 				listener.DataChange(remoting.Event{Path: node, Action: remoting.EventTypeDel})
 				l.pathMapLock.Lock()
-				delete(l.pathMap, zkPath)
+				delete(l.pathMap, node)
 				l.pathMapLock.Unlock()
 			}
 			logger.Warnf("handleZkNodeEvent->listenSelf(zk path{%s}) goroutine exit now", node)
@@ -200,7 +200,7 @@ func (l *ZkEventListener) handleZkNodeEvent(zkPath string, children []string, li
 		logger.Warnf("delete oldNode{%s}", oldNode)
 		listener.DataChange(remoting.Event{Path: oldNode, Action: remoting.EventTypeDel})
 		l.pathMapLock.Lock()
-		delete(l.pathMap, zkPath)
+		delete(l.pathMap, oldNode)
 		l.pathMapLock.Unlock()
 	}
 }

--- a/remoting/zookeeper/listener.go
+++ b/remoting/zookeeper/listener.go
@@ -199,6 +199,9 @@ func (l *ZkEventListener) handleZkNodeEvent(zkPath string, children []string, li
 		oldNode = path.Join(zkPath, n)
 		logger.Warnf("delete oldNode{%s}", oldNode)
 		listener.DataChange(remoting.Event{Path: oldNode, Action: remoting.EventTypeDel})
+		l.pathMapLock.Lock()
+		delete(l.pathMap, zkPath)
+		l.pathMapLock.Unlock()
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/contributing.md before commit pull request.
-->

**What this PR does**:
fix when provider restart,  consumer automatic can not discover service when somtimes 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```