### PR TITLE
Fix: fix AssembleMsg bad use, pass []any as any in variadic function

### DIFF
--- a/filter/sentinel/filter.go
+++ b/filter/sentinel/filter.go
@@ -57,7 +57,7 @@ type DubboLoggerWrapper struct {
 }
 
 func (d DubboLoggerWrapper) Debug(msg string, keysAndValues ...interface{}) {
-	d.Logger.Debug(logging.AssembleMsg(logging.GlobalCallerDepth, "DEBUG", msg, nil, keysAndValues))
+	d.Logger.Debug(logging.AssembleMsg(logging.GlobalCallerDepth, "DEBUG", msg, nil, keysAndValues...))
 }
 
 func (d DubboLoggerWrapper) DebugEnabled() bool {
@@ -65,7 +65,7 @@ func (d DubboLoggerWrapper) DebugEnabled() bool {
 }
 
 func (d DubboLoggerWrapper) Info(msg string, keysAndValues ...interface{}) {
-	d.Logger.Info(logging.AssembleMsg(logging.GlobalCallerDepth, "INFO", msg, nil, keysAndValues))
+	d.Logger.Info(logging.AssembleMsg(logging.GlobalCallerDepth, "INFO", msg, nil, keysAndValues...))
 }
 
 func (d DubboLoggerWrapper) InfoEnabled() bool {
@@ -73,7 +73,7 @@ func (d DubboLoggerWrapper) InfoEnabled() bool {
 }
 
 func (d DubboLoggerWrapper) Warn(msg string, keysAndValues ...interface{}) {
-	d.Logger.Warn(logging.AssembleMsg(logging.GlobalCallerDepth, "WARN", msg, nil, keysAndValues))
+	d.Logger.Warn(logging.AssembleMsg(logging.GlobalCallerDepth, "WARN", msg, nil, keysAndValues...))
 }
 
 func (d DubboLoggerWrapper) WarnEnabled() bool {
@@ -81,7 +81,7 @@ func (d DubboLoggerWrapper) WarnEnabled() bool {
 }
 
 func (d DubboLoggerWrapper) Error(err error, msg string, keysAndValues ...interface{}) {
-	d.Logger.Warn(logging.AssembleMsg(logging.GlobalCallerDepth, "ERROR", msg, err, keysAndValues))
+	d.Logger.Warn(logging.AssembleMsg(logging.GlobalCallerDepth, "ERROR", msg, err, keysAndValues...))
 }
 
 func (d DubboLoggerWrapper) ErrorEnabled() bool {

--- a/registry/polaris/listener.go
+++ b/registry/polaris/listener.go
@@ -18,7 +18,6 @@
 package polaris
 
 import (
-	"bytes"
 	"net/url"
 	"strconv"
 )
@@ -34,7 +33,6 @@ import (
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
-	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/config_center"
 	"dubbo.apache.org/dubbo-go/v3/registry"
 )
@@ -76,13 +74,6 @@ func (pl *polarisListener) Next() (*registry.ServiceEvent, error) {
 func (pl *polarisListener) Close() {
 	// TODO need to add UnWatch in polaris
 	close(pl.closeCh)
-}
-
-func getSubscribeName(url *common.URL) string {
-	var buffer bytes.Buffer
-	buffer.Write([]byte(common.DubboNodes[common.PROVIDER]))
-	appendParam(&buffer, url, constant.InterfaceKey)
-	return buffer.String()
 }
 
 func generateUrl(instance model.Instance) *common.URL {

--- a/registry/polaris/registry.go
+++ b/registry/polaris/registry.go
@@ -37,9 +37,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
-	"dubbo.apache.org/dubbo-go/v3/config_center"
 	"dubbo.apache.org/dubbo-go/v3/registry"
-	"dubbo.apache.org/dubbo-go/v3/remoting"
 	"dubbo.apache.org/dubbo-go/v3/remoting/polaris"
 )
 
@@ -62,12 +60,10 @@ func newPolarisRegistry(url *common.URL) (registry.Registry, error) {
 		return &polarisRegistry{}, err
 	}
 	pRegistry := &polarisRegistry{
-		consumer:     api.NewConsumerAPIByContext(sdkCtx),
 		provider:     api.NewProviderAPIByContext(sdkCtx),
 		lock:         &sync.RWMutex{},
 		registryUrls: make(map[string]*PolarisHeartbeat),
 		listenerLock: &sync.RWMutex{},
-		watchers:     make(map[string]*PolarisServiceWatcher),
 	}
 
 	return pRegistry, nil
@@ -75,13 +71,11 @@ func newPolarisRegistry(url *common.URL) (registry.Registry, error) {
 
 type polarisRegistry struct {
 	url          *common.URL
-	consumer     api.ConsumerAPI
 	provider     api.ProviderAPI
 	lock         *sync.RWMutex
 	registryUrls map[string]*PolarisHeartbeat
 
 	listenerLock *sync.RWMutex
-	watchers     map[string]*PolarisServiceWatcher
 }
 
 // Register will register the service @url to its polaris registry center.
@@ -161,12 +155,6 @@ func (pr *polarisRegistry) Subscribe(url *common.URL, notifyListener registry.No
 		return nil
 	}
 
-	watcher, err := pr.createPolarisWatcherIfAbsent(url)
-
-	if err != nil {
-		return err
-	}
-
 	for {
 		listener, err := NewPolarisListener(url)
 		if err != nil {
@@ -174,13 +162,6 @@ func (pr *polarisRegistry) Subscribe(url *common.URL, notifyListener registry.No
 			<-time.After(time.Duration(RegistryConnDelay) * time.Second)
 			continue
 		}
-
-		watcher.AddSubscriber(func(et remoting.EventType, instances []model.Instance) {
-			for i := range instances {
-				instance := instances[i]
-				listener.events.In() <- &config_center.ConfigChangeEvent{ConfigType: et, Value: instance}
-			}
-		})
 
 		for {
 			serviceEvent, err := listener.Next()
@@ -193,33 +174,6 @@ func (pr *polarisRegistry) Subscribe(url *common.URL, notifyListener registry.No
 			notifyListener.Notify(serviceEvent)
 		}
 	}
-}
-
-func (pr *polarisRegistry) createPolarisWatcherIfAbsent(url *common.URL) (*PolarisServiceWatcher, error) {
-
-	pr.listenerLock.Lock()
-	defer pr.listenerLock.Unlock()
-
-	serviceName := getSubscribeName(url)
-
-	if _, exist := pr.watchers[serviceName]; !exist {
-		subscribeParam := &api.WatchServiceRequest{
-			WatchServiceRequest: model.WatchServiceRequest{
-				Key: model.ServiceKey{
-					Namespace: url.GetParam(constant.PolarisNamespace, constant.PolarisDefaultNamespace),
-					Service:   serviceName,
-				},
-			},
-		}
-
-		watcher, err := newPolarisWatcher(subscribeParam, pr.consumer)
-		if err != nil {
-			return nil, err
-		}
-		pr.watchers[serviceName] = watcher
-	}
-
-	return pr.watchers[serviceName], nil
 }
 
 // UnSubscribe returns nil if unsubscribing registry successfully. If not returns an error.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 

i am write a [linter](https://github.com/alingse/asasalint) to lint bad use `pass []any as any  in variadic function` and check the top go repo.



the `AssembleMsg`  func code is here https://github.com/alibaba/sentinel-golang/blob/2af86608857884da543eabe7941b61d60edc51a4/logging/logging.go#L152-L208

```Go
func AssembleMsg(depth int, logLevel, msg string, err error, keysAndValues ...interface{}) string {
        ....
	kvLen := len(keysAndValues)
	if kvLen&1 != 0 {
		sb.WriteByte(',')
		sb.WriteByte('"')
		sb.WriteString("kvs")
		sb.WriteByte('"')
		sb.WriteByte(':')
		s := fmt.Sprintf("%+v", keysAndValues)
		data := toSafeJSONString(s)
		sb.Write(data)
	} else if kvLen != 0 {
		for i := 0; i < kvLen; {
			k := keysAndValues[i]
			v := keysAndValues[i+1]
        ....
```
if someone call `DubboLoggerWrapper.Info` with  `Info("msg", "name",  "hello", "address", "world")`  for log, 

it will pass whole []any as any into func `AssembleMsg`, 

and got  `kvs: ["name", "hello", "adress",  "world"]` instead of `"name":"hello", "address":"world"`


**Which issue(s) this PR fixes**: 
Fixes #

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [x] All ut passed (run 'go test ./...' in project root)
- [x] After go-fmt ed , run 'go fmt project' using goland.
- [x] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [x] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [x] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [x] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)