### PR TITLE
fix(adasvc): do not load adaptive service filter if not set

### DIFF
--- a/common/constant/default.go
+++ b/common/constant/default.go
@@ -57,8 +57,7 @@ const (
 	// that put the AdaptiveServiceProviderFilterKey at the end.
 	DefaultServiceFilters = EchoFilterKey + "," +
 		MetricsFilterKey + "," + TokenFilterKey + "," + AccessLogFilterKey + "," + TpsLimitFilterKey + "," +
-		GenericServiceFilterKey + "," + ExecuteLimitFilterKey + "," + GracefulShutdownProviderFilterKey + "," +
-		AdaptiveServiceProviderFilterKey
+		GenericServiceFilterKey + "," + ExecuteLimitFilterKey + "," + GracefulShutdownProviderFilterKey
 
 	DefaultReferenceFilters = GracefulShutdownConsumerFilterKey
 )

--- a/config/provider_config.go
+++ b/config/provider_config.go
@@ -19,13 +19,14 @@ package config
 
 import (
 	"fmt"
-	perrors "github.com/pkg/errors"
 )
 
 import (
 	"github.com/creasty/defaults"
 
 	tripleConstant "github.com/dubbogo/triple/pkg/common/constant"
+
+	perrors "github.com/pkg/errors"
 )
 
 import (

--- a/config/provider_config.go
+++ b/config/provider_config.go
@@ -19,6 +19,7 @@ package config
 
 import (
 	"fmt"
+	perrors "github.com/pkg/errors"
 )
 
 import (
@@ -49,8 +50,10 @@ type ProviderConfig struct {
 	FilterConf   interface{}               `yaml:"filter_conf" json:"filter_conf,omitempty" property:"filter_conf"`
 	ConfigType   map[string]string         `yaml:"config_type" json:"config_type,omitempty" property:"config_type"`
 	// adaptive service
+	AdaptiveService        bool `default:"false" yaml:"adaptive-service" json:"adaptive-service" property:"adaptive-service"`
 	AdaptiveServiceVerbose bool `default:"false" yaml:"adaptive-service-verbose" json:"adaptive-service-verbose" property:"adaptive-service-verbose"`
-	rootConfig             *RootConfig
+
+	rootConfig *RootConfig
 }
 
 func (ProviderConfig) Prefix() string {
@@ -97,6 +100,8 @@ func (c *ProviderConfig) Init(rc *RootConfig) error {
 		if err := serviceConfig.Init(rc); err != nil {
 			return err
 		}
+
+		serviceConfig.adaptiveService = c.AdaptiveService
 	}
 
 	for k, v := range rc.Protocols {
@@ -117,6 +122,10 @@ func (c *ProviderConfig) Init(rc *RootConfig) error {
 	}
 	// enable adaptive service verbose
 	if c.AdaptiveServiceVerbose {
+		if !c.AdaptiveService {
+			return perrors.Errorf("The adaptive service is disabled, " +
+				"adaptive service verbose should be disabled either.")
+		}
 		logger.Infof("adaptive service verbose is enabled.")
 		logger.Debugf("debug-level info could be shown.")
 		aslimiter.Verbose = true

--- a/config/service_config.go
+++ b/config/service_config.go
@@ -81,6 +81,7 @@ type ServiceConfig struct {
 	RCProtocolsMap  map[string]*ProtocolConfig
 	RCRegistriesMap map[string]*RegistryConfig
 	ProxyFactoryKey string
+	adaptiveService bool
 	unexported      *atomic.Bool
 	exported        *atomic.Bool
 	export          bool // a flag to control whether the current service should export or not
@@ -378,11 +379,16 @@ func (svc *ServiceConfig) getUrlMap() url.Values {
 	urlMap.Set(constant.EnvironmentKey, ac.Environment)
 
 	// filter
+	var filters string
 	if svc.Filter == "" {
-		urlMap.Set(constant.ServiceFilterKey, constant.DefaultServiceFilters)
+		filters = constant.DefaultServiceFilters
 	} else {
-		urlMap.Set(constant.ServiceFilterKey, svc.Filter)
+		filters = svc.Filter
 	}
+	if svc.adaptiveService {
+		filters += fmt.Sprintf(",%s", constant.AdaptiveServiceProviderFilterKey)
+	}
+	urlMap.Set(constant.ServiceFilterKey, filters)
 
 	// filter special config
 	urlMap.Set(constant.AccessLogFilterKey, svc.AccessLog)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 

**Which issue(s) this PR fixes**: 
Fixes #

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)