### PR TITLE
store zk value with base64.

### DIFF
--- a/config/config_center_config.go
+++ b/config/config_center_config.go
@@ -176,6 +176,18 @@ func startConfigCenter(rc *RootConfig) error {
 	return nil
 }
 
+func (c *CenterConfig) GetDynamicConfiguration() (config_center.DynamicConfiguration, error) {
+	configCenterUrl, err := c.toURL()
+	if err != nil {
+		return nil, err
+	}
+	factory := extension.GetConfigCenterFactory(configCenterUrl.Protocol)
+	if factory == nil {
+		return nil, errors.New("get config center factory failed")
+	}
+	return factory.GetDynamicConfiguration(configCenterUrl)
+}
+
 func (c *CenterConfig) prepareEnvironment(configCenterUrl *common.URL) (string, error) {
 	factory := extension.GetConfigCenterFactory(configCenterUrl.Protocol)
 	if factory == nil {

--- a/config/root_config.go
+++ b/config/root_config.go
@@ -94,7 +94,7 @@ func (rc *RootConfig) Init() error {
 		return err
 	}
 	if err := rc.ConfigCenter.Init(rc); err != nil {
-		logger.Info("config center doesn't start.")
+		logger.Infof("config center doesn't start. error is %s", err)
 	}
 	if err := rc.Application.Init(rc); err != nil {
 		return err

--- a/config_center/dynamic_configuration.go
+++ b/config_center/dynamic_configuration.go
@@ -56,6 +56,8 @@ type DynamicConfiguration interface {
 	GetInternalProperty(string, ...Option) (string, error)
 
 	// PublishConfig will publish the config with the (key, group, value) pair
+	// for zk: path is /$(group)/config/$(key) -> value
+	// for nacos: group, key -> value
 	PublishConfig(string, string, string) error
 
 	// RemoveConfig will remove the config white the (key, group) pair


### PR DESCRIPTION
Find out the problem that zk can't store \n charactor correctly, which is used by config center.