### PR TITLE
upgrade hessian2 to v1.9.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/alibaba/sentinel-golang v1.0.2
 	github.com/apache/dubbo-getty v1.4.5
-	github.com/apache/dubbo-go-hessian2 v1.9.3
+	github.com/apache/dubbo-go-hessian2 v1.9.4
 	github.com/creasty/defaults v1.5.2
 	github.com/dubbogo/go-zookeeper v1.0.3
 	github.com/dubbogo/gost v1.11.18

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/apache/dubbo-getty v1.4.5 h1:MptKbjC0n2Mo/8eFPwirSInH2BfdNG4IZch43PdNvIM=
 github.com/apache/dubbo-getty v1.4.5/go.mod h1:mcDyiu7M/TVrYDyL8TxDemQkOdvEqqHSQ4jOuYejY1w=
 github.com/apache/dubbo-go-hessian2 v1.9.1/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
-github.com/apache/dubbo-go-hessian2 v1.9.3 h1:0G9cdOCiKILem1JRKeZtY0FdIUyvzt30qtukMXPtJks=
-github.com/apache/dubbo-go-hessian2 v1.9.3/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
+github.com/apache/dubbo-go-hessian2 v1.9.4 h1:dj8yT7Jjq7q6skix7Tn/oH/IRmw9dQBQvATnpUDuaHg=
+github.com/apache/dubbo-go-hessian2 v1.9.4/go.mod h1:7rEw9guWABQa6Aqb8HeZcsYPHsOS7XT1qtJvkmI6c5w=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION

**What this PR does**:
upgrade hessian2 to v1.9.4

**Which issue(s) this PR fixes**:
see https://github.com/apache/dubbo-go-hessian2/releases/tag/v1.9.4

**Does this PR introduce a user-facing change?**:
```release-note
- upgrade hessian2 to v1.9.4
```