### PR TITLE
fix(adasvc): do not use adaptive service filter if disabled on the client side

### DIFF
--- a/cluster/cluster/adaptivesvc/cluster_invoker.go
+++ b/cluster/cluster/adaptivesvc/cluster_invoker.go
@@ -66,6 +66,7 @@ func (ivk *adaptiveServiceClusterInvoker) Invoke(ctx context.Context, invocation
 	invoker := lb.Select(invokers, invocation)
 
 	// invoke
+	invocation.SetAttachment(constant.AdaptiveServiceEnabledKey, constant.AdaptiveServiceIsEnabled)
 	result := invoker.Invoke(ctx, invocation)
 
 	// if the adaptive service encounters an error, DO NOT

--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -380,4 +380,7 @@ const (
 	// attachment keys
 	AdaptiveServiceRemainingKey = "adaptive-service.remaining"
 	AdaptiveServiceInflightKey  = "adaptive-service.inflight"
+	AdaptiveServiceEnabledKey   = "adaptive-service.enabled"
+	// enabled value
+	AdaptiveServiceIsEnabled = "1"
 )

--- a/filter/adaptivesvc/filter.go
+++ b/filter/adaptivesvc/filter.go
@@ -64,6 +64,11 @@ func newAdaptiveServiceProviderFilter() filter.Filter {
 
 func (f *adaptiveServiceProviderFilter) Invoke(ctx context.Context, invoker protocol.Invoker,
 	invocation protocol.Invocation) protocol.Result {
+	if invocation.GetAttachmentWithDefaultValue(constant.AdaptiveServiceEnabledKey, "") !=
+		constant.AdaptiveServiceIsEnabled {
+		// the adaptive service is enabled on the invocation
+		return invoker.Invoke(ctx, invocation)
+	}
 
 	l, err := limiterMapperSingleton.getMethodLimiter(invoker.GetURL(), invocation.MethodName())
 	if err != nil {
@@ -91,6 +96,10 @@ func (f *adaptiveServiceProviderFilter) Invoke(ctx context.Context, invoker prot
 
 func (f *adaptiveServiceProviderFilter) OnResponse(_ context.Context, result protocol.Result, invoker protocol.Invoker,
 	invocation protocol.Invocation) protocol.Result {
+	if result.Attachment(constant.AdaptiveServiceEnabledKey, "") != constant.AdaptiveServiceIsEnabled {
+		// the adaptive service is enabled on the invocation
+		return result
+	}
 
 	if isErrAdaptiveSvcInterrupted(result.Error()) {
 		// If the Invoke method of the adaptiveServiceProviderFilter returns an error,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 

**Which issue(s) this PR fixes**: 
Fixes #

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)