### PR TITLE
url  too many colons in address

### DIFF
--- a/common/url.go
+++ b/common/url.go
@@ -270,10 +270,13 @@ func NewURL(urlString string, opts ...Option) (*URL, error) {
 	s.Password, _ = serviceURL.User.Password()
 	s.Location = serviceURL.Host
 	s.Path = serviceURL.Path
-	if strings.Contains(s.Location, ":") {
-		s.Ip, s.Port, err = net.SplitHostPort(s.Location)
-		if err != nil {
-			return &s, perrors.Errorf("net.SplitHostPort(URL.Host{%s}), error{%v}", s.Location, err)
+	for _, location := range strings.Split(s.Location, ",") {
+		if strings.Contains(location, ":") {
+			s.Ip, s.Port, err = net.SplitHostPort(location)
+			if err != nil {
+				return &s, perrors.Errorf("net.SplitHostPort(url.Host{%s}), error{%v}", s.Location, err)
+			}
+			break
 		}
 	}
 	for _, opt := range opts {


### PR DESCRIPTION
当注册中心或者元数据中心address配置为多个例如`127.0.0.1:2181,127.0.0.2:2181,127.0.0.2:2181`时

```
if strings.Contains(location, ":") {
			s.Ip, s.Port, err = net.SplitHostPort(location)
			if err != nil {
				return &s, perrors.Errorf("net.SplitHostPort(url.Host{%s}), error{%v}", s.Location, err)
			}
			break
		}
```
net.SplitHostPort(location) 方法解析会报错too many colons in address，所以url中的host和port取第一个即可


Provider starts metadata report error, and the error is {Start MetadataReport failed.: Invalid MetadataReportConfig.}