### PR TITLE
3.0 notify sleep

### DIFF
--- a/registry/base_registry.go
+++ b/registry/base_registry.go
@@ -407,6 +407,11 @@ func (r *BaseRegistry) UnSubscribe(url *common.URL, notifyListener NotifyListene
 	return nil
 }
 
+// LoadSubscribeInstances load subscribe instance
+func (r *BaseRegistry) LoadSubscribeInstances(url *common.URL, notify NotifyListener) error {
+	return r.facadeBasedRegistry.LoadSubscribeInstances(url, notify)
+}
+
 // closeRegisters close and remove registry client and reset services map
 func (r *BaseRegistry) closeRegisters() {
 	logger.Infof("begin to close provider client")

--- a/registry/directory/directory.go
+++ b/registry/directory/directory.go
@@ -91,6 +91,12 @@ func NewRegistryDirectory(url *common.URL, registry registry.Registry) (director
 	}
 
 	dir.consumerConfigurationListener = newConsumerConfigurationListener(dir)
+	dir.consumerConfigurationListener.addNotifyListener(dir)
+	dir.referenceConfigurationListener = newReferenceConfigurationListener(dir, url)
+
+	if err := dir.registry.LoadSubscribeInstances(url.SubURL, dir); err != nil {
+		return nil, err
+	}
 
 	go dir.subscribe(url.SubURL)
 	return dir, nil
@@ -99,8 +105,6 @@ func NewRegistryDirectory(url *common.URL, registry registry.Registry) (director
 // subscribe from registry
 func (dir *RegistryDirectory) subscribe(url *common.URL) {
 	logger.Debugf("subscribe service :%s for RegistryDirectory.", url.Key())
-	dir.consumerConfigurationListener.addNotifyListener(dir)
-	dir.referenceConfigurationListener = newReferenceConfigurationListener(dir, url)
 	if err := dir.registry.Subscribe(url, dir); err != nil {
 		logger.Error("registry.Subscribe(url:%v, dir:%v) = error:%v", url, dir, err)
 	}

--- a/registry/etcdv3/registry.go
+++ b/registry/etcdv3/registry.go
@@ -168,6 +168,11 @@ func (r *etcdV3Registry) DoUnsubscribe(conf *common.URL) (registry.Listener, err
 	return nil, perrors.New("DoUnsubscribe is not support in etcdV3Registry")
 }
 
+// LoadSubscribeInstances load subscribe instance
+func (r *etcdV3Registry) LoadSubscribeInstances(_ *common.URL, _ registry.NotifyListener) error {
+	return nil
+}
+
 func (r *etcdV3Registry) handleClientRestart() {
 	r.WaitGroup().Add(1)
 	go etcdv3.HandleClientRestart(r)

--- a/registry/mock_registry.go
+++ b/registry/mock_registry.go
@@ -131,6 +131,11 @@ func (r *MockRegistry) UnSubscribe(url *common.URL, notifyListener NotifyListene
 	return nil
 }
 
+// LoadSubscribeInstances load subscribe instance
+func (r *MockRegistry) LoadSubscribeInstances(_ *common.URL, _ NotifyListener) error {
+	return nil
+}
+
 type listener struct {
 	count      int64
 	registry   *MockRegistry

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -58,6 +58,12 @@ type Registry interface {
 	// consumer://10.20.153.10/org.apache.dubbo.foo.BarService?version=1.0.0&application=kylin
 	// listener A listener of the change event, not allowed to be empty
 	UnSubscribe(*common.URL, NotifyListener) error
+
+	// LoadSubscribeInstances Because the subscription is asynchronous,
+	// it may cause the consumer to fail to obtain the provider.
+	// so sync load the instance of the preparing to subscribe service before
+	// formally subscribing.
+	LoadSubscribeInstances(*common.URL, NotifyListener) error
 }
 
 // nolint

--- a/registry/servicediscovery/service_discovery_registry.go
+++ b/registry/servicediscovery/service_discovery_registry.go
@@ -229,6 +229,11 @@ func (s *serviceDiscoveryRegistry) Subscribe(url *common.URL, notify registry.No
 	return nil
 }
 
+// LoadSubscribeInstances load subscribe instance
+func (s *serviceDiscoveryRegistry) LoadSubscribeInstances(_ *common.URL, _ registry.NotifyListener) error {
+	return nil
+}
+
 func getUrlKey(url *common.URL) string {
 	var bf bytes.Buffer
 	if len(url.Protocol) != 0 {

--- a/registry/xds/registry.go
+++ b/registry/xds/registry.go
@@ -127,6 +127,11 @@ func (nr *xdsRegistry) UnSubscribe(url *common.URL, _ registry.NotifyListener) e
 	return nil
 }
 
+// LoadSubscribeInstances load subscribe instance
+func (nr *xdsRegistry) LoadSubscribeInstances(_ *common.URL, _ registry.NotifyListener) error {
+	return nil
+}
+
 // GetURL gets its registration URL
 func (nr *xdsRegistry) GetURL() *common.URL {
 	return nr.registryURL

--- a/registry/zookeeper/registry.go
+++ b/registry/zookeeper/registry.go
@@ -174,6 +174,11 @@ func (r *zkRegistry) DoUnsubscribe(conf *common.URL) (registry.Listener, error) 
 	return r.getCloseListener(conf)
 }
 
+// LoadSubscribeInstances load subscribe instance
+func (r *zkRegistry) LoadSubscribeInstances(_ *common.URL, _ registry.NotifyListener) error {
+	return nil
+}
+
 // CloseAndNilClient closes listeners and clear client
 func (r *zkRegistry) CloseAndNilClient() {
 	r.listener.Close()

--- a/registry/zookeeper/service_discovery.go
+++ b/registry/zookeeper/service_discovery.go
@@ -180,7 +180,7 @@ func (zksd *zookeeperServiceDiscovery) GetInstances(serviceName string) []regist
 	}
 	iss := make([]registry.ServiceInstance, 0, len(criss))
 	for _, cris := range criss {
-		iss = append(iss, zksd.toZookeeperInstance(cris))
+		iss = append(iss, toZookeeperInstance(cris))
 	}
 	return iss
 }
@@ -304,7 +304,7 @@ func (zksd *zookeeperServiceDiscovery) toCuratorInstance(instance registry.Servi
 }
 
 // toZookeeperInstance convert to registry's service instance
-func (zksd *zookeeperServiceDiscovery) toZookeeperInstance(cris *curator_discovery.ServiceInstance) registry.ServiceInstance {
+func toZookeeperInstance(cris *curator_discovery.ServiceInstance) registry.ServiceInstance {
 	pl, ok := cris.Payload.(map[string]interface{})
 	if !ok {
 		logger.Errorf("[zkServiceDiscovery] toZookeeperInstance{%s} payload is not map[string]interface{}", cris.ID)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
修复consumer启动时立即发起调用，出现找不到provider的相关问题。本质原因是因为在consumer启动时会“异步”订阅provider，在发起调用时有可能订阅回调事件还没有被触发，从而导致找不到provider.

修改：在异步订阅前 先同步获取provider实例。(当前pr修改了nacos和polaris，后续可以按需实现zk,etcd.)

**Which issue(s) this PR fixes**: 
Fixes https://github.com/apache/dubbo-go/issues/1991

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)