### PR TITLE
Fix: app level metadata bug

### DIFF
--- a/config/config_loader.go
+++ b/config/config_loader.go
@@ -376,6 +376,10 @@ func registerServiceInstance() {
 			panic(err)
 		}
 	}
+	// publish metadata to remote
+	if remoteMetadataService, err := extension.GetRemoteMetadataService(); err == nil {
+		remoteMetadataService.PublishMetadata(GetApplicationConfig().Name)
+	}
 }
 
 //

--- a/imports/imports.go
+++ b/imports/imports.go
@@ -8,6 +8,7 @@ import (
 	_ "dubbo.apache.org/dubbo-go/v3/config_center/nacos"
 	_ "dubbo.apache.org/dubbo-go/v3/config_center/zookeeper"
 	_ "dubbo.apache.org/dubbo-go/v3/filter/filter_impl"
+	_ "dubbo.apache.org/dubbo-go/v3/metadata/mapping/dynamic"
 	_ "dubbo.apache.org/dubbo-go/v3/metadata/report/etcd"
 	_ "dubbo.apache.org/dubbo-go/v3/metadata/report/nacos"
 	_ "dubbo.apache.org/dubbo-go/v3/metadata/report/zookeeper"


### PR DESCRIPTION

**What this PR does**:

This PR recovers the call of `remoteMetadataService.PublishMetadata` in `registerServiceInstance()`, so the providers could publish the app level metadata to the remote metadata report.