### PR TITLE
Fix: fix bug when creating metrics objects concurrently

### DIFF
--- a/metrics/prometheus/reporter.go
+++ b/metrics/prometheus/reporter.go
@@ -252,11 +252,11 @@ func (reporter *PrometheusReporter) setGauge(gaugeName string, toSetValue float6
 	if len(labelMap) == 0 {
 		// gauge
 		if val, exist := reporter.userGauge.Load(gaugeName); !exist {
-			newGauge := newGauge(gaugeName, reporter.namespace)
-			err := prom.DefaultRegisterer.Register(newGauge)
+			gauge := newGauge(gaugeName, reporter.namespace)
+			err := prom.DefaultRegisterer.Register(gauge)
 			if err == nil {
-				reporter.userGauge.Store(gaugeName, newGauge)
-				newGauge.Set(toSetValue)
+				reporter.userGauge.Store(gaugeName, gauge)
+				gauge.Set(toSetValue)
 			} else if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
 				// A gauge for that metric has been registered before.
 				// Use the old gauge from now on.
@@ -275,11 +275,11 @@ func (reporter *PrometheusReporter) setGauge(gaugeName string, toSetValue float6
 		for k, _ := range labelMap {
 			keyList = append(keyList, k)
 		}
-		newGaugeVec := newGaugeVec(gaugeName, reporter.namespace, keyList)
-		err := prom.DefaultRegisterer.Register(newGaugeVec)
+		gaugeVec := newGaugeVec(gaugeName, reporter.namespace, keyList)
+		err := prom.DefaultRegisterer.Register(gaugeVec)
 		if err == nil {
-			reporter.userGaugeVec.Store(gaugeName, newGaugeVec)
-			newGaugeVec.With(labelMap).Set(toSetValue)
+			reporter.userGaugeVec.Store(gaugeName, gaugeVec)
+			gaugeVec.With(labelMap).Set(toSetValue)
 		} else if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			// A gauge for that metric has been registered before.
 			// Use the old gauge from now on.
@@ -296,11 +296,11 @@ func (reporter *PrometheusReporter) incCounter(counterName string, labelMap prom
 	if len(labelMap) == 0 {
 		// counter
 		if val, exist := reporter.userCounter.Load(counterName); !exist {
-			newCounter := newCounter(counterName, reporter.namespace)
-			err := prom.DefaultRegisterer.Register(newCounter)
+			counter := newCounter(counterName, reporter.namespace)
+			err := prom.DefaultRegisterer.Register(counter)
 			if err == nil {
-				reporter.userCounter.Store(counterName, newCounter)
-				newCounter.Inc()
+				reporter.userCounter.Store(counterName, counter)
+				counter.Inc()
 			} else if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
 				// A counter for that metric has been registered before.
 				// Use the old counter from now on.
@@ -318,11 +318,11 @@ func (reporter *PrometheusReporter) incCounter(counterName string, labelMap prom
 		for k, _ := range labelMap {
 			keyList = append(keyList, k)
 		}
-		newCounterVec := newCounterVec(counterName, reporter.namespace, keyList)
-		err := prom.DefaultRegisterer.Register(newCounterVec)
+		counterVec := newCounterVec(counterName, reporter.namespace, keyList)
+		err := prom.DefaultRegisterer.Register(counterVec)
 		if err == nil {
-			reporter.userCounterVec.Store(counterName, newCounterVec)
-			newCounterVec.With(labelMap).Inc()
+			reporter.userCounterVec.Store(counterName, counterVec)
+			counterVec.With(labelMap).Inc()
 		} else if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			// A counter for that metric has been registered before.
 			// Use the old counter from now on.
@@ -339,11 +339,11 @@ func (reporter *PrometheusReporter) incSummary(summaryName string, toSetValue fl
 	if len(labelMap) == 0 {
 		// summary
 		if val, exist := reporter.userSummary.Load(summaryName); !exist {
-			newSummary := newSummary(summaryName, reporter.namespace)
-			err := prom.DefaultRegisterer.Register(newSummary)
+			summary := newSummary(summaryName, reporter.namespace)
+			err := prom.DefaultRegisterer.Register(summary)
 			if err == nil {
-				reporter.userSummary.Store(summaryName, newSummary)
-				newSummary.Observe(toSetValue)
+				reporter.userSummary.Store(summaryName, summary)
+				summary.Observe(toSetValue)
 			} else if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
 				// A summary for that metric has been registered before.
 				// Use the old summary from now on.
@@ -361,11 +361,11 @@ func (reporter *PrometheusReporter) incSummary(summaryName string, toSetValue fl
 		for k, _ := range labelMap {
 			keyList = append(keyList, k)
 		}
-		newSummaryVec := newSummaryVec(summaryName, reporter.namespace, keyList, reporter.reporterConfig.SummaryMaxAge)
-		err := prom.DefaultRegisterer.Register(newSummaryVec)
+		summaryVec := newSummaryVec(summaryName, reporter.namespace, keyList, reporter.reporterConfig.SummaryMaxAge)
+		err := prom.DefaultRegisterer.Register(summaryVec)
 		if err == nil {
-			reporter.userSummaryVec.Store(summaryName, newSummaryVec)
-			newSummaryVec.With(labelMap).Observe(toSetValue)
+			reporter.userSummaryVec.Store(summaryName, summaryVec)
+			summaryVec.With(labelMap).Observe(toSetValue)
 		} else if are, ok := err.(prometheus.AlreadyRegisteredError); ok {
 			// A summary for that metric has been registered before.
 			// Use the old summary from now on.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
fix bug when creating metrics objects concurrently

**Which issue(s) this PR fixes**: 
Fixes #1953 

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)