### PR TITLE
feat: resolve placeholder

### DIFF
--- a/common/constant/file/suffix.go
+++ b/common/constant/file/suffix.go
@@ -26,3 +26,8 @@ const (
 	YML        = Suffix("yml")
 	PROPERTIES = Suffix("properties")
 )
+
+const (
+	PlaceholderPrefix = "${"
+	PlaceholderSuffix = "}"
+)

--- a/config/config_resolver.go
+++ b/config/config_resolver.go
@@ -76,11 +76,6 @@ func GetConfigResolver(conf *loaderConf) *koanf.Koanf {
 	return resolvePlaceholder(k)
 }
 
-const (
-	PlaceholderPrefix = "${"
-	PlaceholderSuffix = "}"
-)
-
 // resolvePlaceholder replace ${xx} with real value
 func resolvePlaceholder(resolver *koanf.Koanf) *koanf.Koanf {
 	m := make(map[string]interface{})
@@ -107,10 +102,10 @@ func resolvePlaceholder(resolver *koanf.Koanf) *koanf.Koanf {
 
 func checkPlaceholder(s string) (newKey, defaultValue string) {
 	s = strings.TrimSpace(s)
-	if !strings.HasPrefix(s, PlaceholderPrefix) || !strings.HasSuffix(s, PlaceholderSuffix) {
+	if !strings.HasPrefix(s, file.PlaceholderPrefix) || !strings.HasSuffix(s, file.PlaceholderSuffix) {
 		return
 	}
-	s = s[len(PlaceholderPrefix) : len(s)-len(PlaceholderSuffix)]
+	s = s[len(file.PlaceholderPrefix) : len(s)-len(file.PlaceholderSuffix)]
 	indexColon := strings.Index(s, ":")
 	if indexColon == -1 {
 		newKey = strings.TrimSpace(s)

--- a/config/config_resolver.go
+++ b/config/config_resolver.go
@@ -18,14 +18,18 @@
 package config
 
 import (
+	"strings"
+)
+
+import (
 	log "github.com/dubbogo/gost/log/logger"
+
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/json"
 	"github.com/knadh/koanf/parsers/toml"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/confmap"
 	"github.com/knadh/koanf/providers/rawbytes"
-	"strings"
 
 	"github.com/pkg/errors"
 )

--- a/config/config_resolver_test.go
+++ b/config/config_resolver_test.go
@@ -1,9 +1,13 @@
 package config
 
 import (
-	"github.com/knadh/koanf"
-	"github.com/stretchr/testify/assert"
 	"testing"
+)
+
+import (
+	"github.com/knadh/koanf"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestResolvePlaceHolder(t *testing.T) {

--- a/config/config_resolver_test.go
+++ b/config/config_resolver_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"github.com/knadh/koanf"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestResolvePlaceHolder(t *testing.T) {
+	t.Run("test resolver", func(t *testing.T) {
+		conf := NewLoaderConf(WithPath("/Users/zlb/GolandProjects/dubbo-go/config/testdata/config/resolver/application.yaml"))
+		koan := GetConfigResolver(conf)
+		assert.Equal(t, koan.Get("dubbo.config-center.address"), koan.Get("dubbo.registries.nacos.address"))
+		assert.Equal(t, koan.Get("localhost"), koan.Get("dubbo.protocols.dubbo.ip"))
+		assert.Equal(t, nil, koan.Get("dubbo.registries.nacos.group"))
+
+		rc := NewRootConfigBuilder().Build()
+		err := koan.UnmarshalWithConf(rc.Prefix(), rc, koanf.UnmarshalConf{Tag: "yaml"})
+		assert.Nil(t, err)
+		assert.Equal(t, rc.ConfigCenter.Address, rc.Registries["nacos"].Address)
+		//not exist, default
+		assert.Equal(t, "", rc.Registries["nacos"].Group)
+
+	})
+}

--- a/config/config_resolver_test.go
+++ b/config/config_resolver_test.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package config
 
 import (
@@ -16,7 +33,8 @@ func TestResolvePlaceHolder(t *testing.T) {
 		koan := GetConfigResolver(conf)
 		assert.Equal(t, koan.Get("dubbo.config-center.address"), koan.Get("dubbo.registries.nacos.address"))
 		assert.Equal(t, koan.Get("localhost"), koan.Get("dubbo.protocols.dubbo.ip"))
-		assert.Equal(t, nil, koan.Get("dubbo.registries.nacos.group"))
+		assert.Equal(t, "", koan.Get("dubbo.registries.nacos.group"))
+		assert.Equal(t, "dev", koan.Get("dubbo.registries.zk.group"))
 
 		rc := NewRootConfigBuilder().Build()
 		err := koan.UnmarshalWithConf(rc.Prefix(), rc, koanf.UnmarshalConf{Tag: "yaml"})
@@ -24,6 +42,7 @@ func TestResolvePlaceHolder(t *testing.T) {
 		assert.Equal(t, rc.ConfigCenter.Address, rc.Registries["nacos"].Address)
 		//not exist, default
 		assert.Equal(t, "", rc.Registries["nacos"].Group)
+		assert.Equal(t, "dev", rc.Registries["zk"].Group)
 
 	})
 }

--- a/config/config_resolver_test.go
+++ b/config/config_resolver_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestResolvePlaceHolder(t *testing.T) {
 	t.Run("test resolver", func(t *testing.T) {
-		conf := NewLoaderConf(WithPath("/Users/zlb/GolandProjects/dubbo-go/config/testdata/config/resolver/application.yaml"))
+		conf := NewLoaderConf(WithPath("./testdata/config/resolver/application.yaml"))
 		koan := GetConfigResolver(conf)
 		assert.Equal(t, koan.Get("dubbo.config-center.address"), koan.Get("dubbo.registries.nacos.address"))
 		assert.Equal(t, koan.Get("localhost"), koan.Get("dubbo.protocols.dubbo.ip"))

--- a/config/testdata/config/resolver/application.yaml
+++ b/config/testdata/config/resolver/application.yaml
@@ -1,0 +1,36 @@
+localhost: 127.0.0.1
+dubbo:
+  application:
+    name: dubbo-go
+    module: local
+    version: 1.0.0
+    owner: zhaoyunxing
+  config-center:
+    address: nacos://127.0.0.1:8848
+    cluster: dev
+    namespace: dubbo
+    log-dir: ./logs
+  protocols:
+    dubbo:
+      name: dubbo
+      ip: ${localhost}
+      port: 20000
+  registries:
+    nacos:
+      timeout: 5s
+      group: ${notexist}
+      address: ${dubbo.config-center.address}
+    zk:
+      protocol: zookeeper
+      group: dev
+      address: 127.0.0.1:2181
+  services:
+    helloService:
+      interface: org.dubbo.service.HelloService
+      registry-ids: nacos,zk
+    orderService:
+      interface: org.dubbo.service.OrderService
+      registry-ids: nacos
+  provider:
+    register: true
+    services:

--- a/config/testdata/config/resolver/application.yaml
+++ b/config/testdata/config/resolver/application.yaml
@@ -19,10 +19,10 @@ dubbo:
     nacos:
       timeout: 5s
       group: ${notexist}
-      address: ${dubbo.config-center.address}
+      address: ${dubbo.config-center.address:nacos://127.0.0.1:8848}
     zk:
       protocol: zookeeper
-      group: dev
+      group: ${notexist:dev}
       address: 127.0.0.1:2181
   services:
     helloService:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
resolve placeholder `${xxx:defaultValue}`
**Which issue(s) this PR fixes**: 
Fixes #1983

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [x] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)