### PR TITLE
fix(register): fix ip register issue

### DIFF
--- a/registry/base_registry.go
+++ b/registry/base_registry.go
@@ -286,7 +286,7 @@ func (r *BaseRegistry) providerRegistry(c *common.URL, params url.Values, f crea
 	}
 	logger.Debugf("provider url params:%#v", params)
 	var host string
-	if len(c.Ip) > 0 {
+	if len(c.Ip) == 0 {
 		host = localIP
 	} else {
 		host = c.Ip


### PR DESCRIPTION
**What this PR does**: 
`Len (c.ip) > 0` should be given `c.ip` instead of `localIp`
**Which issue(s) this PR fixes**: 
Fixes # IP can be normally exposed according to environmental variables

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [x] All ut passed (run 'go test ./...' in project root)
- [x] After go-fmt ed , run 'go fmt project' using goland.
- [x] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [x] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [x] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [x] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)