### PR TITLE
Ignore node not exist error message and continue retry

### DIFF
--- a/remoting/zookeeper/listener.go
+++ b/remoting/zookeeper/listener.go
@@ -343,7 +343,11 @@ func (l *ZkEventListener) listenDirEvent(conf *common.URL, zkRootPath string, li
 			if MaxFailTimes <= failTimes {
 				failTimes = MaxFailTimes
 			}
-			logger.Errorf("[Zookeeper EventListener][listenDirEvent] Get children of path {%s} with watcher failed, the error is %+v", zkRootPath, err)
+
+			err = perrors.Cause(err)
+			if !strings.Contains(err.Error(), "node does not exist") { // ignore if node not exist
+				logger.Errorf("[Zookeeper EventListener][listenDirEvent] Get children of path {%s} with watcher failed, the error is %+v", zkRootPath, err)
+			}
 			// Maybe the provider does not ready yet, sleep failTimes * ConnDelay senconds to wait
 			after := time.After(timeSecondDuration(failTimes * ConnDelay))
 			select {


### PR DESCRIPTION
When consumer starts before any provider is available, there're error messages that keep printing out on the Consumer side when subscribing/listening to the Zookeeper node.

```text
Get children of path /dubbo/xxxService/providers with watcher failed, the error is zk: node does not exist.
```