### PR TITLE
docs: Change the PATH of cli-v2 in README & RAEDME_CN

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Dubbo-go has supported many RPC protocols, like Triple, Dubbo, JSONRPC, gRPC, HT
 
   * [imports-formatter](https://github.com/dubbogo/tools/blob/master/cmd/imports-formatter/main.go) formatting dubbo-go project import code block.
   * [dubbo-go-cli](https://github.com/dubbogo/tools/blob/master/cmd/dubbogo-cli/main.go) dubbo-go command line tools, by which you can define your own request pkg and gets rsp struct of your server, test your service as telnet and generate hessian.POJO register method body.
-  * [dubbo-go-cli-v2](https://github.com/apache/dubbo-go/blob/master/dubbogo-cli/main.go) new dubbo-go line tools, you can get services from register center, create a demo , create application templates, one-click installation of protoc-gen-go-triple and imports-formatter tools,and has the same features with [dubbo-go-cli](https://github.com/dubbogo/tools/blob/master/cmd/dubbogo-cli/main.go).
+  * [dubbo-go-cli-v2](https://github.com/dubbogo/tools/blob/master/cmd/dubbogo-cli-v2/README_CN.md) new dubbo-go line tools, you can get services from register center, create a demo , create application templates, one-click installation of protoc-gen-go-triple and imports-formatter tools,and has the same features with [dubbo-go-cli](https://github.com/dubbogo/tools/blob/master/cmd/dubbogo-cli/main.go).
   * [protoc-gen-go-triple](https://github.com/dubbogo/tools/blob/master/cmd/protoc-gen-go-triple/main.go) tripe protocol pb file generation tool.
   * [protoc-gen-dubbo3grpc](https://github.com/dubbogo/tools/blob/master/cmd/protoc-gen-dubbo3grpc/main.go) dubbo3 grpc pb file generation tool.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -58,7 +58,7 @@ Dubbo-go 生态覆盖多种网络协议：Triple、Dubbo、JSONRPC、gRPC、HTTP
 
   * [imports-formatter](https://github.com/dubbogo/tools/blob/master/cmd/imports-formatter/main.go) dubbo-go 工程 import 代码块格式化工具
   * [dubbo-go-cli](https://github.com/dubbogo/tools/blob/master/cmd/dubbogo-cli/main.go) dubbo-go 命令行工具、支持展示服务、发起服务调用、定义 dubbogo 服务 struct 等功能、生成 hessian.POJO 方法体
-  * [dubbo-go-cli-v2](https://github.com/apache/dubbo-go/blob/master/dubbogo-cli/main.go) 新 dubbo-go 命令行工具, 支持创建 demo、创建应用模版、一键安装 protoc-gen-go-triple 及 imports-formatter 工具，从注册中心获取服务列表以及兼容 [dubbo-go-cli](https://github.com/dubbogo/tools/blob/master/cmd/dubbogo-cli/main.go) 的所有功能
+  * [dubbo-go-cli-v2](https://github.com/dubbogo/tools/blob/master/cmd/dubbogo-cli-v2/README_CN.md) 新 dubbo-go 命令行工具, 支持创建 demo、创建应用模版、一键安装 protoc-gen-go-triple 及 imports-formatter 工具，从注册中心获取服务列表以及兼容 [dubbo-go-cli](https://github.com/dubbogo/tools/blob/master/cmd/dubbogo-cli/main.go) 的所有功能
   * [protoc-gen-go-triple](https://github.com/dubbogo/tools/blob/master/cmd/protoc-gen-go-triple/main.go) tripe 协议 pb 生成工具
   * [protoc-gen-dubbo3grpc](https://github.com/dubbogo/tools/blob/master/cmd/protoc-gen-dubbo3grpc/main.go) dubbo3 grpc 生成工具
 


### PR DESCRIPTION
The link to cli-v2 in README is no longer valid. It has been updated to the latest path. 
Both the README and RAEDME_CN have been modified.