### PR TITLE
Fix: Dead lock when zkListener is added duplicately

### DIFF
--- a/remoting/zookeeper/listener.go
+++ b/remoting/zookeeper/listener.go
@@ -89,6 +89,7 @@ func (l *ZkEventListener) listenServiceNodeEvent(zkPath string, listener ...remo
 	l.pathMapLock.Lock()
 	a, ok := l.pathMap[zkPath]
 	if !ok || a.Load() > 1 {
+		l.pathMapLock.Unlock()
 		return false
 	}
 	a.Inc()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/contributing.md before commit pull request.
-->

**What this PR does**:

- fix dead lock when listener has been added to `pathMap`.
- integrate unit tests for `registry/zookeeper/service_discovery_test.go` that are dependent on `zk.TestCluster`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1233

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```