### PR TITLE
[ISSUE #2216] fix register instance protocol info to polaris when use tripe

### DIFF
--- a/common/url.go
+++ b/common/url.go
@@ -36,7 +36,9 @@ import (
 	gxset "github.com/dubbogo/gost/container/set"
 
 	"github.com/google/uuid"
+
 	"github.com/jinzhu/copier"
+
 	perrors "github.com/pkg/errors"
 )
 

--- a/config/metric_config.go
+++ b/config/metric_config.go
@@ -19,6 +19,7 @@ package config
 
 import (
 	"github.com/creasty/defaults"
+
 	"github.com/dubbogo/gost/log/logger"
 
 	"github.com/pkg/errors"

--- a/registry/polaris/registry.go
+++ b/registry/polaris/registry.go
@@ -255,12 +255,17 @@ func createRegisterParam(url *common.URL, serviceName string) *api.InstanceRegis
 
 	ver := url.GetParam("version", "")
 
+	protocolVal := protocolForDubboGO
+	if len(url.Protocol) != 0 {
+		protocolVal = url.Protocol
+	}
+
 	req := &api.InstanceRegisterRequest{
 		InstanceRegisterRequest: model.InstanceRegisterRequest{
 			Service:  serviceName,
 			Host:     url.Ip,
 			Port:     port,
-			Protocol: &protocolForDubboGO,
+			Protocol: &protocolVal,
 			Version:  &ver,
 			Metadata: metadata,
 		},

--- a/registry/polaris/registry.go
+++ b/registry/polaris/registry.go
@@ -255,17 +255,12 @@ func createRegisterParam(url *common.URL, serviceName string) *api.InstanceRegis
 
 	ver := url.GetParam("version", "")
 
-	protocolVal := protocolForDubboGO
-	if len(url.Protocol) != 0 {
-		protocolVal = url.Protocol
-	}
-
 	req := &api.InstanceRegisterRequest{
 		InstanceRegisterRequest: model.InstanceRegisterRequest{
 			Service:  serviceName,
 			Host:     url.Ip,
 			Port:     port,
-			Protocol: &protocolVal,
+			Protocol: &url.Protocol,
 			Version:  &ver,
 			Metadata: metadata,
 		},

--- a/registry/polaris/service_discovery.go
+++ b/registry/polaris/service_discovery.go
@@ -317,9 +317,12 @@ func (polaris *polarisServiceDiscovery) String() string {
 
 func convertToRegisterInstance(namespace string, instance registry.ServiceInstance) *api.InstanceRegisterRequest {
 
-	health := instance.IsHealthy()
-	isolate := instance.IsEnable()
-	ttl := 5
+	var (
+		health      = instance.IsHealthy()
+		isolate     = instance.IsEnable()
+		ttl         = 5
+		protocolVal = protocolForDubboGO
+	)
 
 	return &api.InstanceRegisterRequest{
 		InstanceRegisterRequest: model.InstanceRegisterRequest{
@@ -327,7 +330,7 @@ func convertToRegisterInstance(namespace string, instance registry.ServiceInstan
 			Namespace: namespace,
 			Host:      instance.GetHost(),
 			Port:      instance.GetPort(),
-			Protocol:  &protocolForDubboGO,
+			Protocol:  &protocolVal,
 			Metadata:  instance.GetMetadata(),
 			Healthy:   &health,
 			Isolate:   &isolate,

--- a/registry/polaris/service_discovery.go
+++ b/registry/polaris/service_discovery.go
@@ -321,7 +321,7 @@ func convertToRegisterInstance(namespace string, instance registry.ServiceInstan
 		health      = instance.IsHealthy()
 		isolate     = instance.IsEnable()
 		ttl         = 5
-		protocolVal = protocolForDubboGO
+		protocolVal = string(constant.Dubbo)
 	)
 
 	return &api.InstanceRegisterRequest{

--- a/registry/polaris/utils.go
+++ b/registry/polaris/utils.go
@@ -30,10 +30,6 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/registry"
 )
 
-var (
-	protocolForDubboGO string = "dubbo"
-)
-
 type PolarisInstanceInfo struct {
 	instance registry.ServiceInstance
 	url      *common.URL

--- a/remoting/zookeeper/listener.go
+++ b/remoting/zookeeper/listener.go
@@ -23,13 +23,18 @@ import (
 	"sync"
 	"time"
 )
+
 import (
 	"github.com/dubbogo/go-zookeeper/zk"
+
 	gxzookeeper "github.com/dubbogo/gost/database/kv/zk"
 	"github.com/dubbogo/gost/log/logger"
+
 	perrors "github.com/pkg/errors"
+
 	uatomic "go.uber.org/atomic"
 )
+
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 

**Which issue(s) this PR fixes**: 
Fixes #2216 

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)