### PR TITLE
[3.0] ci: Fix CI failures after branch adjustment

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,12 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master, ]
+    branches: "*"
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
-  schedule:
-    - cron: '0 4 * * 5'
+    branches: "*"
 
 permissions:
   contents: read

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master, develop, "1.5", "3.0"]
+    branches: "*"
   pull_request:
     branches: "*"
 
@@ -21,19 +21,15 @@ jobs:
         os:
           - ubuntu-latest
 
-    env:
-      DING_TOKEN: ${{ secrets.DING_TOKEN }}
-      DING_SIGN: ${{ secrets.DING_SIGN }}
-
     steps:
 
-    - name: Set up Go ${{ matrix.go_version }}
+    - name: Setup Go ${{ matrix.go_version }}
       uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go_version }}
       id: go
 
-    - name: Check out code into the Go module directory
+    - name: Checkout
       uses: actions/checkout@v3
 
     - name: Cache dependencies
@@ -47,18 +43,18 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
 
-    - name: Merge base
+    - name: Merge code into the upstream
       if: ${{ github.event_name == 'pull_request' }}
       run: |
-        git fetch origin 3.0
-        git checkout -b 3.0 origin/3.0
+        git fetch origin $GITHUB_BASE_REF
+        git checkout -b $GITHUB_BASE_REF origin/$GITHUB_BASE_REF
         git remote add devrepo https://github.com/${{github.event.pull_request.head.repo.full_name}}.git
         git fetch devrepo ${{github.event.pull_request.head.sha}}
         git config --global user.email "dubbo-go@github-ci.com"
         git config --global user.name "robot"
         git merge ${{github.event.pull_request.head.sha}}
 
-    - name: Get dependencies
+    - name: Install dependencies
       run: |
         if [ -f Gopkg.toml ]; then
             curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
@@ -67,7 +63,7 @@ jobs:
             go get -v -t -d ./...
         fi
 
-    - name: gofmt
+    - name: Format code
       run: |
         go fmt ./... && git status && [[ -z `git status -s` ]]
         # diff -u <(echo -n) <(gofmt -d -s .)
@@ -77,19 +73,21 @@ jobs:
         make verify
 
     # This step only runs when the event type is a pull_request
-    - name: Integrate Test
+    - name: Integration Testing
       if: ${{ github.event_name == 'pull_request' }}
       run: |
-        chmod +x integrate_test.sh && [[ -n "${{github.event.pull_request.head.repo.full_name}}" ]] && [[ -n "${{github.event.pull_request.head.sha}}" ]] && [[ -n "${{github.base_ref}}" ]] && ./integrate_test.sh ${{github.event.pull_request.head.repo.full_name}} ${{github.event.pull_request.head.sha}} ${{github.base_ref}}
+        if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+          chmod +x integrate_test.sh \
+            && [[ -n "${{github.event.pull_request.head.repo.full_name}}" ]] \
+            && [[ -n "${{github.event.pull_request.head.sha}}" ]] \
+            && [[ -n "${{github.base_ref}}" ]] \
+            && ./integrate_test.sh ${{github.event.pull_request.head.repo.full_name}} ${{github.event.pull_request.head.sha}} ${{github.base_ref}}
+        elif [ "$GITHUB_EVENT_NAME" == "push" ]; then
+          chmod +x integrate_test.sh && ./integrate_test.sh $GITHUB_REPOSITORY $GITHUB_SHA $GITHUB_BASE_REF
+        else
+          echo "$GITHUB_EVENT_NAME is an unsupported event type."
+          exit 1
+        fi
 
-    # This step only runs when the event type is a push
-    - name: Integrate Test
-      if: ${{ github.event_name == 'push' }}
-      run: |
-        chmod +x integrate_test.sh && ./integrate_test.sh $GITHUB_REPOSITORY $GITHUB_SHA $GITHUB_BASE_REF
-
-    - name: Post Coverage
+    - name: Codecov
       run: bash <(curl -s https://codecov.io/bash)
-
-    - name: Hello world
-      run: echo Hello world ${{ secrets.DING_TOKEN }} ${{ secrets.DING_SIGN }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,7 +1,7 @@
 name: golangci-lint
 on:
   push:
-    branches: [master, develop, "1.5", "3.0"]
+    branches: "*"
   pull_request:
     branches: "*"
 

--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -64,7 +64,7 @@ const (
 	MaxServerRecvMsgSize   = "max-server-recv-msg-size"
 )
 
-//tls constant
+// tls constant
 const (
 	TLSKey        = "tls_key"
 	TLSCert       = "tls_cert"

--- a/config/config_center_config.go
+++ b/config/config_center_config.go
@@ -103,8 +103,9 @@ func (c *CenterConfig) GetUrlMap() url.Values {
 	return urlMap
 }
 
-//translateConfigAddress translate config address
-//  eg:address=nacos://127.0.0.1:8848 will return 127.0.0.1:8848 and protocol will set nacos
+// translateConfigAddress translate config address
+//
+//	eg:address=nacos://127.0.0.1:8848 will return 127.0.0.1:8848 and protocol will set nacos
 func (c *CenterConfig) translateConfigAddress() string {
 	if strings.Contains(c.Address, "://") {
 		translatedUrl, err := url.Parse(c.Address)

--- a/config/config_loader.go
+++ b/config/config_loader.go
@@ -103,8 +103,7 @@ func registerServiceInstance() {
 	}
 }
 
-//
-//// nolint
+// // nolint
 func createInstance(url *common.URL) (registry.ServiceInstance, error) {
 	appConfig := GetApplicationConfig()
 	port, err := strconv.ParseInt(url.Port, 10, 32)

--- a/config/graceful_shutdown.go
+++ b/config/graceful_shutdown.go
@@ -191,7 +191,7 @@ func waitingProviderProcessedTimeout(shutdownConfig *ShutdownConfig) {
 	}
 }
 
-//for provider. It will wait for processing receiving requests
+// for provider. It will wait for processing receiving requests
 func waitForSendingAndReceivingRequests() {
 	logger.Info("Graceful shutdown --- Keep waiting until sending/accepting requests finish or timeout. ")
 	if rootConfig == nil || rootConfig.Shutdown == nil {

--- a/config/metadata_report_config.go
+++ b/config/metadata_report_config.go
@@ -107,7 +107,6 @@ func publishServiceDefinition(url *common.URL) {
 	}
 }
 
-//
 // selectMetadataServiceExportedURL get already be exported url
 func selectMetadataServiceExportedURL() *common.URL {
 	var selectedUrl *common.URL

--- a/config/reference_config_test.go
+++ b/config/reference_config_test.go
@@ -30,7 +30,8 @@ import (
 	_ "dubbo.apache.org/dubbo-go/v3/proxy/proxy_factory"
 )
 
-//import (
+// import (
+//
 //	"context"
 //	"dubbo.apache.org/dubbo-go/v3/config"
 //	"dubbo.apache.org/dubbo-go/v3/config/applicationConfig"
@@ -41,13 +42,17 @@ import (
 //	registry2 "dubbo.apache.org/dubbo-go/v3/config/registry"
 //	"sync"
 //	"testing"
-//)
 //
-//import (
+// )
+//
+// import (
+//
 //	"github.com/stretchr/testify/assert"
-//)
 //
-//import (
+// )
+//
+// import (
+//
 //	"dubbo.apache.org/dubbo-go/v3/cluster/cluster_impl"
 //	"dubbo.apache.org/dubbo-go/v3/common"
 //	"dubbo.apache.org/dubbo-go/v3/common/constant"
@@ -55,373 +60,376 @@ import (
 //	"dubbo.apache.org/dubbo-go/v3/filter"
 //	"dubbo.apache.org/dubbo-go/v3/protocol"
 //	"dubbo.apache.org/dubbo-go/v3/registry"
-//)
 //
-//var regProtocol protocol.Protocol
+// )
 //
-//func doInitConsumer() {
-//	config.consumerConfig = &consumer.Config{
-//		BaseConfig: base.Config{
-//			applicationConfig.Config: &applicationConfig.Config{
-//				Organization: "dubbo_org",
-//				Name:         "dubbo",
-//				Module:       "module",
-//				Version:      "2.6.0",
-//				Owner:        "dubbo",
-//				Environment:  "test",
-//			},
-//		},
+// var regProtocol protocol.Protocol
 //
-//		Registries: map[string]*registry2.RegistryConfig{
-//			"shanghai_reg1": {
-//				Protocol:   "mock",
-//				TimeoutStr: "2s",
-//				Group:      "shanghai_idc",
-//				Address:    "127.0.0.1:2181",
-//				Username:   "user1",
-//				Password:   "pwd1",
-//			},
-//			"shanghai_reg2": {
-//				Protocol:   "mock",
-//				TimeoutStr: "2s",
-//				Group:      "shanghai_idc",
-//				Address:    "127.0.0.2:2181",
-//				Username:   "user1",
-//				Password:   "pwd1",
-//			},
-//			"hangzhou_reg1": {
-//				Protocol:   "mock",
-//				TimeoutStr: "2s",
-//				Group:      "hangzhou_idc",
-//				Address:    "127.0.0.3:2181",
-//				Username:   "user1",
-//				Password:   "pwd1",
-//			},
-//			"hangzhou_reg2": {
-//				Protocol:   "mock",
-//				TimeoutStr: "2s",
-//				Group:      "hangzhou_idc",
-//				Address:    "127.0.0.4:2181",
-//				Username:   "user1",
-//				Password:   "pwd1",
-//			},
-//		},
-//
-//		References: map[string]*ReferenceConfig{
-//			"MockService": {
-//				id: "MockProvider",
-//				Params: map[string]string{
-//					"serviceid": "soa.mock",
-//					"forks":     "5",
-//				},
-//				Sticky:        false,
-//				Registry:      "shanghai_reg1,shanghai_reg2,hangzhou_reg1,hangzhou_reg2",
-//				InterfaceName: "com.MockService",
-//				Protocol:      "mock",
-//				Cluster:       "failover",
-//				Loadbalance:   "random",
-//				Retries:       "3",
-//				Group:         "huadong_idc",
-//				Version:       "1.0.0",
-//				Methods: []*method.MethodConfig{
-//					{
-//						Name:        "GetUser",
-//						Retries:     "2",
-//						LoadBalance: "random",
-//					},
-//					{
-//						Name:        "GetUser1",
-//						Retries:     "2",
-//						LoadBalance: "random",
-//						Sticky:      true,
-//					},
+//	func doInitConsumer() {
+//		config.consumerConfig = &consumer.Config{
+//			BaseConfig: base.Config{
+//				applicationConfig.Config: &applicationConfig.Config{
+//					Organization: "dubbo_org",
+//					Name:         "dubbo",
+//					Module:       "module",
+//					Version:      "2.6.0",
+//					Owner:        "dubbo",
+//					Environment:  "test",
 //				},
 //			},
-//		},
-//	}
-//}
 //
-//var mockProvider = new(MockProvider)
-//
-//type MockProvider struct{}
-//
-//func (m *MockProvider) Reference() string {
-//	return "MockProvider"
-//}
-//
-//func (m *MockProvider) CallBack(res common.CallbackResponse) {
-//	// CallBack is a mock function. to implement the interface
-//}
-//
-//func doInitConsumerAsync() {
-//	doInitConsumer()
-//	instance.SetConsumerService(mockProvider)
-//	for _, v := range config.consumerConfig.References {
-//		v.Async = true
-//	}
-//}
-//
-//func doInitConsumerWithSingleRegistry() {
-//	config.consumerConfig = &consumer.Config{
-//		BaseConfig: base.Config{
-//			applicationConfig.Config: &applicationConfig.Config{
-//				Organization: "dubbo_org",
-//				Name:         "dubbo",
-//				Module:       "module",
-//				Version:      "2.6.0",
-//				Owner:        "dubbo",
-//				Environment:  "test",
-//			},
-//		},
-//
-//		Registry: &registry2.RegistryConfig{
-//			Address:  "mock://27.0.0.1:2181",
-//			Username: "user1",
-//			Password: "pwd1",
-//		},
-//		Registries: map[string]*registry2.RegistryConfig{},
-//
-//		References: map[string]*ReferenceConfig{
-//			"MockService": {
-//				Params: map[string]string{
-//					"serviceid": "soa.mock",
-//					"forks":     "5",
+//			Registries: map[string]*registry2.RegistryConfig{
+//				"shanghai_reg1": {
+//					Protocol:   "mock",
+//					TimeoutStr: "2s",
+//					Group:      "shanghai_idc",
+//					Address:    "127.0.0.1:2181",
+//					Username:   "user1",
+//					Password:   "pwd1",
 //				},
-//				InterfaceName: "com.MockService",
-//				Protocol:      "mock",
-//				Cluster:       "failover",
-//				Loadbalance:   "random",
-//				Retries:       "3",
-//				Group:         "huadong_idc",
-//				Version:       "1.0.0",
-//				Methods: []*method.MethodConfig{
-//					{
-//						Name:        "GetUser",
-//						Retries:     "2",
-//						LoadBalance: "random",
+//				"shanghai_reg2": {
+//					Protocol:   "mock",
+//					TimeoutStr: "2s",
+//					Group:      "shanghai_idc",
+//					Address:    "127.0.0.2:2181",
+//					Username:   "user1",
+//					Password:   "pwd1",
+//				},
+//				"hangzhou_reg1": {
+//					Protocol:   "mock",
+//					TimeoutStr: "2s",
+//					Group:      "hangzhou_idc",
+//					Address:    "127.0.0.3:2181",
+//					Username:   "user1",
+//					Password:   "pwd1",
+//				},
+//				"hangzhou_reg2": {
+//					Protocol:   "mock",
+//					TimeoutStr: "2s",
+//					Group:      "hangzhou_idc",
+//					Address:    "127.0.0.4:2181",
+//					Username:   "user1",
+//					Password:   "pwd1",
+//				},
+//			},
+//
+//			References: map[string]*ReferenceConfig{
+//				"MockService": {
+//					id: "MockProvider",
+//					Params: map[string]string{
+//						"serviceid": "soa.mock",
+//						"forks":     "5",
 //					},
-//					{
-//						Name:        "GetUser1",
-//						Retries:     "2",
-//						LoadBalance: "random",
+//					Sticky:        false,
+//					Registry:      "shanghai_reg1,shanghai_reg2,hangzhou_reg1,hangzhou_reg2",
+//					InterfaceName: "com.MockService",
+//					Protocol:      "mock",
+//					Cluster:       "failover",
+//					Loadbalance:   "random",
+//					Retries:       "3",
+//					Group:         "huadong_idc",
+//					Version:       "1.0.0",
+//					Methods: []*method.MethodConfig{
+//						{
+//							Name:        "GetUser",
+//							Retries:     "2",
+//							LoadBalance: "random",
+//						},
+//						{
+//							Name:        "GetUser1",
+//							Retries:     "2",
+//							LoadBalance: "random",
+//							Sticky:      true,
+//						},
 //					},
 //				},
 //			},
-//		},
-//	}
-//}
-//
-//func TestReferMultiReg(t *testing.T) {
-//	doInitConsumer()
-//	extension.SetProtocol("registry", GetProtocol)
-//	extension.SetCluster(constant.ZONEAWARE_CLUSTER_NAME, cluster_impl.NewZoneAwareCluster)
-//	for _, reference := range config.consumerConfig.References {
-//		reference.Refer(nil)
-//		assert.NotNil(t, reference.invoker)
-//		assert.NotNil(t, reference.pxy)
-//	}
-//	config.consumerConfig = nil
-//}
-//
-//func TestRefer(t *testing.T) {
-//	doInitConsumer()
-//	extension.SetProtocol("registry", GetProtocol)
-//	extension.SetCluster(constant.ZONEAWARE_CLUSTER_NAME, cluster_impl.NewZoneAwareCluster)
-//
-//	for _, reference := range config.consumerConfig.References {
-//		reference.Refer(nil)
-//		assert.Equal(t, "soa.mock", reference.Params["serviceid"])
-//		assert.NotNil(t, reference.invoker)
-//		assert.NotNil(t, reference.pxy)
-//	}
-//	config.consumerConfig = nil
-//}
-//
-//func TestReferAsync(t *testing.T) {
-//	doInitConsumerAsync()
-//	extension.SetProtocol("registry", GetProtocol)
-//	extension.SetCluster(constant.ZONEAWARE_CLUSTER_NAME, cluster_impl.NewZoneAwareCluster)
-//
-//	for _, reference := range config.consumerConfig.References {
-//		reference.Refer(nil)
-//		assert.Equal(t, "soa.mock", reference.Params["serviceid"])
-//		assert.NotNil(t, reference.invoker)
-//		assert.NotNil(t, reference.pxy)
-//		assert.NotNil(t, reference.pxy.GetCallback())
-//	}
-//	config.consumerConfig = nil
-//}
-//
-//func TestReferP2P(t *testing.T) {
-//	doInitConsumer()
-//	extension.SetProtocol("dubbo", GetProtocol)
-//	mockFilter()
-//	m := config.consumerConfig.References["MockService"]
-//	m.URL = "dubbo://127.0.0.1:20000"
-//
-//	for _, reference := range config.consumerConfig.References {
-//		reference.Refer(nil)
-//		assert.NotNil(t, reference.invoker)
-//		assert.NotNil(t, reference.pxy)
-//	}
-//	config.consumerConfig = nil
-//}
-//
-//func TestReferMultiP2P(t *testing.T) {
-//	doInitConsumer()
-//	extension.SetProtocol("dubbo", GetProtocol)
-//	mockFilter()
-//	m := config.consumerConfig.References["MockService"]
-//	m.URL = "dubbo://127.0.0.1:20000;dubbo://127.0.0.2:20000"
-//
-//	for _, reference := range config.consumerConfig.References {
-//		reference.Refer(nil)
-//		assert.NotNil(t, reference.invoker)
-//		assert.NotNil(t, reference.pxy)
-//	}
-//	config.consumerConfig = nil
-//}
-//
-//func TestReferMultiP2PWithReg(t *testing.T) {
-//	doInitConsumer()
-//	extension.SetProtocol("dubbo", GetProtocol)
-//	extension.SetProtocol("registry", GetProtocol)
-//	mockFilter()
-//	m := config.consumerConfig.References["MockService"]
-//	m.URL = "dubbo://127.0.0.1:20000;registry://127.0.0.2:20000"
-//
-//	for _, reference := range config.consumerConfig.References {
-//		reference.Refer(nil)
-//		assert.NotNil(t, reference.invoker)
-//		assert.NotNil(t, reference.pxy)
-//	}
-//	config.consumerConfig = nil
-//}
-//
-//func TestImplement(t *testing.T) {
-//	doInitConsumer()
-//	extension.SetProtocol("registry", GetProtocol)
-//	extension.SetCluster(constant.ZONEAWARE_CLUSTER_NAME, cluster_impl.NewZoneAwareCluster)
-//	for _, reference := range config.consumerConfig.References {
-//		reference.Refer(nil)
-//		reference.Implement(&config.MockService{})
-//		assert.NotNil(t, reference.GetRPCService())
-//
-//	}
-//	config.consumerConfig = nil
-//}
-//
-//func TestForking(t *testing.T) {
-//	doInitConsumer()
-//	extension.SetProtocol("dubbo", GetProtocol)
-//	extension.SetProtocol("registry", GetProtocol)
-//	mockFilter()
-//	m := config.consumerConfig.References["MockService"]
-//	m.URL = "dubbo://127.0.0.1:20000;registry://127.0.0.2:20000"
-//
-//	for _, reference := range config.consumerConfig.References {
-//		reference.Refer(nil)
-//		forks := int(reference.invoker.GetURL().GetParamInt(constant.FORKS_KEY, constant.DEFAULT_FORKS))
-//		assert.Equal(t, 5, forks)
-//		assert.NotNil(t, reference.pxy)
-//		assert.NotNil(t, reference.Cluster)
-//	}
-//	config.consumerConfig = nil
-//}
-//
-//func TestSticky(t *testing.T) {
-//	doInitConsumer()
-//	extension.SetProtocol("dubbo", GetProtocol)
-//	extension.SetProtocol("registry", GetProtocol)
-//	mockFilter()
-//	m := config.consumerConfig.References["MockService"]
-//	m.URL = "dubbo://127.0.0.1:20000;registry://127.0.0.2:20000"
-//
-//	reference := config.consumerConfig.References["MockService"]
-//	reference.Refer(nil)
-//	referenceSticky := reference.invoker.GetURL().GetParam(constant.STICKY_KEY, "false")
-//	assert.Equal(t, "false", referenceSticky)
-//
-//	method0StickKey := reference.invoker.GetURL().GetMethodParam(reference.Methods[0].Name, constant.STICKY_KEY, "false")
-//	assert.Equal(t, "false", method0StickKey)
-//	method1StickKey := reference.invoker.GetURL().GetMethodParam(reference.Methods[1].Name, constant.STICKY_KEY, "false")
-//	assert.Equal(t, "true", method1StickKey)
-//}
-//
-//func GetProtocol() protocol.Protocol {
-//	if regProtocol != nil {
-//		return regProtocol
-//	}
-//	return newRegistryProtocol()
-//}
-//
-//func newRegistryProtocol() protocol.Protocol {
-//	return &mockRegistryProtocol{}
-//}
-//
-//type mockRegistryProtocol struct {
-//}
-//
-//func (*mockRegistryProtocol) Refer(url *common.URL) protocol.Invoker {
-//	return protocol.NewBaseInvoker(url)
-//}
-//
-//func (*mockRegistryProtocol) Export(invoker protocol.Invoker) protocol.Exporter {
-//	registryURL := getRegistryURL(invoker)
-//	if registryURL.Protocol == "service-discovery" {
-//		metaDataService, err := extension.GetLocalMetadataService("")
-//		if err != nil {
-//			panic(err)
-//		}
-//		ok, err := metaDataService.ExportURL(invoker.GetURL().SubURL.Clone())
-//		if err != nil {
-//			panic(err)
-//		}
-//		if !ok {
-//			panic("The URL has been registry!")
 //		}
 //	}
-//	return protocol.NewBaseExporter("test", invoker, &sync.Map{})
-//}
 //
-//func (*mockRegistryProtocol) Destroy() {
-//	// Destroy is a mock function
-//}
+// var mockProvider = new(MockProvider)
 //
-//func getRegistryURL(invoker protocol.Invoker) *common.URL {
-//	// here add * for return a new url
-//	url := invoker.GetURL()
-//	// if the protocol == registry ,set protocol the registry value in url.params
-//	if url.Protocol == constant.REGISTRY_PROTOCOL {
-//		protocol := url.GetParam(constant.REGISTRY_KEY, "")
-//		url.Protocol = protocol
+// type MockProvider struct{}
+//
+//	func (m *MockProvider) Reference() string {
+//		return "MockProvider"
 //	}
-//	return url
-//}
 //
-//func (p *mockRegistryProtocol) GetRegistries() []registry.Registry {
-//	return []registry.Registry{&config.mockServiceDiscoveryRegistry{}}
-//}
+//	func (m *MockProvider) CallBack(res common.CallbackResponse) {
+//		// CallBack is a mock function. to implement the interface
+//	}
 //
-//func mockFilter() {
-//	consumerFiler := &mockShutdownFilter{}
-//	extension.SetFilter(constant.GracefulShutdownConsumerFilterKey, func() filter.Filter {
-//		return consumerFiler
-//	})
-//}
+//	func doInitConsumerAsync() {
+//		doInitConsumer()
+//		instance.SetConsumerService(mockProvider)
+//		for _, v := range config.consumerConfig.References {
+//			v.Async = true
+//		}
+//	}
 //
-//type mockShutdownFilter struct {
-//}
+//	func doInitConsumerWithSingleRegistry() {
+//		config.consumerConfig = &consumer.Config{
+//			BaseConfig: base.Config{
+//				applicationConfig.Config: &applicationConfig.Config{
+//					Organization: "dubbo_org",
+//					Name:         "dubbo",
+//					Module:       "module",
+//					Version:      "2.6.0",
+//					Owner:        "dubbo",
+//					Environment:  "test",
+//				},
+//			},
 //
-//// Invoke adds the requests count and block the new requests if applicationConfig is closing
-//func (gf *mockShutdownFilter) Invoke(ctx context.Context, invoker protocol.Invoker, invocation protocol.Invocation) protocol.Result {
-//	return invoker.Invoke(ctx, invocation)
-//}
+//			Registry: &registry2.RegistryConfig{
+//				Address:  "mock://27.0.0.1:2181",
+//				Username: "user1",
+//				Password: "pwd1",
+//			},
+//			Registries: map[string]*registry2.RegistryConfig{},
 //
-//// OnResponse reduces the number of active processes then return the process result
-//func (gf *mockShutdownFilter) OnResponse(ctx context.Context, result protocol.Result, invoker protocol.Invoker, invocation protocol.Invocation) protocol.Result {
-//	return result
-//}
+//			References: map[string]*ReferenceConfig{
+//				"MockService": {
+//					Params: map[string]string{
+//						"serviceid": "soa.mock",
+//						"forks":     "5",
+//					},
+//					InterfaceName: "com.MockService",
+//					Protocol:      "mock",
+//					Cluster:       "failover",
+//					Loadbalance:   "random",
+//					Retries:       "3",
+//					Group:         "huadong_idc",
+//					Version:       "1.0.0",
+//					Methods: []*method.MethodConfig{
+//						{
+//							Name:        "GetUser",
+//							Retries:     "2",
+//							LoadBalance: "random",
+//						},
+//						{
+//							Name:        "GetUser1",
+//							Retries:     "2",
+//							LoadBalance: "random",
+//						},
+//					},
+//				},
+//			},
+//		}
+//	}
+//
+//	func TestReferMultiReg(t *testing.T) {
+//		doInitConsumer()
+//		extension.SetProtocol("registry", GetProtocol)
+//		extension.SetCluster(constant.ZONEAWARE_CLUSTER_NAME, cluster_impl.NewZoneAwareCluster)
+//		for _, reference := range config.consumerConfig.References {
+//			reference.Refer(nil)
+//			assert.NotNil(t, reference.invoker)
+//			assert.NotNil(t, reference.pxy)
+//		}
+//		config.consumerConfig = nil
+//	}
+//
+//	func TestRefer(t *testing.T) {
+//		doInitConsumer()
+//		extension.SetProtocol("registry", GetProtocol)
+//		extension.SetCluster(constant.ZONEAWARE_CLUSTER_NAME, cluster_impl.NewZoneAwareCluster)
+//
+//		for _, reference := range config.consumerConfig.References {
+//			reference.Refer(nil)
+//			assert.Equal(t, "soa.mock", reference.Params["serviceid"])
+//			assert.NotNil(t, reference.invoker)
+//			assert.NotNil(t, reference.pxy)
+//		}
+//		config.consumerConfig = nil
+//	}
+//
+//	func TestReferAsync(t *testing.T) {
+//		doInitConsumerAsync()
+//		extension.SetProtocol("registry", GetProtocol)
+//		extension.SetCluster(constant.ZONEAWARE_CLUSTER_NAME, cluster_impl.NewZoneAwareCluster)
+//
+//		for _, reference := range config.consumerConfig.References {
+//			reference.Refer(nil)
+//			assert.Equal(t, "soa.mock", reference.Params["serviceid"])
+//			assert.NotNil(t, reference.invoker)
+//			assert.NotNil(t, reference.pxy)
+//			assert.NotNil(t, reference.pxy.GetCallback())
+//		}
+//		config.consumerConfig = nil
+//	}
+//
+//	func TestReferP2P(t *testing.T) {
+//		doInitConsumer()
+//		extension.SetProtocol("dubbo", GetProtocol)
+//		mockFilter()
+//		m := config.consumerConfig.References["MockService"]
+//		m.URL = "dubbo://127.0.0.1:20000"
+//
+//		for _, reference := range config.consumerConfig.References {
+//			reference.Refer(nil)
+//			assert.NotNil(t, reference.invoker)
+//			assert.NotNil(t, reference.pxy)
+//		}
+//		config.consumerConfig = nil
+//	}
+//
+//	func TestReferMultiP2P(t *testing.T) {
+//		doInitConsumer()
+//		extension.SetProtocol("dubbo", GetProtocol)
+//		mockFilter()
+//		m := config.consumerConfig.References["MockService"]
+//		m.URL = "dubbo://127.0.0.1:20000;dubbo://127.0.0.2:20000"
+//
+//		for _, reference := range config.consumerConfig.References {
+//			reference.Refer(nil)
+//			assert.NotNil(t, reference.invoker)
+//			assert.NotNil(t, reference.pxy)
+//		}
+//		config.consumerConfig = nil
+//	}
+//
+//	func TestReferMultiP2PWithReg(t *testing.T) {
+//		doInitConsumer()
+//		extension.SetProtocol("dubbo", GetProtocol)
+//		extension.SetProtocol("registry", GetProtocol)
+//		mockFilter()
+//		m := config.consumerConfig.References["MockService"]
+//		m.URL = "dubbo://127.0.0.1:20000;registry://127.0.0.2:20000"
+//
+//		for _, reference := range config.consumerConfig.References {
+//			reference.Refer(nil)
+//			assert.NotNil(t, reference.invoker)
+//			assert.NotNil(t, reference.pxy)
+//		}
+//		config.consumerConfig = nil
+//	}
+//
+//	func TestImplement(t *testing.T) {
+//		doInitConsumer()
+//		extension.SetProtocol("registry", GetProtocol)
+//		extension.SetCluster(constant.ZONEAWARE_CLUSTER_NAME, cluster_impl.NewZoneAwareCluster)
+//		for _, reference := range config.consumerConfig.References {
+//			reference.Refer(nil)
+//			reference.Implement(&config.MockService{})
+//			assert.NotNil(t, reference.GetRPCService())
+//
+//		}
+//		config.consumerConfig = nil
+//	}
+//
+//	func TestForking(t *testing.T) {
+//		doInitConsumer()
+//		extension.SetProtocol("dubbo", GetProtocol)
+//		extension.SetProtocol("registry", GetProtocol)
+//		mockFilter()
+//		m := config.consumerConfig.References["MockService"]
+//		m.URL = "dubbo://127.0.0.1:20000;registry://127.0.0.2:20000"
+//
+//		for _, reference := range config.consumerConfig.References {
+//			reference.Refer(nil)
+//			forks := int(reference.invoker.GetURL().GetParamInt(constant.FORKS_KEY, constant.DEFAULT_FORKS))
+//			assert.Equal(t, 5, forks)
+//			assert.NotNil(t, reference.pxy)
+//			assert.NotNil(t, reference.Cluster)
+//		}
+//		config.consumerConfig = nil
+//	}
+//
+//	func TestSticky(t *testing.T) {
+//		doInitConsumer()
+//		extension.SetProtocol("dubbo", GetProtocol)
+//		extension.SetProtocol("registry", GetProtocol)
+//		mockFilter()
+//		m := config.consumerConfig.References["MockService"]
+//		m.URL = "dubbo://127.0.0.1:20000;registry://127.0.0.2:20000"
+//
+//		reference := config.consumerConfig.References["MockService"]
+//		reference.Refer(nil)
+//		referenceSticky := reference.invoker.GetURL().GetParam(constant.STICKY_KEY, "false")
+//		assert.Equal(t, "false", referenceSticky)
+//
+//		method0StickKey := reference.invoker.GetURL().GetMethodParam(reference.Methods[0].Name, constant.STICKY_KEY, "false")
+//		assert.Equal(t, "false", method0StickKey)
+//		method1StickKey := reference.invoker.GetURL().GetMethodParam(reference.Methods[1].Name, constant.STICKY_KEY, "false")
+//		assert.Equal(t, "true", method1StickKey)
+//	}
+//
+//	func GetProtocol() protocol.Protocol {
+//		if regProtocol != nil {
+//			return regProtocol
+//		}
+//		return newRegistryProtocol()
+//	}
+//
+//	func newRegistryProtocol() protocol.Protocol {
+//		return &mockRegistryProtocol{}
+//	}
+//
+// type mockRegistryProtocol struct {
+// }
+//
+//	func (*mockRegistryProtocol) Refer(url *common.URL) protocol.Invoker {
+//		return protocol.NewBaseInvoker(url)
+//	}
+//
+//	func (*mockRegistryProtocol) Export(invoker protocol.Invoker) protocol.Exporter {
+//		registryURL := getRegistryURL(invoker)
+//		if registryURL.Protocol == "service-discovery" {
+//			metaDataService, err := extension.GetLocalMetadataService("")
+//			if err != nil {
+//				panic(err)
+//			}
+//			ok, err := metaDataService.ExportURL(invoker.GetURL().SubURL.Clone())
+//			if err != nil {
+//				panic(err)
+//			}
+//			if !ok {
+//				panic("The URL has been registry!")
+//			}
+//		}
+//		return protocol.NewBaseExporter("test", invoker, &sync.Map{})
+//	}
+//
+//	func (*mockRegistryProtocol) Destroy() {
+//		// Destroy is a mock function
+//	}
+//
+//	func getRegistryURL(invoker protocol.Invoker) *common.URL {
+//		// here add * for return a new url
+//		url := invoker.GetURL()
+//		// if the protocol == registry ,set protocol the registry value in url.params
+//		if url.Protocol == constant.REGISTRY_PROTOCOL {
+//			protocol := url.GetParam(constant.REGISTRY_KEY, "")
+//			url.Protocol = protocol
+//		}
+//		return url
+//	}
+//
+//	func (p *mockRegistryProtocol) GetRegistries() []registry.Registry {
+//		return []registry.Registry{&config.mockServiceDiscoveryRegistry{}}
+//	}
+//
+//	func mockFilter() {
+//		consumerFiler := &mockShutdownFilter{}
+//		extension.SetFilter(constant.GracefulShutdownConsumerFilterKey, func() filter.Filter {
+//			return consumerFiler
+//		})
+//	}
+//
+// type mockShutdownFilter struct {
+// }
+//
+// // Invoke adds the requests count and block the new requests if applicationConfig is closing
+//
+//	func (gf *mockShutdownFilter) Invoke(ctx context.Context, invoker protocol.Invoker, invocation protocol.Invocation) protocol.Result {
+//		return invoker.Invoke(ctx, invocation)
+//	}
+//
+// // OnResponse reduces the number of active processes then return the process result
+//
+//	func (gf *mockShutdownFilter) OnResponse(ctx context.Context, result protocol.Result, invoker protocol.Invoker, invocation protocol.Invocation) protocol.Result {
+//		return result
+//	}
 func TestNewReferenceConfigBuilder(t *testing.T) {
 	registryConfig := NewRegistryConfigWithProtocolDefaultPort("nacos")
 	protocolConfig := NewProtocolConfigBuilder().

--- a/config/registry_config.go
+++ b/config/registry_config.go
@@ -119,8 +119,9 @@ func (c *RegistryConfig) toMetadataReportUrl() (*common.URL, error) {
 	return res, nil
 }
 
-//translateRegistryAddress translate registry address
-//  eg:address=nacos://127.0.0.1:8848 will return 127.0.0.1:8848 and protocol will set nacos
+// translateRegistryAddress translate registry address
+//
+//	eg:address=nacos://127.0.0.1:8848 will return 127.0.0.1:8848 and protocol will set nacos
 func (c *RegistryConfig) translateRegistryAddress() string {
 	if strings.Contains(c.Address, "://") {
 		u, err := url.Parse(c.Address)

--- a/filter/tps/filter.go
+++ b/filter/tps/filter.go
@@ -17,17 +17,18 @@
 
 /*
 Package tps provides a filter for limiting the requests by TPS.
- if you wish to use the TpsLimiter, please add the configuration into your service provider configuration:
- for example:
- "UserProvider":
-   registry: "hangzhouzk"
-   protocol : "dubbo"
-   interface : "com.ikurento.user.UserProvider"
-   ... # other configuration
-   tps.limiter: "method-service", # it should be the name of limiter. if the value is 'default',
-                                  # the MethodServiceTpsLimiter will be used.
-   tps.limit.rejected.handler: "default", # optional, or the name of the implementation
-   if the value of 'tps.limiter' is nil or empty string, the tps filter will do nothing
+
+	if you wish to use the TpsLimiter, please add the configuration into your service provider configuration:
+	for example:
+	"UserProvider":
+	  registry: "hangzhouzk"
+	  protocol : "dubbo"
+	  interface : "com.ikurento.user.UserProvider"
+	  ... # other configuration
+	  tps.limiter: "method-service", # it should be the name of limiter. if the value is 'default',
+	                                 # the MethodServiceTpsLimiter will be used.
+	  tps.limit.rejected.handler: "default", # optional, or the name of the implementation
+	  if the value of 'tps.limiter' is nil or empty string, the tps filter will do nothing
 */
 package tps
 

--- a/filter/tps_limiter.go
+++ b/filter/tps_limiter.go
@@ -24,16 +24,17 @@ import (
 
 // TpsLimiter is the interface which defines the Limiter that judge if the TPS overs the threshold
 //
-// IsAllowable method will check whether this invocation should be enabled for further process
+// # IsAllowable method will check whether this invocation should be enabled for further process
 //
 // please register your implementation by invoking SetTpsLimiter
 // The usage, for example:
 // "UserProvider":
-//   registry: "hangzhouzk"
-//   protocol : "dubbo"
-//   interface : "com.ikurento.user.UserProvider"
-//   ... # other configuration
-//   tps.limiter: "the name of limiter",
+//
+//	registry: "hangzhouzk"
+//	protocol : "dubbo"
+//	interface : "com.ikurento.user.UserProvider"
+//	... # other configuration
+//	tps.limiter: "the name of limiter",
 type TpsLimiter interface {
 	IsAllowable(*common.URL, protocol.Invocation) bool
 }

--- a/metadata/mapping/service_name_mapping.go
+++ b/metadata/mapping/service_name_mapping.go
@@ -28,7 +28,7 @@ import (
 
 // ServiceNameMapping  is the interface which trys to build the mapping between application-level service and interface-level service.
 //
-// Map method will map the service to this application-level service
+// # Map method will map the service to this application-level service
 //
 // Get method will return the application-level services
 type ServiceNameMapping interface {

--- a/protocol/dubbo3/reflection/serverreflection.go
+++ b/protocol/dubbo3/reflection/serverreflection.go
@@ -20,7 +20,6 @@ Package reflection implements server reflection service.
 
 The service implemented is defined in:
 https://github.com/grpc/grpc/blob/master/src/proto/grpc/reflection/v1alpha/reflection.proto.
-
 */
 package reflection
 

--- a/protocol/invoker.go
+++ b/protocol/invoker.go
@@ -41,8 +41,9 @@ var (
 )
 
 // Invoker the service invocation interface for the consumer
-//go:generate mockgen -source invoker.go -destination mock/mock_invoker.go -self_package dubbo.apache.org/dubbo-go/v3/protocol/mock --package mock Invoker
 // Extension - Invoker
+//
+//go:generate mockgen -source invoker.go -destination mock/mock_invoker.go -self_package dubbo.apache.org/dubbo-go/v3/protocol/mock --package mock Invoker
 type Invoker interface {
 	common.Node
 	// Invoke the invocation and return result.

--- a/protocol/jsonrpc/http_test.go
+++ b/protocol/jsonrpc/http_test.go
@@ -25,29 +25,33 @@ import (
 	perrors "github.com/pkg/errors"
 )
 
+// import (
 //
-//import (
 //	"context"
 //	"strings"
 //	"testing"
 //	"time"
-//)
 //
-//import (
+// )
+//
+// import (
+//
 //	"github.com/opentracing/opentracing-go"
 //
 //	perrors "github.com/pkg/errors"
 //
 //	"github.com/stretchr/testify/assert"
-//)
 //
-//import (
+// )
+//
+// import (
+//
 //	"dubbo.apache.org/dubbo-go/v3/common"
 //	"dubbo.apache.org/dubbo-go/v3/common/constant"
 //	"dubbo.apache.org/dubbo-go/v3/proxy/proxy_factory"
 //	"dubbo.apache.org/dubbo-go/v3/protocol"
-//)
 //
+// )
 type (
 	User struct {
 		ID   string `json:"id"`
@@ -58,125 +62,125 @@ type (
 	}
 )
 
+// const (
 //
-//const (
 //	mockJsonCommonUrl = "jsonrpc://127.0.0.1:20001/com.ikurento.user.UserProvider?anyhost=true&" +
 //		"application=BDTService&category=providers&default.timeout=10000&dubbo=dubbo-provider-golang-1.0.0&" +
 //		"environment=dev&interface=com.ikurento.user.UserProvider&ip=192.168.56.1&methods=GetUser%2C&" +
 //		"module=dubbogo+user-info+server&org=ikurento.com&owner=ZX&pid=1447&revision=0.0.1&" +
 //		"side=provider&timeout=3000&timestamp=1556509797245&bean.name=UserProvider"
-//)
 //
-//func TestHTTPClientCall(t *testing.T) {
-//	methods, err := common.ServiceMap.Register("com.ikurento.user.UserProvider", "jsonrpc", "", "", &UserProvider{})
-//	assert.NoError(t, err)
-//	assert.Equal(t, "GetUser,GetUser0,GetUser1,GetUser2,GetUser3,GetUser4", methods)
+// )
 //
-//	// Export
-//	proto := GetProtocol()
-//	url, err := common.NewURL(mockJsonCommonUrl)
-//	assert.NoError(t, err)
-//	proto.Export(&proxy_factory.ProxyInvoker{
-//		BaseInvoker: *protocol.NewBaseInvoker(url),
-//	})
-//	time.Sleep(time.Second * 2)
+//	func TestHTTPClientCall(t *testing.T) {
+//		methods, err := common.ServiceMap.Register("com.ikurento.user.UserProvider", "jsonrpc", "", "", &UserProvider{})
+//		assert.NoError(t, err)
+//		assert.Equal(t, "GetUser,GetUser0,GetUser1,GetUser2,GetUser3,GetUser4", methods)
 //
-//	client := NewHTTPClient(&HTTPOptions{})
+//		// Export
+//		proto := GetProtocol()
+//		url, err := common.NewURL(mockJsonCommonUrl)
+//		assert.NoError(t, err)
+//		proto.Export(&proxy_factory.ProxyInvoker{
+//			BaseInvoker: *protocol.NewBaseInvoker(url),
+//		})
+//		time.Sleep(time.Second * 2)
 //
-//	// call GetUser
-//	ctx := context.WithValue(context.Background(), constant.DUBBOGO_CTX_KEY, map[string]string{
-//		"X-Proxy-ID": "dubbogo",
-//		"X-Services": url.Path,
-//		"X-Method":   "GetUser",
-//	})
+//		client := NewHTTPClient(&HTTPOptions{})
 //
-//	req := client.NewRequest(url, "GetUser", []interface{}{"1", "username"})
-//	reply := &User{}
-//	err = client.Call(ctx, url, req, reply)
-//	assert.NoError(t, err)
-//	assert.Equal(t, "1", reply.ID)
-//	assert.Equal(t, "username", reply.Name)
+//		// call GetUser
+//		ctx := context.WithValue(context.Background(), constant.DUBBOGO_CTX_KEY, map[string]string{
+//			"X-Proxy-ID": "dubbogo",
+//			"X-Services": url.Path,
+//			"X-Method":   "GetUser",
+//		})
 //
-//	// call GetUser0
-//	ctx = context.WithValue(context.Background(), constant.DUBBOGO_CTX_KEY, map[string]string{
-//		"X-Proxy-ID": "dubbogo",
-//		"X-Services": url.Path,
-//		"X-Method":   "GetUser0",
-//	})
-//	req = client.NewRequest(url, "GetUser0", []interface{}{"1", nil, "username"})
-//	reply = &User{}
-//	err = client.Call(ctx, url, req, reply)
-//	assert.NoError(t, err)
-//	assert.Equal(t, "1", reply.ID)
-//	assert.Equal(t, "username", reply.Name)
+//		req := client.NewRequest(url, "GetUser", []interface{}{"1", "username"})
+//		reply := &User{}
+//		err = client.Call(ctx, url, req, reply)
+//		assert.NoError(t, err)
+//		assert.Equal(t, "1", reply.ID)
+//		assert.Equal(t, "username", reply.Name)
 //
-//	// call GetUser1
-//	ctx = context.WithValue(context.Background(), constant.DUBBOGO_CTX_KEY, map[string]string{
-//		"X-Proxy-ID": "dubbogo",
-//		"X-Services": url.Path,
-//		"X-Method":   "GetUser1",
-//	})
-//	req = client.NewRequest(url, "GetUser1", []interface{}{})
-//	reply = &User{}
-//	err = client.Call(ctx, url, req, reply)
-//	assert.True(t, strings.Contains(err.Error(), "500 Internal Server Error"))
-//	assert.True(t, strings.Contains(err.Error(), "\\\"result\\\":{},\\\"error\\\":{\\\"code\\\":-32000,\\\"message\\\":\\\"error\\\"}"))
+//		// call GetUser0
+//		ctx = context.WithValue(context.Background(), constant.DUBBOGO_CTX_KEY, map[string]string{
+//			"X-Proxy-ID": "dubbogo",
+//			"X-Services": url.Path,
+//			"X-Method":   "GetUser0",
+//		})
+//		req = client.NewRequest(url, "GetUser0", []interface{}{"1", nil, "username"})
+//		reply = &User{}
+//		err = client.Call(ctx, url, req, reply)
+//		assert.NoError(t, err)
+//		assert.Equal(t, "1", reply.ID)
+//		assert.Equal(t, "username", reply.Name)
 //
-//	// call GetUser2
-//	ctx = context.WithValue(context.Background(), constant.DUBBOGO_CTX_KEY, map[string]string{
-//		"X-Proxy-ID": "dubbogo",
-//		"X-Services": url.Path,
-//		"X-Method":   "GetUser2",
-//	})
-//	req = client.NewRequest(url, "GetUser2", []interface{}{"1", "username"})
-//	reply1 := []User{}
-//	err = client.Call(ctx, url, req, &reply1)
-//	assert.NoError(t, err)
-//	assert.Equal(t, User{ID: "1", Name: "username"}, reply1[0])
+//		// call GetUser1
+//		ctx = context.WithValue(context.Background(), constant.DUBBOGO_CTX_KEY, map[string]string{
+//			"X-Proxy-ID": "dubbogo",
+//			"X-Services": url.Path,
+//			"X-Method":   "GetUser1",
+//		})
+//		req = client.NewRequest(url, "GetUser1", []interface{}{})
+//		reply = &User{}
+//		err = client.Call(ctx, url, req, reply)
+//		assert.True(t, strings.Contains(err.Error(), "500 Internal Server Error"))
+//		assert.True(t, strings.Contains(err.Error(), "\\\"result\\\":{},\\\"error\\\":{\\\"code\\\":-32000,\\\"message\\\":\\\"error\\\"}"))
 //
-//	// call GetUser3
-//	ctx = context.WithValue(context.Background(), constant.DUBBOGO_CTX_KEY, map[string]string{
-//		"X-Proxy-ID": "dubbogo",
-//		"X-Services": url.Path,
-//		"X-Method":   "GetUser3",
-//	})
-//	req = client.NewRequest(url, "GetUser3", []interface{}{"1", "username"})
-//	reply1 = []User{}
-//	err = client.Call(ctx, url, req, &reply1)
-//	assert.NoError(t, err)
-//	assert.Equal(t, User{ID: "1", Name: "username"}, reply1[0])
+//		// call GetUser2
+//		ctx = context.WithValue(context.Background(), constant.DUBBOGO_CTX_KEY, map[string]string{
+//			"X-Proxy-ID": "dubbogo",
+//			"X-Services": url.Path,
+//			"X-Method":   "GetUser2",
+//		})
+//		req = client.NewRequest(url, "GetUser2", []interface{}{"1", "username"})
+//		reply1 := []User{}
+//		err = client.Call(ctx, url, req, &reply1)
+//		assert.NoError(t, err)
+//		assert.Equal(t, User{ID: "1", Name: "username"}, reply1[0])
 //
-//	// call GetUser4
-//	ctx = context.WithValue(context.Background(), constant.DUBBOGO_CTX_KEY, map[string]string{
-//		"X-Proxy-ID": "dubbogo",
-//		"X-Services": url.Path,
-//		"X-Method":   "GetUser4",
-//	})
-//	req = client.NewRequest(url, "GetUser4", []interface{}{0})
-//	reply = &User{}
-//	err = client.Call(ctx, url, req, reply)
-//	assert.NoError(t, err)
-//	assert.Equal(t, &User{ID: "", Name: ""}, reply)
+//		// call GetUser3
+//		ctx = context.WithValue(context.Background(), constant.DUBBOGO_CTX_KEY, map[string]string{
+//			"X-Proxy-ID": "dubbogo",
+//			"X-Services": url.Path,
+//			"X-Method":   "GetUser3",
+//		})
+//		req = client.NewRequest(url, "GetUser3", []interface{}{"1", "username"})
+//		reply1 = []User{}
+//		err = client.Call(ctx, url, req, &reply1)
+//		assert.NoError(t, err)
+//		assert.Equal(t, User{ID: "1", Name: "username"}, reply1[0])
 //
-//	ctx = context.WithValue(context.Background(), constant.DUBBOGO_CTX_KEY, map[string]string{
-//		"X-Proxy-ID": "dubbogo",
-//		"X-Services": url.Path,
-//		"X-Method":   "GetUser4",
-//	})
+//		// call GetUser4
+//		ctx = context.WithValue(context.Background(), constant.DUBBOGO_CTX_KEY, map[string]string{
+//			"X-Proxy-ID": "dubbogo",
+//			"X-Services": url.Path,
+//			"X-Method":   "GetUser4",
+//		})
+//		req = client.NewRequest(url, "GetUser4", []interface{}{0})
+//		reply = &User{}
+//		err = client.Call(ctx, url, req, reply)
+//		assert.NoError(t, err)
+//		assert.Equal(t, &User{ID: "", Name: ""}, reply)
 //
-//	span := opentracing.StartSpan("Test-Inject-Tracing-ID")
-//	ctx = opentracing.ContextWithSpan(ctx, span)
+//		ctx = context.WithValue(context.Background(), constant.DUBBOGO_CTX_KEY, map[string]string{
+//			"X-Proxy-ID": "dubbogo",
+//			"X-Services": url.Path,
+//			"X-Method":   "GetUser4",
+//		})
 //
-//	req = client.NewRequest(url, "GetUser4", []interface{}{1})
-//	reply = &User{}
-//	err = client.Call(ctx, url, req, reply)
-//	assert.NoError(t, err)
-//	assert.Equal(t, &User{ID: "1", Name: ""}, reply)
+//		span := opentracing.StartSpan("Test-Inject-Tracing-ID")
+//		ctx = opentracing.ContextWithSpan(ctx, span)
 //
-//	// destroy
-//	proto.Destroy()
-//}
+//		req = client.NewRequest(url, "GetUser4", []interface{}{1})
+//		reply = &User{}
+//		err = client.Call(ctx, url, req, reply)
+//		assert.NoError(t, err)
+//		assert.Equal(t, &User{ID: "1", Name: ""}, reply)
 //
+//		// destroy
+//		proto.Destroy()
+//	}
 func (u *UserProvider) GetUser(ctx context.Context, req []interface{}, rsp *User) error {
 	rsp.ID = req[0].(string)
 	rsp.Name = req[1].(string)

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -31,9 +31,9 @@ import (
 
 // Protocol is the interface that wraps the basic Export, Refer and Destroy method.
 //
-// Export method is to export service for remote invocation
+// # Export method is to export service for remote invocation
 //
-// Refer method is to refer a remote service
+// # Refer method is to refer a remote service
 //
 // Destroy method will destroy all invoker and exporter, so it only is called once.
 type Protocol interface {

--- a/protocol/result.go
+++ b/protocol/result.go
@@ -33,7 +33,7 @@ import (
 //
 // SetAttachments method replaces the existing attachments with the specified param.
 //
-// Attachments method gets all attachments
+// # Attachments method gets all attachments
 //
 // AddAttachment method adds the specified map to existing attachments in this instance.
 //

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -87,9 +87,10 @@ func WithProxyImplementFunc(f ImplementFunc) ProxyOption {
 // Implement
 // proxy implement
 // In consumer, RPCService like:
-// 		type XxxProvider struct {
-//  		Yyy func(ctx context.Context, args []interface{}, rsp *Zzz) error
-// 		}
+//
+//			type XxxProvider struct {
+//	 		Yyy func(ctx context.Context, args []interface{}, rsp *Zzz) error
+//			}
 func (p *Proxy) Implement(v common.RPCService) {
 	p.once.Do(func() {
 		p.implement(p, v)

--- a/remoting/etcdv3/client.go
+++ b/remoting/etcdv3/client.go
@@ -59,7 +59,7 @@ func ValidateClient(container clientFacade, opts ...gxetcd.Option) error {
 	return nil
 }
 
-//  nolint
+// nolint
 func NewServiceDiscoveryClient(opts ...gxetcd.Option) *gxetcd.Client {
 	options := &gxetcd.Options{
 		Heartbeat: 1, // default heartbeat

--- a/xds/balancer/clusterresolver/configbuilder.go
+++ b/xds/balancer/clusterresolver/configbuilder.go
@@ -73,22 +73,23 @@ type priorityConfig struct {
 // If xds lb policy is ROUND_ROBIN, the children will be weighted_target for
 // locality picking, and round_robin for endpoint picking.
 //
-//                                   ┌────────┐
-//                                   │priority│
-//                                   └┬──────┬┘
-//                                    │      │
-//                        ┌───────────▼┐    ┌▼───────────┐
-//                        │cluster_impl│    │cluster_impl│
-//                        └─┬──────────┘    └──────────┬─┘
-//                          │                          │
-//           ┌──────────────▼─┐                      ┌─▼──────────────┐
-//           │locality_picking│                      │locality_picking│
-//           └┬──────────────┬┘                      └┬──────────────┬┘
-//            │              │                        │              │
-//          ┌─▼─┐          ┌─▼─┐                    ┌─▼─┐          ┌─▼─┐
-//          │LRS│          │LRS│                    │LRS│          │LRS│
-//          └─┬─┘          └─┬─┘                    └─┬─┘          └─┬─┘
-//            │              │                        │              │
+//	                         ┌────────┐
+//	                         │priority│
+//	                         └┬──────┬┘
+//	                          │      │
+//	              ┌───────────▼┐    ┌▼───────────┐
+//	              │cluster_impl│    │cluster_impl│
+//	              └─┬──────────┘    └──────────┬─┘
+//	                │                          │
+//	 ┌──────────────▼─┐                      ┌─▼──────────────┐
+//	 │locality_picking│                      │locality_picking│
+//	 └┬──────────────┬┘                      └┬──────────────┬┘
+//	  │              │                        │              │
+//	┌─▼─┐          ┌─▼─┐                    ┌─▼─┐          ┌─▼─┐
+//	│LRS│          │LRS│                    │LRS│          │LRS│
+//	└─┬─┘          └─┬─┘                    └─┬─┘          └─┬─┘
+//	  │              │                        │              │
+//
 // ┌──────────▼─────┐  ┌─────▼──────────┐  ┌──────────▼─────┐  ┌─────▼──────────┐
 // │endpoint_picking│  │endpoint_picking│  │endpoint_picking│  │endpoint_picking│
 // └────────────────┘  └────────────────┘  └────────────────┘  └────────────────┘
@@ -97,14 +98,17 @@ type priorityConfig struct {
 // The endpoints from all localities will be flattened to one addresses list,
 // and the ring_hash policy will pick endpoints from it.
 //
-//           ┌────────┐
-//           │priority│
-//           └┬──────┬┘
-//            │      │
+//	┌────────┐
+//	│priority│
+//	└┬──────┬┘
+//	 │      │
+//
 // ┌──────────▼─┐  ┌─▼──────────┐
 // │cluster_impl│  │cluster_impl│
 // └──────┬─────┘  └─────┬──────┘
-//        │              │
+//
+//	│              │
+//
 // ┌──────▼─────┐  ┌─────▼──────┐
 // │ ring_hash  │  │ ring_hash  │
 // └────────────┘  └────────────┘

--- a/xds/balancer/priority/balancer_priority.go
+++ b/xds/balancer/priority/balancer_priority.go
@@ -61,15 +61,15 @@ var (
 // set parent ClientConn to TransientFailure
 // - Otherwise, Scan all children from p0, and check balancer stats:
 //   - For any of the following cases:
-// 	   - If balancer is not started (not built), this is either a new child
-//       with high priority, or a new builder for an existing child.
-// 	   - If balancer is READY
-// 	   - If this is the lowest priority
+//   - If balancer is not started (not built), this is either a new child
+//     with high priority, or a new builder for an existing child.
+//   - If balancer is READY
+//   - If this is the lowest priority
 //   - do the following:
-//     - if this is not the old childInUse, override picker so old picker is no
-//       longer used.
-//     - switch to it (because all higher priorities are neither new or Ready)
-//     - forward the new addresses and config
+//   - if this is not the old childInUse, override picker so old picker is no
+//     longer used.
+//   - switch to it (because all higher priorities are neither new or Ready)
+//   - forward the new addresses and config
 //
 // Caller must hold b.mu.
 func (b *priorityBalancer) syncPriority() {
@@ -255,6 +255,7 @@ func (b *priorityBalancer) handleChildStateUpdate(childName string, s balancer.S
 // - If it's from higher priority:
 //   - Switch to this priority
 //   - Forward the update
+//
 // - If it's from priorityInUse:
 //   - Forward only
 //
@@ -282,13 +283,14 @@ func (b *priorityBalancer) handlePriorityWithNewStateReady(child *childBalancer,
 // An update with state TransientFailure:
 // - If it's from a higher priority:
 //   - Do not forward, and do nothing
+//
 // - If it's from priorityInUse:
 //   - If there's no lower:
-//     - Forward and do nothing else
+//   - Forward and do nothing else
 //   - If there's a lower priority:
-//     - Switch to the lower
-//     - Forward the lower child's state
-//     - Do NOT forward this update
+//   - Switch to the lower
+//   - Forward the lower child's state
+//   - Do NOT forward this update
 //
 // Caller must make sure priorityInUse is not higher than priority.
 //
@@ -320,6 +322,7 @@ func (b *priorityBalancer) handlePriorityWithNewStateTransientFailure(child *chi
 // An update with state Connecting:
 // - If it's from a higher priority
 //   - Do nothing
+//
 // - If it's from priorityInUse, the behavior depends on previous state.
 //
 // When new state is Connecting, the behavior depends on previous state. If the

--- a/xds/balancer/ringhash/ringhash.go
+++ b/xds/balancer/ringhash/ringhash.go
@@ -323,10 +323,11 @@ func (b *ringhashBalancer) ResolverError(err error) {
 // It triggers an update to cc when:
 // - the new state is TransientFailure, to update the error message
 //   - it's possible that this is a noop, but sending an extra update is easier
-//   than comparing errors
+//     than comparing errors
+//
 // - the aggregated state is changed
 //   - the same picker will be sent again, but this update may trigger a re-pick
-//   for some RPCs.
+//     for some RPCs.
 func (b *ringhashBalancer) UpdateSubConnState(sc balancer.SubConn, state balancer.SubConnState) {
 	s := state.ConnectivityState
 	b.logger.Infof("handle SubConn state change: %p, %v", sc, s)

--- a/xds/client/controller/transport.go
+++ b/xds/client/controller/transport.go
@@ -115,10 +115,10 @@ func (t *Controller) run(ctx context.Context) {
 // new requests to send on the stream.
 //
 // For each new request (watchAction), it's
-//  - processed and added to the watch map
-//    - so resend will pick them up when there are new streams
-//  - sent on the current stream if there's one
-//    - the current stream is cleared when any send on it fails
+//   - processed and added to the watch map
+//   - so resend will pick them up when there are new streams
+//   - sent on the current stream if there's one
+//   - the current stream is cleared when any send on it fails
 //
 // For each new stream, all the existing requests will be resent.
 //

--- a/xds/client/controller/version/v2/client.go
+++ b/xds/client/controller/version/v2/client.go
@@ -99,10 +99,10 @@ func (v2c *client) NewStream(ctx context.Context, cc *grpc.ClientConn) (grpc.Cli
 // rType, on the provided stream.
 //
 // version is the ack version to be sent with the request
-// - If this is the new request (not an ack/nack), version will be empty.
-// - If this is an ack, version will be the version from the response.
-// - If this is a nack, version will be the previous acked version (from
-//   versionMap). If there was no ack before, it will be empty.
+//   - If this is the new request (not an ack/nack), version will be empty.
+//   - If this is an ack, version will be the version from the response.
+//   - If this is a nack, version will be the previous acked version (from
+//     versionMap). If there was no ack before, it will be empty.
 func (v2c *client) SendRequest(s grpc.ClientStream, resourceNames []string, rType resource.ResourceType, version, nonce, errMsg string) error {
 	stream, ok := s.(adsStream)
 	if !ok {

--- a/xds/client/controller/version/v3/client.go
+++ b/xds/client/controller/version/v3/client.go
@@ -101,10 +101,10 @@ func (v3c *client) SetMetadata(p *_struct.Struct) {
 // rType, on the provided stream.
 //
 // version is the ack version to be sent with the request
-// - If this is the new request (not an ack/nack), version will be empty.
-// - If this is an ack, version will be the version from the response.
-// - If this is a nack, version will be the previous acked version (from
-//   versionMap). If there was no ack before, it will be empty.
+//   - If this is the new request (not an ack/nack), version will be empty.
+//   - If this is an ack, version will be the version from the response.
+//   - If this is a nack, version will be the previous acked version (from
+//     versionMap). If there was no ack before, it will be empty.
 func (v3c *client) SendRequest(s grpc.ClientStream, resourceNames []string, rType resource.ResourceType, version, nonce, errMsg string) error {
 	stream, ok := s.(adsStream)
 	if !ok {

--- a/xds/client/resource/filter_chain.go
+++ b/xds/client/resource/filter_chain.go
@@ -171,11 +171,11 @@ const (
 // filter chains in a single Listener resource. It also contains the default
 // filter chain specified in the Listener resource. It provides two important
 // pieces of functionality:
-// 1. Validate the filter chains in an incoming Listener resource to make sure
-//    that there aren't filter chains which contain the same match criteria.
-// 2. As part of performing the above validation, it builds an internal data
-//    structure which will if used to look up the matching filter chain at
-//    connection time.
+//  1. Validate the filter chains in an incoming Listener resource to make sure
+//     that there aren't filter chains which contain the same match criteria.
+//  2. As part of performing the above validation, it builds an internal data
+//     structure which will if used to look up the matching filter chain at
+//     connection time.
 //
 // The logic specified in the documentation around the xDS FilterChainMatch
 // proto mentions 8 criteria to match on.

--- a/xds/client/resource/matcher.go
+++ b/xds/client/resource/matcher.go
@@ -220,17 +220,17 @@ func match(domain, host string) (domainMatchType, bool) {
 // matches host
 //
 // The domains field support 4 different matching pattern types:
-//  - Exact match
-//  - Suffix match (e.g. “*ABC”)
-//  - Prefix match (e.g. “ABC*)
-//  - Universal match (e.g. “*”)
+//   - Exact match
+//   - Suffix match (e.g. “*ABC”)
+//   - Prefix match (e.g. “ABC*)
+//   - Universal match (e.g. “*”)
 //
 // The best match is defined as:
-//  - A match is better if it’s matching pattern type is better
-//    - Exact match > suffix match > prefix match > universal match
-//  - If two matches are of the same pattern type, the longer match is better
-//    - This is to compare the length of the matching pattern, e.g. “*ABCDE” >
-//    “*ABC”
+//   - A match is better if it’s matching pattern type is better
+//   - Exact match > suffix match > prefix match > universal match
+//   - If two matches are of the same pattern type, the longer match is better
+//   - This is to compare the length of the matching pattern, e.g. “*ABCDE” >
+//     “*ABC”
 func FindBestMatchingVirtualHost(host string, vHosts []*VirtualHost) *VirtualHost { // Maybe move this crap to client
 	var (
 		matchVh   *VirtualHost

--- a/xds/credentials/cert_manager.go
+++ b/xds/credentials/cert_manager.go
@@ -52,7 +52,7 @@ func init() {
 	internal.GetCertificateProviderBuilder = certprovider.GetBuilder
 }
 
-//CertManager manage agent or no agent cert
+// CertManager manage agent or no agent cert
 type CertManager interface {
 	GetCertificate() ([]tls.Certificate, error)
 	GetRootCertificate() (*x509.CertPool, error)
@@ -89,7 +89,7 @@ type AgentCertManager struct {
 	provider certprovider.Provider
 }
 
-//GetRootCertificate return certificate of ca
+// GetRootCertificate return certificate of ca
 func (c *AgentCertManager) GetRootCertificate() (*x509.CertPool, error) {
 	material, err := c.provider.KeyMaterial(context.Background())
 	if err != nil {
@@ -98,7 +98,7 @@ func (c *AgentCertManager) GetRootCertificate() (*x509.CertPool, error) {
 	return material.Roots, nil
 }
 
-//GetCertificate return certificate of application
+// GetCertificate return certificate of application
 func (c *AgentCertManager) GetCertificate() ([]tls.Certificate, error) {
 	material, err := c.provider.KeyMaterial(context.Background())
 	if err != nil {
@@ -138,7 +138,7 @@ type CACertManager struct {
 	rootPath string
 }
 
-//GetCertificate return certificate of application
+// GetCertificate return certificate of application
 func (c *CACertManager) GetCertificate() ([]tls.Certificate, error) {
 	//cert expired
 	if time.Now().After(c.NoAfter) {
@@ -149,7 +149,7 @@ func (c *CACertManager) GetCertificate() ([]tls.Certificate, error) {
 	return c.Certs, nil
 }
 
-//GetRootCertificate return certificate of ca
+// GetRootCertificate return certificate of ca
 func (c *CACertManager) GetRootCertificate() (*x509.CertPool, error) {
 	//root expired
 	if time.Now().After(c.RootNoAfter) {

--- a/xds/credentials/certprovider/distributor.go
+++ b/xds/credentials/certprovider/distributor.go
@@ -38,11 +38,11 @@ import (
 //
 // Provider implementations which choose to use a Distributor should do the
 // following:
-// - create a new Distributor using the NewDistributor() function.
-// - invoke the Set() method whenever they have new key material or errors to
-//   report.
-// - delegate to the distributor when handing calls to KeyMaterial().
-// - invoke the Stop() method when they are done using the distributor.
+//   - create a new Distributor using the NewDistributor() function.
+//   - invoke the Set() method whenever they have new key material or errors to
+//     report.
+//   - delegate to the distributor when handing calls to KeyMaterial().
+//   - invoke the Stop() method when they are done using the distributor.
 type Distributor struct {
 	// mu protects the underlying key material.
 	mu   sync.Mutex

--- a/xds/credentials/token_provider.go
+++ b/xds/credentials/token_provider.go
@@ -22,7 +22,7 @@ import (
 	"io/ioutil"
 )
 
-//provide k8s service account
+// provide k8s service account
 type saTokenProvider struct {
 	Token     string
 	tokenPath string

--- a/xds/server/conn_wrapper.go
+++ b/xds/server/conn_wrapper.go
@@ -39,13 +39,13 @@ import (
 
 // connWrapper is a thin wrapper around a net.Conn returned by Accept(). It
 // provides the following additional functionality:
-// 1. A way to retrieve the configured deadline. This is required by the
-//    ServerHandshake() method of the xdsCredentials when it attempts to read
-//    key material from the certificate providers.
-// 2. Implements the XDSHandshakeInfo() method used by the xdsCredentials to
-//    retrieve the configured certificate providers.
-// 3. xDS filter_chain matching logic to select appropriate security
-//    configuration for the incoming connection.
+//  1. A way to retrieve the configured deadline. This is required by the
+//     ServerHandshake() method of the xdsCredentials when it attempts to read
+//     key material from the certificate providers.
+//  2. Implements the XDSHandshakeInfo() method used by the xdsCredentials to
+//     retrieve the configured certificate providers.
+//  3. xDS filter_chain matching logic to select appropriate security
+//     configuration for the incoming connection.
 type connWrapper struct {
 	net.Conn
 

--- a/xds/utils/balancergroup/balancergroup.go
+++ b/xds/utils/balancergroup/balancergroup.go
@@ -187,18 +187,18 @@ func (sbc *subBalancerWrapper) stopBalancer() {
 // sub-balancer manager by a high level balancer.
 //
 // Updates from ClientConn are forwarded to sub-balancers
-//  - service config update
-//  - address update
-//  - subConn state change
-//     - find the corresponding balancer and forward
+//   - service config update
+//   - address update
+//   - subConn state change
+//   - find the corresponding balancer and forward
 //
 // Actions from sub-balances are forwarded to parent ClientConn
-//  - new/remove SubConn
-//  - picker update and health states change
-//     - sub-pickers are sent to an aggregator provided by the parent, which
+//   - new/remove SubConn
+//   - picker update and health states change
+//   - sub-pickers are sent to an aggregator provided by the parent, which
 //     will group them into a group-picker. The aggregated connectivity state is
 //     also handled by the aggregator.
-//  - resolveNow
+//   - resolveNow
 //
 // Sub-balancers are only built when the balancer group is started. If the
 // balancer group is closed, the sub-balancers are also closed. And it's

--- a/xds/utils/grpclog/grpclog.go
+++ b/xds/utils/grpclog/grpclog.go
@@ -124,7 +124,7 @@ type LoggerV2 interface {
 // This is a copy of the DepthLoggerV2 defined in the external grpclog package.
 // It is defined here to avoid a circular dependency.
 //
-// Experimental
+// # Experimental
 //
 // Notice: This type is EXPERIMENTAL and may be changed or removed in a
 // later release.

--- a/xds/utils/grpcutil/method.go
+++ b/xds/utils/grpcutil/method.go
@@ -30,7 +30,6 @@ import (
 
 // ParseMethod splits service and method from the input. It expects format
 // "/service/method".
-//
 func ParseMethod(methodName string) (service, method string, _ error) {
 	if !strings.HasPrefix(methodName, "/") {
 		return "", "", errors.New("invalid method name: should start with /")

--- a/xds/utils/hierarchy/hierarchy.go
+++ b/xds/utils/hierarchy/hierarchy.go
@@ -75,26 +75,29 @@ func Set(addr resolver.Address, path []string) resolver.Address {
 //
 // Input:
 // [
-//   {addr0, path: [p0, wt0]}
-//   {addr1, path: [p0, wt1]}
-//   {addr2, path: [p1, wt2]}
-//   {addr3, path: [p1, wt3]}
+//
+//	{addr0, path: [p0, wt0]}
+//	{addr1, path: [p0, wt1]}
+//	{addr2, path: [p1, wt2]}
+//	{addr3, path: [p1, wt3]}
+//
 // ]
 //
 // Addresses will be split into p0/p1, and the p0/p1 will be removed from the
 // path.
 //
 // Output:
-// {
-//   p0: [
-//     {addr0, path: [wt0]},
-//     {addr1, path: [wt1]},
-//   ],
-//   p1: [
-//     {addr2, path: [wt2]},
-//     {addr3, path: [wt3]},
-//   ],
-// }
+//
+//	{
+//	  p0: [
+//	    {addr0, path: [wt0]},
+//	    {addr1, path: [wt1]},
+//	  ],
+//	  p1: [
+//	    {addr2, path: [wt2]},
+//	    {addr3, path: [wt3]},
+//	  ],
+//	}
 //
 // If hierarchical path is not set, or has no path in it, the address is
 // dropped.

--- a/xds/utils/serviceconfig/serviceconfig.go
+++ b/xds/utils/serviceconfig/serviceconfig.go
@@ -75,10 +75,10 @@ func (bc *BalancerConfig) MarshalJSON() ([]byte, error) {
 // ServiceConfig contains a list of loadBalancingConfigs, each with a name and
 // config. This method iterates through that list in order, and stops at the
 // first policy that is supported.
-// - If the config for the first supported policy is invalid, the whole service
-//   config is invalid.
-// - If the list doesn't contain any supported policy, the whole service config
-//   is invalid.
+//   - If the config for the first supported policy is invalid, the whole service
+//     config is invalid.
+//   - If the list doesn't contain any supported policy, the whole service config
+//     is invalid.
 func (bc *BalancerConfig) UnmarshalJSON(b []byte) error {
 	var ir intermediateBalancerConfig
 	err := json.Unmarshal(b, &ir)


### PR DESCRIPTION
This PR backports CI settings to the 3.0 branch, and formats the code by the 1.20 `gofmt`. Go formatter whose version is above 1.19 formats comments as well, see: https://go.dev/blog/go1.19.

Fixes: #2281

Signed-off-by: Xuewei Niu <justxuewei@apache.org>