### PR TITLE
[Bugfix] Custom triple server message size

### DIFF
--- a/common/constant/default.go
+++ b/common/constant/default.go
@@ -17,6 +17,8 @@
 
 package constant
 
+import "math"
+
 const (
 	Dubbo            = "dubbo"
 	ProviderProtocol = "provider"
@@ -90,4 +92,12 @@ const (
 const (
 	ServiceDiscoveryDefaultGroup = "DEFAULT_GROUP"
 	NotAvailable                 = "N/A"
+)
+
+const (
+	DefaultMaxServerRecvMsgSize = 1024 * 1024 * 4
+	DefaultMaxServerSendMsgSize = math.MaxInt32
+
+	DefaultMaxCallRecvMsgSize = 1024 * 1024 * 4
+	DefaultMaxCallSendMsgSize = math.MaxInt32
 )

--- a/config/protocol_config.go
+++ b/config/protocol_config.go
@@ -31,6 +31,9 @@ type ProtocolConfig struct {
 	Ip     string      `yaml:"ip"  json:"ip,omitempty" property:"ip"`
 	Port   string      `default:"20000" yaml:"port" json:"port,omitempty" property:"port"`
 	Params interface{} `yaml:"params" json:"params,omitempty" property:"params"`
+
+	MaxServerSendMsgSize string `yaml:"max-server-send-msg-size" json:"max-server-send-msg-size,omitempty"`
+	MaxServerRecvMsgSize string `default:"4mib" yaml:"max-server-recv-msg-size" json:"max-server-recv-msg-size,omitempty"`
 }
 
 // Prefix dubbo.config-center
@@ -74,6 +77,16 @@ func (pcb *ProtocolConfigBuilder) SetPort(port string) *ProtocolConfigBuilder {
 
 func (pcb *ProtocolConfigBuilder) SetParams(params interface{}) *ProtocolConfigBuilder {
 	pcb.protocolConfig.Params = params
+	return pcb
+}
+
+func (pcb *ProtocolConfigBuilder) SetMaxServerSendMsgSize(maxServerSendMsgSize string) *ProtocolConfigBuilder {
+	pcb.protocolConfig.MaxServerSendMsgSize = maxServerSendMsgSize
+	return pcb
+}
+
+func (pcb *ProtocolConfigBuilder) SetMaxServerRecvMsgSize(maxServerRecvMsgSize string) *ProtocolConfigBuilder {
+	pcb.protocolConfig.MaxServerRecvMsgSize = maxServerRecvMsgSize
 	return pcb
 }
 

--- a/config/protocol_config.go
+++ b/config/protocol_config.go
@@ -32,7 +32,10 @@ type ProtocolConfig struct {
 	Port   string      `default:"20000" yaml:"port" json:"port,omitempty" property:"port"`
 	Params interface{} `yaml:"params" json:"params,omitempty" property:"params"`
 
+	// MaxServerSendMsgSize max size of server send message, 1mb=1000kb=1000000b 1mib=1024kb=1048576b.
+	// more detail to see https://pkg.go.dev/github.com/dustin/go-humanize#pkg-constants
 	MaxServerSendMsgSize string `yaml:"max-server-send-msg-size" json:"max-server-send-msg-size,omitempty"`
+	// MaxServerRecvMsgSize max size of server receive message
 	MaxServerRecvMsgSize string `default:"4mib" yaml:"max-server-recv-msg-size" json:"max-server-recv-msg-size,omitempty"`
 }
 

--- a/config/protocol_config_test.go
+++ b/config/protocol_config_test.go
@@ -35,6 +35,7 @@ func TestGetProtocolsConfig(t *testing.T) {
 		// default
 		assert.Equal(t, "dubbo", protocols["dubbo"].Name)
 		assert.Equal(t, string("20000"), protocols["dubbo"].Port)
+		assert.Equal(t, "4mib", protocols["dubbo"].MaxServerRecvMsgSize)
 	})
 
 	t.Run("use config", func(t *testing.T) {
@@ -45,5 +46,7 @@ func TestGetProtocolsConfig(t *testing.T) {
 		// default
 		assert.Equal(t, "dubbo", protocols["dubbo"].Name)
 		assert.Equal(t, string("20000"), protocols["dubbo"].Port)
+		assert.Equal(t, "4mib", protocols["dubbo"].MaxServerSendMsgSize)
+		assert.Equal(t, "4mib", protocols["dubbo"].MaxServerRecvMsgSize)
 	})
 }

--- a/config/testdata/config/protocol/application.yaml
+++ b/config/testdata/config/protocol/application.yaml
@@ -5,3 +5,8 @@ dubbo:
       group: dev
       address: nacos://127.0.0.1:8848
   protocols:
+    dubbo:
+      name: dubbo
+      port: 20000
+      max-server-send-msg-size: 4mib
+      max-server-recv-msg-size: 4mib

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,8 @@ require (
 	github.com/dubbogo/go-zookeeper v1.0.4-0.20211212162352-f9d2183d89d5
 	github.com/dubbogo/gost v1.13.2
 	github.com/dubbogo/grpc-go v1.42.10
-	github.com/dubbogo/triple v1.2.2-rc2
+	github.com/dubbogo/triple v1.2.2-rc3
+	github.com/dustin/go-humanize v1.0.0
 	github.com/emicklei/go-restful/v3 v3.10.1
 	github.com/envoyproxy/go-control-plane v0.11.0
 	github.com/fsnotify/fsnotify v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -405,7 +405,6 @@ github.com/apache/dubbo-getty v1.4.9 h1:Y8l1EYJqIc7BnmyfYtvG4H4Nmu4v7P1uS31fFQGd
 github.com/apache/dubbo-getty v1.4.9/go.mod h1:6qmrqBSPGs3B35zwEuGhEYNVsx1nfGT/xzV2yOt2amM=
 github.com/apache/dubbo-go-hessian2 v1.9.1/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
 github.com/apache/dubbo-go-hessian2 v1.9.3/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
-github.com/apache/dubbo-go-hessian2 v1.11.4/go.mod h1:QP9Tc0w/B/mDopjusebo/c7GgEfl6Lz8jeuFg8JA6yw=
 github.com/apache/dubbo-go-hessian2 v1.12.0 h1:n2JXPMGc4u/ihBbOt25d3mmv1k92X9TvLnqfgyNscKQ=
 github.com/apache/dubbo-go-hessian2 v1.12.0/go.mod h1:QP9Tc0w/B/mDopjusebo/c7GgEfl6Lz8jeuFg8JA6yw=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -524,8 +523,8 @@ github.com/dubbogo/grpc-go v1.42.10/go.mod h1:JMkPt1mIHL96GAFeYsMoMjew6f1ROKycik
 github.com/dubbogo/jsonparser v1.0.1/go.mod h1:tYAtpctvSP/tWw4MeelsowSPgXQRVHHWbqL6ynps8jU=
 github.com/dubbogo/net v0.0.4/go.mod h1:1CGOnM7X3he+qgGNqjeADuE5vKZQx/eMSeUkpU3ujIc=
 github.com/dubbogo/triple v1.0.9/go.mod h1:1t9me4j4CTvNDcsMZy6/OGarbRyAUSY0tFXGXHCp7Iw=
-github.com/dubbogo/triple v1.2.2-rc2 h1:2AaLd+uKwnNnR3qOIXTNPU/OHk77qIDNGMX3GstEtaY=
-github.com/dubbogo/triple v1.2.2-rc2/go.mod h1:8qprF2uJX82IE5hjiIuswp416sEr0oL/+bb7IjiizYs=
+github.com/dubbogo/triple v1.2.2-rc3 h1:9rxLqru35MmJkypCHJMiZb1VzwH+zmbPBend9Cq+VOI=
+github.com/dubbogo/triple v1.2.2-rc3/go.mod h1:9pgEahtmsY/avYJp3dzUQE8CMMVe1NtGBmUhfICKLJk=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -1153,8 +1152,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 h1:uruHq4
 github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/toolkits/concurrent v0.0.0-20150624120057-a4371d70e3e3/go.mod h1:QDlpd3qS71vYtakd2hmdpqhJ9nwv6mD6A30bQ1BPBFE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
-github.com/uber/jaeger-client-go v2.30.0+incompatible h1:D6wyKGCecFaSRUpo8lCVbaOOb6ThwMmTEbhRwtKR97o=
-github.com/uber/jaeger-client-go v2.30.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
+github.com/uber/jaeger-client-go v2.29.1+incompatible h1:R9ec3zO3sGpzs0abd43Y+fBZRJ9uiH6lXyR/+u6brW4=
+github.com/uber/jaeger-client-go v2.29.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.4.1+incompatible h1:td4jdvLcExb4cBISKIpHuGoVXh+dVKhn2Um6rjCsSsg=
 github.com/uber/jaeger-lib v2.4.1+incompatible/go.mod h1:ComeNDZlWwrWnDv8aPp0Ba6+uUTzImX/AauajbLI56U=
 github.com/ugorji/go v1.2.6 h1:tGiWC9HENWE2tqYycIqFTNorMmFRVhNwCpDOpWqnk8E=

--- a/protocol/dubbo3/dubbo3_invoker.go
+++ b/protocol/dubbo3/dubbo3_invoker.go
@@ -28,6 +28,7 @@ import (
 
 import (
 	"github.com/dubbogo/gost/log/logger"
+	"github.com/dustin/go-humanize"
 
 	"github.com/dubbogo/grpc-go/metadata"
 
@@ -84,16 +85,16 @@ func NewDubboInvoker(url *common.URL) (*DubboInvoker, error) {
 		triConfig.WithHeaderGroup(url.GetParam(constant.GroupKey, "")),
 		triConfig.WithLogger(logger.GetLogger()),
 	}
-	if maxCall := url.GetParam(constant.MaxCallRecvMsgSize, ""); maxCall != "" {
-		if size, err := strconv.Atoi(maxCall); err == nil && size != 0 {
-			opts = append(opts, triConfig.WithGRPCMaxCallRecvMessageSize(size))
-		}
+	maxCallRecvMsgSize := constant.DefaultMaxCallRecvMsgSize
+	if maxCall, err := humanize.ParseBytes(url.GetParam(constant.MaxCallRecvMsgSize, "")); err == nil && maxCall != 0 {
+		maxCallRecvMsgSize = int(maxCall)
 	}
-	if maxCall := url.GetParam(constant.MaxCallSendMsgSize, ""); maxCall != "" {
-		if size, err := strconv.Atoi(maxCall); err == nil && size != 0 {
-			opts = append(opts, triConfig.WithGRPCMaxCallSendMessageSize(size))
-		}
+	maxCallSendMsgSize := constant.DefaultMaxCallSendMsgSize
+	if maxCall, err := humanize.ParseBytes(url.GetParam(constant.MaxCallSendMsgSize, "")); err == nil && maxCall != 0 {
+		maxCallSendMsgSize = int(maxCall)
 	}
+	opts = append(opts, triConfig.WithGRPCMaxCallRecvMessageSize(maxCallRecvMsgSize))
+	opts = append(opts, triConfig.WithGRPCMaxCallSendMessageSize(maxCallSendMsgSize))
 
 	tracingKey := url.GetParam(constant.TracingConfigKey, "")
 	if tracingKey != "" {

--- a/protocol/dubbo3/dubbo3_protocol.go
+++ b/protocol/dubbo3/dubbo3_protocol.go
@@ -21,12 +21,12 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strconv"
 	"sync"
 )
 
 import (
 	"github.com/dubbogo/gost/log/logger"
+	"github.com/dustin/go-humanize"
 
 	"github.com/dubbogo/grpc-go"
 	"github.com/dubbogo/grpc-go/metadata"
@@ -242,16 +242,16 @@ func (dp *DubboProtocol) openServer(url *common.URL, tripleCodecType tripleConst
 		}
 	}
 
-	if maxCall := url.GetParam(constant.MaxServerRecvMsgSize, ""); maxCall != "" {
-		if size, err := strconv.Atoi(maxCall); err == nil && size != 0 {
-			opts = append(opts, triConfig.WithGRPCMaxServerRecvMessageSize(size))
-		}
+	maxServerRecvMsgSize := constant.DefaultMaxServerRecvMsgSize
+	if recvMsgSize, err := humanize.ParseBytes(url.GetParam(constant.MaxServerRecvMsgSize, "")); err == nil && recvMsgSize != 0 {
+		maxServerRecvMsgSize = int(recvMsgSize)
 	}
-	if maxCall := url.GetParam(constant.MaxServerSendMsgSize, ""); maxCall != "" {
-		if size, err := strconv.Atoi(maxCall); err == nil && size != 0 {
-			opts = append(opts, triConfig.WithGRPCMaxServerSendMessageSize(size))
-		}
+	maxServerSendMsgSize := constant.DefaultMaxServerSendMsgSize
+	if sendMsgSize, err := humanize.ParseBytes(url.GetParam(constant.MaxServerSendMsgSize, "")); err == nil && sendMsgSize != 0 {
+		maxServerSendMsgSize = int(sendMsgSize)
 	}
+	opts = append(opts, triConfig.WithGRPCMaxServerRecvMessageSize(maxServerRecvMsgSize))
+	opts = append(opts, triConfig.WithGRPCMaxServerSendMessageSize(maxServerSendMsgSize))
 
 	triOption := triConfig.NewTripleOption(opts...)
 

--- a/protocol/grpc/client.go
+++ b/protocol/grpc/client.go
@@ -19,13 +19,13 @@ package grpc
 
 import (
 	"reflect"
-	"strconv"
 	"sync"
 	"time"
 )
 
 import (
 	"github.com/dubbogo/gost/log/logger"
+	"github.com/dustin/go-humanize"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 
@@ -61,7 +61,16 @@ func NewClient(url *common.URL) (*Client, error) {
 	// If not, will return NoopTracer.
 	tracer := opentracing.GlobalTracer()
 	dialOpts := make([]grpc.DialOption, 0, 4)
-	maxMessageSize, _ := strconv.Atoi(url.GetParam(constant.MessageSizeKey, "4"))
+
+	// set max send and recv msg size
+	maxCallRecvMsgSize := constant.DefaultMaxCallRecvMsgSize
+	if recvMsgSize, err := humanize.ParseBytes(url.GetParam(constant.MaxCallRecvMsgSize, "0")); err == nil && recvMsgSize != 0 {
+		maxCallRecvMsgSize = int(recvMsgSize)
+	}
+	maxCallSendMsgSize := constant.DefaultMaxCallSendMsgSize
+	if sendMsgSize, err := humanize.ParseBytes(url.GetParam(constant.MaxCallSendMsgSize, "0")); err == nil && sendMsgSize != 0 {
+		maxCallSendMsgSize = int(sendMsgSize)
+	}
 
 	// consumer config client connectTimeout
 	//connectTimeout := config.GetConsumerConfig().ConnectTimeout
@@ -74,8 +83,8 @@ func NewClient(url *common.URL) (*Client, error) {
 		grpc.WithStreamInterceptor(otgrpc.OpenTracingStreamClientInterceptor(tracer, otgrpc.LogPayloads())),
 		grpc.WithDefaultCallOptions(
 			grpc.CallContentSubtype(clientConf.ContentSubType),
-			grpc.MaxCallRecvMsgSize(1024*1024*maxMessageSize),
-			grpc.MaxCallSendMsgSize(1024*1024*maxMessageSize),
+			grpc.MaxCallRecvMsgSize(maxCallRecvMsgSize),
+			grpc.MaxCallSendMsgSize(maxCallSendMsgSize),
 		),
 	)
 	tlsConfig := config.GetRootConfig().TLSConfig

--- a/protocol/grpc/client.go
+++ b/protocol/grpc/client.go
@@ -64,11 +64,11 @@ func NewClient(url *common.URL) (*Client, error) {
 
 	// set max send and recv msg size
 	maxCallRecvMsgSize := constant.DefaultMaxCallRecvMsgSize
-	if recvMsgSize, err := humanize.ParseBytes(url.GetParam(constant.MaxCallRecvMsgSize, "0")); err == nil && recvMsgSize != 0 {
+	if recvMsgSize, err := humanize.ParseBytes(url.GetParam(constant.MaxCallRecvMsgSize, "")); err == nil && recvMsgSize > 0 {
 		maxCallRecvMsgSize = int(recvMsgSize)
 	}
 	maxCallSendMsgSize := constant.DefaultMaxCallSendMsgSize
-	if sendMsgSize, err := humanize.ParseBytes(url.GetParam(constant.MaxCallSendMsgSize, "0")); err == nil && sendMsgSize != 0 {
+	if sendMsgSize, err := humanize.ParseBytes(url.GetParam(constant.MaxCallSendMsgSize, "")); err == nil && sendMsgSize > 0 {
 		maxCallSendMsgSize = int(sendMsgSize)
 	}
 

--- a/protocol/grpc/client_test.go
+++ b/protocol/grpc/client_test.go
@@ -19,6 +19,8 @@ package grpc
 
 import (
 	"context"
+	"fmt"
+	"github.com/dustin/go-humanize"
 	"testing"
 )
 
@@ -87,4 +89,9 @@ func TestStreamClient(t *testing.T) {
 	routeChatStream, err := client.RouteChat(context.Background())
 	assert.NoError(t, err)
 	routeguide.RunRouteChat(routeChatStream)
+}
+
+func TestT(t *testing.T) {
+	bytes, err := humanize.ParseBytes("0")
+	fmt.Println(bytes, err)
 }

--- a/protocol/grpc/grpc_protocol.go
+++ b/protocol/grpc/grpc_protocol.go
@@ -18,7 +18,6 @@
 package grpc
 
 import (
-	"strconv"
 	"sync"
 )
 
@@ -28,7 +27,6 @@ import (
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
-	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/protocol"
 )
@@ -82,9 +80,7 @@ func (gp *GrpcProtocol) openServer(url *common.URL) {
 		panic("[GrpcProtocol]" + url.Key() + "is not existing")
 	}
 
-	grpcMessageSize, _ := strconv.Atoi(url.GetParam(constant.MessageSizeKey, "4"))
 	srv := NewServer()
-	srv.SetBufferSize(grpcMessageSize)
 	gp.serverMap[url.Location] = srv
 	srv.Start(url)
 }

--- a/protocol/grpc/server.go
+++ b/protocol/grpc/server.go
@@ -27,6 +27,7 @@ import (
 
 import (
 	"github.com/dubbogo/gost/log/logger"
+	"github.com/dustin/go-humanize"
 
 	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 
@@ -40,6 +41,7 @@ import (
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/config"
 	"dubbo.apache.org/dubbo-go/v3/protocol"
 )
@@ -81,6 +83,15 @@ func (s *Server) Start(url *common.URL) {
 		panic(err)
 	}
 
+	maxServerRecvMsgSize := constant.DefaultMaxServerRecvMsgSize
+	if recvMsgSize, convertErr := humanize.ParseBytes(url.GetParam(constant.MaxServerRecvMsgSize, "")); convertErr == nil && recvMsgSize != 0 {
+		maxServerRecvMsgSize = int(recvMsgSize)
+	}
+	maxServerSendMsgSize := constant.DefaultMaxServerSendMsgSize
+	if sendMsgSize, convertErr := humanize.ParseBytes(url.GetParam(constant.MaxServerSendMsgSize, "")); err == convertErr && sendMsgSize != 0 {
+		maxServerSendMsgSize = int(sendMsgSize)
+	}
+
 	// If global trace instance was set, then server tracer instance
 	// can be get. If not, will return NoopTracer.
 	tracer := opentracing.GlobalTracer()
@@ -88,8 +99,8 @@ func (s *Server) Start(url *common.URL) {
 	serverOpts = append(serverOpts,
 		grpc.UnaryInterceptor(otgrpc.OpenTracingServerInterceptor(tracer)),
 		grpc.StreamInterceptor(otgrpc.OpenTracingStreamServerInterceptor(tracer)),
-		grpc.MaxRecvMsgSize(1024*1024*s.bufferSize),
-		grpc.MaxSendMsgSize(1024*1024*s.bufferSize),
+		grpc.MaxRecvMsgSize(maxServerRecvMsgSize),
+		grpc.MaxSendMsgSize(maxServerSendMsgSize),
 	)
 
 	tlsConfig := config.GetRootConfig().TLSConfig


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->
According to the pr of #1654, for the client side, the function works normally, but for the server side, the order of Provider Export is not always the same, resulting in sometimes max-server-send-msg-size not taking effect, and for the server side, it is not possible to customize the message size based on the request, so a more appropriate The more appropriate setting should be placed on the protocol.
This pr also fixes the grpc protocol, which can also be used to customize the message size in this way.

**What this PR does**: 
Custom triple/grpc server message size
For message size , The available units are, b/kb/kib/mib/mb/gib/gb, 1kb = 1000b and 1kib = 1024b

Provider:
```yaml
dubbo:
  protocols:
    triple:
      name: tri
      port: 20000
      max-server-send-msg-size: 4mib
      max-server-recv-msg-size: 4mib
```
Consumer:
```yaml
  consumer:
    references:
      GreeterClientImpl:
        protocol: tri
        params:
          max-call-send-msg-size: 4mib
          max-call-recv-msg-size: 4mib
```

**Which issue(s) this PR fixes**: 
Fixes #2176 

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [x] All ut passed (run 'go test ./...' in project root)
- [x] After go-fmt ed , run 'go fmt project' using goland.
- [x] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [x] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [x] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples projM1 Slice is not Support)