### PR TITLE
Fix(#1974):fix shutdown InternalSignal default value

### DIFF
--- a/config/graceful_shutdown.go
+++ b/config/graceful_shutdown.go
@@ -71,7 +71,7 @@ func gracefulShutdownInit() {
 		filter.Set(constant.GracefulShutdownFilterShutdownConfig, GetShutDown())
 	}
 
-	if GetShutDown().InternalSignal {
+	if GetShutDown().GetInternalSignal() {
 		signals := make(chan os.Signal, 1)
 		signal.Notify(signals, ShutdownSignals...)
 

--- a/config/graceful_shutdown_config.go
+++ b/config/graceful_shutdown_config.go
@@ -66,7 +66,7 @@ type ShutdownConfig struct {
 	// when we try to shutdown the applicationConfig, we will reject the new requests. In most cases, you don't need to configure this.
 	RejectRequestHandler string `yaml:"reject-handler" json:"reject-handler,omitempty" property:"reject_handler"`
 	// internal listen kill signal，the default is true.
-	InternalSignal bool `default:"true" yaml:"internal-signal" json:"internal.signal,omitempty" property:"internal.signal"`
+	InternalSignal *bool `default:"true" yaml:"internal-signal" json:"internal.signal,omitempty" property:"internal.signal"`
 	// offline request window length
 	OfflineRequestWindowTimeout string `yaml:"offline-request-window-timeout" json:"offlineRequestWindowTimeout,omitempty" property:"offlineRequestWindowTimeout"`
 	// true -> new request will be rejected.
@@ -157,7 +157,7 @@ func (scb *ShutdownConfigBuilder) SetRejectRequest(rejectRequest bool) *Shutdown
 }
 
 func (scb *ShutdownConfigBuilder) SetInternalSignal(internalSignal bool) *ShutdownConfigBuilder {
-	scb.shutdownConfig.InternalSignal = internalSignal
+	scb.shutdownConfig.InternalSignal = &internalSignal
 	return scb
 }
 

--- a/config/graceful_shutdown_config.go
+++ b/config/graceful_shutdown_config.go
@@ -124,6 +124,13 @@ func (config *ShutdownConfig) GetConsumerUpdateWaitTime() time.Duration {
 	return result
 }
 
+func (config *ShutdownConfig) GetInternalSignal() bool {
+	if config.InternalSignal == nil {
+		return false
+	}
+	return *config.InternalSignal
+}
+
 func (config *ShutdownConfig) Init() error {
 	return defaults.Set(config)
 }
@@ -162,7 +169,7 @@ func (scb *ShutdownConfigBuilder) SetInternalSignal(internalSignal bool) *Shutdo
 }
 
 func (scb *ShutdownConfigBuilder) Build() *ShutdownConfig {
-	defaults.Set(scb)
+	defaults.MustSet(scb.shutdownConfig)
 	return scb.shutdownConfig
 }
 

--- a/config/graceful_shutdown_config_test.go
+++ b/config/graceful_shutdown_config_test.go
@@ -68,7 +68,7 @@ func TestNewShutDownConfigBuilder(t *testing.T) {
 		SetOfflineRequestWindowTimeout("13s").
 		SetRejectRequestHandler("handler").
 		SetRejectRequest(true).
-		SetInternalSignal(true).
+		SetInternalSignal(false).
 		Build()
 
 	assert.Equal(t, config.Prefix(), constant.ShutdownConfigPrefix)
@@ -86,4 +86,18 @@ func TestNewShutDownConfigBuilder(t *testing.T) {
 
 	waitTime := config.GetConsumerUpdateWaitTime()
 	assert.Equal(t, waitTime, 3*time.Second)
+
+	assert.Equal(t, config.GetInternalSignal(), false)
+}
+
+func TestGetInternalSignal(t *testing.T) {
+	config := NewShutDownConfigBuilder().
+		SetTimeout("10s").
+		SetStepTimeout("15s").
+		SetOfflineRequestWindowTimeout("13s").
+		SetRejectRequestHandler("handler").
+		SetRejectRequest(true).
+		Build()
+
+	assert.Equal(t, config.GetInternalSignal(), true)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 

https://github.com/apache/dubbo-go/issues/1974  fix shotdown InternalSignal default value

**Which issue(s) this PR fixes**: 
Fixes #

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [x] All ut passed (run 'go test ./...' in project root)
- [x] After go-fmt ed , run 'go fmt project' using goland.
- [x] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [x] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [x] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [x] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)