### PR TITLE
Fix: fix revision calc

### DIFF
--- a/common/metadata_info.go
+++ b/common/metadata_info.go
@@ -87,17 +87,17 @@ func (mi *MetadataInfo) CalAndGetRevision() string {
 	if len(mi.Services) == 0 {
 		return "0"
 	}
-	candidates := make([]string, 8)
+	candidates := make([]string, 0, 8)
 
 	for _, s := range mi.Services {
-		sk := s.ServiceKey
+		iface := s.URL.GetParam(constant.InterfaceKey, "")
 		ms := s.URL.Methods
 		if len(ms) == 0 {
-			candidates = append(candidates, sk)
+			candidates = append(candidates, iface)
 		} else {
 			for _, m := range ms {
 				// methods are part of candidates
-				candidates = append(candidates, sk+constant.KeySeparator+m)
+				candidates = append(candidates, iface+constant.KeySeparator+m)
 			}
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
fix different revision calc in `service_revision_customizer.go:resolveRevision` and `metadata_info.go:(*MetadataInfo).CalcAndGetRevision`, which make client get empty server metadata.

**Which issue(s) this PR fixes**: 
Fixes #1925

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [x] All ut passed (run 'go test ./...' in project root)
- [x] After go-fmt ed , run 'go fmt project' using goland.
- [x] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [x] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [x] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [x] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)