### PR TITLE
Use summary type to observe p99

### DIFF
--- a/config/metric_config.go
+++ b/config/metric_config.go
@@ -19,6 +19,7 @@ package config
 
 import (
 	"github.com/creasty/defaults"
+
 	"github.com/pkg/errors"
 )
 

--- a/config/metric_config.go
+++ b/config/metric_config.go
@@ -19,7 +19,6 @@ package config
 
 import (
 	"github.com/creasty/defaults"
-
 	"github.com/pkg/errors"
 )
 
@@ -36,6 +35,7 @@ type MetricConfig struct {
 	Port               string `default:"9090" yaml:"port" json:"port,omitempty" property:"port"`
 	Path               string `default:"/metrics" yaml:"path" json:"path,omitempty" property:"path"`
 	PushGatewayAddress string `default:"" yaml:"push-gateway-address" json:"push-gateway-address,omitempty" property:"push-gateway-address"`
+	SummaryMaxAge      int64  `default:"600000000000" yaml:"summary-max-age" json:"summary-max-age,omitempty" property:"summary-max-age"`
 }
 
 func (mc *MetricConfig) ToReporterConfig() *metrics.ReporterConfig {
@@ -51,6 +51,7 @@ func (mc *MetricConfig) ToReporterConfig() *metrics.ReporterConfig {
 	defaultMetricsReportConfig.Port = mc.Port
 	defaultMetricsReportConfig.Path = mc.Path
 	defaultMetricsReportConfig.PushGatewayAddress = mc.PushGatewayAddress
+	defaultMetricsReportConfig.SummaryMaxAge = mc.SummaryMaxAge
 	return defaultMetricsReportConfig
 }
 

--- a/metrics/prometheus/reporter.go
+++ b/metrics/prometheus/reporter.go
@@ -176,7 +176,7 @@ func newSummary(name, namespace string) prometheus.Summary {
 
 // newSummaryVec create SummaryVec, the Namespace is dubbo
 // the objectives is from my experience.
-func newSummaryVec(name, namespace string, labels []string) *prometheus.SummaryVec {
+func newSummaryVec(name, namespace string, labels []string, maxAge int64) *prometheus.SummaryVec {
 	return prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Namespace: namespace,
@@ -189,6 +189,7 @@ func newSummaryVec(name, namespace string, labels []string) *prometheus.SummaryV
 				0.99:  0.001,
 				0.999: 0.0001,
 			},
+			MaxAge: time.Duration(maxAge),
 		},
 		labels,
 	)
@@ -213,10 +214,9 @@ func newPrometheusReporter(reporterConfig *metrics.ReporterConfig) metrics.Repor
 		reporterInitOnce.Do(func() {
 			reporterInstance = &PrometheusReporter{
 				namespace:            reporterConfig.Namespace,
-				consumerRTSummaryVec: newSummaryVec(consumerPrefix+serviceKey+rtSuffix, reporterConfig.Namespace, labelNames),
-				providerRTSummaryVec: newSummaryVec(providerPrefix+serviceKey+rtSuffix, reporterConfig.Namespace, labelNames),
+				consumerRTSummaryVec: newSummaryVec(consumerPrefix+serviceKey+rtSuffix, reporterConfig.Namespace, labelNames, reporterConfig.SummaryMaxAge),
+				providerRTSummaryVec: newSummaryVec(providerPrefix+serviceKey+rtSuffix, reporterConfig.Namespace, labelNames, reporterConfig.SummaryMaxAge),
 			}
-
 			prom.DefaultRegisterer.MustRegister(reporterInstance.consumerRTSummaryVec, reporterInstance.providerRTSummaryVec)
 			metricsExporter, err := ocprom.NewExporter(ocprom.Options{
 				Registry: prom.DefaultRegisterer.(*prom.Registry),

--- a/metrics/prometheus/reporter.go
+++ b/metrics/prometheus/reporter.go
@@ -212,7 +212,7 @@ func newPrometheusReporter(reporterConfig *metrics.ReporterConfig) metrics.Repor
 	if reporterInstance == nil {
 		reporterInitOnce.Do(func() {
 			reporterInstance = &PrometheusReporter{
-				namespace:          reporterConfig.Namespace,
+				namespace:            reporterConfig.Namespace,
 				consumerRTSummaryVec: newSummaryVec(consumerPrefix+serviceKey+rtSuffix, reporterConfig.Namespace, labelNames),
 				providerRTSummaryVec: newSummaryVec(providerPrefix+serviceKey+rtSuffix, reporterConfig.Namespace, labelNames),
 			}

--- a/metrics/prometheus/reporter.go
+++ b/metrics/prometheus/reporter.go
@@ -78,9 +78,9 @@ func init() {
 // https://prometheus.io/docs/guides/go-application/
 type PrometheusReporter struct {
 	// report the consumer-side's rt gauge data
-	consumerRTGaugeVec *prometheus.SummaryVec
+	consumerRTSummaryVec *prometheus.SummaryVec
 	// report the provider-side's rt gauge data
-	providerRTGaugeVec *prometheus.SummaryVec
+	providerRTSummaryVec *prometheus.SummaryVec
 	// todo tps support
 	// report the consumer-side's tps gauge data
 	consumerTPSGaugeVec *prometheus.GaugeVec
@@ -104,9 +104,9 @@ func (reporter *PrometheusReporter) Report(ctx context.Context, invoker protocol
 	url := invoker.GetURL()
 	var rtVec *prometheus.SummaryVec
 	if isProvider(url) {
-		rtVec = reporter.providerRTGaugeVec
+		rtVec = reporter.providerRTSummaryVec
 	} else if isConsumer(url) {
-		rtVec = reporter.consumerRTGaugeVec
+		rtVec = reporter.consumerRTSummaryVec
 	} else {
 		logger.Warnf("The url belongs neither the consumer nor the provider, "+
 			"so the invocation will be ignored. url: %s", url.String())
@@ -213,11 +213,11 @@ func newPrometheusReporter(reporterConfig *metrics.ReporterConfig) metrics.Repor
 		reporterInitOnce.Do(func() {
 			reporterInstance = &PrometheusReporter{
 				namespace:          reporterConfig.Namespace,
-				consumerRTGaugeVec: newSummaryVec(consumerPrefix+serviceKey+rtSuffix, reporterConfig.Namespace, labelNames),
-				providerRTGaugeVec: newSummaryVec(providerPrefix+serviceKey+rtSuffix, reporterConfig.Namespace, labelNames),
+				consumerRTSummaryVec: newSummaryVec(consumerPrefix+serviceKey+rtSuffix, reporterConfig.Namespace, labelNames),
+				providerRTSummaryVec: newSummaryVec(providerPrefix+serviceKey+rtSuffix, reporterConfig.Namespace, labelNames),
 			}
 
-			prom.DefaultRegisterer.MustRegister(reporterInstance.consumerRTGaugeVec, reporterInstance.providerRTGaugeVec)
+			prom.DefaultRegisterer.MustRegister(reporterInstance.consumerRTSummaryVec, reporterInstance.providerRTSummaryVec)
 			metricsExporter, err := ocprom.NewExporter(ocprom.Options{
 				Registry: prom.DefaultRegisterer.(*prom.Registry),
 			})

--- a/metrics/reporter.go
+++ b/metrics/reporter.go
@@ -26,6 +26,8 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/protocol"
 )
 
+const DefMaxAge = 600000000000
+
 type ReporterConfig struct {
 	Enable             bool
 	Namespace          string
@@ -33,6 +35,7 @@ type ReporterConfig struct {
 	Port               string
 	Path               string
 	PushGatewayAddress string
+	SummaryMaxAge      int64
 }
 
 type ReportMode string
@@ -50,6 +53,7 @@ func NewReporterConfig() *ReporterConfig {
 		Path:               "/metrics",
 		Mode:               ReportModePull,
 		PushGatewayAddress: "",
+		SummaryMaxAge:      DefMaxAge,
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: jyz0309 <45495947@qq.com>

<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
Change metric type to observe RT P99 value.
**Which issue(s) this PR fixes**: 
None.

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [x] All ut passed (run 'go test ./...' in project root)
- [x] After go-fmt ed , run 'go fmt project' using goland.
- [x] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [x] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [x] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [x] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)