### PR TITLE
Imp: upgrade getty from 1.4.7-rc2 to 1.4.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Workiva/go-datastructures v1.0.52
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/alibaba/sentinel-golang v1.0.4
-	github.com/apache/dubbo-getty v1.4.7-rc2
+	github.com/apache/dubbo-getty v1.4.7
 	github.com/apache/dubbo-go-hessian2 v1.10.2
 	github.com/creasty/defaults v1.5.2
 	github.com/dubbogo/go-zookeeper v1.0.4-0.20211212162352-f9d2183d89d5

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/alibaba/sentinel-golang v1.0.4/go.mod h1:Lag5rIYyJiPOylK8Kku2P+a23gdK
 github.com/aliyun/alibaba-cloud-sdk-go v1.61.18 h1:zOVTBdCKFd9JbCKz9/nt+FovbjPFmb7mUnp8nH9fQBA=
 github.com/aliyun/alibaba-cloud-sdk-go v1.61.18/go.mod h1:v8ESoHo4SyHmuB4b1tJqDHxfTGEciD+yhvOU/5s1Rfk=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/apache/dubbo-getty v1.4.7-rc2 h1:Q/vDRoT35kSa0iMdMJSTjBFFHjLryDWPitq3ZwXjze0=
-github.com/apache/dubbo-getty v1.4.7-rc2/go.mod h1:+6IHweEgfMCShEzGzQw2H7Wt33nYTJ/U9lNH9tHrzMM=
+github.com/apache/dubbo-getty v1.4.7 h1:DckNY2c9i8FF3xX1w7fWqsgBz108EE4mLpeedwYBuLw=
+github.com/apache/dubbo-getty v1.4.7/go.mod h1:+6IHweEgfMCShEzGzQw2H7Wt33nYTJ/U9lNH9tHrzMM=
 github.com/apache/dubbo-go-hessian2 v1.9.1/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
 github.com/apache/dubbo-go-hessian2 v1.9.3/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
 github.com/apache/dubbo-go-hessian2 v1.10.2 h1:Wb27FKBmgutoZWcXHt1C/WM4e+sBVW0NdLQQZ5ITlrU=


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
现在有两种 Panic 的问题被修复了，主要是因为连接中断导致 Connection 这个对象被清理了，然后有其他协程内会执行 Connection 这个对象就会出现 Panic 的问题。
 - 当连接中断的时候，Getty 会收到一个 EOF Error，接着 defer 会执行 gc() 函数，他会把 Connection 设置为 nil。但是有很多个 Task 被放到了 Pool 里面，等待 Pool 调度到 Task 的时候，他会开启协程去执行 Task。这时候 Connection 已经被设置为空了，那么用到 Connection 的函数就会出现 panic 的问题。
 - 在 Dubbo go 中会执行 GetActive 这个函数，GetActive 也是操作 Connection 内的函数，但是其实那时候可能因为上层的超时或者解析失败已经连接中断，那么 Connection 已经被清除了，所以就出现了 Panic 的问题。
**Which issue(s) this PR fixes**: 
Fixes #

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)