### PR TITLE
fix: add get dynamic configuration api

### DIFF
--- a/config/config_center_config.go
+++ b/config/config_center_config.go
@@ -176,6 +176,18 @@ func startConfigCenter(rc *RootConfig) error {
 	return nil
 }
 
+func (c *CenterConfig) GetDynamicConfiguration() (config_center.DynamicConfiguration, error) {
+	configCenterUrl, err := c.toURL()
+	if err != nil {
+		return nil, err
+	}
+	factory := extension.GetConfigCenterFactory(configCenterUrl.Protocol)
+	if factory == nil {
+		return nil, errors.New("get config center factory failed")
+	}
+	return factory.GetDynamicConfiguration(configCenterUrl)
+}
+
 func (c *CenterConfig) prepareEnvironment(configCenterUrl *common.URL) (string, error) {
 	factory := extension.GetConfigCenterFactory(configCenterUrl.Protocol)
 	if factory == nil {

--- a/config_center/dynamic_configuration.go
+++ b/config_center/dynamic_configuration.go
@@ -56,6 +56,8 @@ type DynamicConfiguration interface {
 	GetInternalProperty(string, ...Option) (string, error)
 
 	// PublishConfig will publish the config with the (key, group, value) pair
+	// for zk: path is /$(group)/config/$(key) -> value
+	// for nacos: group, key -> value
 	PublishConfig(string, string, string) error
 
 	// RemoveConfig will remove the config white the (key, group) pair


### PR DESCRIPTION
This API can create dynamic configuration from centerConfig generated by config api.
This gives developers more flexibility to use a particular dubbogo feature module.
After this PR, we can use use configuration api in this way:
```go
dynamicConfig, err := config.NewConfigCenterConfig(
		config.WithConfigCenterProtocol("zookeeper"),
		config.WithConfigCenterAddress("127.0.0.1:2181")).GetDynamicConfiguration()
	if err != nil{
		panic(err)
	}
	if err := dynamicConfig.PublishConfig("dubbo-go-samples-configcenter-zookeeper-client","dubbogo", `## set in config center, group is 'dubbo', dataid is 'dubbo-go-samples-configcenter-nacos-client', namespace is default
dubbo:
  registries:
    "demoZK":
      protocol: "nacos"
      timeout: "3s"
      address: "127.0.0.1:8848"
  consumer:
    registry:
      - demoZK
    references:
      "greeterImpl":
        protocol: "tri"
        interface: "com.apache.dubbo.sample.basic.IGreeter" # must be compatible with grpc or dubbo-java`); err !=nil{
		panic(err)
	}


	config.SetConsumerService(grpcGreeterImpl)

	centerConfig := config.NewConfigCenterConfig(
		config.WithConfigCenterProtocol("zookeeper"),
		config.WithConfigCenterAddress("localhost:2181"),
		config.WithConfigCenterDataID("dubbo-go-samples-configcenter-zookeeper-client"),
		config.WithConfigCenterGroup("dubbogo"),
	)

	rootConfig := config.NewRootConfig(
		config.WithRootCenterConfig(centerConfig),
	)

	if err := rootConfig.Init(); err != nil {
		panic(err)
	}

```