### PR TITLE
Fix:timeout don't support ms bug #2086

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/dubbogo/go-zookeeper v1.0.4-0.20211212162352-f9d2183d89d5
 	github.com/dubbogo/gost v1.12.6-0.20220824084206-300e27e9e524
 	github.com/dubbogo/grpc-go v1.42.10
-	github.com/dubbogo/triple v1.1.8
+	github.com/dubbogo/triple v1.2.0
 	github.com/emicklei/go-restful/v3 v3.8.0
 	github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1
 	github.com/fsnotify/fsnotify v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -182,6 +182,8 @@ github.com/dubbogo/net v0.0.4/go.mod h1:1CGOnM7X3he+qgGNqjeADuE5vKZQx/eMSeUkpU3u
 github.com/dubbogo/triple v1.0.9/go.mod h1:1t9me4j4CTvNDcsMZy6/OGarbRyAUSY0tFXGXHCp7Iw=
 github.com/dubbogo/triple v1.1.8 h1:yE+J3W1NTZCEPa1FoX+VWZH6UF1c0+A2MGfERlU2zbI=
 github.com/dubbogo/triple v1.1.8/go.mod h1:9pgEahtmsY/avYJp3dzUQE8CMMVe1NtGBmUhfICKLJk=
+github.com/dubbogo/triple v1.2.0 h1:GN75OEAS2WSp/s+sO1FYbQI7F9+U1qQTgIEaCv9gCLQ=
+github.com/dubbogo/triple v1.2.0/go.mod h1:9pgEahtmsY/avYJp3dzUQE8CMMVe1NtGBmUhfICKLJk=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=

--- a/protocol/dubbo3/dubbo3_invoker.go
+++ b/protocol/dubbo3/dubbo3_invoker.go
@@ -77,7 +77,7 @@ func NewDubboInvoker(url *common.URL) (*DubboInvoker, error) {
 	triCodecType := tripleConstant.CodecType(dubboSerializerType)
 	// new triple client
 	opts := []triConfig.OptionFunction{
-		triConfig.WithClientTimeout(uint32(timeout.Seconds())),
+		triConfig.WithClientTimeout(timeout),
 		triConfig.WithCodecType(triCodecType),
 		triConfig.WithLocation(url.Location),
 		triConfig.WithHeaderAppVersion(url.GetParam(constant.AppVersionKey, "")),

--- a/protocol/dubbo3/dubbo3_invoker_test.go
+++ b/protocol/dubbo3/dubbo3_invoker_test.go
@@ -64,3 +64,35 @@ func TestInvoke(t *testing.T) {
 	assert.NotNil(t, res.Result())
 	assert.Equal(t, "Hello request name", bizReply.Message)
 }
+
+func TestInvokeTimoutConfig(t *testing.T) {
+	go internal.InitDubboServer()
+	time.Sleep(time.Second * 3)
+
+	// test for millisecond
+	tmpMockUrl := mockDubbo3CommonUrl2 + "&timeout=300ms"
+	url, err := common.NewURL(tmpMockUrl)
+	assert.Nil(t, err)
+
+	invoker, err := NewDubboInvoker(url)
+	assert.Nil(t, err)
+
+	assert.Equal(t, invoker.timeout, time.Duration(time.Millisecond*300))
+
+	// test for second
+	tmpMockUrl = mockDubbo3CommonUrl2 + "&timeout=1s"
+	url, err = common.NewURL(tmpMockUrl)
+	assert.Nil(t, err)
+
+	invoker, err = NewDubboInvoker(url)
+	assert.Nil(t, err)
+	assert.Equal(t, invoker.timeout, time.Duration(time.Second))
+
+	// test for timeout default config
+	url, err = common.NewURL(mockDubbo3CommonUrl2)
+	assert.Nil(t, err)
+
+	invoker, err = NewDubboInvoker(url)
+	assert.Nil(t, err)
+	assert.Equal(t, invoker.timeout, time.Duration(time.Second*3))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
fix timeout don't support ms bug
**Which issue(s) this PR fixes**: 
Fixes #
#2086
**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)