### PR TITLE
fix(config): fix the type of reject request

### DIFF
--- a/config/graceful_shutdown_config.go
+++ b/config/graceful_shutdown_config.go
@@ -67,7 +67,7 @@ type ShutdownConfig struct {
 	InternalSignal bool `default:"true" yaml:"internal-signal" json:"internal.signal,omitempty" property:"internal.signal"`
 
 	// true -> new request will be rejected.
-	RejectRequest bool
+	RejectRequest atomic.Bool
 	// active invocation
 	ConsumerActiveCount atomic.Int32
 	ProviderActiveCount atomic.Int32
@@ -138,7 +138,7 @@ func (scb *ShutdownConfigBuilder) SetRejectRequestHandler(rejectRequestHandler s
 }
 
 func (scb *ShutdownConfigBuilder) SetRejectRequest(rejectRequest bool) *ShutdownConfigBuilder {
-	scb.shutdownConfig.RejectRequest = rejectRequest
+	scb.shutdownConfig.RejectRequest.Store(rejectRequest)
 	return scb
 }
 

--- a/config/graceful_shutdown_config_test.go
+++ b/config/graceful_shutdown_config_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestShutdownConfigGetTimeout(t *testing.T) {
 	config := ShutdownConfig{}
-	assert.False(t, config.RejectRequest)
+	assert.False(t, config.RejectRequest.Load())
 
 	config = ShutdownConfig{
 		Timeout:     "60s",

--- a/filter/graceful_shutdown/procider_filter_test.go
+++ b/filter/graceful_shutdown/procider_filter_test.go
@@ -65,7 +65,7 @@ func TestProviderFilterInvoke(t *testing.T) {
 	assert.NotNil(t, result)
 	assert.Nil(t, result.Error())
 
-	config.GetShutDown().RejectRequest = true
+	config.GetShutDown().RejectRequest.Store(true)
 	result = filter.Invoke(context.Background(), protocol.NewBaseInvoker(url), invocation)
 	assert.NotNil(t, result)
 	assert.NotNil(t, result.Error().Error(), "Rejected")

--- a/filter/graceful_shutdown/provider_filter.go
+++ b/filter/graceful_shutdown/provider_filter.go
@@ -89,7 +89,7 @@ func (f *providerGracefulShutdownFilter) rejectNewRequest() bool {
 	if f.shutdownConfig == nil {
 		return false
 	}
-	return f.shutdownConfig.RejectRequest
+	return f.shutdownConfig.RejectRequest.Load()
 }
 
 func (f *providerGracefulShutdownFilter) getRejectHandler() filter.RejectedExecutionHandler {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 

The PR #1731 wants to use atomic package, but forgot to change the type of the RejectRequest, this PR fixed this problem.

**Which issue(s) this PR fixes**: 
Fixes #1731

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)