### PR TITLE
fix: disable metrics filter by default instead

### DIFF
--- a/config/metric_config.go
+++ b/config/metric_config.go
@@ -31,7 +31,7 @@ import (
 type MetricConfig struct {
 	Mode               string `default:"pull" yaml:"mode" json:"mode,omitempty" property:"mode"` // push or pull,
 	Namespace          string `default:"dubbo" yaml:"namespace" json:"namespace,omitempty" property:"namespace"`
-	Enable             *bool  `default:"true" yaml:"enable" json:"enable,omitempty" property:"enable"`
+	Enable             *bool  `default:"false" yaml:"enable" json:"enable,omitempty" property:"enable"`
 	Port               string `default:"9090" yaml:"port" json:"port,omitempty" property:"port"`
 	Path               string `default:"/metrics" yaml:"path" json:"path,omitempty" property:"path"`
 	PushGatewayAddress string `default:"" yaml:"push-gateway-address" json:"push-gateway-address,omitempty" property:"push-gateway-address"`


### PR DESCRIPTION
Enable multiple dubbo go instances, the metrics function is enabled by default and the default port of the Prometheus server is 9000, which will cause port occupation problems. It is better to turn off the metrics function by default, and leave it to the user to decide whether to enable it and enable port configuration.

---

启用多个 dubbo go 实例，metrics 功能默认开启且 Prometheus server 默认端口为9000，会产生端口占用的问题。不如默认关闭 metrics 功能，是否启用以及启用端口配置交由用户来做决定。