### PR TITLE
Fix: bugfix of metrics and config

### DIFF
--- a/config/config_loader_options.go
+++ b/config/config_loader_options.go
@@ -47,7 +47,7 @@ type loaderConf struct {
 }
 
 func NewLoaderConf(opts ...LoaderConfOption) *loaderConf {
-	configFilePath := "./conf/dubbogo.yaml"
+	configFilePath := "../conf/dubbogo.yaml"
 	if configFilePathFromEnv := os.Getenv(constant.ConfigFileEnvKey); configFilePathFromEnv != "" {
 		configFilePath = configFilePathFromEnv
 	}

--- a/config/metric_config.go
+++ b/config/metric_config.go
@@ -32,7 +32,7 @@ import (
 type MetricConfig struct {
 	Mode               string `default:"pull" yaml:"mode" json:"mode,omitempty" property:"mode"` // push or pull,
 	Namespace          string `default:"dubbo" yaml:"namespace" json:"namespace,omitempty" property:"namespace"`
-	Enable             string `default:"true" yaml:"enable" json:"enable,omitempty" property:"enable"`
+	Enable             bool   `default:"true" yaml:"enable" json:"enable,omitempty" property:"enable"`
 	Port               string `default:"9090" yaml:"port" json:"port,omitempty" property:"port"`
 	Path               string `default:"/metrics" yaml:"path" json:"path,omitempty" property:"path"`
 	PushGatewayAddress string `default:"" yaml:"push-gateway-address" json:"push-gateway-address,omitempty" property:"push-gateway-address"`
@@ -47,7 +47,7 @@ func (mc *MetricConfig) ToReporterConfig() *metrics.ReporterConfig {
 		defaultMetricsReportConfig.Namespace = mc.Namespace
 	}
 
-	defaultMetricsReportConfig.Enable = mc.Enable == "1"
+	defaultMetricsReportConfig.Enable = mc.Enable
 	defaultMetricsReportConfig.Port = mc.Port
 	defaultMetricsReportConfig.Path = mc.Path
 	defaultMetricsReportConfig.PushGatewayAddress = mc.PushGatewayAddress

--- a/config/reference_config.go
+++ b/config/reference_config.go
@@ -385,6 +385,11 @@ func (pcb *ReferenceConfigBuilder) SetProtocol(protocol string) *ReferenceConfig
 	return pcb
 }
 
+func (pcb *ReferenceConfigBuilder) SetURL(url string) *ReferenceConfigBuilder {
+	pcb.referenceConfig.URL = url
+	return pcb
+}
+
 func (pcb *ReferenceConfigBuilder) Build() *ReferenceConfig {
 	return pcb.referenceConfig
 }

--- a/imports/imports.go
+++ b/imports/imports.go
@@ -51,6 +51,8 @@ import (
 	_ "dubbo.apache.org/dubbo-go/v3/filter/sentinel"
 	_ "dubbo.apache.org/dubbo-go/v3/filter/token"
 	_ "dubbo.apache.org/dubbo-go/v3/filter/tps"
+	_ "dubbo.apache.org/dubbo-go/v3/filter/tps/limiter"
+	_ "dubbo.apache.org/dubbo-go/v3/filter/tps/strategy"
 	_ "dubbo.apache.org/dubbo-go/v3/filter/tracing"
 	_ "dubbo.apache.org/dubbo-go/v3/metadata/mapping/metadata"
 	_ "dubbo.apache.org/dubbo-go/v3/metadata/report/etcd"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
1. Fix MetricsConfig's Enable type string to bool, default enable.
2. Add `func (pcb *ReferenceConfigBuilder) SetURL(url string) ` to *ReferenceConfigBuilder
3. Add default tps limiter and strategy to import/imports.go

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [x] All ut passed (run 'go test ./...' in project root)
- [x] After go-fmt ed , run 'go fmt project' using goland.
- [x] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [x] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [x] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [x] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)