### PR TITLE
Fix: token filter type assertion

### DIFF
--- a/filter/token/filter.go
+++ b/filter/token/filter.go
@@ -62,7 +62,7 @@ func (f *tokenFilter) Invoke(ctx context.Context, invoker protocol.Invoker, invo
 	if len(invokerTkn) > 0 {
 		attachs := invocation.Attachments()
 		remoteTkn, exist := attachs[constant.TokenKey]
-		if exist && remoteTkn != nil && strings.EqualFold(invokerTkn, remoteTkn.(string)) {
+		if exist && remoteTkn != nil && strings.EqualFold(invokerTkn, remoteTkn.([]string)[0]) {
 			return invoker.Invoke(ctx, invocation)
 		}
 		return &protocol.RPCResult{Err: perrors.Errorf("Invalid token! Forbid invoke remote service %v method %s ",


### PR DESCRIPTION
**What this PR does**: 
Fix type assertion in token filter.
remoteTkn must be assert to []string[0], because of http2 header limitation.

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)