### PR TITLE
非路由策略下，不触发节点变更的数据变更协程消息

### DIFF
--- a/cluster/router/chain/chain.go
+++ b/cluster/router/chain/chain.go
@@ -113,6 +113,10 @@ func (c *RouterChain) AddRouters(routers []router.PriorityRouter) {
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 	c.routers = newRouters
+	if len(extension.GetRouterFactories()) == 0 {
+		return
+	}
+
 	go func() {
 		c.notify <- struct{}{}
 	}()
@@ -124,6 +128,9 @@ func (c *RouterChain) SetInvokers(invokers []protocol.Invoker) {
 	c.mutex.Lock()
 	c.invokers = invokers
 	c.mutex.Unlock()
+	if len(extension.GetRouterFactories()) == 0 {
+		return
+	}
 
 	go func() {
 		c.notify <- struct{}{}


### PR DESCRIPTION
1、1.5.7版本不指定路由策略下会发生协程泄漏，通过pprof发现下面两处会有协程泄漏，cluster/router/chain/chain.go；
`func (c *RouterChain) AddRouters(routers []router.PriorityRouter) {
	newRouters := make([]router.PriorityRouter, 0, len(c.builtinRouters)+len(routers))
	newRouters = append(newRouters, c.builtinRouters...)
	newRouters = append(newRouters, routers...)
	sortRouter(newRouters)
	c.mutex.Lock()
	defer c.mutex.Unlock()
	c.routers = newRouters

	go func() {
		c.notify <- struct{}{}
	}()
}

// SetInvokers receives updated invokers from registry center. If the times of notification exceeds countThreshold and
// time interval exceeds timeThreshold since last cache update, then notify to update the cache.
func (c *RouterChain) SetInvokers(invokers []protocol.Invoker) {
	c.mutex.Lock()
	c.invokers = invokers
	c.mutex.Unlock()

	go func() {
		c.notify <- struct{}{}
	}()
}`
这里面两处的c.notify <- struct{}{}会阻塞，因为loop方法不会运行