### PR TITLE
fix(proto): fix getting attributes issue

### DIFF
--- a/protocol/invocation/rpcinvocation.go
+++ b/protocol/invocation/rpcinvocation.go
@@ -234,7 +234,7 @@ func (r *RPCInvocation) GetAttributeWithDefaultValue(key string, defaultValue in
 	if r.attributes == nil {
 		return defaultValue
 	}
-	if value, ok := r.attachments[key]; ok {
+	if value, ok := r.attributes[key]; ok {
 		return value
 	}
 	return defaultValue


### PR DESCRIPTION
RPCInvocation::GetAttributeWithDefaultValue() has a typo which couldn't
get attributes correctly, this PR fixes that issue.

Signed-off-by: Xuewei Niu <justxuewei@apache.org>

<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 

**Which issue(s) this PR fixes**: 
Fixes #

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)