### PR TITLE
fix: #1320 泛化调用+应用级服务发现，客户端 panic

### DIFF
--- a/common/rpc_service.go
+++ b/common/rpc_service.go
@@ -366,7 +366,9 @@ func suiteMethod(method reflect.Method) *MethodType {
 
 	// The latest return type of the method must be error.
 	if returnType := mtype.Out(outNum - 1); returnType != typeOfError {
-		logger.Warnf("the latest return type %s of method %q is not error", returnType, mname)
+		if mname != METHOD_MAPPER {
+			logger.Warnf("the latest return type %s of method %q is not error", returnType, mname)
+		}
 		return nil
 	}
 

--- a/config/config_center_config.go
+++ b/config/config_center_config.go
@@ -121,7 +121,7 @@ func (b *configCenter) startConfigCenter(baseConfig BaseConfig) error {
 		return err
 	}
 	if err = b.prepareEnvironment(baseConfig, newUrl); err != nil {
-		return perrors.WithMessagef(err, "start config center error!")
+		return perrors.WithMessagef(err, "start config center failed!")
 	}
 	// c.fresh()
 	return nil
@@ -135,9 +135,10 @@ func (b *configCenter) prepareEnvironment(baseConfig BaseConfig, configCenterUrl
 		return perrors.WithStack(err)
 	}
 	config.GetEnvInstance().SetDynamicConfiguration(dynamicConfig)
+	logger.Infof("Set Dynamic Configuration %s success!", dynamicConfig)
 	content, err := dynamicConfig.GetProperties(baseConfig.ConfigCenterConfig.ConfigFile, config_center.WithGroup(baseConfig.ConfigCenterConfig.Group))
 	if err != nil {
-		logger.Errorf("Get config content in dynamic configuration error , error message is %v", err)
+		logger.Warnf("Get config content in dynamic configuration failed , message is %v\n", err)
 		return perrors.WithStack(err)
 	}
 	var appGroup string

--- a/config/config_center_config.go
+++ b/config/config_center_config.go
@@ -138,7 +138,7 @@ func (b *configCenter) prepareEnvironment(baseConfig BaseConfig, configCenterUrl
 	logger.Infof("Set Dynamic Configuration %s success!", dynamicConfig)
 	content, err := dynamicConfig.GetProperties(baseConfig.ConfigCenterConfig.ConfigFile, config_center.WithGroup(baseConfig.ConfigCenterConfig.Group))
 	if err != nil {
-		logger.Warnf("Get config content in dynamic configuration failed , message is %v\n", err)
+		logger.Warnf("Get config content in dynamic configuration failed , message is %v", err)
 		return perrors.WithStack(err)
 	}
 	var appGroup string

--- a/config/config_loader.go
+++ b/config/config_loader.go
@@ -216,7 +216,7 @@ func loadProviderConfig() {
 
 	checkApplicationName(providerConfig.ApplicationConfig)
 	if err := configCenterRefreshProvider(); err != nil {
-		logger.Errorf("[provider config center refresh] %#v", err)
+		logger.Warnf("[provider config center start failed with message %#v", err)
 	}
 
 	// start the metadata report if config set

--- a/config/provider_config.go
+++ b/config/provider_config.go
@@ -100,7 +100,7 @@ func configCenterRefreshProvider() error {
 	if providerConfig.ConfigCenterConfig != nil {
 		providerConfig.fatherConfig = providerConfig
 		if err := providerConfig.startConfigCenter((*providerConfig).BaseConfig); err != nil {
-			return perrors.Errorf("start config center error , error message is {%v}", perrors.WithStack(err))
+			return perrors.Errorf("start config center failed , message is {%v}", perrors.WithStack(err))
 		}
 		providerConfig.fresh()
 	}

--- a/config/reference_config.go
+++ b/config/reference_config.go
@@ -281,6 +281,8 @@ func (c *ReferenceConfig) getUrlMap() url.Values {
 
 // GenericLoad ...
 func (c *ReferenceConfig) GenericLoad(id string) {
+	extension.SetAndInitGlobalDispatcher(GetBaseConfig().EventDispatcherType)
+	configCenterRefreshConsumer()
 	genericService := NewGenericService(c.id)
 	SetConsumerService(genericService)
 	c.id = id

--- a/config/reference_config.go
+++ b/config/reference_config.go
@@ -279,7 +279,7 @@ func (c *ReferenceConfig) getUrlMap() url.Values {
 	return urlMap
 }
 
-// GenericLoad ...
+// GenericLoad start config center, and create generic service with referenceKey @id
 func (c *ReferenceConfig) GenericLoad(id string) {
 	extension.SetAndInitGlobalDispatcher(GetBaseConfig().EventDispatcherType)
 	configCenterRefreshConsumer()

--- a/remoting/zookeeper/listener.go
+++ b/remoting/zookeeper/listener.go
@@ -306,7 +306,7 @@ func (l *ZkEventListener) listenDirEvent(conf *common.URL, zkPath string, listen
 			}
 			logger.Debugf("Get children!{%s}", dubboPath)
 			if !listener.DataChange(remoting.Event{Path: dubboPath, Action: remoting.EventTypeAdd, Content: string(content)}) {
-				logger.Warnf("Send remoting event EventTypeAdd fail, path {%v}", dubboPath)
+				logger.Warnf("Send remoting event EventTypeAdd fail, path {%v}, maybe you don't want to use config center to store config content.", dubboPath)
 				l.pathMapLock.Lock()
 				delete(l.pathMap, zkPath)
 				l.pathMapLock.Unlock()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1320 
Fixes #1325 
增加了generic client 必要的启动逻辑，确保不会panic
修改配置中心初始化时错误的日志为warning

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```