### PR TITLE
Imp: move aksk auth to codec layer

### DIFF
--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -318,6 +318,7 @@ const (
 	RequestTimestampKey         = "timestamp"         // key of request timestamp
 	RequestSignatureKey         = "signature"         // key of request signature
 	AKKey                       = "ak"                // AK key
+	SKKey                       = "sk"                // SK key
 	SignatureStringFormat       = "%s#%s#%s#%s"       // signature format
 	ParameterSignatureEnableKey = "param.sign"        // key whether enable signature
 	Consumer                    = "consumer"          // consumer

--- a/filter/auth/default_authenticator.go
+++ b/filter/auth/default_authenticator.go
@@ -104,7 +104,7 @@ func (authenticator *defaultAuthenticator) Authenticate(invocation protocol.Invo
 	originSignature := invocation.GetAttachmentWithDefaultValue(constant.RequestSignatureKey, "")
 	consumer := invocation.GetAttachmentWithDefaultValue(constant.Consumer, "")
 	content := invocation.GetAttachmentWithDefaultValue("content", "")
-	
+
 	if IsEmpty(accessKeyId, false) || IsEmpty(consumer, false) ||
 		IsEmpty(requestTimestamp, false) || IsEmpty(originSignature, false) {
 		return errors.New("failed to authenticate your ak/sk, maybe the consumer has not enabled the auth")

--- a/filter/auth/default_authenticator.go
+++ b/filter/auth/default_authenticator.go
@@ -65,12 +65,13 @@ func (authenticator *defaultAuthenticator) Sign(invocation protocol.Invocation, 
 		return errors.New("get accesskey pair failed, cause: " + err.Error())
 	}
 	inv := invocation.(*invocation_impl.RPCInvocation)
-	signature, err := getSignature(url, invocation, accessKeyPair.SecretKey, currentTimeMillis)
-	if err != nil {
-		return err
-	}
-	inv.SetAttachment(constant.RequestSignatureKey, signature)
+	// signature, err := getSignature(url, invocation, accessKeyPair.SecretKey, currentTimeMillis)
+	// if err != nil {
+	// 	return err
+	// }
+	// inv.SetAttachment(constant.RequestSignatureKey, signature)
 	inv.SetAttachment(constant.RequestTimestampKey, currentTimeMillis)
+	inv.SetAttachment(constant.SKKey, accessKeyPair.SecretKey)
 	inv.SetAttachment(constant.AKKey, accessKeyPair.AccessKey)
 	inv.SetAttachment(constant.Consumer, consumer)
 	return nil
@@ -102,6 +103,8 @@ func (authenticator *defaultAuthenticator) Authenticate(invocation protocol.Invo
 	requestTimestamp := invocation.GetAttachmentWithDefaultValue(constant.RequestTimestampKey, "")
 	originSignature := invocation.GetAttachmentWithDefaultValue(constant.RequestSignatureKey, "")
 	consumer := invocation.GetAttachmentWithDefaultValue(constant.Consumer, "")
+	content := invocation.GetAttachmentWithDefaultValue("content", "")
+	
 	if IsEmpty(accessKeyId, false) || IsEmpty(consumer, false) ||
 		IsEmpty(requestTimestamp, false) || IsEmpty(originSignature, false) {
 		return errors.New("failed to authenticate your ak/sk, maybe the consumer has not enabled the auth")
@@ -112,7 +115,9 @@ func (authenticator *defaultAuthenticator) Authenticate(invocation protocol.Invo
 		return errors.New("failed to authenticate , can't load the accessKeyPair")
 	}
 
-	computeSignature, err := getSignature(url, invocation, accessKeyPair.SecretKey, requestTimestamp)
+	// computeSignature, err := getSignature(url, invocation, accessKeyPair.SecretKey, requestTimestamp)
+
+	computeSignature := Sign(content, accessKeyPair.SecretKey)
 	if err != nil {
 		return err
 	}

--- a/filter/auth/default_authenticator.go
+++ b/filter/auth/default_authenticator.go
@@ -19,7 +19,6 @@ package auth
 
 import (
 	"errors"
-	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -65,35 +64,12 @@ func (authenticator *defaultAuthenticator) Sign(invocation protocol.Invocation, 
 		return errors.New("get accesskey pair failed, cause: " + err.Error())
 	}
 	inv := invocation.(*invocation_impl.RPCInvocation)
-	// signature, err := getSignature(url, invocation, accessKeyPair.SecretKey, currentTimeMillis)
-	// if err != nil {
-	// 	return err
-	// }
-	// inv.SetAttachment(constant.RequestSignatureKey, signature)
+
 	inv.SetAttachment(constant.RequestTimestampKey, currentTimeMillis)
 	inv.SetAttachment(constant.SKKey, accessKeyPair.SecretKey)
 	inv.SetAttachment(constant.AKKey, accessKeyPair.AccessKey)
 	inv.SetAttachment(constant.Consumer, consumer)
 	return nil
-}
-
-// getSignature
-// get signature by the metadata and params of the invocation
-func getSignature(url *common.URL, invocation protocol.Invocation, secrectKey string, currentTime string) (string, error) {
-	requestString := fmt.Sprintf(constant.SignatureStringFormat,
-		url.ColonSeparatedKey(), invocation.MethodName(), secrectKey, currentTime)
-	var signature string
-	if parameterEncrypt := url.GetParamBool(constant.ParameterSignatureEnableKey, false); parameterEncrypt {
-		var err error
-		if signature, err = SignWithParams(invocation.Arguments(), requestString, secrectKey); err != nil {
-			// TODO
-			return "", errors.New("sign the request with params failed, cause:" + err.Error())
-		}
-	} else {
-		signature = Sign(requestString, secrectKey)
-	}
-
-	return signature, nil
 }
 
 // Authenticate verifies whether the signature sent by the requester is correct
@@ -114,8 +90,6 @@ func (authenticator *defaultAuthenticator) Authenticate(invocation protocol.Invo
 	if err != nil {
 		return errors.New("failed to authenticate , can't load the accessKeyPair")
 	}
-
-	// computeSignature, err := getSignature(url, invocation, accessKeyPair.SecretKey, requestTimestamp)
 
 	computeSignature := Sign(content, accessKeyPair.SecretKey)
 	if err != nil {

--- a/filter/auth/provider_auth_filter_test.go
+++ b/filter/auth/provider_auth_filter_test.go
@@ -19,6 +19,7 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
 	"strconv"
 	"testing"
 	"time"
@@ -51,15 +52,17 @@ func TestProviderAuthFilter_Invoke(t *testing.T) {
 			ID   int64
 		}{"YUYU", 1},
 	}
-	inv := invocation.NewRPCInvocation("test", parmas, nil)
 	requestTime := strconv.Itoa(int(time.Now().Unix() * 1000))
-	signature, _ := getSignature(url, inv, secret, requestTime)
+	
+	content, _ := json.Marshal(parmas)
+	signature := doSign(content, secret)
 
-	inv = invocation.NewRPCInvocation("test", []interface{}{"OK"}, map[string]interface{}{
+	inv := invocation.NewRPCInvocation("test", []interface{}{"OK"}, map[string]interface{}{
 		constant.RequestSignatureKey: signature,
 		constant.Consumer:            "test",
 		constant.RequestTimestampKey: requestTime,
 		constant.AKKey:               access,
+		"content":				      string(content),
 	})
 	ctrl := gomock.NewController(t)
 	filter := &authFilter{}

--- a/filter/auth/sign_util.go
+++ b/filter/auth/sign_util.go
@@ -21,8 +21,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/json"
-	"errors"
 	"strings"
 )
 
@@ -37,29 +35,6 @@ import (
 // Sign gets a signature string with given bytes
 func Sign(metadata, key string) string {
 	return doSign([]byte(metadata), key)
-}
-
-// SignWithParams returns a signature with giving params and metadata.
-func SignWithParams(params []interface{}, metadata, key string) (string, error) {
-	if len(params) == 0 {
-		return Sign(metadata, key), nil
-	}
-
-	data := append(params, metadata)
-	if bytes, err := toBytes(data); err != nil {
-		// TODO
-		return "", errors.New("data convert to bytes failed")
-	} else {
-		return doSign(bytes, key), nil
-	}
-}
-
-func toBytes(data []interface{}) ([]byte, error) {
-	if bytes, err := json.Marshal(data); err != nil {
-		return nil, errors.New("")
-	} else {
-		return bytes, nil
-	}
 }
 
 func doSign(bytes []byte, key string) string {

--- a/filter/auth/sign_util.go
+++ b/filter/auth/sign_util.go
@@ -24,9 +24,8 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
-)
 
-import (
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"github.com/dubbogo/gost/log/logger"
 )
 
@@ -76,4 +75,16 @@ func IsEmpty(s string, allowSpace bool) bool {
 		return strings.TrimSpace(s) == ""
 	}
 	return false
+}
+
+func GenSignBlock(bytes []byte, key interface{}) map[string]interface{} {
+	signBlock := make(map[string]interface{})
+	if key != nil {
+		signature := doSign(bytes, key.(string))
+		signBlock[constant.RequestSignatureKey] = signature
+	} else {
+		signBlock[constant.RequestSignatureKey] = nil
+	}
+	signBlock["contentLen"] = len(bytes)
+	return signBlock
 }

--- a/filter/auth/sign_util.go
+++ b/filter/auth/sign_util.go
@@ -24,9 +24,14 @@ import (
 	"encoding/json"
 	"errors"
 	"strings"
+)
 
-	"dubbo.apache.org/dubbo-go/v3/common/constant"
+import (
 	"github.com/dubbogo/gost/log/logger"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
 )
 
 // Sign gets a signature string with given bytes

--- a/filter/auth/sign_util_test.go
+++ b/filter/auth/sign_util_test.go
@@ -25,6 +25,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+import (
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+)
+
 func TestIsEmpty(t *testing.T) {
 	type args struct {
 		s          string
@@ -58,19 +62,6 @@ func TestSign(t *testing.T) {
 	assert.NotNil(t, signature)
 }
 
-func TestSignWithParams(t *testing.T) {
-	metadata := "com.ikurento.user.UserProvider::sayHi"
-	key := "key"
-	params := []interface{}{
-		"a", 1, struct {
-			Name string
-			ID   int64
-		}{"YuYu", 1},
-	}
-	signature, _ := SignWithParams(params, metadata, key)
-	assert.False(t, IsEmpty(signature, false))
-}
-
 func Test_doSign(t *testing.T) {
 	sign := doSign([]byte("DubboGo"), "key")
 	sign1 := doSign([]byte("DubboGo"), "key")
@@ -80,21 +71,17 @@ func Test_doSign(t *testing.T) {
 	assert.NotEqual(t, sign1, sign2)
 }
 
-func Test_toBytes(t *testing.T) {
-	params := []interface{}{
-		"a", 1, struct {
-			Name string
-			ID   int64
-		}{"YuYu", 1},
-	}
-	params2 := []interface{}{
-		"a", 1, struct {
-			Name string
-			ID   int64
-		}{"YuYu", 1},
-	}
-	jsonBytes, _ := toBytes(params)
-	jsonBytes2, _ := toBytes(params2)
-	assert.NotNil(t, jsonBytes)
-	assert.Equal(t, jsonBytes, jsonBytes2)
+func Test_GenSignBlock(t *testing.T) {
+	signBlock := GenSignBlock([]byte("DubboGo"), "key")
+	assert.NotNil(t, signBlock[constant.RequestSignatureKey])
+	assert.Equal(t, signBlock["contentLen"], len([]byte("DubboGo")))
+
+	signBlock1 := GenSignBlock([]byte("DubboGo"), nil)
+	assert.Nil(t, signBlock1[constant.RequestSignatureKey])
+	assert.Equal(t, signBlock1["contentLen"], len([]byte("DubboGo")))
+
+	signBlock2 := GenSignBlock([]byte("DubboGo"), "key")
+	signBlock3 := GenSignBlock([]byte("DubboGo"), "key2")
+	assert.Equal(t, signBlock[constant.RequestSignatureKey], signBlock2[constant.RequestSignatureKey])
+	assert.NotEqual(t, signBlock[constant.RequestSignatureKey], signBlock3[constant.RequestSignatureKey])
 }

--- a/protocol/dubbo/impl/codec.go
+++ b/protocol/dubbo/impl/codec.go
@@ -20,13 +20,20 @@ package impl
 import (
 	"bufio"
 	"encoding/binary"
+)
 
+import (
+	hessian "github.com/apache/dubbo-go-hessian2"
+
+	"github.com/dubbogo/gost/log/logger"
+
+	perrors "github.com/pkg/errors"
+)
+
+import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/filter/auth"
 	"dubbo.apache.org/dubbo-go/v3/remoting"
-	hessian "github.com/apache/dubbo-go-hessian2"
-	"github.com/dubbogo/gost/log/logger"
-	perrors "github.com/pkg/errors"
 )
 
 type ProtocolCodec struct {
@@ -326,4 +333,3 @@ func NewDubboCodec(reader *bufio.Reader) *ProtocolCodec {
 		serializer: s,
 	}
 }
-

--- a/protocol/dubbo/impl/hessian.go
+++ b/protocol/dubbo/impl/hessian.go
@@ -155,6 +155,26 @@ func marshalRequest(encoder *hessian.Encoder, p DubboPackage) ([]byte, error) {
 	return encoder.Buffer(), err
 }
 
+func (h HessianSerializer) MarshalSign(s map[string]interface{}) ([]byte, error) {
+	encoder := hessian.NewEncoder()
+	err := encoder.Encode(s)
+	return encoder.Buffer(), err
+}
+
+func (h HessianSerializer) UnmarshalSign(body []byte) (map[interface{}]interface{}, error) {
+	decoder := hessian.NewDecoder(body)
+	sign, err := decoder.Decode()
+
+	if err != nil {
+		return nil, perrors.WithStack(err)
+	}
+
+	if v, ok := sign.(map[interface{}]interface{}); ok {
+		return v, nil
+	}
+	return nil, perrors.Errorf("get wrong signature: %+v", sign)
+}
+
 var versionInt = make(map[string]int)
 
 // https://github.com/apache/dubbo/blob/dubbo-2.7.1/dubbo-common/src/main/java/org/apache/dubbo/common/Version.java#L96

--- a/protocol/dubbo/impl/serialize.go
+++ b/protocol/dubbo/impl/serialize.go
@@ -23,7 +23,9 @@ import (
 
 type Serializer interface {
 	Marshal(p DubboPackage) ([]byte, error)
+	MarshalSign(map[string]interface{}) ([]byte, error)
 	Unmarshal([]byte, *DubboPackage) error
+	UnmarshalSign([]byte) (map[interface{}]interface{}, error)
 }
 
 func LoadSerializer(p *DubboPackage) error {


### PR DESCRIPTION
**What this PR does**: 
This PR moves ak/sk based signature authentication to codec layer and is implemented on dubbo protocol.

This method can validate entire request body, thus avoid vulnerablity in deserialization.

**Which issue(s) this PR is related to**: 
#1906 

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)