### PR TITLE
feat: use notifyAll insteadOf notify for listener events notify

### DIFF
--- a/registry/directory/directory.go
+++ b/registry/directory/directory.go
@@ -141,7 +141,7 @@ func (dir *RegistryDirectory) refreshInvokers(event *registry.ServiceEvent) {
 }
 
 // refreshAllInvokers the argument is the complete list of the service events,  we can safely assume any cached invoker
-// not in the incoming list can be removed.  The Action of serviceEvent should be EventTypeUpdate.
+// not in the incoming list can be removed.  The Action of serviceEvent should be EventTypeUpdate or EventTypeAdd.
 func (dir *RegistryDirectory) refreshAllInvokers(events []*registry.ServiceEvent, callback func()) {
 	var (
 		oldInvokers []protocol.Invoker
@@ -152,7 +152,7 @@ func (dir *RegistryDirectory) refreshAllInvokers(events []*registry.ServiceEvent
 
 	// loop the events to check the Action should be EventTypeUpdate.
 	for _, event := range events {
-		if event.Action != remoting.EventTypeUpdate {
+		if event.Action != remoting.EventTypeUpdate && event.Action != remoting.EventTypeAdd {
 			panic("Your implements of register center is wrong, " +
 				"please check the Action of ServiceEvent should be EventTypeUpdate")
 		}
@@ -186,9 +186,9 @@ func (dir *RegistryDirectory) refreshAllInvokers(events []*registry.ServiceEvent
 				addEvents = append(addEvents, event)
 			}
 		}
-		// loop the updateEvents
+		// loop the serviceEvents
 		for _, event := range addEvents {
-			logger.Debugf("[Registry Directory] registry update, result{%s}", event)
+			logger.Debugf("[Registry Directory] registry changed, result{%s}", event)
 			if event != nil && event.Service != nil {
 				logger.Infof("[Registry Directory] selector add service url{%s}", event.Service.String())
 			}

--- a/registry/event/service_instances_changed_listener_impl.go
+++ b/registry/event/service_instances_changed_listener_impl.go
@@ -130,12 +130,14 @@ func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error
 
 		for key, notifyListener := range lstn.listeners {
 			urls := lstn.serviceUrls[key]
+			events := make([]*registry.ServiceEvent, 0, len(urls))
 			for _, url := range urls {
-				notifyListener.Notify(&registry.ServiceEvent{
+				events = append(events, &registry.ServiceEvent{
 					Action:  remoting.EventTypeAdd,
 					Service: url,
 				})
 			}
+			notifyListener.NotifyAll(events, func() {})
 		}
 	}
 	return nil


### PR DESCRIPTION
Signed-off-by: xiaoxu <lexuscyborg103@gmail.com>

<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
![image](https://user-images.githubusercontent.com/10649416/187834800-3beac389-3930-4530-a265-f3eb50c1ca14.png)

`Notify one after one` might have performance issues, this PR makes serviceListeners notify events concurrently and do not wait for notification complated.

I am wondering if it's needed to add a sync.WaitGroup after NotifyAll to wait notification completed or not.

**Which issue(s) this PR fixes**: 
Fixes https://github.com/apache/dubbo-go/issues/2030

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [x] All ut passed (run 'go test ./...' in project root)
- [x] After go-fmt ed , run 'go fmt project' using goland.
- [x] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [x] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)