### PR TITLE
Ftr: Added more event distribution types and improved event distribution mechanism for 1.5

### DIFF
--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -350,3 +350,17 @@ const (
 	// SERVICE_DISCOVERY_KEY indicate which service discovery instance will be used
 	SERVICE_DISCOVERY_KEY = "service_discovery"
 )
+
+// Loader Hook
+const (
+	HOOK_EVENT_PARAM_KEY               = "config-loader-hook-event"
+	HOOK_EVENT_ERROR_MESSAGE_PARAM_KEY = "config-loader-hook-error-message"
+
+	HOOK_EVENT_BEFORE_CONSUMER_CONNECT  = "before-consumer-connect"
+	HOOK_EVENT_CONSUMER_CONNECT_SUCCESS = "consumer-connect-success"
+	HOOK_EVENT_CONSUMER_CONNECT_FAIL    = "consumer-connect-fail"
+
+	HOOK_EVENT_BEFORE_PROVIDER_CONNECT  = "before-provider-connect"
+	HOOK_EVENT_PROVIDER_CONNECT_SUCCESS = "provider-connect-success"
+	HOOK_EVENT_PROVIDER_CONNECT_FAIL    = "provider-connect-fail"
+)

--- a/common/extension/config_post_processor.go
+++ b/common/extension/config_post_processor.go
@@ -43,3 +43,17 @@ func GetConfigPostProcessors() []interfaces.ConfigPostProcessor {
 	}
 	return ret
 }
+
+func GetConfigLoaderHooks() []interfaces.ConfigLoaderHook {
+	var ret []interfaces.ConfigLoaderHook
+	for _, v := range processors {
+		h, ok := v.(interfaces.ConfigLoaderHook)
+		if ok {
+			ret = append(ret, h)
+		}
+	}
+	if ret == nil {
+		return make([]interfaces.ConfigLoaderHook, 0)
+	}
+	return ret
+}

--- a/config/graceful_shutdown.go
+++ b/config/graceful_shutdown.go
@@ -67,6 +67,7 @@ func GracefulShutdownInit() {
 			// gracefulShutdownOnce.Do(func() {
 			time.AfterFunc(totalTimeout(), func() {
 				logger.Warn("Shutdown gracefully timeout, application will shutdown immediately. ")
+				postBeforeShutdown()
 				os.Exit(0)
 			})
 			BeforeShutdown()
@@ -76,6 +77,7 @@ func GracefulShutdownInit() {
 					debug.WriteHeapDump(os.Stdout.Fd())
 				}
 			}
+			postBeforeShutdown()
 			os.Exit(0)
 		}
 	}()
@@ -222,4 +224,10 @@ func getConsumerProtocols() *gxset.HashSet {
 		result.Add(reference.Protocol)
 	}
 	return result
+}
+
+func postBeforeShutdown() {
+	for _, h := range extension.GetConfigLoaderHooks() {
+		h.BeforeShutdown()
+	}
 }

--- a/config/interfaces/config_post_processor.go
+++ b/config/interfaces/config_post_processor.go
@@ -25,8 +25,24 @@ import (
 // ServiceConfig during deployment time.
 type ConfigPostProcessor interface {
 	// PostProcessReferenceConfig customizes ReferenceConfig's params.
+	// PostProcessReferenceConfig emit on refer customer (GetParam(constant.HOOK_EVENT_PARAM_KEY): before-consumer-connect, consumer-connect-success, consumer-connect-fail)
 	PostProcessReferenceConfig(*common.URL)
 
 	// PostProcessServiceConfig customizes ServiceConfig's params.
+	// PostProcessServiceConfig emit on export provider (GetParam(constant.HOOK_EVENT_PARAM_KEY): before-provider-connect, provider-connect-success, provider-connect-fail)
 	PostProcessServiceConfig(*common.URL)
+}
+
+// ConfigLoaderHook is extends ConfigPostProcessor
+type ConfigLoaderHook interface {
+	ConfigPostProcessor
+
+	// AllConsumersConnectComplete emit on all consumers export complete
+	AllConsumersConnectComplete()
+
+	// AllProvidersConnectComplete emit on all providers export complete
+	AllProvidersConnectComplete()
+
+	// BeforeShutdown emit on before shutdown
+	BeforeShutdown()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**:
分发机制
![未命名文件](https://user-images.githubusercontent.com/9605663/130192341-1e6eb11d-4e0e-455e-b4de-4794ca523f58.jpg)

[单元测试](https://github.com/Chans-Open-Source/dubbo-go/blob/866b03c3153136ee7f4203de4aa2047aaff14f7f/config/config_loader_test.go#L147)
```go
// 实现事件分发接口
type CustomEvent struct {
	t *testing.T
}

// implements interfaces.ConfigPostProcessor's functions
func (c CustomEvent) PostProcessReferenceConfig(u *common.URL) {
	logger.Debug("PostProcessReferenceConfig Start")
	logger.Debug("Event: ", u.GetParam(constant.HOOK_EVENT_PARAM_KEY, ""))
	logger.Debug("Url: ", u)
	logger.Debug("Error Message: ", u.GetParam(constant.HOOK_EVENT_ERROR_MESSAGE_PARAM_KEY, ""))
	logger.Debug("PostProcessReferenceConfig End")
	assert.Equal(c.t, u.GetParam(constant.SIDE_KEY, ""), "consumer")
}
func (c CustomEvent) PostProcessServiceConfig(u *common.URL) {
	logger.Debug("PostProcessServiceConfig Start")
	logger.Debug("Event: ", u.GetParam(constant.HOOK_EVENT_PARAM_KEY, ""))
	logger.Debug("Url: ", u)
	logger.Debug("Error Message: ", u.GetParam(constant.HOOK_EVENT_ERROR_MESSAGE_PARAM_KEY, ""))
	logger.Debug("PostProcessServiceConfig End")
	assert.Equal(c.t, u.GetParam(constant.SIDE_KEY, ""), "provider")
}

// implements interfaces.ConfigLoaderHook's functions
func (c CustomEvent) AllConsumersConnectComplete() {
	logger.Debug("AllConsumersConnectComplete")
}
func (c CustomEvent) AllProvidersConnectComplete() {
	logger.Debug("AllProvidersConnectComplete")
}
func (c CustomEvent) BeforeShutdown() {
	logger.Debug("BeforeShutdown")
}

func TestLoadWithEventDispatch(t *testing.T) {
	doInitConsumer()
	doInitProvider()
	for _, v := range providerConfig.Services {
		v.export = true
	}

	ms := &MockService{}
	SetConsumerService(ms)
	SetProviderService(ms)

	extension.SetProtocol("registry", GetProtocol)
	extension.SetCluster(constant.ZONEAWARE_CLUSTER_NAME, cluster_impl.NewZoneAwareCluster)
	extension.SetProxyFactory("default", proxy_factory.NewDefaultProxyFactory)
	GetApplicationConfig().MetadataType = "mock"
	var mm *mockMetadataService
	extension.SetMetadataService("mock", func() (metadataService service.MetadataService, err error) {
		if mm == nil {
			mm = &mockMetadataService{
				exportedServiceURLs: new(sync.Map),
				lock:                new(sync.RWMutex),
			}
		}
		return mm, nil
	})

	extension.SetConfigPostProcessor("TestLoadWithEventDispatch", CustomEvent{t})

	Load()

	assert.Equal(t, ms, GetRPCService(ms.Reference()))
	ms2 := &struct {
		MockService
	}{}
	RPCService(ms2)
	assert.NotEqual(t, ms2, GetRPCService(ms2.Reference()))

	conServices = map[string]common.RPCService{}
	proServices = map[string]common.RPCService{}
	err := common.ServiceMap.UnRegister("com.MockService", "mock",
		common.ServiceKey("com.MockService", "huadong_idc", "1.0.0"))
	assert.Nil(t, err)
	consumerConfig = nil
	providerConfig = nil
}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #1364

**Special notes for your reviewer**:
钩子方式的实现方式 #1372

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
- 已兼容旧版分发机制
- 如需使用新版机制，自定义事件实现interfaces.ConfigLoaderHook的想法函数即可
```