### PR TITLE
modify map use in nacos service_discovery; Fix issue-1165

### DIFF
--- a/metadata/service/inmemory/service.go
+++ b/metadata/service/inmemory/service.go
@@ -164,7 +164,7 @@ func (mts *MetadataService) ExportURL(url *common.URL) (bool, error) {
 	mts.mOnce.Do(func() {
 		mts.metadataInfo = common.NewMetadataInfWithApp(config.GetApplicationConfig().Name)
 	})
-	mts.metadataInfo.AddService(common.NewServiceInfoWithUrl(url))
+	mts.metadataInfo.AddService(common.NewServiceInfoWithURL(url))
 	return mts.addURL(mts.exportedServiceURLs, url), nil
 }
 
@@ -175,7 +175,7 @@ func (mts *MetadataService) UnexportURL(url *common.URL) error {
 		return nil
 	}
 	if mts.metadataInfo != nil {
-		mts.metadataInfo.RemoveService(common.NewServiceInfoWithUrl(url))
+		mts.metadataInfo.RemoveService(common.NewServiceInfoWithURL(url))
 	}
 	mts.removeURL(mts.exportedServiceURLs, url)
 	return nil

--- a/registry/nacos/service_discovery.go
+++ b/registry/nacos/service_discovery.go
@@ -313,18 +313,11 @@ var (
 )
 
 // newNacosServiceDiscovery will create new service discovery instance
-// use double-check pattern to reduce race condition
 func newNacosServiceDiscovery(name string) (registry.ServiceDiscovery, error) {
-	instance, ok := instanceMap[name]
-	if ok {
-		return instance, nil
-	}
-
 	initLock.Lock()
 	defer initLock.Unlock()
 
-	// double check
-	instance, ok = instanceMap[name]
+	instance, ok := instanceMap[name]
 	if ok {
 		return instance, nil
 	}
@@ -350,10 +343,11 @@ func newNacosServiceDiscovery(name string) (registry.ServiceDiscovery, error) {
 
 	descriptor := fmt.Sprintf("nacos-service-discovery[%s]", remoteConfig.Address)
 
-	return &nacosServiceDiscovery{
+	newInstance := &nacosServiceDiscovery{
 		group:             group,
 		namingClient:      client,
 		descriptor:        descriptor,
 		registryInstances: []registry.ServiceInstance{},
-	}, nil
+	}
+	return newInstance, nil
 }

--- a/registry/nacos/service_discovery.go
+++ b/registry/nacos/service_discovery.go
@@ -349,5 +349,6 @@ func newNacosServiceDiscovery(name string) (registry.ServiceDiscovery, error) {
 		descriptor:        descriptor,
 		registryInstances: []registry.ServiceInstance{},
 	}
+	instanceMap[name] = newInstance
 	return newInstance, nil
 }


### PR DESCRIPTION
**What this PR does**:
fix issue-1165 , remove double-check when reading ServiceDiscovery instanceMap

**Which issue(s) this PR fixes**:
Fixes #1165 

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
NONE
