### PR TITLE
Fix: fix rand.Seed() duplicate concurrent calls

### DIFF
--- a/cluster/loadbalance/p2c/loadbalance.go
+++ b/cluster/loadbalance/p2c/loadbalance.go
@@ -44,6 +44,7 @@ var (
 )
 
 func init() {
+	rand.Seed(randSeed())
 	extension.SetLoadbalance(constant.LoadBalanceKeyP2C, newP2CLoadBalance)
 }
 
@@ -78,7 +79,6 @@ func (l *p2cLoadBalance) Select(invokers []protocol.Invoker, invocation protocol
 	if len(invokers) == 2 {
 		i, j = 0, 1
 	} else {
-		rand.Seed(randSeed())
 		i = rand.Intn(len(invokers))
 		j = i
 		for i == j {

--- a/cluster/loadbalance/p2c/loadbalance_test.go
+++ b/cluster/loadbalance/p2c/loadbalance_test.go
@@ -18,6 +18,7 @@
 package p2c
 
 import (
+	"math/rand"
 	"testing"
 )
 
@@ -37,16 +38,18 @@ import (
 func TestLoadBalance(t *testing.T) {
 	lb := newP2CLoadBalance()
 	invocation := protoinvoc.NewRPCInvocation("TestMethod", []interface{}{}, nil)
-	randSeed = func() int64 {
+	randSeed := func() int64 {
 		return 0
 	}
 
 	t.Run("no invokers", func(t *testing.T) {
+		rand.Seed(randSeed())
 		ivk := lb.Select([]protocol.Invoker{}, invocation)
 		assert.Nil(t, ivk)
 	})
 
 	t.Run("one invoker", func(t *testing.T) {
+		rand.Seed(randSeed())
 		url0, _ := common.NewURL("dubbo://192.168.1.0:20000/com.ikurento.user.UserProvider")
 
 		ivkArr := []protocol.Invoker{
@@ -57,6 +60,7 @@ func TestLoadBalance(t *testing.T) {
 	})
 
 	t.Run("two invokers", func(t *testing.T) {
+		rand.Seed(randSeed())
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -86,6 +90,7 @@ func TestLoadBalance(t *testing.T) {
 	})
 
 	t.Run("multiple invokers", func(t *testing.T) {
+		rand.Seed(randSeed())
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -117,6 +122,7 @@ func TestLoadBalance(t *testing.T) {
 	})
 
 	t.Run("metrics i not found", func(t *testing.T) {
+		rand.Seed(randSeed())
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 
@@ -144,6 +150,7 @@ func TestLoadBalance(t *testing.T) {
 	})
 
 	t.Run("metrics j not found", func(t *testing.T) {
+		rand.Seed(randSeed())
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
 

--- a/registry/servicediscovery/instance/random/random_service_instance_selector.go
+++ b/registry/servicediscovery/instance/random/random_service_instance_selector.go
@@ -30,6 +30,7 @@ import (
 )
 
 func init() {
+	rand.Seed(time.Now().UnixNano())
 	extension.SetServiceInstanceSelector("random", NewRandomServiceInstanceSelector)
 }
 
@@ -47,7 +48,6 @@ func (r *RandomServiceInstanceSelector) Select(url *common.URL, serviceInstances
 	if len(serviceInstances) == 1 {
 		return serviceInstances[0]
 	}
-	rand.Seed(time.Now().UnixNano())
 	index := rand.Intn(len(serviceInstances))
 	return serviceInstances[index]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
Move the rand.Seed() call to init()

**Which issue(s) this PR fixes**: 
Fixes #1957 

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)