### PR TITLE
directory refine

### DIFF
--- a/registry/directory/directory.go
+++ b/registry/directory/directory.go
@@ -279,22 +279,17 @@ func (dir *RegistryDirectory) convertUrl(res *registry.ServiceEvent) *common.URL
 }
 
 func (dir *RegistryDirectory) toGroupInvokers() []protocol.Invoker {
-	var (
-		err             error
-		newInvokersList []protocol.Invoker
-	)
+	var err error
+
 	groupInvokersMap := make(map[string][]protocol.Invoker)
 
 	dir.cacheInvokersMap.Range(func(key, value interface{}) bool {
-		newInvokersList = append(newInvokersList, value.(protocol.Invoker))
+		invoker := value.(protocol.Invoker)
+		group := invoker.GetURL().GetParam(constant.GroupKey, "")
+		groupInvokersMap[group] = append(groupInvokersMap[group], invoker)
 		return true
 	})
 
-	for _, invoker := range newInvokersList {
-		group := invoker.GetURL().GetParam(constant.GroupKey, "")
-
-		groupInvokersMap[group] = append(groupInvokersMap[group], invoker)
-	}
 	groupInvokersList := make([]protocol.Invoker, 0, len(groupInvokersMap))
 	if len(groupInvokersMap) == 1 {
 		// len is 1 it means no group setting ,so do not need cluster again


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
refine RegistryDirectory. toGroupInvokers func

**Which issue(s) this PR fixes**: 
Fixes #

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [x] All ut passed (run 'go test ./...' in project root)
- [x] After go-fmt ed , run 'go fmt project' using goland.
- [x] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [x] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)