### PR TITLE
Ftr: Add config loader hooks

### DIFF
--- a/config/config_loader.go
+++ b/config/config_loader.go
@@ -59,6 +59,8 @@ var (
 	confBaseFile                    string
 	uniformVirtualServiceConfigPath string
 	uniformDestRuleConfigPath       string
+
+	loaderHooks map[string][]LoaderHook
 )
 
 // loaded consumer & provider config from xxx.yml, and log config from xxx.xml
@@ -190,6 +192,17 @@ func loadConsumerConfig() {
 	for {
 		checkok := true
 		for _, refconfig := range consumerConfig.References {
+			consumerConnectHookInfo := &ConsumerConnectInfo{
+				id:            refconfig.id,
+				protocol:      refconfig.Protocol,
+				registry:      refconfig.Registry,
+				interfaceName: refconfig.InterfaceName,
+				group:         refconfig.Group,
+				version:       refconfig.Version,
+			}
+			emitHook(&beforeConsumerConnectHook{
+				HookParams: consumerConnectHookInfo,
+			})
 			if (refconfig.Check != nil && *refconfig.Check) ||
 				(refconfig.Check == nil && consumerConfig.Check != nil && *consumerConfig.Check) ||
 				(refconfig.Check == nil && consumerConfig.Check == nil) { // default to true
@@ -200,6 +213,12 @@ func loadConsumerConfig() {
 					if count > maxWait {
 						errMsg := fmt.Sprintf("Failed to check the status of the service %v. No provider available for the service to the consumer use dubbo version %v", refconfig.InterfaceName, constant.Version)
 						logger.Error(errMsg)
+						emitHook(&consumerConnectFailHook{
+							HookParams: &ConsumerConnectFailInfo{
+								ConsumerConnectInfo: *consumerConnectHookInfo,
+								message:             errMsg,
+							},
+						})
 						panic(errMsg)
 					}
 					time.Sleep(time.Second * 1)
@@ -207,13 +226,18 @@ func loadConsumerConfig() {
 				}
 				if refconfig.invoker == nil {
 					logger.Warnf("The interface %s invoker not exist, may you should check your interface config.", refconfig.InterfaceName)
+					continue
 				}
 			}
+			emitHook(&consumerConnectSuccessHook{
+				HookParams: consumerConnectHookInfo,
+			})
 		}
 		if checkok {
 			break
 		}
 	}
+	emitHook(&allConsumersConnectCompleteHook{})
 }
 
 func loadProviderConfig() {
@@ -268,11 +292,34 @@ func loadProviderConfig() {
 		svs.id = key
 		svs.Implement(rpcService)
 		svs.Protocols = providerConfig.Protocols
+		providerConnectHookInfo := &ProviderConnectInfo{
+			id:            svs.id,
+			protocol:      svs.Protocol,
+			registry:      svs.Registry,
+			interfaceName: svs.InterfaceName,
+			group:         svs.Group,
+			version:       svs.Version,
+		}
+		emitHook(&beforeProviderConnectHook{
+			HookParams: providerConnectHookInfo,
+		})
 		if err := svs.Export(); err != nil {
-			panic(fmt.Sprintf("service %s export failed! err: %#v", key, err))
+			errMsg := fmt.Sprintf("service %s export failed! err: %#v", key, err)
+			emitHook(&providerConnectFailHook{
+				HookParams: &ProviderConnectFailInfo{
+					ProviderConnectInfo: *providerConnectHookInfo,
+					message:             errMsg,
+				},
+			})
+			panic(errMsg)
+		} else {
+			emitHook(&providerConnectSuccessHook{
+				HookParams: providerConnectHookInfo,
+			})
 		}
 	}
 	registerServiceInstance()
+	emitHook(&allProvidersConnectCompleteHook{})
 }
 
 // registerServiceInstance register service instance
@@ -297,6 +344,7 @@ func registerServiceInstance() {
 		if sdr, ok = r.(registry.ServiceDiscoveryHolder); !ok {
 			continue
 		}
+		instance.GetMetadata()
 		err := sdr.GetServiceDiscovery().Register(instance)
 		if err != nil {
 			panic(err)

--- a/config/config_loader_hook.go
+++ b/config/config_loader_hook.go
@@ -1,0 +1,319 @@
+package config
+
+import (
+	"reflect"
+)
+
+type LoaderHook interface {
+	emit() bool
+	emitWithParams(params interface{}) bool
+}
+
+func getLoaderHookType(hook LoaderHook) string {
+	return reflect.TypeOf(hook).Elem().String()
+}
+
+func getLoaderHookParams(t LoaderHook) interface{} {
+	return reflect.ValueOf(t).Elem().FieldByName("HookParams").Elem().Interface()
+}
+
+func AddLoaderHooks(hooks ...LoaderHook) {
+	if len(hooks) > 0 {
+		if loaderHooks == nil {
+			loaderHooks = map[string][]LoaderHook{}
+		}
+		for _, hook := range hooks {
+			hookType := getLoaderHookType(hook)
+			var hooks []LoaderHook
+			if hs, ok := loaderHooks[hookType]; ok {
+				hooks = hs
+			}
+			if hooks == nil {
+				hooks = []LoaderHook{}
+			}
+			loaderHooks[hookType] = append(hooks, hook)
+		}
+	}
+}
+
+func RemoveLoaderHooks(hooks ...LoaderHook) {
+	if loaderHooks != nil && len(loaderHooks) > 0 {
+		for _, rmHook := range hooks {
+			hookType := getLoaderHookType(rmHook)
+			if hooks, ok := loaderHooks[hookType]; ok {
+				for index, targetHook := range hooks {
+					if rmHook == targetHook {
+						newHooks := append(hooks[:index], hooks[index+1:]...)
+						if len(newHooks) == 0 {
+							delete(loaderHooks, hookType)
+						} else {
+							loaderHooks[hookType] = newHooks
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+}
+
+func emitHook(t LoaderHook) {
+	if loaderHooks != nil && len(loaderHooks) > 0 {
+		hookType := getLoaderHookType(t)
+		if hooks, ok := loaderHooks[hookType]; ok {
+			for _, hook := range hooks {
+				if !hook.emit() {
+					hook.emitWithParams(getLoaderHookParams(t))
+				}
+			}
+		}
+	}
+}
+
+// emit on before shutdown
+type BeforeShutdownHookEvent func()
+
+type beforeShutdownHook struct {
+	onEvent func()
+}
+
+func (h *beforeShutdownHook) emit() bool {
+	h.onEvent()
+	return true
+}
+
+func (h *beforeShutdownHook) emitWithParams(params interface{}) bool {
+	return params == nil
+}
+
+func NewBeforeShutdownHook(onEvent BeforeShutdownHookEvent) *beforeShutdownHook {
+	return &beforeShutdownHook{
+		onEvent,
+	}
+}
+
+// Consumer Hooks
+// emit on before export consumer
+type BeforeConsumerConnectHookEvent func(info *ConsumerConnectInfo)
+
+// emit on consumer export success
+type ConsumerConnectSuccessHookEvent func(info *ConsumerConnectInfo)
+
+// emit on consumer export fail
+type ConsumerConnectFailHookEvent func(info *ConsumerConnectFailInfo)
+
+// emit on all consumers export complete
+type AllConsumersConnectCompleteHookEvent func()
+
+type beforeConsumerConnectHook struct {
+	onEvent BeforeConsumerConnectHookEvent
+
+	HookParams *ConsumerConnectInfo
+}
+
+type consumerConnectSuccessHook struct {
+	onEvent ConsumerConnectSuccessHookEvent
+
+	HookParams *ConsumerConnectInfo
+}
+
+type consumerConnectFailHook struct {
+	onEvent ConsumerConnectFailHookEvent
+
+	HookParams *ConsumerConnectFailInfo
+}
+
+type allConsumersConnectCompleteHook struct {
+	onEvent func()
+}
+
+type ConsumerConnectInfo struct {
+	id            string
+	protocol      string
+	registry      string
+	interfaceName string
+	group         string
+	version       string
+}
+
+type ConsumerConnectFailInfo struct {
+	ConsumerConnectInfo
+
+	message string
+}
+
+func (h *beforeConsumerConnectHook) emit() bool {
+	return false
+}
+
+func (h *beforeConsumerConnectHook) emitWithParams(params interface{}) bool {
+	info := params.(ConsumerConnectInfo)
+	h.onEvent(&info)
+	return true
+}
+
+func (h *consumerConnectSuccessHook) emit() bool {
+	return false
+}
+
+func (h *consumerConnectSuccessHook) emitWithParams(params interface{}) bool {
+	info := params.(ConsumerConnectInfo)
+	h.onEvent(&info)
+	return true
+}
+
+func (h *consumerConnectFailHook) emit() bool {
+	return false
+}
+
+func (h *consumerConnectFailHook) emitWithParams(params interface{}) bool {
+	info := params.(ConsumerConnectFailInfo)
+	h.onEvent(&info)
+	return true
+}
+
+func (h *allConsumersConnectCompleteHook) emit() bool {
+	h.onEvent()
+	return true
+}
+
+func (h *allConsumersConnectCompleteHook) emitWithParams(params interface{}) bool {
+	return params == nil
+}
+
+func NewBeforeConsumerConnectHook(onEvent BeforeConsumerConnectHookEvent) *beforeConsumerConnectHook {
+	hook := &beforeConsumerConnectHook{}
+	hook.onEvent = onEvent
+	return hook
+}
+
+func NewConsumerConnectSuccessHook(onEvent ConsumerConnectSuccessHookEvent) *consumerConnectSuccessHook {
+	hook := &consumerConnectSuccessHook{}
+	hook.onEvent = onEvent
+	return hook
+}
+
+func NewConsumerConnectFailHook(onEvent ConsumerConnectFailHookEvent) *consumerConnectFailHook {
+	hook := &consumerConnectFailHook{}
+	hook.onEvent = onEvent
+	return hook
+}
+
+func NewAllConsumersConnectCompleteHook(onEvent AllConsumersConnectCompleteHookEvent) *allConsumersConnectCompleteHook {
+	return &allConsumersConnectCompleteHook{
+		onEvent,
+	}
+}
+
+// Provider Hooks
+// emit on before export provider
+type BeforeProviderConnectHookEvent func(info *ProviderConnectInfo)
+
+// emit on provider export success
+type ProviderConnectSuccessHookEvent func(info *ProviderConnectInfo)
+
+// emit on provider export fail
+type ProviderConnectFailHookEvent func(info *ProviderConnectFailInfo)
+
+// emit on all providers export complete
+type AllProvidersConnectCompleteHookEvent func()
+
+type beforeProviderConnectHook struct {
+	onEvent BeforeProviderConnectHookEvent
+
+	HookParams *ProviderConnectInfo
+}
+
+type providerConnectSuccessHook struct {
+	onEvent ProviderConnectSuccessHookEvent
+
+	HookParams *ProviderConnectInfo
+}
+
+type providerConnectFailHook struct {
+	onEvent ProviderConnectFailHookEvent
+
+	HookParams *ProviderConnectFailInfo
+}
+
+type allProvidersConnectCompleteHook struct {
+	onEvent func()
+}
+
+type ProviderConnectInfo struct {
+	id            string
+	protocol      string
+	registry      string
+	interfaceName string
+	group         string
+	version       string
+}
+
+type ProviderConnectFailInfo struct {
+	ProviderConnectInfo
+
+	message string
+}
+
+func (h *beforeProviderConnectHook) emit() bool {
+	return false
+}
+
+func (h *beforeProviderConnectHook) emitWithParams(params interface{}) bool {
+	info := params.(ProviderConnectInfo)
+	h.onEvent(&info)
+	return true
+}
+
+func (h *providerConnectSuccessHook) emit() bool {
+	return false
+}
+
+func (h *providerConnectSuccessHook) emitWithParams(params interface{}) bool {
+	info := params.(ProviderConnectInfo)
+	h.onEvent(&info)
+	return true
+}
+
+func (h *providerConnectFailHook) emit() bool {
+	return false
+}
+
+func (h *providerConnectFailHook) emitWithParams(params interface{}) bool {
+	info := params.(ProviderConnectFailInfo)
+	h.onEvent(&info)
+	return true
+}
+
+func (h *allProvidersConnectCompleteHook) emit() bool {
+	h.onEvent()
+	return true
+}
+
+func (h *allProvidersConnectCompleteHook) emitWithParams(params interface{}) bool {
+	return params == nil
+}
+
+func NewBeforeProviderConnectHook(onEvent BeforeProviderConnectHookEvent) *beforeProviderConnectHook {
+	hook := &beforeProviderConnectHook{}
+	hook.onEvent = onEvent
+	return hook
+}
+
+func NewProviderConnectSuccessHook(onEvent ProviderConnectSuccessHookEvent) *providerConnectSuccessHook {
+	hook := &providerConnectSuccessHook{}
+	hook.onEvent = onEvent
+	return hook
+}
+
+func NewProviderConnectFailHook(onEvent ProviderConnectFailHookEvent) *providerConnectFailHook {
+	hook := &providerConnectFailHook{}
+	hook.onEvent = onEvent
+	return hook
+}
+
+func NewAllProvidersConnectCompleteHook(onEvent AllProvidersConnectCompleteHookEvent) *allProvidersConnectCompleteHook {
+	return &allProvidersConnectCompleteHook{
+		onEvent,
+	}
+}

--- a/config/config_loader_test.go
+++ b/config/config_loader_test.go
@@ -123,6 +123,105 @@ func TestLoad(t *testing.T) {
 	providerConfig = nil
 }
 
+func TestLoadWithLoaderHooks(t *testing.T) {
+	extension.SetFilter(constant.GracefulShutdownConsumerFilterKey, func() filter.Filter {
+		return &mockGracefulShutdownFilter{}
+	})
+	extension.SetFilter(constant.GracefulShutdownProviderFilterKey, func() filter.Filter {
+		return &mockGracefulShutdownFilter{}
+	})
+
+	doInitConsumer()
+	doInitProvider()
+
+	ms := &MockService{}
+	SetConsumerService(ms)
+	SetProviderService(ms)
+
+	extension.SetProtocol("registry", GetProtocol)
+	extension.SetCluster(constant.ZONEAWARE_CLUSTER_NAME, cluster_impl.NewZoneAwareCluster)
+	extension.SetProxyFactory("default", proxy_factory.NewDefaultProxyFactory)
+	GetApplicationConfig().MetadataType = "mock"
+	var mm *mockMetadataService
+	extension.SetLocalMetadataService("mock", func() (metadataService service.MetadataService, err error) {
+		if mm == nil {
+			mm = &mockMetadataService{
+				exportedServiceURLs: new(sync.Map),
+				lock:                new(sync.RWMutex),
+			}
+		}
+		return mm, nil
+	})
+
+	// create consumer loader hooks
+	beforeConsumerConnectHook := NewBeforeConsumerConnectHook(func(info *ConsumerConnectInfo) {
+		logger.Debug("BeforeConsumerConnectHook", info)
+		assert.NotNil(t, info)
+	})
+	consumerConnectSuccessHook := NewConsumerConnectSuccessHook(func(info *ConsumerConnectInfo) {
+		logger.Debug("ConsumerConnectSuccessHook", info)
+		assert.NotNil(t, info)
+	})
+	consumerConnectFailHook := NewConsumerConnectFailHook(func(info *ConsumerConnectFailInfo) {
+		logger.Debug("ConsumerConnectFailHook", info)
+		assert.NotNil(t, info)
+	})
+	allConsumersConnectCompleteHook := NewAllConsumersConnectCompleteHook(func() {
+		logger.Debug("AllConsumersConnectCompleteHook")
+	})
+	// create provider loader hooks
+	beforeProviderConnectHook := NewBeforeProviderConnectHook(func(info *ProviderConnectInfo) {
+		logger.Debug("BeforeProviderConnectHook", info)
+		assert.NotNil(t, info)
+	})
+	providerConnectSuccessHook := NewProviderConnectSuccessHook(func(info *ProviderConnectInfo) {
+		logger.Debug("ProviderConnectSuccessHook", info)
+		assert.NotNil(t, info)
+	})
+	providerConnectFailHook := NewProviderConnectFailHook(func(info *ProviderConnectFailInfo) {
+		logger.Debug("ProviderConnectFailHook", info)
+		assert.NotNil(t, info)
+	})
+	allProvidersConnectCompleteHook := NewAllProvidersConnectCompleteHook(func() {
+		logger.Debug("AllProvidersConnectCompleteHook")
+	})
+
+	beforeShutdownHook := NewBeforeShutdownHook(func() {
+		logger.Debug("BeforeShutDownHook")
+	})
+	AddLoaderHooks(
+		// Consumer Hooks
+		beforeConsumerConnectHook,
+		consumerConnectSuccessHook,
+		consumerConnectFailHook,
+		allConsumersConnectCompleteHook,
+		// Provider Hooks
+		beforeProviderConnectHook,
+		providerConnectSuccessHook,
+		providerConnectFailHook,
+		allProvidersConnectCompleteHook,
+		// Shut Down hook
+		beforeShutdownHook,
+	)
+
+	Load()
+
+	assert.Equal(t, ms, GetRPCService(ms.Reference()))
+	ms2 := &struct {
+		MockService
+	}{}
+	RPCService(ms2)
+	assert.NotEqual(t, ms2, GetRPCService(ms2.Reference()))
+
+	conServices = map[string]common.RPCService{}
+	proServices = map[string]common.RPCService{}
+	err := common.ServiceMap.UnRegister("com.MockService", "mock",
+		common.ServiceKey("com.MockService", "huadong_idc", "1.0.0"))
+	assert.Nil(t, err)
+	consumerConfig = nil
+	providerConfig = nil
+}
+
 func TestLoadWithSingleReg(t *testing.T) {
 	doInitConsumerWithSingleRegistry()
 	mockInitProviderWithSingleRegistry()

--- a/config/graceful_shutdown.go
+++ b/config/graceful_shutdown.go
@@ -74,6 +74,7 @@ func GracefulShutdownInit() {
 			// gracefulShutdownOnce.Do(func() {
 			time.AfterFunc(totalTimeout(), func() {
 				logger.Warn("Shutdown gracefully timeout, application will shutdown immediately. ")
+				emitHook(&beforeShutdownHook{})
 				os.Exit(0)
 			})
 			BeforeShutdown()
@@ -83,6 +84,9 @@ func GracefulShutdownInit() {
 					debug.WriteHeapDump(os.Stdout.Fd())
 				}
 			}
+
+			emitHook(&beforeShutdownHook{})
+
 			os.Exit(0)
 		}
 	}()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**:
Hook Type:
- BeforeShutdownHook
- BeforeConsumerConnectHook
- ConsumerConnectSuccessHook
- ConsumerConnectFailHook
- AllConsumerConnectCompleteHook
- BeforeProviderConnectHook
- ProviderConnectSuccessHook
- ProviderConnectFailHook
- AllProviderConnectCompleteHook

Create Instance:
- NewBeforeShutdownHook(func() {})
- NewBeforeConsumerConnectHook(func(info *ConsumerConnectInfo) {})
- NewConsumerConnectSuccessHook(func(info *ConsumerConnectInfo) {})
- NewConsumerConnectFailHook(func(info *ConsumerConnectFailInfo) {})
- NewAllConsumersConnectCompleteHook(func() {})
- NewBeforeProviderConnectHook(func(info *ProviderConnectInfo) {})
- NewProviderConnectSuccessHook(func(info *ProviderConnectInfo) {})
- NewProviderConnectFailHook(func(info *ProviderConnectFailInfo) {})
- NewAllProvidersConnectCompleteHook(func() {})

Add/Remove Hooks:
- config.AddLoaderHooks(...hooks)
- config.RemoveLoaderHooks(...hooks)

Unit Test:
- config_loader_test.TestLoadWithLoaderHooks
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1364

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```