### PR TITLE
【WIP】Fix: service discovery registry notify before return

### DIFF
--- a/registry/servicediscovery/service_discovery_registry.go
+++ b/registry/servicediscovery/service_discovery_registry.go
@@ -19,7 +19,6 @@ package servicediscovery
 
 import (
 	"bytes"
-	"dubbo.apache.org/dubbo-go/v3/remoting"
 	"strings"
 	"sync"
 )
@@ -43,6 +42,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/registry"
 	"dubbo.apache.org/dubbo-go/v3/registry/event"
 	"dubbo.apache.org/dubbo-go/v3/registry/servicediscovery/synthesizer"
+	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
 
 func init() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->
在异步订阅前先同步获取provider实例。(当前 pr 修复 serviceDiscoveryRegistry )

**What this PR does**: 

**Which issue(s) this PR fixes**: 
Fixes #1991 

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)