### PR TITLE
config merge

### DIFF
--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -220,6 +220,7 @@ const (
 	TracingConfigPrefix        = "dubbo.tracing"
 	LoggerConfigPrefix         = "dubbo.logger"
 	CustomConfigPrefix         = "dubbo.custom"
+	ProfilesConfigPrefix       = "dubbo.profiles"
 )
 
 const (

--- a/config/config_loader.go
+++ b/config/config_loader.go
@@ -45,6 +45,7 @@ func Load(opts ...LoaderConfOption) error {
 	conf := NewLoaderConf(opts...)
 	if conf.rc == nil {
 		koan := GetConfigResolver(conf)
+		koan = conf.MergeConfig(koan, nil)
 		if err := koan.UnmarshalWithConf(rootConfig.Prefix(),
 			rootConfig, koanf.UnmarshalConf{Tag: "yaml"}); err != nil {
 			return err

--- a/config/config_loader.go
+++ b/config/config_loader.go
@@ -45,7 +45,7 @@ func Load(opts ...LoaderConfOption) error {
 	conf := NewLoaderConf(opts...)
 	if conf.rc == nil {
 		koan := GetConfigResolver(conf)
-		koan = conf.MergeConfig(koan, nil)
+		koan = conf.MergeConfig(koan)
 		if err := koan.UnmarshalWithConf(rootConfig.Prefix(),
 			rootConfig, koanf.UnmarshalConf{Tag: "yaml"}); err != nil {
 			return err

--- a/config/config_loader_options.go
+++ b/config/config_loader_options.go
@@ -201,22 +201,25 @@ func resolverFilePath(path string) (name, suffix string) {
 }
 
 //MergeConfig merge config file
-func (conf *loaderConf) MergeConfig(koan *koanf.Koanf, config []byte) *koanf.Koanf {
-	var activeKoan *koanf.Koanf
+func (conf *loaderConf) MergeConfig(koan *koanf.Koanf) *koanf.Koanf {
+	var (
+		activeKoan *koanf.Koanf
+		activeConf *loaderConf
+	)
 	active := koan.String("dubbo.profiles.active")
 	active = getLegalActive(active)
 	logger.Infof("The following profiles are active: %s", active)
-	if config == nil && defaultActive != active {
+	if defaultActive != active {
 		path := conf.getActiveFilePath(active)
 		if !pathExists(path) {
 			logger.Debugf("Config file:%s not exist skip config merge", path)
 			return koan
 		}
-		activeConf := NewLoaderConf(WithPath(path))
+		activeConf = NewLoaderConf(WithPath(path))
 		activeKoan = GetConfigResolver(activeConf)
-	}
-	if err := koan.Merge(activeKoan); err != nil {
-		logger.Debugf("Config merge err %s", err)
+		if err := koan.Merge(activeKoan); err != nil {
+			logger.Debugf("Config merge err %s", err)
+		}
 	}
 	return koan
 }

--- a/config/config_loader_options.go
+++ b/config/config_loader_options.go
@@ -232,8 +232,7 @@ func (conf *loaderConf) getActiveFilePath(active string) string {
 func pathExists(path string) bool {
 	if _, err := os.Stat(path); err == nil {
 		return true
-	} else if os.IsNotExist(err) {
-		return false
+	} else {
+		return !os.IsNotExist(err)
 	}
-	return false
 }

--- a/config/config_loader_options_test.go
+++ b/config/config_loader_options_test.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -70,4 +71,39 @@ func TestNewLoaderConf_WithSuffix(t *testing.T) {
 	)
 
 	assert.Equal(t, conf.suffix, string(file.PROPERTIES))
+}
+
+func TestResolverFilePath(t *testing.T) {
+	name, suffix := resolverFilePath("../config/application.properties")
+	assert.Equal(t, name, "application")
+	assert.Equal(t, suffix, "properties")
+}
+
+func TestResolverFilePath_Illegal_Path(t *testing.T) {
+	name, suffix := resolverFilePath("application.properties")
+	assert.Equal(t, name, "application")
+	assert.Equal(t, suffix, "properties")
+}
+
+func TestResolverFilePath_Illegal_Path_Name(t *testing.T) {
+	name, suffix := resolverFilePath("application")
+	assert.Equal(t, name, "application")
+	assert.Equal(t, suffix, string(file.YAML))
+}
+
+func Test_getActiveFilePath(t *testing.T) {
+	conf := NewLoaderConf(
+		WithSuffix(file.JSON),
+		WithPath("../config/testdata/config/properties/application.properties"),
+	)
+
+	filePath := conf.getActiveFilePath("dev")
+
+	assert.Equal(t, strings.HasSuffix(filePath, "application-dev.properties"), true)
+
+	exists := pathExists(filePath)
+	assert.Equal(t, exists, false)
+	exists = pathExists("application.properties")
+	assert.Equal(t, exists, false)
+
 }

--- a/config/profiles_config.go
+++ b/config/profiles_config.go
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+)
+
+var (
+	defaultActive = "default"
+)
+
+type ProfilesConfig struct {
+	// active profiles
+	Active string
+}
+
+// Prefix dubbo.profiles
+func (ProfilesConfig) Prefix() string {
+	return constant.ProfilesConfigPrefix
+}
+
+// getLegalActive if active is null return default
+func getLegalActive(active string) string {
+	if len(active) == 0 {
+		return defaultActive
+	}
+	return active
+}

--- a/config/profiles_config_test.go
+++ b/config/profiles_config_test.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package config
 
 import (

--- a/config/profiles_config_test.go
+++ b/config/profiles_config_test.go
@@ -1,11 +1,12 @@
 package config
 
 import (
-	"github.com/knadh/koanf"
 	"testing"
 )
 
 import (
+	"github.com/knadh/koanf"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/config/profiles_config_test.go
+++ b/config/profiles_config_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"github.com/knadh/koanf"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+)
+
+func TestProfilesConfig_Prefix(t *testing.T) {
+	profiles := &ProfilesConfig{}
+	assert.Equal(t, profiles.Prefix(), constant.ProfilesConfigPrefix)
+}
+
+func TestLoaderConf_MergeConfig(t *testing.T) {
+	rc := NewRootConfigBuilder().Build()
+	conf := NewLoaderConf(WithPath("./testdata/config/active/application.yaml"))
+	koan := GetConfigResolver(conf)
+	koan = conf.MergeConfig(koan, nil)
+
+	err := koan.UnmarshalWithConf(rc.Prefix(), rc, koanf.UnmarshalConf{Tag: "yaml"})
+	assert.Nil(t, err)
+
+	registries := rc.Registries
+	assert.NotNil(t, registries)
+	assert.Equal(t, registries["nacos"].Timeout, "10s")
+	assert.Equal(t, registries["nacos"].Address, "nacos://127.0.0.1:8848")
+
+	protocols := rc.Protocols
+	assert.NotNil(t, protocols)
+	assert.Equal(t, protocols["dubbo"].Name, "dubbo")
+	assert.Equal(t, protocols["dubbo"].Port, "20000")
+
+	consumer := rc.Consumer
+	assert.NotNil(t, consumer)
+	assert.Equal(t, consumer.References["helloService"].Protocol, "dubbo")
+	assert.Equal(t, consumer.References["helloService"].InterfaceName, "org.github.dubbo.HelloService")
+}

--- a/config/profiles_config_test.go
+++ b/config/profiles_config_test.go
@@ -40,7 +40,7 @@ func TestLoaderConf_MergeConfig(t *testing.T) {
 	rc := NewRootConfigBuilder().Build()
 	conf := NewLoaderConf(WithPath("./testdata/config/active/application.yaml"))
 	koan := GetConfigResolver(conf)
-	koan = conf.MergeConfig(koan, nil)
+	koan = conf.MergeConfig(koan)
 
 	err := koan.UnmarshalWithConf(rc.Prefix(), rc, koanf.UnmarshalConf{Tag: "yaml"})
 	assert.Nil(t, err)

--- a/config/profiles_config_test.go
+++ b/config/profiles_config_test.go
@@ -60,3 +60,16 @@ func TestLoaderConf_MergeConfig(t *testing.T) {
 	assert.Equal(t, consumer.References["helloService"].Protocol, "dubbo")
 	assert.Equal(t, consumer.References["helloService"].InterfaceName, "org.github.dubbo.HelloService")
 }
+
+func Test_getLegalActive(t *testing.T) {
+
+	t.Run("default", func(t *testing.T) {
+		active := getLegalActive("")
+		assert.Equal(t, active, "default")
+	})
+
+	t.Run("normal", func(t *testing.T) {
+		active := getLegalActive("active")
+		assert.Equal(t, active, "active")
+	})
+}

--- a/config/root_config.go
+++ b/config/root_config.go
@@ -85,6 +85,9 @@ type RootConfig struct {
 	CacheFile string `yaml:"cache_file" json:"cache_file,omitempty" property:"cache_file"`
 
 	Custom *CustomConfig `yaml:"custom" json:"custom,omitempty" property:"custom"`
+
+	// Profiles config
+	Profiles *ProfilesConfig `yaml:"profiles" json:"profiles,omitempty" property:"profiles"`
 }
 
 func SetRootConfig(r RootConfig) {

--- a/config/testdata/config/active/application-local.yaml
+++ b/config/testdata/config/active/application-local.yaml
@@ -1,0 +1,16 @@
+dubbo:
+  profiles:
+    active: local
+  registries:
+    nacos:
+      timeout: 10s
+      address: nacos://127.0.0.1:8848
+  protocols:
+    dubbo:
+      name: dubbo
+      port: 20000
+  consumer:
+    references:
+      helloService:
+        protocol: dubbo
+        interface: org.github.dubbo.HelloService

--- a/config/testdata/config/active/application.yaml
+++ b/config/testdata/config/active/application.yaml
@@ -1,0 +1,7 @@
+dubbo:
+  profiles:
+    active: local
+  registries:
+    nacos:
+      timeout: 3s
+      address: nacos://127.0.0.1:8848


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
主要逻辑是根据`dubbogo.yaml`文件里面配置的`dubbo.profiles.active`值合并文件
例如:在`dubbogo.yaml`文件里面配置了`dubbo.profiles.active=local`则会合并`dubbogo.yaml`和`dubbogo-local.yaml`两个配置文件里面的内容。
但是如果你通过命令`export DUBBO_GO_CONFIG_PATH= PATH_TO_SAMPLES/helloworld/go-server/conf/application.yaml`则会合并`application.yaml`和`application-local.yaml`两个文件
### 覆盖说明
> 出现重复值按照`active`里面的为最终结果

例如：在`dubbogo.yaml`里面配置`dubbo.registries.nacos.timeout=3s`在`dubbogo-local.yaml`里面配置值是`10s`,最终`dubbo.registries.nacos.timeout=10s`

![image](https://user-images.githubusercontent.com/18088210/154417036-a2570b5b-8875-4f89-b496-8912d3bda392.png)

**Which issue(s) this PR fixes**: 
Fixes #

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [x] All ut passed (run 'go test ./...' in project root)
- [x] After go-fmt ed , run 'go fmt project' using goland.
- [x] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [x] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [x] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [x] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)