### PR TITLE
3.0 remove directory consumer configuration listener

### DIFF
--- a/registry/directory/directory.go
+++ b/registry/directory/directory.go
@@ -90,9 +90,9 @@ func NewRegistryDirectory(url *common.URL, registry registry.Registry) (director
 		logger.Warnf("fail to create router chain with url: %s, err is: %v", url.SubURL, err)
 	}
 
-	dir.consumerConfigurationListener = newConsumerConfigurationListener(dir)
-	dir.consumerConfigurationListener.addNotifyListener(dir)
-	dir.referenceConfigurationListener = newReferenceConfigurationListener(dir, url)
+	//dir.consumerConfigurationListener = newConsumerConfigurationListener(dir)
+	//dir.consumerConfigurationListener.addNotifyListener(dir)
+	//dir.referenceConfigurationListener = newReferenceConfigurationListener(dir, url)
 
 	if err := dir.registry.LoadSubscribeInstances(url.SubURL, dir); err != nil {
 		return nil, err
@@ -449,8 +449,8 @@ func (dir *RegistryDirectory) Destroy() {
 
 func (dir *RegistryDirectory) overrideUrl(targetUrl *common.URL) {
 	doOverrideUrl(dir.configurators, targetUrl)
-	doOverrideUrl(dir.consumerConfigurationListener.Configurators(), targetUrl)
-	doOverrideUrl(dir.referenceConfigurationListener.Configurators(), targetUrl)
+	//doOverrideUrl(dir.consumerConfigurationListener.Configurators(), targetUrl)
+	//doOverrideUrl(dir.referenceConfigurationListener.Configurators(), targetUrl)
 }
 
 func (dir *RegistryDirectory) getConsumerUrl(c *common.URL) *common.URL {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
remove directory consumer configuration listener

**Which issue(s) this PR fixes**: 
Fixes https://github.com/apache/dubbo-go/issues/2151

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)