### PR TITLE
Ftr: Add config loader hooks for 1.5.

### DIFF
--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -350,3 +350,8 @@ const (
 	// SERVICE_DISCOVERY_KEY indicate which service discovery instance will be used
 	SERVICE_DISCOVERY_KEY = "service_discovery"
 )
+
+// Loader Hook
+const (
+	HookParams = "HookParams"
+)

--- a/config/config_loader_hook.go
+++ b/config/config_loader_hook.go
@@ -1,0 +1,367 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"fmt"
+	"reflect"
+)
+
+import (
+	"github.com/apache/dubbo-go/common/constant"
+)
+
+const (
+	hookParams = constant.HookParams
+)
+
+type LoaderHook interface {
+	emit() bool
+	// if you want to use emitWithParams, you must add HookParams field and make emit return false
+	emitWithParams(params interface{}) bool
+}
+
+func getLoaderHookType(t LoaderHook) reflect.Type {
+	hookType := reflect.TypeOf(t)
+	if reflect.Ptr == hookType.Kind() {
+		hookType = hookType.Elem()
+	}
+	return hookType
+}
+
+func getLoaderHookTypeString(t LoaderHook) string {
+	return getLoaderHookType(t).String()
+}
+
+func getLoaderHookInfo(v reflect.Value) reflect.Value {
+	if reflect.Ptr == v.Kind() {
+		v = v.Elem()
+	}
+	return v
+}
+
+func getLoaderHookParams(t LoaderHook) interface{} {
+	hookType := getLoaderHookType(t)
+	_, existed := hookType.FieldByName(hookParams)
+	if !existed {
+		panic(fmt.Sprintf("Hook field [%s] not existed for %s", hookParams, hookType.Name()))
+	}
+	hookParams := getLoaderHookInfo(reflect.ValueOf(t)).FieldByName(hookParams)
+	return getLoaderHookInfo(hookParams).Interface()
+}
+
+func AddLoaderHooks(hooks ...LoaderHook) {
+	if len(hooks) > 0 {
+		if loaderHooks == nil {
+			loaderHooks = map[string][]LoaderHook{}
+		}
+		for _, hook := range hooks {
+			hookType := getLoaderHookTypeString(hook)
+			var hooks []LoaderHook
+			if hs, ok := loaderHooks[hookType]; ok {
+				hooks = hs
+			}
+			if hooks == nil {
+				hooks = []LoaderHook{}
+			}
+			loaderHooks[hookType] = append(hooks, hook)
+		}
+	}
+}
+
+func RemoveLoaderHooks(hooks ...LoaderHook) {
+	if loaderHooks != nil && len(loaderHooks) > 0 {
+		for _, rmHook := range hooks {
+			hookType := getLoaderHookTypeString(rmHook)
+			if hooks, ok := loaderHooks[hookType]; ok {
+				for index, targetHook := range hooks {
+					if rmHook == targetHook {
+						newHooks := append(hooks[:index], hooks[index+1:]...)
+						if len(newHooks) == 0 {
+							delete(loaderHooks, hookType)
+						} else {
+							loaderHooks[hookType] = newHooks
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+}
+
+func emitHook(t LoaderHook) {
+	if loaderHooks != nil && len(loaderHooks) > 0 {
+		hookType := getLoaderHookTypeString(t)
+		if hooks, ok := loaderHooks[hookType]; ok {
+			for _, hook := range hooks {
+				if !hook.emit() {
+					hook.emitWithParams(getLoaderHookParams(t))
+				}
+			}
+		}
+	}
+}
+
+// emit on before shutdown
+type BeforeShutdownHookEvent func()
+
+type beforeShutdownHook struct {
+	onEvent func()
+}
+
+func (h *beforeShutdownHook) emit() bool {
+	h.onEvent()
+	return true
+}
+
+func (h *beforeShutdownHook) emitWithParams(params interface{}) bool {
+	return params == nil
+}
+
+func NewBeforeShutdownHook(onEvent BeforeShutdownHookEvent) *beforeShutdownHook {
+	return &beforeShutdownHook{
+		onEvent,
+	}
+}
+
+// Consumer Hooks
+// emit on before export consumer
+type BeforeConsumerConnectHookEvent func(info *ConsumerConnectInfo)
+
+// emit on consumer export success
+type ConsumerConnectSuccessHookEvent func(info *ConsumerConnectInfo)
+
+// emit on consumer export fail
+type ConsumerConnectFailHookEvent func(info *ConsumerConnectFailInfo)
+
+// emit on all consumers export complete
+type AllConsumersConnectCompleteHookEvent func()
+
+type beforeConsumerConnectHook struct {
+	onEvent BeforeConsumerConnectHookEvent
+
+	HookParams *ConsumerConnectInfo
+}
+
+type consumerConnectSuccessHook struct {
+	onEvent ConsumerConnectSuccessHookEvent
+
+	HookParams *ConsumerConnectInfo
+}
+
+type consumerConnectFailHook struct {
+	onEvent ConsumerConnectFailHookEvent
+
+	HookParams *ConsumerConnectFailInfo
+}
+
+type allConsumersConnectCompleteHook struct {
+	onEvent func()
+}
+
+type ConsumerConnectInfo struct {
+	id            string
+	protocol      string
+	registry      string
+	interfaceName string
+	group         string
+	version       string
+}
+
+type ConsumerConnectFailInfo struct {
+	ConsumerConnectInfo
+
+	message string
+}
+
+func (h *beforeConsumerConnectHook) emit() bool {
+	return false
+}
+
+func (h *beforeConsumerConnectHook) emitWithParams(params interface{}) bool {
+	info := params.(ConsumerConnectInfo)
+	h.onEvent(&info)
+	return true
+}
+
+func (h *consumerConnectSuccessHook) emit() bool {
+	return false
+}
+
+func (h *consumerConnectSuccessHook) emitWithParams(params interface{}) bool {
+	info := params.(ConsumerConnectInfo)
+	h.onEvent(&info)
+	return true
+}
+
+func (h *consumerConnectFailHook) emit() bool {
+	return false
+}
+
+func (h *consumerConnectFailHook) emitWithParams(params interface{}) bool {
+	info := params.(ConsumerConnectFailInfo)
+	h.onEvent(&info)
+	return true
+}
+
+func (h *allConsumersConnectCompleteHook) emit() bool {
+	h.onEvent()
+	return true
+}
+
+func (h *allConsumersConnectCompleteHook) emitWithParams(params interface{}) bool {
+	return params == nil
+}
+
+func NewBeforeConsumerConnectHook(onEvent BeforeConsumerConnectHookEvent) *beforeConsumerConnectHook {
+	hook := &beforeConsumerConnectHook{}
+	hook.onEvent = onEvent
+	return hook
+}
+
+func NewConsumerConnectSuccessHook(onEvent ConsumerConnectSuccessHookEvent) *consumerConnectSuccessHook {
+	hook := &consumerConnectSuccessHook{}
+	hook.onEvent = onEvent
+	return hook
+}
+
+func NewConsumerConnectFailHook(onEvent ConsumerConnectFailHookEvent) *consumerConnectFailHook {
+	hook := &consumerConnectFailHook{}
+	hook.onEvent = onEvent
+	return hook
+}
+
+func NewAllConsumersConnectCompleteHook(onEvent AllConsumersConnectCompleteHookEvent) *allConsumersConnectCompleteHook {
+	return &allConsumersConnectCompleteHook{
+		onEvent,
+	}
+}
+
+// Provider Hooks
+// emit on before export provider
+type BeforeProviderConnectHookEvent func(info *ProviderConnectInfo)
+
+// emit on provider export success
+type ProviderConnectSuccessHookEvent func(info *ProviderConnectInfo)
+
+// emit on provider export fail
+type ProviderConnectFailHookEvent func(info *ProviderConnectFailInfo)
+
+// emit on all providers export complete
+type AllProvidersConnectCompleteHookEvent func()
+
+type beforeProviderConnectHook struct {
+	onEvent BeforeProviderConnectHookEvent
+
+	HookParams *ProviderConnectInfo
+}
+
+type providerConnectSuccessHook struct {
+	onEvent ProviderConnectSuccessHookEvent
+
+	HookParams *ProviderConnectInfo
+}
+
+type providerConnectFailHook struct {
+	onEvent ProviderConnectFailHookEvent
+
+	HookParams *ProviderConnectFailInfo
+}
+
+type allProvidersConnectCompleteHook struct {
+	onEvent func()
+}
+
+type ProviderConnectInfo struct {
+	id            string
+	protocol      string
+	registry      string
+	interfaceName string
+	group         string
+	version       string
+}
+
+type ProviderConnectFailInfo struct {
+	ProviderConnectInfo
+
+	message string
+}
+
+func (h *beforeProviderConnectHook) emit() bool {
+	return false
+}
+
+func (h *beforeProviderConnectHook) emitWithParams(params interface{}) bool {
+	info := params.(ProviderConnectInfo)
+	h.onEvent(&info)
+	return true
+}
+
+func (h *providerConnectSuccessHook) emit() bool {
+	return false
+}
+
+func (h *providerConnectSuccessHook) emitWithParams(params interface{}) bool {
+	info := params.(ProviderConnectInfo)
+	h.onEvent(&info)
+	return true
+}
+
+func (h *providerConnectFailHook) emit() bool {
+	return false
+}
+
+func (h *providerConnectFailHook) emitWithParams(params interface{}) bool {
+	info := params.(ProviderConnectFailInfo)
+	h.onEvent(&info)
+	return true
+}
+
+func (h *allProvidersConnectCompleteHook) emit() bool {
+	h.onEvent()
+	return true
+}
+
+func (h *allProvidersConnectCompleteHook) emitWithParams(params interface{}) bool {
+	return params == nil
+}
+
+func NewBeforeProviderConnectHook(onEvent BeforeProviderConnectHookEvent) *beforeProviderConnectHook {
+	hook := &beforeProviderConnectHook{}
+	hook.onEvent = onEvent
+	return hook
+}
+
+func NewProviderConnectSuccessHook(onEvent ProviderConnectSuccessHookEvent) *providerConnectSuccessHook {
+	hook := &providerConnectSuccessHook{}
+	hook.onEvent = onEvent
+	return hook
+}
+
+func NewProviderConnectFailHook(onEvent ProviderConnectFailHookEvent) *providerConnectFailHook {
+	hook := &providerConnectFailHook{}
+	hook.onEvent = onEvent
+	return hook
+}
+
+func NewAllProvidersConnectCompleteHook(onEvent AllProvidersConnectCompleteHookEvent) *allProvidersConnectCompleteHook {
+	return &allProvidersConnectCompleteHook{
+		onEvent,
+	}
+}

--- a/config/config_loader_test.go
+++ b/config/config_loader_test.go
@@ -149,6 +149,13 @@ func TestLoadWithLoaderHooks(t *testing.T) {
 	})
 	allConsumersConnectCompleteHook := NewAllConsumersConnectCompleteHook(func() {
 		logger.Debug("AllConsumersConnectCompleteHook")
+		RemoveLoaderHooks( // Remove some consumer loader hooks
+			beforeConsumerConnectHook,
+			consumerConnectSuccessHook,
+			consumerConnectFailHook,
+		)
+		logger.Debug("LoaderHooks length = ", len(loaderHooks), " after AllConsumersConnectCompleteHook")
+		assert.Equal(t, len(loaderHooks), 6)
 	})
 	// create provider loader hooks
 	beforeProviderConnectHook := NewBeforeProviderConnectHook(func(info *ProviderConnectInfo) {
@@ -165,10 +172,30 @@ func TestLoadWithLoaderHooks(t *testing.T) {
 	})
 	allProvidersConnectCompleteHook := NewAllProvidersConnectCompleteHook(func() {
 		logger.Debug("AllProvidersConnectCompleteHook")
+		RemoveLoaderHooks( // Remove some provider loader hooks
+			beforeProviderConnectHook,
+			providerConnectSuccessHook,
+			providerConnectFailHook,
+		)
+		logger.Debug("LoaderHooks length = ", len(loaderHooks), " after AllProvidersConnectCompleteHook")
+		assert.Equal(t, len(loaderHooks), 3)
 	})
 
 	beforeShutdownHook := NewBeforeShutdownHook(func() {
 		logger.Debug("BeforeShutDownHook")
+		RemoveLoaderHooks( // Remove some consumer and provider loader hooks
+			// Consumer Hooks
+			beforeConsumerConnectHook,
+			consumerConnectSuccessHook,
+			consumerConnectFailHook,
+			allConsumersConnectCompleteHook,
+			// Provider Hooks
+			beforeProviderConnectHook,
+			providerConnectSuccessHook,
+			providerConnectFailHook,
+			allProvidersConnectCompleteHook,
+		)
+		assert.Equal(t, len(loaderHooks), 1)
 	})
 	AddLoaderHooks(
 		// Consumer Hooks
@@ -184,6 +211,7 @@ func TestLoadWithLoaderHooks(t *testing.T) {
 		// Shut Down hook
 		beforeShutdownHook,
 	)
+	assert.Equal(t, len(loaderHooks), 9)
 
 	Load()
 

--- a/config/graceful_shutdown.go
+++ b/config/graceful_shutdown.go
@@ -67,6 +67,7 @@ func GracefulShutdownInit() {
 			// gracefulShutdownOnce.Do(func() {
 			time.AfterFunc(totalTimeout(), func() {
 				logger.Warn("Shutdown gracefully timeout, application will shutdown immediately. ")
+				emitHook(&beforeShutdownHook{})
 				os.Exit(0)
 			})
 			BeforeShutdown()
@@ -76,6 +77,7 @@ func GracefulShutdownInit() {
 					debug.WriteHeapDump(os.Stdout.Fd())
 				}
 			}
+			emitHook(&beforeShutdownHook{})
 			os.Exit(0)
 		}
 	}()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**:
```go

func TestLoadWithLoaderHooks(t *testing.T) {
	extension.SetFilter(constant.GracefulShutdownConsumerFilterKey, func() filter.Filter {
		return &mockGracefulShutdownFilter{}
	})
	extension.SetFilter(constant.GracefulShutdownProviderFilterKey, func() filter.Filter {
		return &mockGracefulShutdownFilter{}
	})

	doInitConsumer()
	doInitProvider()

	ms := &MockService{}
	SetConsumerService(ms)
	SetProviderService(ms)

	extension.SetProtocol("registry", GetProtocol)
	extension.SetCluster(constant.ZONEAWARE_CLUSTER_NAME, cluster_impl.NewZoneAwareCluster)
	extension.SetProxyFactory("default", proxy_factory.NewDefaultProxyFactory)
	GetApplicationConfig().MetadataType = "mock"
	var mm *mockMetadataService
	extension.SetLocalMetadataService("mock", func() (metadataService service.MetadataService, err error) {
		if mm == nil {
			mm = &mockMetadataService{
				exportedServiceURLs: new(sync.Map),
				lock:                new(sync.RWMutex),
			}
		}
		return mm, nil
	})

	// create consumer loader hooks
	beforeConsumerConnectHook := NewBeforeConsumerConnectHook(func(info *ConsumerConnectInfo) {
		logger.Debug("BeforeConsumerConnectHook", info)
		assert.NotNil(t, info)
	})
	consumerConnectSuccessHook := NewConsumerConnectSuccessHook(func(info *ConsumerConnectInfo) {
		logger.Debug("ConsumerConnectSuccessHook", info)
		assert.NotNil(t, info)
	})
	consumerConnectFailHook := NewConsumerConnectFailHook(func(info *ConsumerConnectFailInfo) {
		logger.Debug("ConsumerConnectFailHook", info)
		assert.NotNil(t, info)
	})
	allConsumersConnectCompleteHook := NewAllConsumersConnectCompleteHook(func() {
		logger.Debug("AllConsumersConnectCompleteHook")
		RemoveLoaderHooks( // Remove some consumer loader hooks
			beforeConsumerConnectHook,
			consumerConnectSuccessHook,
			consumerConnectFailHook,
		)
		logger.Debug("LoaderHooks length = ", len(loaderHooks), " after AllConsumersConnectCompleteHook")
		// beforeConsumerConnectHook, consumerConnectSuccessHook 
                // and consumerConnectFailHook have been removed
		assert.Equal(t, len(loaderHooks), 6)
	})
	// create provider loader hooks
	beforeProviderConnectHook := NewBeforeProviderConnectHook(func(info *ProviderConnectInfo) {
		logger.Debug("BeforeProviderConnectHook", info)
		assert.NotNil(t, info)
	})
	providerConnectSuccessHook := NewProviderConnectSuccessHook(func(info *ProviderConnectInfo) {
		logger.Debug("ProviderConnectSuccessHook", info)
		assert.NotNil(t, info)
	})
	providerConnectFailHook := NewProviderConnectFailHook(func(info *ProviderConnectFailInfo) {
		logger.Debug("ProviderConnectFailHook", info)
		assert.NotNil(t, info)
	})
	allProvidersConnectCompleteHook := NewAllProvidersConnectCompleteHook(func() {
		logger.Debug("AllProvidersConnectCompleteHook")
		RemoveLoaderHooks( // Remove some provider loader hooks
			beforeProviderConnectHook,
			providerConnectSuccessHook,
			providerConnectFailHook,
		)
		logger.Debug("LoaderHooks length = ", len(loaderHooks), " after AllProvidersConnectCompleteHook")
		// beforeProviderConnectHook, providerConnectSuccessHook
                // and providerConnectFailHook have been removed
		assert.Equal(t, len(loaderHooks), 3)
	})

	beforeShutdownHook := NewBeforeShutdownHook(func() {
		logger.Debug("BeforeShutDownHook")
		RemoveLoaderHooks( // Remove some consumer and provider loader hooks
			// Consumer Hooks
			beforeConsumerConnectHook,
			consumerConnectSuccessHook,
			consumerConnectFailHook,
			allConsumersConnectCompleteHook,
			// Provider Hooks
			beforeProviderConnectHook,
			providerConnectSuccessHook,
			providerConnectFailHook,
			allProvidersConnectCompleteHook,
		)
		assert.Equal(t, len(loaderHooks), 1)
	})
	// add loader hooks before config.Load
	AddLoaderHooks(
		// Consumer Hooks
		beforeConsumerConnectHook,
		consumerConnectSuccessHook,
		consumerConnectFailHook,
		allConsumersConnectCompleteHook,
		// Provider Hooks
		beforeProviderConnectHook,
		providerConnectSuccessHook,
		providerConnectFailHook,
		allProvidersConnectCompleteHook,
		// Shut Down hook
		beforeShutdownHook,
	)
	// check loaderHooks length
	assert.Equal(t, len(loaderHooks), 9)

	Load()

	assert.Equal(t, ms, GetRPCService(ms.Reference()))
	ms2 := &struct {
		MockService
	}{}
	RPCService(ms2)
	assert.NotEqual(t, ms2, GetRPCService(ms2.Reference()))

	conServices = map[string]common.RPCService{}
	proServices = map[string]common.RPCService{}
	err := common.ServiceMap.UnRegister("com.MockService", "mock",
		common.ServiceKey("com.MockService", "huadong_idc", "1.0.0"))
	assert.Nil(t, err)
	consumerConfig = nil
	providerConfig = nil
}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1364

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```