### PR TITLE
fix: limit rpc package data size by user's config rather than DEFAULT_LEN.

### DIFF
--- a/protocol/dubbo/hessian2/hessian_request.go
+++ b/protocol/dubbo/hessian2/hessian_request.go
@@ -173,7 +173,7 @@ END:
 	byteArray = encoder.Buffer()
 	pkgLen = len(byteArray)
 	if pkgLen > int(DEFAULT_LEN) { // 8M
-		return nil, perrors.Errorf("Data length %d too large, max payload %d", pkgLen, DEFAULT_LEN)
+		logger.Warnf("Data length %d too large, recommand max payload %d", pkgLen, DEFAULT_LEN)
 	}
 	// byteArray{body length}
 	binary.BigEndian.PutUint32(byteArray[12:], uint32(pkgLen-HEADER_LENGTH))

--- a/protocol/dubbo/hessian2/hessian_response.go
+++ b/protocol/dubbo/hessian2/hessian_response.go
@@ -165,7 +165,7 @@ func packResponse(header DubboHeader, ret interface{}) ([]byte, error) {
 	byteArray = hessian.EncNull(byteArray) // if not, "java client" will throw exception  "unexpected end of file"
 	pkgLen := len(byteArray)
 	if pkgLen > int(DEFAULT_LEN) { // 8M
-		return nil, perrors.Errorf("Data length %d too large, max payload %d", pkgLen, DEFAULT_LEN)
+		logger.Warnf("Data length %d too large, recommand max payload %d", pkgLen, DEFAULT_LEN)
 	}
 	// byteArray{body length}
 	binary.BigEndian.PutUint32(byteArray[12:], uint32(pkgLen-HEADER_LENGTH))

--- a/protocol/dubbo/impl/codec.go
+++ b/protocol/dubbo/impl/codec.go
@@ -229,8 +229,8 @@ func packRequest(p DubboPackage, serializer Serializer) ([]byte, error) {
 			return nil, err
 		}
 		pkgLen = len(body)
-		if pkgLen > int(DEFAULT_LEN) { // 8M
-			return nil, perrors.Errorf("Data length %d too large, max payload %d", pkgLen, DEFAULT_LEN)
+		if pkgLen > int(DEFAULT_LEN) { // recommand 8M
+			logger.Warnf("Data length %d too large, recommand max payload %d", pkgLen, DEFAULT_LEN)
 		}
 		byteArray = append(byteArray, body...)
 	}
@@ -266,8 +266,8 @@ func packResponse(p DubboPackage, serializer Serializer) ([]byte, error) {
 	}
 
 	pkgLen := len(body)
-	if pkgLen > int(DEFAULT_LEN) { // 8M
-		return nil, perrors.Errorf("Data length %d too large, max payload %d", pkgLen, DEFAULT_LEN)
+	if pkgLen > int(DEFAULT_LEN) { // recommand 8M
+		logger.Warnf("Data length %d too large, recommand max payload %d", pkgLen, DEFAULT_LEN)
 	}
 	// byteArray{body length}
 	binary.BigEndian.PutUint32(byteArray[12:], uint32(pkgLen))

--- a/remoting/getty/readwriter.go
+++ b/remoting/getty/readwriter.go
@@ -66,8 +66,14 @@ func (p *RpcClientPackageHandler) Read(ss getty.Session, data []byte) (interface
 // Write send the data to server
 func (p *RpcClientPackageHandler) Write(ss getty.Session, pkg interface{}) ([]byte, error) {
 	req, ok := pkg.(*remoting.Request)
+	maxBufLength := clientConf.GettySessionParam.MaxMsgLen + hessian.HEADER_LENGTH
 	if ok {
 		buf, err := (p.client.codec).EncodeRequest(req)
+		bufLength := buf.Len()
+		if bufLength > maxBufLength {
+			logger.Errorf("Data length %d too large, max payload %d", bufLength-hessian.HEADER_LENGTH, clientConf.GettySessionParam.MaxMsgLen)
+			return nil, perrors.Errorf("Data length %d too large, max payload %d", bufLength-hessian.HEADER_LENGTH, clientConf.GettySessionParam.MaxMsgLen)
+		}
 		if err != nil {
 			logger.Warnf("binary.Write(req{%#v}) = err{%#v}", req, perrors.WithStack(err))
 			return nil, perrors.WithStack(err)
@@ -78,6 +84,11 @@ func (p *RpcClientPackageHandler) Write(ss getty.Session, pkg interface{}) ([]by
 	res, ok := pkg.(*remoting.Response)
 	if ok {
 		buf, err := (p.client.codec).EncodeResponse(res)
+		bufLength := buf.Len()
+		if bufLength > maxBufLength {
+			logger.Errorf("Data length %d too large, max payload %d", bufLength-hessian.HEADER_LENGTH, clientConf.GettySessionParam.MaxMsgLen)
+			return nil, perrors.Errorf("Data length %d too large, max payload %d", bufLength-hessian.HEADER_LENGTH, clientConf.GettySessionParam.MaxMsgLen)
+		}
 		if err != nil {
 			logger.Warnf("binary.Write(res{%#v}) = err{%#v}", req, perrors.WithStack(err))
 			return nil, perrors.WithStack(err)
@@ -119,8 +130,14 @@ func (p *RpcServerPackageHandler) Read(ss getty.Session, data []byte) (interface
 // Write send the data to client
 func (p *RpcServerPackageHandler) Write(ss getty.Session, pkg interface{}) ([]byte, error) {
 	res, ok := pkg.(*remoting.Response)
+	maxBufLength := srvConf.GettySessionParam.MaxMsgLen + hessian.HEADER_LENGTH
 	if ok {
 		buf, err := (p.server.codec).EncodeResponse(res)
+		bufLength := buf.Len()
+		if bufLength > maxBufLength {
+			logger.Errorf("Data length %d too large, max payload %d", bufLength-hessian.HEADER_LENGTH, srvConf.GettySessionParam.MaxMsgLen)
+			return nil, perrors.Errorf("Data length %d too large, max payload %d", bufLength-hessian.HEADER_LENGTH, srvConf.GettySessionParam.MaxMsgLen)
+		}
 		if err != nil {
 			logger.Warnf("binary.Write(res{%#v}) = err{%#v}", res, perrors.WithStack(err))
 			return nil, perrors.WithStack(err)
@@ -131,6 +148,11 @@ func (p *RpcServerPackageHandler) Write(ss getty.Session, pkg interface{}) ([]by
 	req, ok := pkg.(*remoting.Request)
 	if ok {
 		buf, err := (p.server.codec).EncodeRequest(req)
+		bufLength := buf.Len()
+		if bufLength > maxBufLength {
+			logger.Errorf("Data length %d too large, max payload %d", bufLength-hessian.HEADER_LENGTH, srvConf.GettySessionParam.MaxMsgLen)
+			return nil, perrors.Errorf("Data length %d too large, max payload %d", bufLength-hessian.HEADER_LENGTH, srvConf.GettySessionParam.MaxMsgLen)
+		}
 		if err != nil {
 			logger.Warnf("binary.Write(req{%#v}) = err{%#v}", res, perrors.WithStack(err))
 			return nil, perrors.WithStack(err)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 

  * Dubbo recommand package data length not greater than 8MiB.
  * If package data length greater than 8MiB, generate warnning.
  * If package data lenght greater than user's config, generate exception.

Signed-off-by: stonex <1479765922@qq.com>

**Which issue(s) this PR fixes**: 
Fixes #1839

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [x] All ut passed (run 'go test ./...' in project root)
- [x] After go-fmt ed , run 'go fmt project' using goland.
- [x] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [x] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [x] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [x] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)