### PR TITLE
Fix: Interface conversion when parsing Hystrix filter config in yaml file (#1883)

### DIFF
--- a/filter/hystrix/filter.go
+++ b/filter/hystrix/filter.go
@@ -21,6 +21,7 @@ package hystrix
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"regexp"
 	"sync"
 )
@@ -252,7 +253,14 @@ func initConfigConsumer() error {
 	if config.GetConsumerConfig().FilterConf == nil {
 		return perrors.Errorf("no config for hystrix_consumer")
 	}
-	filterConfig := config.GetConsumerConfig().FilterConf.(map[interface{}]interface{})[HYSTRIX]
+	filterConfig_ := config.GetConsumerConfig().FilterConf
+	var filterConfig interface{}
+	switch reflect.ValueOf(filterConfig_).Interface().(type) {
+	case map[interface{}]interface{}:
+		filterConfig = config.GetConsumerConfig().FilterConf.(map[interface{}]interface{})[HYSTRIX]
+	case map[string]interface{}:
+		filterConfig = config.GetConsumerConfig().FilterConf.(map[string]interface{})[HYSTRIX]
+	}
 	if filterConfig == nil {
 		return perrors.Errorf("no config for hystrix_consumer")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->
I tested the problem mentioned in [#1883](https://github.com/apache/dubbo-go/issues/1883). When I trying to set hystrix in config file, I get the type conversion problem, even though I have used it as example in the source code(https://github.com/apache/dubbo-go/blob/master/filter/hystrix/filter.go#L86-L126). 

**What this PR does**: 

- Add a type check to fix interface conversion error when parsing Hystrix filter config in yaml file.

**Which issue(s) this PR fixes**: 
Fixes #1883

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)