### PR TITLE
Revert "Fix: 'must' is a modal verb, and the verb prototype should be added a…"

### DIFF
--- a/filter/metrics/filter.go
+++ b/filter/metrics/filter.go
@@ -31,7 +31,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/protocol"
 )
 
-// must initialize before using the filter and after loading configuration
+// must initialized before using the filter and after loading configuration
 var metricFilterInstance *Filter
 
 func init() {


### PR DESCRIPTION
Reverts apache/dubbo-go#2279