### PR TITLE
fix RootConfig and getty-session-param

### DIFF
--- a/config/root_config.go
+++ b/config/root_config.go
@@ -191,6 +191,7 @@ func (rc *RootConfig) Init() error {
 	if err := rc.Shutdown.Init(); err != nil {
 		return err
 	}
+	SetRootConfig(*rc)
 	// todo if we can remove this from Init in the future?
 	rc.Start()
 	return nil

--- a/remoting/getty/config.go
+++ b/remoting/getty/config.go
@@ -76,7 +76,7 @@ type (
 		QueueNumber int `default:"0" yaml:"queue-number" json:"queue-number,omitempty"`
 
 		// session tcp parameters
-		GettySessionParam GettySessionParam `required:"true" yaml:",inline" json:",inline"`
+		GettySessionParam GettySessionParam `required:"true" yaml:"getty-session-param" json:"getty-session-param,omitempty"`
 	}
 
 	// ClientConfig holds supported types by the multi config package
@@ -104,7 +104,7 @@ type (
 		QueueNumber int `default:"0" yaml:"queue-number" json:"queue-number,omitempty"`
 
 		// session tcp parameters
-		GettySessionParam GettySessionParam `required:"true" yaml:",inline" json:",inline"`
+		GettySessionParam GettySessionParam `required:"true" yaml:"getty-session-param" json:"getty-session-param,omitempty"`
 	}
 )
 


### PR DESCRIPTION
**What this PR does**: 
1.When init of rootConfig is used, `var rootConfig` is not configured. This variable is default by default, rootConfig parameter should be given after init，If this is not done, `GetRootConfig()` will not get the correct value.
2. The `GettySessionParam` serialization alias is missing, which causes the content to not be configured.
**Which issue(s) this PR fixes**: 
Fixes #
Fixed that`GetRootConfig() `could not get parameters correctly
Fixed that `GettySessionParam` could not be serialized correctly
- [x] All ut passed (run 'go test ./...' in project root)
- [x] After go-fmt ed , run 'go fmt project' using goland.
- [x] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [x] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [x] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [x] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)