### PR TITLE
Fix: attachments maybe nil or empty string

### DIFF
--- a/protocol/dubbo/impl/hessian.go
+++ b/protocol/dubbo/impl/hessian.go
@@ -254,7 +254,7 @@ func unmarshalRequestBody(body []byte, p *DubboPackage) error {
 		return perrors.WithStack(err)
 	}
 
-	if attachments == nil {
+	if attachments == nil || attachments == "" {
 		attachments = map[interface{}]interface{}{constant.InterfaceKey: target}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**:

Unmarshal request body by `hession.go` , the attribute `attachments` maybe nil or empty string, and will stop the invoked

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
if attachments nil or empty string , default a value that for normal invoking

Fixes #1583 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```