### PR TITLE
upgrade hessian to v1.11.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/alibaba/sentinel-golang v1.0.4
 	github.com/apache/dubbo-getty v1.4.9-0.20220825024508-3da63c3257fa
-	github.com/apache/dubbo-go-hessian2 v1.11.1
+	github.com/apache/dubbo-go-hessian2 v1.11.2
 	github.com/cespare/xxhash/v2 v2.1.2
 	github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4
 	github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/apache/dubbo-getty v1.4.9-0.20220825024508-3da63c3257fa h1:siT9WaTLlb
 github.com/apache/dubbo-getty v1.4.9-0.20220825024508-3da63c3257fa/go.mod h1:6qmrqBSPGs3B35zwEuGhEYNVsx1nfGT/xzV2yOt2amM=
 github.com/apache/dubbo-go-hessian2 v1.9.1/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
 github.com/apache/dubbo-go-hessian2 v1.9.3/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
-github.com/apache/dubbo-go-hessian2 v1.11.1 h1:03xs4QCAZHY/gHCOWgOmIUW6Yc842FCLz4R0hxCzPr8=
-github.com/apache/dubbo-go-hessian2 v1.11.1/go.mod h1:7rEw9guWABQa6Aqb8HeZcsYPHsOS7XT1qtJvkmI6c5w=
+github.com/apache/dubbo-go-hessian2 v1.11.2 h1:FYWtimJ2At77e/RhS45s8m78QRUILy/MlKUmORQ8Emo=
+github.com/apache/dubbo-go-hessian2 v1.11.2/go.mod h1:7rEw9guWABQa6Aqb8HeZcsYPHsOS7XT1qtJvkmI6c5w=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
upgrade hessian to v1.11.2

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)