### PR TITLE
fix: #1323 delete zk registry when set defualt consumer/provider config

### DIFF
--- a/common/constant/default.go
+++ b/common/constant/default.go
@@ -94,11 +94,3 @@ const (
 	DEFAULT_LOG_CONF_FILE_PATH      = "../profiles/dev/log.yml"
 	DEFAULT_ROUTER_CONF_FILE_PATH   = "../profiles/dev/router.yml"
 )
-
-// default config value
-const (
-	DEFAULT_REGISTRY_ZK_ID       = "demoZK"
-	DEFAULT_REGISTRY_ZK_PROTOCOL = ZOOKEEPER_KEY
-	DEFAULT_REGISTRY_ZK_TIMEOUT  = "3s"
-	DEFAULT_REGISTRY_ZK_ADDRESS  = "127.0.0.1:2181"
-)

--- a/config/config_loader.go
+++ b/config/config_loader.go
@@ -95,17 +95,9 @@ func DefaultInit() []LoaderInitOption {
 
 // setDefaultValue set default value for providerConfig or consumerConfig if it is null
 func setDefaultValue(target interface{}) {
-	registryConfig := &RegistryConfig{
-		Protocol:   constant.DEFAULT_REGISTRY_ZK_PROTOCOL,
-		TimeoutStr: constant.DEFAULT_REGISTRY_ZK_TIMEOUT,
-		Address:    constant.DEFAULT_REGISTRY_ZK_ADDRESS,
-	}
 	switch target.(type) {
 	case *ProviderConfig:
 		p := target.(*ProviderConfig)
-		if len(p.Registries) == 0 && p.Registry == nil {
-			p.Registries[constant.DEFAULT_REGISTRY_ZK_ID] = registryConfig
-		}
 		if len(p.Protocols) == 0 {
 			p.Protocols[constant.DEFAULT_PROTOCOL] = &ProtocolConfig{
 				Name: constant.DEFAULT_PROTOCOL,
@@ -117,9 +109,6 @@ func setDefaultValue(target interface{}) {
 		}
 	default:
 		c := target.(*ConsumerConfig)
-		if len(c.Registries) == 0 && c.Registry == nil {
-			c.Registries[constant.DEFAULT_REGISTRY_ZK_ID] = registryConfig
-		}
 		if c.ApplicationConfig == nil {
 			c.ApplicationConfig = NewDefaultApplicationConfig()
 		}

--- a/config/config_loader_test.go
+++ b/config/config_loader_test.go
@@ -207,9 +207,6 @@ func TestSetDefaultValue(t *testing.T) {
 	proConfig := &ProviderConfig{Registries: make(map[string]*RegistryConfig), Protocols: make(map[string]*ProtocolConfig)}
 	assert.Nil(t, proConfig.ApplicationConfig)
 	setDefaultValue(proConfig)
-	assert.Equal(t, proConfig.Registries["demoZK"].Address, "127.0.0.1:2181")
-	assert.Equal(t, proConfig.Registries["demoZK"].TimeoutStr, "3s")
-	assert.Equal(t, proConfig.Registries["demoZK"].Protocol, "zookeeper")
 	assert.Equal(t, proConfig.Protocols["dubbo"].Name, "dubbo")
 	assert.Equal(t, proConfig.Protocols["dubbo"].Port, "20000")
 	assert.NotNil(t, proConfig.ApplicationConfig)
@@ -217,9 +214,6 @@ func TestSetDefaultValue(t *testing.T) {
 	conConfig := &ConsumerConfig{Registries: make(map[string]*RegistryConfig)}
 	assert.Nil(t, conConfig.ApplicationConfig)
 	setDefaultValue(conConfig)
-	assert.Equal(t, conConfig.Registries["demoZK"].Address, "127.0.0.1:2181")
-	assert.Equal(t, conConfig.Registries["demoZK"].TimeoutStr, "3s")
-	assert.Equal(t, conConfig.Registries["demoZK"].Protocol, "zookeeper")
 	assert.NotNil(t, conConfig.ApplicationConfig)
 
 }

--- a/config/reference_config.go
+++ b/config/reference_config.go
@@ -133,9 +133,9 @@ func (c *ReferenceConfig) Refer(_ interface{}) {
 
 	if len(c.urls) == 1 {
 		c.invoker = extension.GetProtocol(c.urls[0].Protocol).Refer(c.urls[0])
-		// c.URL != "" is direct call
+		// c.URL != "" is direct call, and will overide c.invoker
 		if c.URL != "" {
-			//filter
+			// filter
 			c.invoker = protocolwrapper.BuildInvokerChain(c.invoker, constant.REFERENCE_FILTER_KEY)
 
 			// cluster


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1323 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```