### PR TITLE
Ftr: 支持Nacos下自定义服务的GroupName，保持与Java一致

### DIFF
--- a/registry/directory/directory.go
+++ b/registry/directory/directory.go
@@ -92,6 +92,11 @@ func NewRegistryDirectory(url *common.URL, registry registry.Registry) (cluster.
 
 	dir.consumerConfigurationListener = newConsumerConfigurationListener(dir)
 
+	// exchange data
+	subUrl := url.Clone()
+	subUrl.SubURL = nil
+	url.SubURL.SubURL = subUrl
+
 	go dir.subscribe(url.SubURL)
 	return dir, nil
 }

--- a/registry/nacos/listener.go
+++ b/registry/nacos/listener.go
@@ -188,7 +188,12 @@ func (nl *nacosListener) startListen() error {
 		return perrors.New("nacos naming namingClient stopped")
 	}
 	serviceName := getSubscribeName(nl.listenUrl)
-	nl.subscribeParam = &vo.SubscribeParam{ServiceName: serviceName, SubscribeCallback: nl.Callback}
+	groupName := nl.listenUrl.SubURL.GetParam(constant.GROUP_KEY, "")
+	nl.subscribeParam = &vo.SubscribeParam{
+		ServiceName:       serviceName,
+		GroupName:         groupName,
+		SubscribeCallback: nl.Callback,
+	}
 	go func() {
 		_ = nl.namingClient.Client().Subscribe(nl.subscribeParam)
 	}()

--- a/registry/nacos/registry.go
+++ b/registry/nacos/registry.go
@@ -81,7 +81,7 @@ func appendParam(target *bytes.Buffer, url *common.URL, key string) {
 	}
 }
 
-func createRegisterParam(url *common.URL, serviceName string) vo.RegisterInstanceParam {
+func createRegisterParam(url *common.URL, serviceName string, groupName string) vo.RegisterInstanceParam {
 	category := getCategory(url)
 	params := make(map[string]string)
 
@@ -109,6 +109,7 @@ func createRegisterParam(url *common.URL, serviceName string) vo.RegisterInstanc
 		Healthy:     true,
 		Ephemeral:   true,
 		ServiceName: serviceName,
+		GroupName:   groupName,
 	}
 	return instance
 }
@@ -116,7 +117,8 @@ func createRegisterParam(url *common.URL, serviceName string) vo.RegisterInstanc
 // Register will register the service @url to its nacos registry center
 func (nr *nacosRegistry) Register(url *common.URL) error {
 	serviceName := getServiceName(url)
-	param := createRegisterParam(url, serviceName)
+	groupName := nr.URL.GetParam(constant.GROUP_KEY, "")
+	param := createRegisterParam(url, serviceName, groupName)
 	isRegistry, err := nr.namingClient.Client().RegisterInstance(param)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1139 

**Special notes for your reviewer**: 
## config:
### providers:
![image](https://user-images.githubusercontent.com/9605663/127629250-f8fc8b51-51b4-42a9-a99a-9264ca3ac1bf.png)

### consumers:
![image](https://user-images.githubusercontent.com/9605663/127629157-550e9621-d647-4ef9-bc34-57a54bdd9cab.png)

## center:
![image](https://user-images.githubusercontent.com/9605663/127442436-eede8550-1b5c-475c-9883-bf92a658f1cc.png)


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Config file support use service_discovery.services.group to custom services group_name on nacos.
```