### PR TITLE
performance optimization: change time.After => time.NewTimer

### DIFF
--- a/protocol/grpc/server.go
+++ b/protocol/grpc/server.go
@@ -115,7 +115,8 @@ func waitGrpcExporter(providerServices map[string]*config.ServiceConfig) {
 	t := time.NewTicker(50 * time.Millisecond)
 	defer t.Stop()
 	pLen := len(providerServices)
-	ta := time.After(10 * time.Second)
+	ta := time.NewTimer(10 * time.Second)
+	defer ta.Stop()
 
 	for {
 		select {
@@ -124,7 +125,7 @@ func waitGrpcExporter(providerServices map[string]*config.ServiceConfig) {
 			if pLen == mLen {
 				return
 			}
-		case <-ta:
+		case <-ta.C:
 			panic("wait grpc exporter timeout when start grpc server")
 		}
 	}

--- a/tools/cli/client/client.go
+++ b/tools/cli/client/client.go
@@ -143,11 +143,12 @@ func (t *TelnetClient) processSingleRequest(req *protocol.Request, userPkg inter
 	go t.readInputData(string(inputData), requestDataChannel)
 	go t.readServerData(t.conn, responseDataChannel)
 
-	timeAfter := time.After(t.responseTimeout)
+	timeAfter := time.NewTimer(t.responseTimeout)
+	defer timeAfter.Stop()
 
 	for {
 		select {
-		case <-timeAfter:
+		case <-timeAfter.C:
 			log.Println("request timeout to:", t.tcpAddr)
 			return
 		case request := <-requestDataChannel:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/contributing.md before commit pull request.
-->

**What this PR does**:
Ues time.Timer instead the time.After
```
// After waits for the duration to elapse and then sends the current time
// on the returned channel.
// It is equivalent to NewTimer(d).C.
// The underlying Timer is not recovered by the garbage collector
// until the timer fires. If efficiency is a concern, use NewTimer
// instead and call Timer.Stop if the timer is no longer needed.
func After(d Duration) <-chan Time {
	return NewTimer(d).C
}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```