### PR TITLE
Ftr: change log to dubbo go logger

### DIFF
--- a/protocol/dubbo3/internal/server.go
+++ b/protocol/dubbo3/internal/server.go
@@ -19,11 +19,11 @@ package internal
 
 import (
 	"context"
-	"log"
 )
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
+	log "dubbo.apache.org/dubbo-go/v3/common/logger"
 	_ "dubbo.apache.org/dubbo-go/v3/common/proxy/proxy_factory"
 	"dubbo.apache.org/dubbo-go/v3/config"
 	_ "dubbo.apache.org/dubbo-go/v3/filter/filter_impl"
@@ -37,7 +37,7 @@ type Server struct {
 
 // SayHello implements helloworld.GreeterServer
 func (s *Server) SayHello(ctx context.Context, in *HelloRequest) (*HelloReply, error) {
-	log.Printf("Received: %v", in.GetName())
+	log.Infof("Received: %v", in.GetName())
 	return &HelloReply{Message: "Hello " + in.GetName()}, nil
 }
 

--- a/protocol/grpc/internal/helloworld/server.go
+++ b/protocol/grpc/internal/helloworld/server.go
@@ -19,12 +19,15 @@ package helloworld
 
 import (
 	"context"
-	"log"
 	"net"
 )
 
 import (
 	"google.golang.org/grpc"
+)
+
+import (
+	log "dubbo.apache.org/dubbo-go/v3/common/logger"
 )
 
 // server is used to implement helloworld.GreeterServer.
@@ -40,7 +43,7 @@ func NewService() *server {
 
 // SayHello implements helloworld.GreeterServer
 func (s *server) SayHello(ctx context.Context, in *HelloRequest) (*HelloReply, error) {
-	log.Printf("Received: %v", in.GetName())
+	log.Infof("Received: %v", in.GetName())
 	return &HelloReply{Message: "Hello " + in.GetName()}, nil
 }
 

--- a/protocol/grpc/internal/routeguide/client.go
+++ b/protocol/grpc/internal/routeguide/client.go
@@ -19,12 +19,12 @@ package routeguide
 
 import (
 	"io"
-	"log"
 	"math/rand"
 	"time"
 )
 
 import (
+	log "dubbo.apache.org/dubbo-go/v3/common/logger"
 	"dubbo.apache.org/dubbo-go/v3/config"
 )
 
@@ -43,7 +43,7 @@ func PrintFeatures(stream RouteGuide_ListFeaturesClient) {
 		if err != nil {
 			log.Fatalf("Fait to receive a feature: %v", err)
 		}
-		log.Printf("Feature: name: %q, point:(%v, %v)", feature.GetName(),
+		log.Infof("Feature: name: %q, point:(%v, %v)", feature.GetName(),
 			feature.GetLocation().GetLatitude(), feature.GetLocation().GetLongitude())
 	}
 }
@@ -57,7 +57,7 @@ func RunRecordRoute(stream RouteGuide_RecordRouteClient) {
 	for i := 0; i < pointCount; i++ {
 		points = append(points, randomPoint(r))
 	}
-	log.Printf("Traversing %d points.", len(points))
+	log.Infof("Traversing %d points.", len(points))
 	for _, point := range points {
 		if err := stream.Send(point); err != nil {
 			log.Fatalf("%v.Send(%v) = %v", stream, point, err)
@@ -67,7 +67,7 @@ func RunRecordRoute(stream RouteGuide_RecordRouteClient) {
 	if err != nil {
 		log.Fatalf("%v.CloseAndRecv() got error %v, want %v", stream, err, nil)
 	}
-	log.Printf("Route summary: %v", reply)
+	log.Infof("Route summary: %v", reply)
 }
 
 // runRouteChat receives a sequence of route notes, while sending notes for various locations.
@@ -92,7 +92,7 @@ func RunRouteChat(stream RouteGuide_RouteChatClient) {
 			if err != nil {
 				log.Fatalf("Failed to receive a note : %v", err)
 			}
-			log.Printf("Got message %s at point(%d, %d)", in.Message, in.Location.Latitude, in.Location.Longitude)
+			log.Infof("Got message %s at point(%d, %d)", in.Message, in.Location.Latitude, in.Location.Longitude)
 		}
 	}()
 	for _, note := range notes {

--- a/protocol/grpc/internal/routeguide/server.go
+++ b/protocol/grpc/internal/routeguide/server.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"math"
 	"net"
 	"sync"
@@ -33,6 +32,10 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	"google.golang.org/grpc"
+)
+
+import (
+	log "dubbo.apache.org/dubbo-go/v3/common/logger"
 )
 
 type routeGuideServer struct {


### PR DESCRIPTION
Some code in the project uses native log, such as :
```go
import (
    "log"
)

log.Printf("xxx")
```
Now change it to the unified use of the framework itself logger, the code is in `common/logger` ，the modified method of use is: 
```go
import (
    log "dubbo.apache.org/dubbo-go/v3/common/logger"
)

log.Infof("xxx")
```