### PR TITLE
fix: add more setter of ReferenceConfigBuilder

### DIFF
--- a/config/reference_config.go
+++ b/config/reference_config.go
@@ -404,6 +404,76 @@ func (pcb *ReferenceConfigBuilder) SetURL(url string) *ReferenceConfigBuilder {
 	return pcb
 }
 
+func (pcb *ReferenceConfigBuilder) SetFilter(filter string) *ReferenceConfigBuilder {
+	pcb.referenceConfig.Filter = filter
+	return pcb
+}
+
+func (pcb *ReferenceConfigBuilder) SetLoadbalance(loadbalance string) *ReferenceConfigBuilder {
+	pcb.referenceConfig.Loadbalance = loadbalance
+	return pcb
+}
+
+func (pcb *ReferenceConfigBuilder) SetRetries(retries string) *ReferenceConfigBuilder {
+	pcb.referenceConfig.Retries = retries
+	return pcb
+}
+
+func (pcb *ReferenceConfigBuilder) SetGroup(group string) *ReferenceConfigBuilder {
+	pcb.referenceConfig.Group = group
+	return pcb
+}
+
+func (pcb *ReferenceConfigBuilder) SetVersion(version string) *ReferenceConfigBuilder {
+	pcb.referenceConfig.Version = version
+	return pcb
+}
+
+func (pcb *ReferenceConfigBuilder) SetProvidedBy(providedBy string) *ReferenceConfigBuilder {
+	pcb.referenceConfig.ProvidedBy = providedBy
+	return pcb
+}
+
+func (pcb *ReferenceConfigBuilder) SetMethodConfig(methodConfigs []*MethodConfig) *ReferenceConfigBuilder {
+	pcb.referenceConfig.Methods = methodConfigs
+	return pcb
+}
+
+func (pcb *ReferenceConfigBuilder) AddMethodConfig(methodConfig *MethodConfig) *ReferenceConfigBuilder {
+	pcb.referenceConfig.Methods = append(pcb.referenceConfig.Methods, methodConfig)
+	return pcb
+}
+
+func (pcb *ReferenceConfigBuilder) SetAsync(async bool) *ReferenceConfigBuilder {
+	pcb.referenceConfig.Async = async
+	return pcb
+}
+
+func (pcb *ReferenceConfigBuilder) SetParams(params map[string]string) *ReferenceConfigBuilder {
+	pcb.referenceConfig.Params = params
+	return pcb
+}
+
+func (pcb *ReferenceConfigBuilder) SetSticky(sticky bool) *ReferenceConfigBuilder {
+	pcb.referenceConfig.Sticky = sticky
+	return pcb
+}
+
+func (pcb *ReferenceConfigBuilder) SetRequestTimeout(requestTimeout string) *ReferenceConfigBuilder {
+	pcb.referenceConfig.RequestTimeout = requestTimeout
+	return pcb
+}
+
+func (pcb *ReferenceConfigBuilder) SetForceTag(forceTag bool) *ReferenceConfigBuilder {
+	pcb.referenceConfig.ForceTag = forceTag
+	return pcb
+}
+
+func (pcb *ReferenceConfigBuilder) SetTracingKey(tracingKey string) *ReferenceConfigBuilder {
+	pcb.referenceConfig.TracingKey = tracingKey
+	return pcb
+}
+
 func (pcb *ReferenceConfigBuilder) Build() *ReferenceConfig {
 	return pcb.referenceConfig
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
add more setter of ReferenceConfigBuilder
**Which issue(s) this PR fixes**: 
Fixes #2078

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)