### PR TITLE
refactor(registry): keep the name of protocol registry plugin consistent

### DIFF
--- a/config/config_loader.go
+++ b/config/config_loader.go
@@ -77,7 +77,7 @@ func registerServiceInstance() {
 	if err != nil {
 		panic(err)
 	}
-	p := extension.GetProtocol(constant.RegistryKey)
+	p := extension.GetProtocol(constant.RegistryProtocol)
 	var rp registry.RegistryFactory
 	var ok bool
 	if rp, ok = p.(registry.RegistryFactory); !ok {

--- a/config/graceful_shutdown.go
+++ b/config/graceful_shutdown.go
@@ -119,7 +119,7 @@ func BeforeShutdown() {
 
 func destroyAllRegistries() {
 	logger.Info("Graceful shutdown --- Destroy all registriesConfig. ")
-	registryProtocol := extension.GetProtocol(constant.RegistryKey)
+	registryProtocol := extension.GetProtocol(constant.RegistryProtocol)
 	registryProtocol.Destroy()
 }
 

--- a/config/service_config.go
+++ b/config/service_config.go
@@ -294,7 +294,7 @@ func (s *ServiceConfig) Export() error {
 			s.cacheMutex.Lock()
 			if s.cacheProtocol == nil {
 				logger.Debugf(fmt.Sprintf("First load the registry protocol, url is {%v}!", ivkURL))
-				s.cacheProtocol = extension.GetProtocol("registry")
+				s.cacheProtocol = extension.GetProtocol(constant.RegistryProtocol)
 			}
 			s.cacheMutex.Unlock()
 

--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -70,7 +70,7 @@ type registryProtocol struct {
 }
 
 func init() {
-	extension.SetProtocol("registry", GetProtocol)
+	extension.SetProtocol(constant.RegistryProtocol, GetProtocol)
 }
 
 func newRegistryProtocol() *registryProtocol {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
keep the name of protocol registry plugin consistent
**Which issue(s) this PR fixes**: 
Fixes #2045 

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)