### PR TITLE
fix: fix unexpected error when provider and consumer exist together

### DIFF
--- a/config/consumer_config.go
+++ b/config/consumer_config.go
@@ -137,24 +137,24 @@ func (cc *ConsumerConfig) Load() {
 	var count int
 	for {
 		checkok := true
-		for _, refconfig := range cc.References {
-			if (refconfig.Check != nil && *refconfig.Check) ||
-				(refconfig.Check == nil && cc.Check) ||
-				(refconfig.Check == nil) { // default to true
+		for key, ref := range cc.References {
+			if (ref.Check != nil && *ref.Check && GetProviderService(key) == nil) ||
+				(ref.Check == nil && cc.Check && GetProviderService(key) == nil) ||
+				(ref.Check == nil && GetProviderService(key) == nil) { // default to true
 
-				if refconfig.invoker != nil && !refconfig.invoker.IsAvailable() {
+				if ref.invoker != nil && !ref.invoker.IsAvailable() {
 					checkok = false
 					count++
 					if count > maxWait {
-						errMsg := fmt.Sprintf("No provider available of the service %v.please check configuration.", refconfig.InterfaceName)
+						errMsg := fmt.Sprintf("No provider available of the service %v.please check configuration.", ref.InterfaceName)
 						logger.Error(errMsg)
 						panic(errMsg)
 					}
 					time.Sleep(time.Second * 1)
 					break
 				}
-				if refconfig.invoker == nil {
-					logger.Warnf("The interface %s invoker not exist, may you should check your interface config.", refconfig.InterfaceName)
+				if ref.invoker == nil {
+					logger.Warnf("The interface %s invoker not exist, may you should check your interface config.", ref.InterfaceName)
 				}
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
解决consumer和provider同时存在的时候启动异常
**Which issue(s) this PR fixes**: 
Fixes #
https://github.com/apache/dubbo-go/issues/1764
**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [x] All ut passed (run 'go test ./...' in project root)
- [x] After go-fmt ed , run 'go fmt project' using goland.
- [x] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [x] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [x] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [x] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)