### PR TITLE
Fix/zkname

### DIFF
--- a/config_center/zookeeper/impl.go
+++ b/config_center/zookeeper/impl.go
@@ -64,7 +64,7 @@ func newZookeeperDynamicConfiguration(url *common.URL) (*zookeeperDynamicConfigu
 		url:      url,
 		rootPath: "/" + url.GetParam(constant.CONFIG_NAMESPACE_KEY, config_center.DEFAULT_GROUP) + "/config",
 	}
-	err := zookeeper.ValidateZookeeperClient(c, ZkClient)
+	err := zookeeper.ValidateZookeeperClient(c, url.Location)
 	if err != nil {
 		logger.Errorf("zookeeper client start error ,error message is %v", err)
 		return nil, err

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -40,11 +40,6 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/remoting/zookeeper"
 )
 
-const (
-	// RegistryZkClient zk client name
-	RegistryZkClient = "zk registry"
-)
-
 func init() {
 	extension.SetRegistry("zookeeper", newZkRegistry)
 }

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -74,7 +74,7 @@ func newZkRegistry(url *common.URL) (registry.Registry, error) {
 	}
 	r.InitBaseRegistry(url, r)
 
-	err = zookeeper.ValidateZookeeperClient(r, RegistryZkClient)
+	err = zookeeper.ValidateZookeeperClient(r, url.Location)
 	if err != nil {
 		return nil, err
 	}

--- a/registry/zookeeper/service_discovery.go
+++ b/registry/zookeeper/service_discovery.go
@@ -45,7 +45,7 @@ import (
 )
 
 const (
-	// RegistryZkClient zk client name
+	// ServiceDiscoveryZkClient zk client name
 	ServiceDiscoveryZkClient = "zk service discovery"
 )
 
@@ -108,7 +108,7 @@ func newZookeeperServiceDiscovery(name string) (registry.ServiceDiscovery, error
 		url:      url,
 		rootPath: rootPath,
 	}
-	err := zookeeper.ValidateZookeeperClient(zksd, ServiceDiscoveryZkClient)
+	err := zookeeper.ValidateZookeeperClient(zksd, url.Location)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/contributing.md before commit pull request.
-->

**What this PR does**:
Change zkname from default to url.Location, which is more clear to define the zk client. The old way would let different directories with different zk location to have same zk client, which will caust bugs in 1.5 and 3.0 's multy-zone samples.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```