### PR TITLE
3.0 support set nacos ContextPath

### DIFF
--- a/remoting/nacos/builder.go
+++ b/remoting/nacos/builder.go
@@ -69,8 +69,17 @@ func GetNacosConfig(url *common.URL) ([]nacosConstant.ServerConfig, nacosConstan
 			return []nacosConstant.ServerConfig{}, nacosConstant.ClientConfig{},
 				perrors.WithMessagef(err, "split [%s] ", addr)
 		}
-		port, _ := strconv.Atoi(portStr)
-		serverConfigs = append(serverConfigs, nacosConstant.ServerConfig{IpAddr: ip, Port: uint64(port)})
+		portContextPath := strings.Split(portStr, constant.PathSeparator)
+		port, err := strconv.Atoi(portContextPath[0])
+		if err != nil {
+			return []nacosConstant.ServerConfig{}, nacosConstant.ClientConfig{},
+				perrors.WithMessagef(err, "port [%s] ", portContextPath[0])
+		}
+		var contextPath string
+		if len(portContextPath) > 1 {
+			contextPath = constant.PathSeparator + strings.Join(portContextPath[1:], constant.PathSeparator)
+		}
+		serverConfigs = append(serverConfigs, nacosConstant.ServerConfig{IpAddr: ip, Port: uint64(port), ContextPath: contextPath})
 	}
 
 	timeout := url.GetParamDuration(constant.TimeoutKey, constant.DefaultRegTimeout)

--- a/remoting/nacos/builder_test.go
+++ b/remoting/nacos/builder_test.go
@@ -34,26 +34,44 @@ import (
 )
 
 func TestNewNacosClient(t *testing.T) {
-	rc := &config.RemoteConfig{}
-	rc.Protocol = "nacos"
-	rc.Username = "nacos"
-	client, err := NewNacosClient(rc)
+	t.Run("AddressIsNil", func(t *testing.T) {
+		rc := &config.RemoteConfig{}
+		rc.Protocol = "nacos"
+		rc.Username = "nacos"
+		client, err := NewNacosClient(rc)
 
-	// address is nil
-	assert.Nil(t, client)
-	assert.NotNil(t, err)
+		// address is nil
+		assert.Nil(t, client)
+		assert.NotNil(t, err)
+	})
 
-	rc.Address = "console.nacos.io:80:123"
-	client, err = NewNacosClient(rc)
-	// invalid address
-	assert.Nil(t, client)
-	assert.NotNil(t, err)
+	t.Run("InvalidAddress", func(t *testing.T) {
+		rc := &config.RemoteConfig{}
+		rc.Address = "console.nacos.io:80:123"
+		client, err := NewNacosClient(rc)
+		// invalid address
+		assert.Nil(t, client)
+		assert.NotNil(t, err)
+	})
 
-	rc.Address = "console.nacos.io:80"
-	rc.Timeout = "10s"
-	client, err = NewNacosClient(rc)
-	assert.NotNil(t, client)
-	assert.Nil(t, err)
+	t.Run("Normal", func(t *testing.T) {
+		rc := &config.RemoteConfig{}
+		rc.Address = "console.nacos.io:80"
+		rc.Protocol = "nacos"
+		rc.Timeout = "10s"
+		client, err := NewNacosClient(rc)
+		assert.NotNil(t, client)
+		assert.Nil(t, err)
+	})
+
+	t.Run("NormalHasContextPath", func(t *testing.T) {
+		rc := &config.RemoteConfig{}
+		rc.Address = "console.nacos.io:80/nacos"
+		rc.Protocol = "nacos"
+		client, err := NewNacosClient(rc)
+		assert.NotNil(t, client)
+		assert.Nil(t, err)
+	})
 }
 
 func TestGetNacosConfig(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**:
support set nacos context path
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/apache/dubbo-go/issues/1653

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
# registry config
registries:
  "demoNacos":
    protocol: "nacos"
    timeout	: "3s"
    address: "127.0.0.1:8848" or. "127.0.0.1:8848/nacos"
```