### PR TITLE
fix:  service register url's group and version key with "" value.

### DIFF
--- a/config/service_config.go
+++ b/config/service_config.go
@@ -348,8 +348,12 @@ func (svc *ServiceConfig) getUrlMap() url.Values {
 	urlMap.Set(constant.LoadbalanceKey, svc.Loadbalance)
 	urlMap.Set(constant.WarmupKey, svc.Warmup)
 	urlMap.Set(constant.RetriesKey, svc.Retries)
-	urlMap.Set(constant.GroupKey, svc.Group)
-	urlMap.Set(constant.VersionKey, svc.Version)
+	if svc.Group != "" {
+		urlMap.Set(constant.GroupKey, svc.Group)
+	}
+	if svc.Version != "" {
+		urlMap.Set(constant.VersionKey, svc.Version)
+	}
 	urlMap.Set(constant.RegistryRoleKey, strconv.Itoa(common.PROVIDER))
 	urlMap.Set(constant.ReleaseKey, "dubbo-golang-"+constant.Version)
 	urlMap.Set(constant.SideKey, (common.RoleType(common.PROVIDER)).Role())


### PR DESCRIPTION
As for java client, if user set 'version' to '1.0.0" and doesn't set 'group' key. the reference url's param contains version=1.0.0 and doesn't contain 'group' key.
But golang server regster 'group' key with "" value even if user didn't configure service's 'group' field in config file.
That's a bug. I open this pr is to let url to be register, doesn't contain group or value key, if user didn't set.