### PR TITLE
fix: add nacos methods key

### DIFF
--- a/registry/nacos/registry.go
+++ b/registry/nacos/registry.go
@@ -95,6 +95,7 @@ func createRegisterParam(url *common.URL, serviceName string, groupName string) 
 	params[constant.NacosCategoryKey] = category
 	params[constant.NacosProtocolKey] = url.Protocol
 	params[constant.NacosPathKey] = url.Path
+	params[constant.MethodsKey] = strings.Join(url.Methods, ",")
 	if len(url.Ip) == 0 {
 		url.Ip = localIP
 	}


### PR DESCRIPTION
- nacos registry servicce  provider's url methods key is empty now, and is used by pixiu-gateway