### PR TITLE
fix(RootConfig): When using init of rootConfig, rootConfig is not configured, and [getty-session-param] is wrong

### DIFF
--- a/config/root_config.go
+++ b/config/root_config.go
@@ -212,6 +212,7 @@ func (rc *RootConfig) Init() error {
 	if err := rc.Shutdown.Init(); err != nil {
 		return err
 	}
+	SetRootConfig(*rc)
 	// todo if we can remove this from Init in the future?
 	rc.Start()
 	return nil

--- a/remoting/getty/config.go
+++ b/remoting/getty/config.go
@@ -76,7 +76,7 @@ type (
 		QueueNumber int `default:"0" yaml:"queue-number" json:"queue-number,omitempty"`
 
 		// session tcp parameters
-		GettySessionParam GettySessionParam `required:"true" yaml:",inline" json:",inline"`
+		GettySessionParam GettySessionParam `required:"true" yaml:"getty-session-param" json:"getty-session-param"`
 	}
 
 	// ClientConfig holds supported types by the multi config package
@@ -104,7 +104,7 @@ type (
 		QueueNumber int `default:"0" yaml:"queue-number" json:"queue-number,omitempty"`
 
 		// session tcp parameters
-		GettySessionParam GettySessionParam `required:"true" yaml:",inline" json:",inline"`
+		GettySessionParam GettySessionParam `required:"true" yaml:"getty-session-param" json:"getty-session-param"`
 	}
 )
 


### PR DESCRIPTION
**What this PR does**: 
When using the init of `RootConfig,` the `Rootconfig` is not given the relevant configuration, which leads to the failure of `GetRootConfig()` to obtain the relevant configuration correctly, and the ` getty-session-param` is wrong, which leads to the failure of normal serialization
**Which issue(s) this PR fixes**: 
Fixed that `GetRootconfig() `can get parameters correctly

Fixed that [Getty session param] can be serialized normally

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)