### PR TITLE
fix: github action

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         git fetch origin 3.0
         git checkout -b 3.0 origin/3.0
-        git remote add devrepo https://github.com/${{github.event.pull_request.head.repo.full_name}}/dubbo-go.git
+        git remote add devrepo https://github.com/${{github.event.pull_request.head.repo.full_name}}.git
         git fetch devrepo ${{github.event.pull_request.head.sha}}
         git merge devrepo/${{github.event.pull_request.head.sha}}
 

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -45,12 +45,13 @@ jobs:
           ${{ runner.os }}-go-
 
     - name: Merge base
+      if: ${{ github.event_name == 'pull_request' }}
       run: |
         git fetch origin 3.0
         git checkout -b 3.0 origin/3.0
-        git remote add devrepo https://github.com/$GITHUB_REPOSITORY/dubbo-go.git
-        git fetch devrepo $GITHUB_SHA
-        git merge devrepo/$GITHUB_SHA
+        git remote add devrepo https://github.com/${{github.event.pull_request.head.repo.full_name}}/dubbo-go.git
+        git fetch devrepo ${{github.event.pull_request.head.sha}}
+        git merge devrepo/${{github.event.pull_request.head.sha}}
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -50,8 +50,8 @@ jobs:
         git fetch origin 3.0
         git checkout -b 3.0 origin/3.0
         git remote add devrepo https://github.com/${{github.event.pull_request.head.repo.full_name}}.git
-        git fetch devrepo ${{github.event.pull_request.head.sha}}
-        git merge devrepo/${{github.event.pull_request.head.sha}}
+        git fetch devrepo ${{github.base_ref}}
+        git merge devrepo/${{github.base_ref}}
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -46,11 +46,11 @@ jobs:
 
     - name: Merge base
       run: |
-        git branch | awk '{print $1}'
-        git remote -v | awk '{print $1 $2}'
-        git remote add upstream https://github.com/apache/dubbo-go.git
-        git fetch upstream 3.0
-        git checkout -b 3.0 upstream/3.0
+        git fetch origin 3.0
+        git checkout -b 3.0 origin/3.0
+        git remote add devrepo https://github.com/$GITHUB_REPOSITORY/dubbo-go.git
+        git fetch devrepo $GITHUB_SHA
+        git merge devrepo/$GITHUB_SHA
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -46,9 +46,10 @@ jobs:
 
     - name: Merge base
       run: |
-        git branch
-        git remote -v
+        git branch | awk '{print $1}'
+        git remote -v | awk '{print $1}'
         git remote add upstream https://github.com/apache/dubbo-go.git
+        git fetch upstream 3.0
         git checkout -b 3.0 upstream/3.0
 
     - name: Get dependencies

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Merge base
       run: |
         git branch | awk '{print $1}'
-        git remote -v | awk '{print $1}'
+        git remote -v | awk '{print $1 $2}'
         git remote add upstream https://github.com/apache/dubbo-go.git
         git fetch upstream 3.0
         git checkout -b 3.0 upstream/3.0

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -50,8 +50,8 @@ jobs:
         git fetch origin 3.0
         git checkout -b 3.0 origin/3.0
         git remote add devrepo https://github.com/${{github.event.pull_request.head.repo.full_name}}.git
-        git fetch devrepo ${{github.base_ref}}
-        git merge devrepo/${{github.base_ref}}
+        git fetch devrepo ${{github.event.pull_request.head.repo.ref}}
+        git merge devrepo/${{github.event.pull_request.head.repo.ref}}
 
     - name: Get dependencies
       run: |

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -52,6 +52,7 @@ jobs:
         git remote add devrepo https://github.com/${{github.event.pull_request.head.repo.full_name}}.git
         git fetch devrepo ${{github.event.pull_request.head.sha}}
         git config --global user.email "dubbo-go@github-ci.com"
+        git config --global user.name "robot"
         git merge ${{github.event.pull_request.head.sha}}
 
     - name: Get dependencies

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -51,6 +51,7 @@ jobs:
         git checkout -b 3.0 origin/3.0
         git remote add devrepo https://github.com/${{github.event.pull_request.head.repo.full_name}}.git
         git fetch devrepo ${{github.event.pull_request.head.sha}}
+        git config --global user.email "dubbo-go@github-ci.com"
         git merge ${{github.event.pull_request.head.sha}}
 
     - name: Get dependencies

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -44,6 +44,13 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
+    - name: Merge base
+      run: |
+        git branch
+        git remote -v
+        git remote add upstream https://github.com/apache/dubbo-go.git
+        git checkout -b 3.0 upstream/3.0
+
     - name: Get dependencies
       run: |
         if [ -f Gopkg.toml ]; then

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -50,8 +50,8 @@ jobs:
         git fetch origin 3.0
         git checkout -b 3.0 origin/3.0
         git remote add devrepo https://github.com/${{github.event.pull_request.head.repo.full_name}}.git
-        git fetch devrepo ${{github.event.pull_request.head.repo.ref}}
-        git merge devrepo/${{github.event.pull_request.head.repo.ref}}
+        git fetch devrepo ${{github.event.pull_request.head.sha}}
+        git merge ${{github.event.pull_request.head.sha}}
 
     - name: Get dependencies
       run: |


### PR DESCRIPTION
Merge develop branch to 3.0 before running ci.

Some errors occurs that when two developers run ci in there pr, they all passed. But error occurs after the two prs merged, because ci only check the developer's branch, but NOT the branch after merged to base(3.0).

![image](https://user-images.githubusercontent.com/45508533/157384327-9f1dbfa7-c47d-4730-b5b8-9a3e2deeccab.png)


This pr Add `Merge Base` ci procedure, to merge develop branch to base(3.0) before running ci.