### PR TITLE
upgrade hessian2 to v1.11.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/alibaba/sentinel-golang v1.0.4
 	github.com/apache/dubbo-getty v1.4.7-rc2
-	github.com/apache/dubbo-go-hessian2 v1.10.2
+	github.com/apache/dubbo-go-hessian2 v1.11.0
 	github.com/creasty/defaults v1.5.2
 	github.com/dubbogo/go-zookeeper v1.0.4-0.20211212162352-f9d2183d89d5
 	github.com/dubbogo/gost v1.11.22

--- a/go.sum
+++ b/go.sum
@@ -85,8 +85,8 @@ github.com/apache/dubbo-getty v1.4.7-rc2 h1:Q/vDRoT35kSa0iMdMJSTjBFFHjLryDWPitq3
 github.com/apache/dubbo-getty v1.4.7-rc2/go.mod h1:+6IHweEgfMCShEzGzQw2H7Wt33nYTJ/U9lNH9tHrzMM=
 github.com/apache/dubbo-go-hessian2 v1.9.1/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
 github.com/apache/dubbo-go-hessian2 v1.9.3/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
-github.com/apache/dubbo-go-hessian2 v1.10.2 h1:Wb27FKBmgutoZWcXHt1C/WM4e+sBVW0NdLQQZ5ITlrU=
-github.com/apache/dubbo-go-hessian2 v1.10.2/go.mod h1:7rEw9guWABQa6Aqb8HeZcsYPHsOS7XT1qtJvkmI6c5w=
+github.com/apache/dubbo-go-hessian2 v1.11.0 h1:VTdT6NStuEqNmyT3AdSN2DLDBqhXvAAyAAAoh9hLavk=
+github.com/apache/dubbo-go-hessian2 v1.11.0/go.mod h1:7rEw9guWABQa6Aqb8HeZcsYPHsOS7XT1qtJvkmI6c5w=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/protocol/dubbo/hessian2/hessian_dubbo_test.go
+++ b/protocol/dubbo/hessian2/hessian_dubbo_test.go
@@ -214,7 +214,7 @@ func TestHessianCodec_ReadAttachments(t *testing.T) {
 	t.Log(h)
 
 	err = codecR1.ReadBody(body)
-	assert.Equal(t, "can not find go type name com.test.caseb in registry", err.Error())
+	assert.NoError(t, err)
 	attrs, err := codecR2.ReadAttachments()
 	assert.NoError(t, err)
 	assert.Equal(t, "2.6.4", attrs[DUBBO_VERSION_KEY])

--- a/protocol/dubbo/hessian2/hessian_dubbo_test.go
+++ b/protocol/dubbo/hessian2/hessian_dubbo_test.go
@@ -116,39 +116,52 @@ func doTestResponse(t *testing.T, packageType PackageType, responseStatus byte, 
 func TestResponse(t *testing.T) {
 	caseObj := Case{A: "a", B: 1}
 	decodedResponse := &DubboResponse{}
+	hessian.RegisterPOJO(&caseObj)
 
 	arr := []*Case{&caseObj}
-	var arrRes []interface{}
-	decodedResponse.RspObj = &arrRes
+	decodedResponse.RspObj = nil
 	doTestResponse(t, PackageResponse, Response_OK, arr, decodedResponse, func() {
+		arrRes, ok := decodedResponse.RspObj.([]*Case)
+		if !ok {
+			t.Errorf("expect []*Case, but get %s", reflect.TypeOf(decodedResponse.RspObj).String())
+			return
+		}
 		assert.Equal(t, 1, len(arrRes))
 		assert.Equal(t, &caseObj, arrRes[0])
 	})
 
-	decodedResponse.RspObj = &Case{}
-	doTestResponse(t, PackageResponse, Response_OK, &Case{A: "a", B: 1}, decodedResponse, nil)
+	doTestResponse(t, PackageResponse, Response_OK, &caseObj, decodedResponse, func() {
+		assert.Equal(t, &caseObj, decodedResponse.RspObj)
+	})
 
 	s := "ok!!!!!"
-	strObj := ""
-	decodedResponse.RspObj = &strObj
-	doTestResponse(t, PackageResponse, Response_OK, s, decodedResponse, nil)
+	doTestResponse(t, PackageResponse, Response_OK, s, decodedResponse, func() {
+		assert.Equal(t, s, decodedResponse.RspObj)
+	})
 
-	var intObj int64
-	decodedResponse.RspObj = &intObj
-	doTestResponse(t, PackageResponse, Response_OK, int64(3), decodedResponse, nil)
+	doTestResponse(t, PackageResponse, Response_OK, int64(3), decodedResponse, func() {
+		assert.Equal(t, int64(3), decodedResponse.RspObj)
+	})
 
-	boolObj := false
-	decodedResponse.RspObj = &boolObj
-	doTestResponse(t, PackageResponse, Response_OK, true, decodedResponse, nil)
+	doTestResponse(t, PackageResponse, Response_OK, true, decodedResponse, func() {
+		assert.Equal(t, true, decodedResponse.RspObj)
+	})
 
-	strObj = ""
-	decodedResponse.RspObj = &strObj
-	doTestResponse(t, PackageResponse, hessian.Response_SERVER_ERROR, "error!!!!!", decodedResponse, nil)
+	errorMsg := "error!!!!!"
+	decodedResponse.RspObj = nil
+	doTestResponse(t, PackageResponse, Response_SERVER_ERROR, errorMsg, decodedResponse, func() {
+		assert.Equal(t, "java exception:error!!!!!", decodedResponse.Exception.Error())
+	})
 
+	decodedResponse.RspObj = nil
+	decodedResponse.Exception = nil
 	mapObj := map[string][]*Case{"key": {&caseObj}}
-	mapRes := map[interface{}]interface{}{}
-	decodedResponse.RspObj = &mapRes
 	doTestResponse(t, PackageResponse, Response_OK, mapObj, decodedResponse, func() {
+		mapRes, ok := decodedResponse.RspObj.(map[interface{}]interface{})
+		if !ok {
+			t.Errorf("expect map[string][]*Case, but get %s", reflect.TypeOf(decodedResponse.RspObj).String())
+			return
+		}
 		c, ok := mapRes["key"]
 		if !ok {
 			assert.FailNow(t, "no key in decoded response map")

--- a/protocol/dubbo/hessian2/hessian_response.go
+++ b/protocol/dubbo/hessian2/hessian_response.go
@@ -228,13 +228,9 @@ func unpackResponseBody(decoder *hessian.Decoder, resp interface{}) error {
 			}
 		}
 
-		// If the return value is nil,
-		// we should consider it normal
-		if rsp == nil {
-			return nil
-		}
+		response.RspObj = rsp
 
-		return perrors.WithStack(ReflectResponse(rsp, response.RspObj))
+		return nil
 
 	case RESPONSE_NULL_VALUE, RESPONSE_NULL_VALUE_WITH_ATTACHMENTS:
 		if rspType == RESPONSE_NULL_VALUE_WITH_ATTACHMENTS {


### PR DESCRIPTION

**What this PR does**: 
upgrade hessian2 to v1.11.0, see https://github.com/apache/dubbo-go-hessian2/releases/tag/v1.11.0

**Which issue(s) this PR fixes**: 
None

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)