### PR TITLE
feat: expose TLSConfig for config api

### DIFF
--- a/config/root_config.go
+++ b/config/root_config.go
@@ -106,6 +106,13 @@ func GetShutDown() *ShutdownConfig {
 	return NewShutDownConfigBuilder().Build()
 }
 
+func GetTLSConfig() *TLSConfig {
+	if err := check(); err == nil && rootConfig.TLSConfig != nil {
+		return rootConfig.TLSConfig
+	}
+	return NewTLSConfigBuilder().Build()
+}
+
 // getRegistryIds get registry ids
 func (rc *RootConfig) getRegistryIds() []string {
 	ids := make([]string, 0)
@@ -225,6 +232,7 @@ func newEmptyRootConfig() *RootConfig {
 		Logger:         NewLoggerConfigBuilder().Build(),
 		Custom:         NewCustomConfigBuilder().Build(),
 		Shutdown:       NewShutDownConfigBuilder().Build(),
+		TLSConfig:      NewTLSConfigBuilder().Build(),
 	}
 	return newRootConfig
 }
@@ -319,6 +327,11 @@ func (rb *RootConfigBuilder) SetCustom(customConfig *CustomConfig) *RootConfigBu
 
 func (rb *RootConfigBuilder) SetShutDown(shutDownConfig *ShutdownConfig) *RootConfigBuilder {
 	rb.rootConfig.Shutdown = shutDownConfig
+	return rb
+}
+
+func (rb *RootConfigBuilder) SetTLSConfig(tlsConfig *TLSConfig) *RootConfigBuilder {
+	rb.rootConfig.TLSConfig = tlsConfig
 	return rb
 }
 

--- a/config/tls_config.go
+++ b/config/tls_config.go
@@ -91,3 +91,35 @@ func GetClientTlsConfig(opt *TLSConfig) (*tls.Config, error) {
 	}
 	return cfg, err
 }
+
+type TLSConfigBuilder struct {
+	tlsConfig *TLSConfig
+}
+
+func NewTLSConfigBuilder() *TLSConfigBuilder {
+	return &TLSConfigBuilder{tlsConfig: &TLSConfig{}}
+}
+
+func (tcb *TLSConfigBuilder) SetCACertFile(caCertFile string) *TLSConfigBuilder {
+	tcb.tlsConfig.CACertFile = caCertFile
+	return tcb
+}
+
+func (tcb *TLSConfigBuilder) SetTLSCertFile(tlsCertFile string) *TLSConfigBuilder {
+	tcb.tlsConfig.TLSCertFile = tlsCertFile
+	return tcb
+}
+
+func (tcb *TLSConfigBuilder) SetTLSKeyFile(tlsKeyFile string) *TLSConfigBuilder {
+	tcb.tlsConfig.TLSKeyFile = tlsKeyFile
+	return tcb
+}
+
+func (tcb *TLSConfigBuilder) SetTLSServerName(tlsServerName string) *TLSConfigBuilder {
+	tcb.tlsConfig.TLSServerName = tlsServerName
+	return tcb
+}
+
+func (tcb *TLSConfigBuilder) Build() *TLSConfig {
+	return tcb.tlsConfig
+}

--- a/protocol/grpc/client.go
+++ b/protocol/grpc/client.go
@@ -18,6 +18,7 @@
 package grpc
 
 import (
+	"crypto/tls"
 	"reflect"
 	"strconv"
 	"sync"
@@ -78,19 +79,13 @@ func NewClient(url *common.URL) (*Client, error) {
 			grpc.MaxCallSendMsgSize(1024*1024*maxMessageSize),
 		),
 	)
-	tlsConfig := config.GetRootConfig().TLSConfig
-
-	if tlsConfig != nil {
-		cfg, err := config.GetClientTlsConfig(&config.TLSConfig{
-			CACertFile:    tlsConfig.CACertFile,
-			TLSCertFile:   tlsConfig.TLSCertFile,
-			TLSKeyFile:    tlsConfig.TLSKeyFile,
-			TLSServerName: tlsConfig.TLSServerName,
-		})
+	var cfg *tls.Config
+	var err error
+	if cfg, err = config.GetClientTlsConfig(config.GetTLSConfig()); err != nil {
+		return nil, err
+	}
+	if cfg != nil {
 		logger.Infof("Grpc Client initialized the TLSConfig configuration")
-		if err != nil {
-			return nil, err
-		}
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(cfg)))
 	} else {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/protocol/grpc/server.go
+++ b/protocol/grpc/server.go
@@ -92,18 +92,11 @@ func (s *Server) Start(url *common.URL) {
 		grpc.MaxSendMsgSize(1024*1024*s.bufferSize),
 	)
 
-	tlsConfig := config.GetRootConfig().TLSConfig
-	if tlsConfig != nil {
-		var cfg *tls.Config
-		cfg, err = config.GetServerTlsConfig(&config.TLSConfig{
-			CACertFile:    tlsConfig.CACertFile,
-			TLSCertFile:   tlsConfig.TLSCertFile,
-			TLSKeyFile:    tlsConfig.TLSKeyFile,
-			TLSServerName: tlsConfig.TLSServerName,
-		})
-		if err != nil {
-			return
-		}
+	var cfg *tls.Config
+	if cfg, err = config.GetServerTlsConfig(config.GetTLSConfig()); err != nil {
+		return
+	}
+	if cfg != nil {
 		logger.Infof("Grpc Server initialized the TLSConfig configuration")
 		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(cfg)))
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 
expose TLSConfig for config api

**Which issue(s) this PR fixes**: 
Fixes #

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)