### PR TITLE
fix: complete grpc based protocol panic recover handle.

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -71,12 +71,13 @@ jobs:
       run: |
         export PATH=$PATH:$(go env GOPATH)/bin
         export GO111MODULE=on
-        export $(go env | grep GOROOT |  sed 's/\"//g')
         cd ~
         go get -u github.com/dubbogo/tools/cmd/imports-formatter@v1.0.7
 
     - name: Check improts
       run: |
+        export $(go env | grep GOROOT | sed 's/\"//g')
+        echo $GOROOT
         imports-formatter -path .
         git status && [[ -z `git status -s` ]]
 

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -71,6 +71,7 @@ jobs:
       run: |
         export PATH=$PATH:$(go env GOPATH)/bin
         export GO111MODULE=on
+        export $(go env | grep GOROOT |  sed 's/\"//g')
         cd ~
         go get -u github.com/dubbogo/tools/cmd/imports-formatter@v1.0.7
 

--- a/common/proxy/proxy_factory/default.go
+++ b/common/proxy/proxy_factory/default.go
@@ -19,6 +19,7 @@ package proxy_factory
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 )
@@ -84,8 +85,8 @@ type ProxyInvoker struct {
 }
 
 // Invoke is used to call service method by invocation
-func (pi *ProxyInvoker) Invoke(ctx context.Context, invocation protocol.Invocation) protocol.Result {
-	result := &protocol.RPCResult{}
+func (pi *ProxyInvoker) Invoke(ctx context.Context, invocation protocol.Invocation) (result protocol.Result) {
+	result = &protocol.RPCResult{}
 	result.SetAttachments(invocation.Attachments())
 
 	// get providerUrl. The origin url may be is registry URL.
@@ -142,6 +143,21 @@ func (pi *ProxyInvoker) Invoke(ctx context.Context, invocation protocol.Invocati
 	//	replyv = reflect.New(method.ArgsType()[len(method.ArgsType())-1].Elem())
 	//	in = append(in, replyv)
 	//}
+
+	defer func() {
+		if e := recover(); e != nil {
+			if err, ok := e.(error); ok {
+				logger.Errorf("Invoke function error: %+v, service: %#v", perrors.WithStack(err), url)
+				result.SetError(e.(error))
+			} else if err, ok := e.(string); ok {
+				logger.Errorf("Invoke function error: %+v, service: %#v", perrors.New(err), url)
+				result.SetError(perrors.New(err))
+			} else {
+				logger.Errorf("Invoke function error: %+v, this is impossible. service: %#v", e, url)
+				result.SetError(fmt.Errorf("Invoke function error, unknow exception: %+v", e))
+			}
+		}
+	}()
 
 	returnValues := method.Method().Func.Call(in)
 

--- a/common/proxy/proxy_factory/utils.go
+++ b/common/proxy/proxy_factory/utils.go
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proxy_factory
+
+import (
+	"fmt"
+	"reflect"
+)
+
+import (
+	perrors "github.com/pkg/errors"
+)
+
+// CallLocalMethod is used to handle invoke exception in user func.
+func callLocalMethod(method reflect.Method, in []reflect.Value) ([]reflect.Value, error) {
+	var (
+		returnValues []reflect.Value
+		retErr       error
+	)
+
+	func() {
+		defer func() {
+			if e := recover(); e != nil {
+				if err, ok := e.(error); ok {
+					retErr = err
+				} else if err, ok := e.(string); ok {
+					retErr = perrors.New(err)
+				} else {
+					retErr = fmt.Errorf("invoke function error, unknow exception: %+v", e)
+				}
+			}
+		}()
+
+		returnValues = method.Func.Call(in)
+	}()
+
+	if retErr != nil {
+		return nil, retErr
+	}
+
+	return returnValues, retErr
+}

--- a/remoting/getty/listener.go
+++ b/remoting/getty/listener.go
@@ -280,8 +280,8 @@ func (h *RpcServerHandler) OnMessage(session getty.Session, pkg interface{}) {
 
 	if result.Err != nil {
 		// This error is caused by two way:
-		// 1. Service invoke sucess and return error.
-		// 2. Service invoke fail and generate panic, but don't handle this panic.
+		// 1. Service invoke success and return error.
+		// 2. Service invoke fail and generate panic, but user don't handle this panic.
 		resp.Status = hessian.Response_SERVER_ERROR
 	}
 

--- a/remoting/getty/listener.go
+++ b/remoting/getty/listener.go
@@ -18,7 +18,6 @@
 package getty
 
 import (
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -265,27 +264,6 @@ func (h *RpcServerHandler) OnMessage(session getty.Session, pkg interface{}) {
 		return
 	}
 
-	defer func() {
-		if e := recover(); e != nil {
-			resp.Status = hessian.Response_SERVER_ERROR
-			if err, ok := e.(error); ok {
-				logger.Errorf("OnMessage panic: %+v, req: %#v", perrors.WithStack(err), req.Data)
-				resp.Error = perrors.WithStack(err)
-			} else if err, ok := e.(string); ok {
-				logger.Errorf("OnMessage panic: %+v, req: %#v", perrors.New(err), req.Data)
-				resp.Error = perrors.New(err)
-			} else {
-				logger.Errorf("OnMessage panic: %+v, this is impossible. req: %#v", e, req.Data)
-				resp.Error = fmt.Errorf("OnMessage panic unknow exception. %+v", e)
-			}
-
-			if !req.TwoWay {
-				return
-			}
-			reply(session, resp)
-		}
-	}()
-
 	invoc, ok := req.Data.(*invocation.RPCInvocation)
 	if !ok {
 		panic("create invocation occur some exception for the type is not suitable one.")
@@ -299,6 +277,14 @@ func (h *RpcServerHandler) OnMessage(session getty.Session, pkg interface{}) {
 		return
 	}
 	resp.Result = result
+
+	if result.Err != nil {
+		// This error is caused by two way:
+		// 1. Service invoke sucess and return error.
+		// 2. Service invoke fail and generate panic, but don't handle this panic.
+		resp.Status = hessian.Response_SERVER_ERROR
+	}
+
 	reply(session, resp)
 }
 

--- a/remoting/getty/listener.go
+++ b/remoting/getty/listener.go
@@ -278,13 +278,6 @@ func (h *RpcServerHandler) OnMessage(session getty.Session, pkg interface{}) {
 	}
 	resp.Result = result
 
-	if result.Err != nil {
-		// This error is caused by two way:
-		// 1. Service invoke success and return error.
-		// 2. Service invoke fail and generate panic, but user don't handle this panic.
-		resp.Status = hessian.Response_SERVER_ERROR
-	}
-
 	reply(session, resp)
 }
 


### PR DESCRIPTION
Signed-off-by: stonex <1479765922@qq.com>

<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
+ Dubbo3.0 and grpc based service in dubbo-golang will crash if user throw exception in their code, only getty based protocol catch these exception in method `OnMessage`.
+ Catch user's exception in `Invoke` to prevent the server from hanging up due to the exception .

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)