### PR TITLE
Ftr: add fatal method for logger(config-enhance branch)

### DIFF
--- a/common/logger/logger.go
+++ b/common/logger/logger.go
@@ -50,11 +50,13 @@ type Logger interface {
 	Warn(args ...interface{})
 	Error(args ...interface{})
 	Debug(args ...interface{})
+	Fatal(args ...interface{})
 
 	Infof(fmt string, args ...interface{})
 	Warnf(fmt string, args ...interface{})
 	Errorf(fmt string, args ...interface{})
 	Debugf(fmt string, args ...interface{})
+	Fatalf(fmt string, args ...interface{})
 }
 
 // InitLogger use for init logger by @conf

--- a/common/logger/logging.go
+++ b/common/logger/logging.go
@@ -56,3 +56,13 @@ func Errorf(fmt string, args ...interface{}) {
 func Debugf(fmt string, args ...interface{}) {
 	logger.Debugf(fmt, args...)
 }
+
+// Fatal logs a message, then calls os.Exit.
+func Fatal(args ...interface{}) {
+	logger.Fatal(args...)
+}
+
+// Fatalf logs a templated message, then calls os.Exit.
+func Fatalf(fmt string, args ...interface{}) {
+	logger.Fatalf(fmt, args...)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module dubbo.apache.org/dubbo-go/v3
 go 1.15
 
 require (
+	bou.ke/monkey v1.0.2
 	github.com/RoaringBitmap/roaring v0.7.1
 	github.com/Workiva/go-datastructures v1.0.52
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 bazil.org/fuse v0.0.0-20160811212531-371fbbdaa898/go.mod h1:Xbm+BRKSBEpa4q4hTSxohYNQpsxXPbPry4JJWOB3LB8=
+bou.ke/monkey v1.0.2 h1:kWcnsrCNUatbxncxR/ThdYqbytgOIArtYWqcQLQzKLI=
+bou.ke/monkey v1.0.2/go.mod h1:OqickVX3tNx6t33n1xvtTtu85YN5s6cKwVug+oHMaIA=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=


### PR DESCRIPTION
* Logger 接口添加 fatal 和 fatalf 方法
* 由于 zap 的 fatal 方法会调用 os.Exit 因此导入了 "bou.ke/monkey" 包用于测试 fatal，防止因执行 logger.Fatal 导致单测 ci 失败 