### PR TITLE
hessian2 supports setting the type of Java method parameters

### DIFF
--- a/protocol/dubbo/impl/hessian.go
+++ b/protocol/dubbo/impl/hessian.go
@@ -490,6 +490,10 @@ func getArgType(v interface{}) string {
 		}
 		switch t.Kind() {
 		case reflect.Struct:
+			p, ok := v.(hessian.Param)
+			if ok {
+				return p.JavaParamName()
+			}
 			v, ok := v.(hessian.POJO)
 			if ok {
 				return v.JavaClassName()

--- a/protocol/dubbo/impl/hessian_test.go
+++ b/protocol/dubbo/impl/hessian_test.go
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package impl
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	dubboParam = "org.apache.dubbo.param"
+	dubboPojo  = "org.apache.dubbo.pojo"
+)
+
+type Param struct {
+}
+
+func (p *Param) JavaClassName() string {
+	return dubboPojo
+}
+
+func (p *Param) JavaParamName() string {
+	return dubboParam
+}
+
+type Pojo struct {
+}
+
+func (p *Pojo) JavaClassName() string {
+	return dubboPojo
+}
+
+func TestGetArgType(t *testing.T) {
+
+	t.Run("pojo", func(t *testing.T) {
+		assert.Equal(t, dubboPojo, getArgType(&Pojo{}))
+	})
+
+	t.Run("param", func(t *testing.T) {
+		assert.Equal(t, dubboParam, getArgType(&Param{}))
+	})
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**:
hessian2 supports setting the type of Java method parameters
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/apache/dubbo-go/issues/1624

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```