### PR TITLE
fix: The metadata invoker is destroyed too early

### DIFF
--- a/config/provider_config.go
+++ b/config/provider_config.go
@@ -164,19 +164,16 @@ func (c *ProviderConfig) Load() {
 				continue
 			}
 			// service doesn't config in config file, create one with default
-			logger.Warnf("Dubbogo can not find service with registeredTypeName %s in configuration. Use the default configuration instead.", registeredTypeName)
 			supportPBPackagerNameSerivce, ok := service.(common.TriplePBService)
-			serviceConfig = NewServiceConfigBuilder().Build()
 			if !ok {
-				logger.Errorf("Dubbogo do not read service interface name with registeredTypeName = %s."+
-					"Please run go install github.com/dubbogo/dubbogo-cli/cmd/protoc-gen-go-triple@latest to update your "+
-					"protoc-gen-go-triple and re-generate your pb file again."+
-					"If you are not using pb serialization, please set 'interface' field in service config.", registeredTypeName)
+				logger.Warnf(
+					"The provider service %s is ignored: neither the config is found, nor it is a valid Triple service.",
+					registeredTypeName)
 				continue
-			} else {
-				// use interface name defined by pb
-				serviceConfig.Interface = supportPBPackagerNameSerivce.XXX_InterfaceName()
 			}
+			serviceConfig = NewServiceConfigBuilder().Build()
+			// use interface name defined by pb
+			serviceConfig.Interface = supportPBPackagerNameSerivce.XXX_InterfaceName()
 			if err := serviceConfig.Init(rootConfig); err != nil {
 				logger.Errorf("Service with refKey = %s init failed with error = %s")
 			}

--- a/config/service.go
+++ b/config/service.go
@@ -19,10 +19,9 @@ package config
 
 import (
 	"sync"
-)
 
-import (
 	"dubbo.apache.org/dubbo-go/v3/common"
+	"github.com/dubbogo/gost/log/logger"
 )
 
 var (
@@ -38,7 +37,10 @@ var (
 func SetConsumerService(service common.RPCService) {
 	ref := common.GetReference(service)
 	conServicesLock.Lock()
-	defer conServicesLock.Unlock()
+	defer func() {
+		conServicesLock.Unlock()
+		logger.Debugf("A consumer service %s was registered successfully.", ref)
+	}()
 	conServices[ref] = service
 }
 
@@ -46,7 +48,10 @@ func SetConsumerService(service common.RPCService) {
 func SetProviderService(service common.RPCService) {
 	ref := common.GetReference(service)
 	proServicesLock.Lock()
-	defer proServicesLock.Unlock()
+	defer func() {
+		proServicesLock.Unlock()
+		logger.Debugf("A provider service %s was registered successfully.", ref)
+	}()
 	proServices[ref] = service
 }
 

--- a/metadata/service/local/service_proxy.go
+++ b/metadata/service/local/service_proxy.go
@@ -181,8 +181,6 @@ func (m *MetadataServiceProxy) GetMetadataInfo(revision string) (*common.Metadat
 		invocation.WithAttachments(map[string]interface{}{constant.AsyncKey: "false"}),
 		invocation.WithParameterValues([]reflect.Value{rV}))
 	res := m.invkr.Invoke(context.Background(), inv)
-	// when request finished, invoker will colse
-	defer m.invkr.Destroy()
 	if res.Error() != nil {
 		logger.Errorf("could not get the metadata info from remote provider: %v", res.Error())
 		return nil, res.Error()


### PR DESCRIPTION
The PR fixes the problem that the metadata invoker is destroyed too early.
Please refer to the issue for more details. Plus, this PR updates some logs
about registering services.

Fixes: #2321

Signed-off-by: Xuewei Niu <justxuewei@apache.org>
