### PR TITLE
fix: ZapConfig OutputPaths default set stdout

### DIFF
--- a/config/logger_config.go
+++ b/config/logger_config.go
@@ -46,7 +46,7 @@ type ZapConfig struct {
 	DisableStacktrace bool                   `default:"false" json:"disable-stacktrace,omitempty" yaml:"disable-stacktrace" property:"disable-stacktrace"`
 	Encoding          string                 `default:"console" json:"encoding,omitempty" yaml:"encoding" property:"encoding"`
 	EncoderConfig     EncoderConfig          `default:"" json:"encoder-config,omitempty" yaml:"encoder-config" property:"encoder-config"`
-	OutputPaths       []string               `default:"[\"stderr\"]" json:"output-paths,omitempty" yaml:"output-paths" property:"output-paths"`
+	OutputPaths       []string               `default:"[\"stdout\"]" json:"output-paths,omitempty" yaml:"output-paths" property:"output-paths"`
 	ErrorOutputPaths  []string               `default:"[\"stderr\"]" json:"error-output-paths,omitempty" yaml:"error-output-paths" property:"error-output-paths"`
 	InitialFields     map[string]interface{} `default:"" json:"initial-fields,omitempty" yaml:"initial-fields" property:"initial-fields"`
 }

--- a/config/logger_config_test.go
+++ b/config/logger_config_test.go
@@ -34,7 +34,7 @@ func TestLoggerInit(t *testing.T) {
 		assert.NotNil(t, rootConfig)
 		loggerConfig := rootConfig.Logger
 		assert.NotNil(t, loggerConfig)
-		assert.Equal(t, []string{"stderr"}, loggerConfig.ZapConfig.OutputPaths)
+		assert.Equal(t, []string{"stdout"}, loggerConfig.ZapConfig.OutputPaths)
 	})
 
 	t.Run("use config", func(t *testing.T) {


### PR DESCRIPTION
**Which issue(s) this PR fixes**: 
Fixes #2148 ZapConfig OutputPaths default set stdout