### PR TITLE
Fix: decode net stream bytes as getty rule

### DIFF
--- a/protocol/dubbo/impl/codec.go
+++ b/protocol/dubbo/impl/codec.go
@@ -156,6 +156,11 @@ func (c *ProtocolCodec) Decode(p *DubboPackage) error {
 			return err
 		}
 	}
+
+	if c.reader.Size() < p.GetBodyLen() {
+		return hessian.ErrBodyNotEnough
+	}
+
 	body, err := c.reader.Peek(p.GetBodyLen())
 	if err != nil {
 		return err

--- a/remoting/codec.go
+++ b/remoting/codec.go
@@ -24,7 +24,7 @@ import (
 type Codec interface {
 	EncodeRequest(request *Request) (*bytes.Buffer, error)
 	EncodeResponse(response *Response) (*bytes.Buffer, error)
-	Decode(data []byte) (DecodeResult, int, error)
+	Decode(data []byte) (*DecodeResult, int, error)
 }
 
 type DecodeResult struct {

--- a/remoting/getty/listener.go
+++ b/remoting/getty/listener.go
@@ -100,8 +100,8 @@ func (h *RpcClientHandler) OnClose(session getty.Session) {
 
 // OnMessage get response from getty server, and update the session to the getty client session list
 func (h *RpcClientHandler) OnMessage(session getty.Session, pkg interface{}) {
-	result, ok := pkg.(remoting.DecodeResult)
-	if !ok {
+	result, ok := pkg.(*remoting.DecodeResult)
+	if !ok || result == ((*remoting.DecodeResult)(nil)) {
 		logger.Errorf("illegal package")
 		return
 	}
@@ -241,8 +241,8 @@ func (h *RpcServerHandler) OnMessage(session getty.Session, pkg interface{}) {
 	}
 	h.rwlock.Unlock()
 
-	decodeResult, drOK := pkg.(remoting.DecodeResult)
-	if !drOK {
+	decodeResult, drOK := pkg.(*remoting.DecodeResult)
+	if !drOK || decodeResult == ((*remoting.DecodeResult)(nil)) {
 		logger.Errorf("illegal package{%#v}", pkg)
 		return
 	}

--- a/remoting/getty/readwriter.go
+++ b/remoting/getty/readwriter.go
@@ -18,14 +18,11 @@
 package getty
 
 import (
-	"errors"
 	"reflect"
 )
 
 import (
 	"github.com/apache/dubbo-getty"
-
-	hessian "github.com/apache/dubbo-go-hessian2"
 
 	perrors "github.com/pkg/errors"
 )
@@ -48,19 +45,17 @@ func NewRpcClientPackageHandler(client *Client) *RpcClientPackageHandler {
 // Read data from server. if the package size from server is larger than 4096 byte, server will read 4096 byte
 // and send to client each time. the Read can assemble it.
 func (p *RpcClientPackageHandler) Read(ss getty.Session, data []byte) (interface{}, int, error) {
-	resp, length, err := (p.client.codec).Decode(data)
-	//err := pkg.Unmarshal(buf, p.client)
+	rsp, length, err := (p.client.codec).Decode(data)
 	if err != nil {
-		if errors.Is(err, hessian.ErrHeaderNotEnough) || errors.Is(err, hessian.ErrBodyNotEnough) {
-			return nil, 0, nil
-		}
-
-		logger.Errorf("pkg.Unmarshal(ss:%+v, len(@data):%d) = error:%+v", ss, len(data), err)
-
+		err = perrors.WithStack(err)
+	}
+	if rsp == ((*remoting.DecodeResult)(nil)) {
 		return nil, length, err
 	}
-
-	return resp, length, nil
+	if rsp.Result == ((*remoting.Response)(nil)) || rsp.Result == ((*remoting.Request)(nil)) {
+		return nil, length, err
+	}
+	return rsp, length, err
 }
 
 // Write send the data to server
@@ -110,15 +105,15 @@ func NewRpcServerPackageHandler(server *Server) *RpcServerPackageHandler {
 // and send to client each time. the Read can assemble it.
 func (p *RpcServerPackageHandler) Read(ss getty.Session, data []byte) (interface{}, int, error) {
 	req, length, err := (p.server.codec).Decode(data)
-	//resp,len, err := (*p.).DecodeResponse(buf)
 	if err != nil {
-		if errors.Is(err, hessian.ErrHeaderNotEnough) || errors.Is(err, hessian.ErrBodyNotEnough) {
-			return nil, 0, nil
-		}
+		err = perrors.WithStack(err)
+	}
+	if req == ((*remoting.DecodeResult)(nil)) {
+		return nil, length, err
+	}
 
-		logger.Errorf("pkg.Unmarshal(ss:%+v, len(@data):%d) = error:%+v", ss, len(data), err)
-
-		return nil, 0, err
+	if req.Result == ((*remoting.Request)(nil)) || req.Result == ((*remoting.Response)(nil)) {
+		return nil, length, err // as getty rule
 	}
 
 	return req, length, err
@@ -148,5 +143,4 @@ func (p *RpcServerPackageHandler) Write(ss getty.Session, pkg interface{}) ([]by
 
 	logger.Errorf("illegal pkg:%+v\n, it is %+v", pkg, reflect.TypeOf(pkg))
 	return nil, perrors.New("invalid rpc response")
-
 }

--- a/remoting/getty/readwriter_test.go
+++ b/remoting/getty/readwriter_test.go
@@ -197,8 +197,8 @@ func testDecodeTCPPackage(t *testing.T, svr *Server, client *Client) {
 	assert.True(t, incompletePkgLen >= impl.HEADER_LENGTH, "header buffer too short")
 	incompletePkg := pkgBytes[0 : incompletePkgLen-1]
 	pkg, pkgLen, err := pkgReadHandler.Read(nil, incompletePkg)
-	assert.NoError(t, err)
-	assert.Equal(t, pkg, nil)
+	assert.Equal(t, err.Error(), "body buffer too short")
+	assert.Equal(t, pkg.(*remoting.DecodeResult).Result, nil)
 	assert.Equal(t, pkgLen, 0)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
fix decode net stream bytes as getty rule in 1.5
**Which issue(s) this PR fixes**: 
Fixes #

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)