### PR TITLE
refactor: make rt metric more performance and easy to use

### DIFF
--- a/common/host_util.go
+++ b/common/host_util.go
@@ -31,8 +31,10 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 )
 
-var localIp string
-var localHostname string
+var (
+	localIp       string
+	localHostname string
+)
 
 func GetLocalIp() string {
 	if len(localIp) != 0 {

--- a/common/host_util_test.go
+++ b/common/host_util_test.go
@@ -34,6 +34,10 @@ func TestGetLocalIp(t *testing.T) {
 	assert.NotNil(t, GetLocalIp())
 }
 
+func TestGetLocalHostName(t *testing.T) {
+	assert.NotNil(t, GetLocalHostName())
+}
+
 func TestHandleRegisterIPAndPort(t *testing.T) {
 	url := NewURLWithOptions(WithIp("1.2.3.4"), WithPort("20000"))
 	HandleRegisterIPAndPort(url)

--- a/metrics/api.go
+++ b/metrics/api.go
@@ -65,6 +65,7 @@ type MetricRegistry interface {
 	Gauge(*MetricId) GaugeMetric         // add or update a gauge
 	Histogram(*MetricId) ObservableMetric // add a metric num to a histogram
 	Summary(*MetricId) ObservableMetric     // add a metric num to a summary
+	Rt(*MetricId) ObservableMetric     // add a metric num to a rt
 	Export()                             // expose metric data， such as Prometheus http exporter
 	// GetMetrics() []*MetricSample // get all metric data
 	// GetMetricsString() (string, error) // get text format metric data
@@ -134,7 +135,7 @@ type GaugeMetric interface {
 }
 // histogram summary rt metric
 type ObservableMetric interface {
-	Record(float64)
+	Observe(float64)
 }
 
 // StatesMetrics multi metrics，include total,success num, fail num，call MetricsRegistry save data

--- a/metrics/api.go
+++ b/metrics/api.go
@@ -28,7 +28,7 @@ import (
 var (
 	registries = make(map[string]func(*ReporterConfig) MetricRegistry)
 	collectors = make([]CollectorFunc, 0)
-	registry MetricRegistry
+	registry   MetricRegistry
 )
 
 // CollectorFunc used to extend more indicators
@@ -61,12 +61,12 @@ func AddCollector(name string, fun func(MetricRegistry, *ReporterConfig)) {
 
 // MetricRegistry data container，data compute、expose、agg
 type MetricRegistry interface {
-	Counter(*MetricId) CounterMetric     // add or update a counter
-	Gauge(*MetricId) GaugeMetric         // add or update a gauge
+	Counter(*MetricId) CounterMetric      // add or update a counter
+	Gauge(*MetricId) GaugeMetric          // add or update a gauge
 	Histogram(*MetricId) ObservableMetric // add a metric num to a histogram
-	Summary(*MetricId) ObservableMetric     // add a metric num to a summary
-	Rt(*MetricId) ObservableMetric     // add a metric num to a rt
-	Export()                             // expose metric data， such as Prometheus http exporter
+	Summary(*MetricId) ObservableMetric   // add a metric num to a summary
+	Rt(*MetricId) ObservableMetric        // add a metric num to a rt
+	Export()                              // expose metric data， such as Prometheus http exporter
 	// GetMetrics() []*MetricSample // get all metric data
 	// GetMetricsString() (string, error) // get text format metric data
 }
@@ -133,6 +133,7 @@ type GaugeMetric interface {
 	// Add(float64)
 	// Sub(float64)
 }
+
 // histogram summary rt metric
 type ObservableMetric interface {
 	Observe(float64)

--- a/metrics/api.go
+++ b/metrics/api.go
@@ -61,14 +61,20 @@ func AddCollector(name string, fun func(MetricRegistry, *ReporterConfig)) {
 
 // MetricRegistry data container，data compute、expose、agg
 type MetricRegistry interface {
-	Counter(*MetricId) CounterMetric      // add or update a counter
-	Gauge(*MetricId) GaugeMetric          // add or update a gauge
-	Histogram(*MetricId) ObservableMetric // add a metric num to a histogram
-	Summary(*MetricId) ObservableMetric   // add a metric num to a summary
-	Rt(*MetricId) ObservableMetric        // add a metric num to a rt
-	Export()                              // expose metric data， such as Prometheus http exporter
+	Counter(*MetricId) CounterMetric        // add or update a counter
+	Gauge(*MetricId) GaugeMetric            // add or update a gauge
+	Histogram(*MetricId) ObservableMetric   // add a metric num to a histogram
+	Summary(*MetricId) ObservableMetric     // add a metric num to a summary
+	Rt(*MetricId, *RtOpts) ObservableMetric // add a metric num to a rt
+	Export()                                // expose metric data， such as Prometheus http exporter
 	// GetMetrics() []*MetricSample // get all metric data
 	// GetMetricsString() (string, error) // get text format metric data
+}
+
+type RtOpts struct {
+	Aggregate         bool
+	BucketNum         int   // only for aggRt
+	TimeWindowSeconds int64 // only for aggRt
 }
 
 // multi registry，like micrometer CompositeMeterRegistry

--- a/metrics/prometheus/registry.go
+++ b/metrics/prometheus/registry.go
@@ -39,16 +39,16 @@ func init() {
 }
 
 type promMetricRegistry struct {
-	r prom.Registerer // for convenience of testing
+	r    prom.Registerer // for convenience of testing
 	vecs sync.Map
 }
 
-func (p *promMetricRegistry) getOrComputeVec(key string, supplier func()interface{}) interface{} {
+func (p *promMetricRegistry) getOrComputeVec(key string, supplier func() interface{}) interface{} {
 	v, ok := p.vecs.Load(key)
 	if !ok {
 		v, ok = p.vecs.LoadOrStore(key, supplier())
 		if !ok {
-			p.r.MustRegister(v.(prom.Collector))// only registe collector which stored success
+			p.r.MustRegister(v.(prom.Collector)) // only registe collector which stored success
 		}
 	}
 	return v
@@ -97,9 +97,9 @@ func (p *promMetricRegistry) Summary(m *metrics.MetricId) metrics.ObservableMetr
 func (p *promMetricRegistry) Rt(m *metrics.MetricId) metrics.ObservableMetric {
 	vec := p.getOrComputeVec(m.Name, func() interface{} {
 		return NewRtVec(&RtOpts{
-			Name: m.Name,
-			Help: m.Desc,
-			bucketNum: 10, // TODO configurable
+			Name:              m.Name,
+			Help:              m.Desc,
+			bucketNum:         10,  // TODO configurable
 			timeWindowSeconds: 120, // TODO configurable
 		}, m.TagKeys())
 	}).(*RtVec)

--- a/metrics/prometheus/registry.go
+++ b/metrics/prometheus/registry.go
@@ -86,7 +86,7 @@ func (p *promMetricRegistry) Gauge(m *metrics.MetricId) metrics.GaugeMetric {
 	return &gauge{pg: g}
 }
 
-func (p *promMetricRegistry) Histogram(m *metrics.MetricId) metrics.HistogramMetric {
+func (p *promMetricRegistry) Histogram(m *metrics.MetricId) metrics.ObservableMetric {
 	p.mtx.RLock()
 	vec, ok := p.hvm[m.Name]
 	p.mtx.RUnlock()
@@ -103,7 +103,7 @@ func (p *promMetricRegistry) Histogram(m *metrics.MetricId) metrics.HistogramMet
 	return &histogram{ph: h.(prom.Histogram)}
 }
 
-func (p *promMetricRegistry) Summary(m *metrics.MetricId) metrics.SummaryMetric {
+func (p *promMetricRegistry) Summary(m *metrics.MetricId) metrics.ObservableMetric {
 	p.mtx.RLock()
 	vec, ok := p.svm[m.Name]
 	p.mtx.RUnlock()

--- a/metrics/prometheus/registry.go
+++ b/metrics/prometheus/registry.go
@@ -24,6 +24,7 @@ import (
 
 import (
 	prom "github.com/prometheus/client_golang/prometheus"
+
 	"github.com/prometheus/common/expfmt"
 )
 

--- a/metrics/prometheus/registry_test.go
+++ b/metrics/prometheus/registry_test.go
@@ -33,18 +33,17 @@ import (
 )
 
 var (
-	tags = map[string]string{"app": "dubbo", "version": "1.0.0"}
+	tags     = map[string]string{"app": "dubbo", "version": "1.0.0"}
 	metricId = &metrics.MetricId{Name: "dubbo_request", Desc: "request", Tags: tags}
 )
 
-
 func TestPromMetricRegistryCounter(t *testing.T) {
 	p := &promMetricRegistry{r: prom.NewRegistry()}
-	p.Counter(metricId).Inc();
+	p.Counter(metricId).Inc()
 	text, err := p.Scrape()
 	assert.Nil(t, err)
-	assert.Contains(t, text,"# HELP dubbo_request request\n# TYPE dubbo_request counter")
-	assert.Contains(t, text,`dubbo_request{app="dubbo",version="1.0.0"} 1`)
+	assert.Contains(t, text, "# HELP dubbo_request request\n# TYPE dubbo_request counter")
+	assert.Contains(t, text, `dubbo_request{app="dubbo",version="1.0.0"} 1`)
 }
 
 func TestPromMetricRegistryGauge(t *testing.T) {
@@ -80,7 +79,7 @@ func TestPromMetricRegistrySummary(t *testing.T) {
 
 func TestPromMetricRegistryRt(t *testing.T) {
 	p := &promMetricRegistry{r: prom.NewRegistry()}
-	for i := 0; i < 10;i++ {
+	for i := 0; i < 10; i++ {
 		p.Rt(metricId).Observe(10 * float64(i))
 	}
 	text, err := p.Scrape()
@@ -98,13 +97,13 @@ func TestPromMetricRegistryCounterConcurrent(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func() {
-			p.Counter(metricId).Inc();	
+			p.Counter(metricId).Inc()
 			wg.Done()
 		}()
 	}
 	wg.Wait()
 	text, err := p.Scrape()
 	assert.Nil(t, err)
-	assert.Contains(t, text,"# HELP dubbo_request request\n# TYPE dubbo_request counter")
-	assert.Contains(t, text,`dubbo_request{app="dubbo",version="1.0.0"} 10`)
+	assert.Contains(t, text, "# HELP dubbo_request request\n# TYPE dubbo_request counter")
+	assert.Contains(t, text, `dubbo_request{app="dubbo",version="1.0.0"} 10`)
 }

--- a/metrics/prometheus/registry_test.go
+++ b/metrics/prometheus/registry_test.go
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus
+
+import (
+	"sync"
+	"testing"
+
+	"dubbo.apache.org/dubbo-go/v3/metrics"
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	tags = map[string]string{"app": "dubbo", "version": "1.0.0"}
+	metricId = &metrics.MetricId{Name: "dubbo_request", Desc: "request", Tags: tags}
+)
+
+
+func TestPromMetricRegistryCounter(t *testing.T) {
+	p := &promMetricRegistry{r: prom.NewRegistry()}
+	p.Counter(metricId).Inc();
+	text, err := p.Scrape()
+	assert.Nil(t, err)
+	assert.Contains(t, text,"# HELP dubbo_request request\n# TYPE dubbo_request counter")
+	assert.Contains(t, text,`dubbo_request{app="dubbo",version="1.0.0"} 1`)
+}
+
+func TestPromMetricRegistryGauge(t *testing.T) {
+	p := &promMetricRegistry{r: prom.NewRegistry()}
+	p.Gauge(metricId).Set(100)
+	text, err := p.Scrape()
+	assert.Nil(t, err)
+	assert.Contains(t, text, "# HELP dubbo_request request\n# TYPE dubbo_request gauge")
+	assert.Contains(t, text, `dubbo_request{app="dubbo",version="1.0.0"} 100`)
+
+}
+
+func TestPromMetricRegistryHistogram(t *testing.T) {
+	p := &promMetricRegistry{r: prom.NewRegistry()}
+	p.Histogram(metricId).Observe(100)
+	text, err := p.Scrape()
+	assert.Nil(t, err)
+	assert.Contains(t, text, "# HELP dubbo_request request\n# TYPE dubbo_request histogram")
+	assert.Contains(t, text, `dubbo_request_bucket{app="dubbo",version="1.0.0",le="+Inf"} 1`)
+	assert.Contains(t, text, `dubbo_request_sum{app="dubbo",version="1.0.0"} 100`)
+	assert.Contains(t, text, `dubbo_request_count{app="dubbo",version="1.0.0"} 1`)
+}
+
+func TestPromMetricRegistrySummary(t *testing.T) {
+	p := &promMetricRegistry{r: prom.NewRegistry()}
+	p.Summary(metricId).Observe(100)
+	text, err := p.Scrape()
+	assert.Nil(t, err)
+	assert.Contains(t, text, "# HELP dubbo_request request\n# TYPE dubbo_request summary")
+	assert.Contains(t, text, "dubbo_request_sum{app=\"dubbo\",version=\"1.0.0\"} 100")
+	assert.Contains(t, text, "dubbo_request_count{app=\"dubbo\",version=\"1.0.0\"} 1")
+}
+
+func TestPromMetricRegistryRt(t *testing.T) {
+	p := &promMetricRegistry{r: prom.NewRegistry()}
+	for i := 0; i < 10;i++ {
+		p.Rt(metricId).Observe(10 * float64(i))
+	}
+	text, err := p.Scrape()
+	assert.Nil(t, err)
+	assert.Contains(t, text, "# HELP dubbo_request_avg Average request\n# TYPE dubbo_request_avg gauge\ndubbo_request_avg{app=\"dubbo\",version=\"1.0.0\"} 45")
+	assert.Contains(t, text, "# HELP dubbo_request_last Last request\n# TYPE dubbo_request_last gauge\ndubbo_request_last{app=\"dubbo\",version=\"1.0.0\"} 90")
+	assert.Contains(t, text, "# HELP dubbo_request_max Max request\n# TYPE dubbo_request_max gauge\ndubbo_request_max{app=\"dubbo\",version=\"1.0.0\"} 90")
+	assert.Contains(t, text, "# HELP dubbo_request_min Min request\n# TYPE dubbo_request_min gauge\ndubbo_request_min{app=\"dubbo\",version=\"1.0.0\"} 0")
+	assert.Contains(t, text, "# HELP dubbo_request_sum Sum request\n# TYPE dubbo_request_sum gauge\ndubbo_request_sum{app=\"dubbo\",version=\"1.0.0\"} 450")
+}
+
+func TestPromMetricRegistryCounterConcurrent(t *testing.T) {
+	p := &promMetricRegistry{r: prom.NewRegistry()}
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			p.Counter(metricId).Inc();	
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	text, err := p.Scrape()
+	assert.Nil(t, err)
+	assert.Contains(t, text,"# HELP dubbo_request request\n# TYPE dubbo_request counter")
+	assert.Contains(t, text,`dubbo_request{app="dubbo",version="1.0.0"} 10`)
+}

--- a/metrics/prometheus/registry_test.go
+++ b/metrics/prometheus/registry_test.go
@@ -20,10 +20,16 @@ package prometheus
 import (
 	"sync"
 	"testing"
+)
 
-	"dubbo.apache.org/dubbo-go/v3/metrics"
+import (
 	prom "github.com/prometheus/client_golang/prometheus"
+
 	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/metrics"
 )
 
 var (

--- a/metrics/prometheus/reporter.go
+++ b/metrics/prometheus/reporter.go
@@ -26,6 +26,7 @@ import (
 
 import (
 	"github.com/dubbogo/gost/log/logger"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )

--- a/metrics/prometheus/rt_vec.go
+++ b/metrics/prometheus/rt_vec.go
@@ -19,9 +19,14 @@ package prometheus
 
 import (
 	"sync"
+)
 
-	"dubbo.apache.org/dubbo-go/v3/metrics/util/aggregate"
+import (
 	prom "github.com/prometheus/client_golang/prometheus"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/metrics/util/aggregate"
 )
 
 type rtMetric struct {

--- a/metrics/prometheus/rt_vec.go
+++ b/metrics/prometheus/rt_vec.go
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus
+
+import (
+	"sync"
+
+	"dubbo.apache.org/dubbo-go/v3/metrics/util/aggregate"
+	prom "github.com/prometheus/client_golang/prometheus"
+)
+
+type rtMetric struct {
+	nameSuffix string
+	helpPrefix string
+	valueFunc  func(*aggregate.Result) float64
+}
+
+func (m *rtMetric) desc(opts *RtOpts, labels []string) *prom.Desc {
+	return prom.NewDesc(prom.BuildFQName(opts.Namespace, opts.Subsystem, opts.Name+m.nameSuffix), m.helpPrefix+opts.Help, labels, opts.ConstLabels)
+}
+
+var rtMetrics = make([]*rtMetric, 5)
+
+func init() {
+	rtMetrics[0] = &rtMetric{nameSuffix: "_sum", helpPrefix: "Sum ", valueFunc: func(r *aggregate.Result) float64 { return r.Total }}
+	rtMetrics[1] = &rtMetric{nameSuffix: "_last", helpPrefix: "Last ", valueFunc: func(r *aggregate.Result) float64 { return r.Last }}
+	rtMetrics[2] = &rtMetric{nameSuffix: "_min", helpPrefix: "Min ", valueFunc: func(r *aggregate.Result) float64 { return r.Min }}
+	rtMetrics[3] = &rtMetric{nameSuffix: "_max", helpPrefix: "Max ", valueFunc: func(r *aggregate.Result) float64 { return r.Max }}
+	rtMetrics[4] = &rtMetric{nameSuffix: "_avg", helpPrefix: "Average ", valueFunc: func(r *aggregate.Result) float64 { return r.Avg }}
+}
+
+type RtOpts struct {
+	Namespace         string
+	Subsystem         string
+	Name              string
+	Help              string
+	ConstLabels       prom.Labels
+	bucketNum         int
+	timeWindowSeconds int64
+}
+
+type valueAgg struct {
+	tags map[string]string
+	agg  *aggregate.TimeWindowAggregator
+}
+
+func (v *valueAgg) Observe(val float64) {
+	v.agg.Add(val)
+}
+
+func buildKey(m map[string]string, labNames []string) string {
+	var k string
+	for _, label := range labNames {
+		if len(k) == 0 {
+			k += m[label]
+		} else {
+			k += "_" + m[label]
+		}
+	}
+	return k
+}
+
+func buildLabelValues(m map[string]string, labNames []string) []string {
+	values := make([]string, len(m))
+	for i, label := range labNames {
+		values[i] = m[label]
+	}
+	return values
+}
+
+type RtVec struct {
+	opts       *RtOpts
+	labelNames []string
+	aggMap     sync.Map
+}
+
+func NewRtVec(opts *RtOpts, labNames []string) *RtVec {
+	return &RtVec{
+		opts:       opts,
+		labelNames: labNames,
+	}
+}
+
+func (r *RtVec) With(tags map[string]string) prom.Observer {
+	k := buildKey(tags, r.labelNames)
+	return r.computeIfAbsent(k, func() *valueAgg {
+		return &valueAgg{
+			tags: tags,
+			agg:  aggregate.NewTimeWindowAggregator(r.opts.bucketNum, r.opts.timeWindowSeconds),
+		}
+	})
+}
+
+func (r *RtVec) computeIfAbsent(k string, supplier func() *valueAgg) *valueAgg {
+	v, ok := r.aggMap.Load(k)
+	if !ok {
+		v, _ = r.aggMap.LoadOrStore(k, supplier())
+	}
+	return v.(*valueAgg)
+}
+
+func (r *RtVec) Collect(ch chan<- prom.Metric) {
+	r.aggMap.Range(func(key, val interface{}) bool {
+		v := val.(*valueAgg)
+		res := v.agg.Result()
+		for _, m := range rtMetrics {
+			ch <- prom.MustNewConstMetric(m.desc(r.opts, r.labelNames), prom.GaugeValue, m.valueFunc(res), buildLabelValues(v.tags, r.labelNames)...)
+		}
+		return true
+	})
+}
+
+func (r *RtVec) Describe(ch chan<- *prom.Desc) {
+	for _, m := range rtMetrics {
+		ch <- m.desc(r.opts, r.labelNames)
+	}
+}

--- a/metrics/prometheus/rt_vec.go
+++ b/metrics/prometheus/rt_vec.go
@@ -18,6 +18,7 @@
 package prometheus
 
 import (
+	"bytes"
 	"sync"
 )
 
@@ -69,19 +70,18 @@ func (v *valueAgg) Observe(val float64) {
 }
 
 func buildKey(m map[string]string, labNames []string) string {
-	var k string
+	var buffer bytes.Buffer
 	for _, label := range labNames {
-		if len(k) == 0 {
-			k += m[label]
-		} else {
-			k += "_" + m[label]
+		if buffer.Len() != 0 {
+			buffer.WriteString("_")
 		}
+		buffer.WriteString(m[label])
 	}
-	return k
+	return buffer.String()
 }
 
 func buildLabelValues(m map[string]string, labNames []string) []string {
-	values := make([]string, len(m))
+	values := make([]string, len(labNames))
 	for i, label := range labNames {
 		values[i] = m[label]
 	}

--- a/metrics/prometheus/rt_vec_test.go
+++ b/metrics/prometheus/rt_vec_test.go
@@ -21,10 +21,16 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+)
 
-	"dubbo.apache.org/dubbo-go/v3/metrics/util/aggregate"
+import (
 	prom "github.com/prometheus/client_golang/prometheus"
+
 	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/metrics/util/aggregate"
 )
 
 func TestRtVecCollect(t *testing.T) {

--- a/metrics/prometheus/rt_vec_test.go
+++ b/metrics/prometheus/rt_vec_test.go
@@ -122,7 +122,9 @@ func TestRtVecWith(t *testing.T) {
 		labelNames: []string{"app", "version"},
 	}
 	labels := map[string]string{"app": "dubbo", "version": "1.0.0"}
-	assert.True(t, r.With(labels) == r.With(labels)) // init once
+	first := r.With(labels)
+	second := r.With(labels)
+	assert.True(t, first == second) // init once
 }
 
 func TestRtVecWithConcurrent(t *testing.T) {

--- a/metrics/prometheus/rt_vec_test.go
+++ b/metrics/prometheus/rt_vec_test.go
@@ -109,7 +109,7 @@ func TestValueObserve(t *testing.T) {
 		Max:   1,
 		Count: 1,
 		Total: 1,
-		Last: 1,
+		Last:  1,
 	}
 	for i, v := range rts {
 		v.Observe(float64(1))

--- a/metrics/prometheus/rt_vec_test.go
+++ b/metrics/prometheus/rt_vec_test.go
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package prometheus
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"dubbo.apache.org/dubbo-go/v3/metrics/util/aggregate"
+	prom "github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRtVecCollect(t *testing.T) {
+	r := &RtVec{
+		opts: &RtOpts{
+			Name:              "request_num",
+			bucketNum:         10,
+			timeWindowSeconds: 120,
+			Help:              "Request cost",
+		},
+		labelNames: []string{"app", "version"},
+	}
+	labels := map[string]string{"app": "dubbo", "version": "1.0.0"}
+	r.With(labels).Observe(100)
+	ch := make(chan prom.Metric, len(rtMetrics))
+	r.Collect(ch)
+	close(ch)
+	assert.Equal(t, len(ch), len(rtMetrics))
+	for _, m := range rtMetrics {
+		metric, ok := <-ch
+		if !ok {
+			t.Error("not enough metrics")
+		} else {
+			str := metric.Desc().String()
+			assert.Contains(t, str, m.nameSuffix)
+			assert.Contains(t, str, m.helpPrefix)
+			assert.Contains(t, str, "app")
+			assert.Contains(t, str, "version")
+		}
+	}
+}
+
+func TestRtVecDescribe(t *testing.T) {
+	r := &RtVec{
+		opts: &RtOpts{
+			Name:              "request_num",
+			bucketNum:         10,
+			timeWindowSeconds: 120,
+			Help:              "Request cost",
+		},
+		labelNames: []string{"app", "version"},
+	}
+	ch := make(chan *prom.Desc, len(rtMetrics))
+	r.Describe(ch)
+	close(ch)
+	assert.Equal(t, len(ch), len(rtMetrics))
+	for _, m := range rtMetrics {
+		desc, ok := <-ch
+		if !ok {
+			t.Error(t, "not enough desc")
+		} else {
+			str := desc.String()
+			assert.Contains(t, str, m.nameSuffix)
+			assert.Contains(t, str, m.helpPrefix)
+			assert.Contains(t, str, "app")
+			assert.Contains(t, str, "version")
+		}
+	}
+}
+
+func TestValueAggObserve(t *testing.T) {
+	v := &valueAgg{
+		tags: map[string]string{},
+		agg:  aggregate.NewTimeWindowAggregator(10, 10),
+	}
+	v.Observe(float64(1))
+	r := v.agg.Result()
+	want := &aggregate.Result{
+		Avg:   1,
+		Min:   1,
+		Max:   1,
+		Count: 1,
+		Total: 1,
+		Last:  1,
+	}
+	if !reflect.DeepEqual(r, want) {
+		t.Errorf("Result() = %v, want %v", r, want)
+	}
+}
+
+func TestRtVecWith(t *testing.T) {
+	r := &RtVec{
+		opts: &RtOpts{
+			Name:              "request_num",
+			bucketNum:         10,
+			timeWindowSeconds: 120,
+			Help:              "Request cost",
+		},
+		labelNames: []string{"app", "version"},
+	}
+	labels := map[string]string{"app": "dubbo", "version": "1.0.0"}
+	assert.True(t, r.With(labels) == r.With(labels)) // init once
+}
+
+func TestRtVecWithConcurrent(t *testing.T) {
+	r := &RtVec{
+		opts: &RtOpts{
+			Name:              "request_num",
+			bucketNum:         10,
+			timeWindowSeconds: 120,
+			Help:              "Request cost",
+		},
+		labelNames: []string{"app", "version"},
+	}
+	labels := map[string]string{"app": "dubbo", "version": "1.0.0"}
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			r.With(labels).Observe(100)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	res := r.With(labels).(*valueAgg).agg.Result()
+	assert.True(t, res.Count == uint64(10))
+}

--- a/metrics/prometheus/util.go
+++ b/metrics/prometheus/util.go
@@ -24,6 +24,7 @@ import (
 
 import (
 	"github.com/dubbogo/gost/log/logger"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/metrics/registry/collector.go
+++ b/metrics/registry/collector.go
@@ -101,7 +101,7 @@ func (rc *registryCollector) notifyHandler(event *RegistryMetricsEvent) {
 	// Event is converted to metrics
 	// Save metrics to the MetricRegistry
 	rc.regRegistry.Counter(metrics.NewMetricId(NotifyMetricRequests, metrics.GetApplicationLevel())).Inc()
-	rc.regRegistry.Histogram(metrics.NewMetricId(NotifyMetricNumLast, metrics.GetApplicationLevel())).Record(float64(event.End.UnixNano()) / float64(time.Second))
+	rc.regRegistry.Histogram(metrics.NewMetricId(NotifyMetricNumLast, metrics.GetApplicationLevel())).Observe(float64(event.End.UnixNano()) / float64(time.Second))
 	metric := metrics.ComputeIfAbsentCache(dubboNotifyRt, func() interface{} {
 		return newTimeMetrics(NotifyRtMillisecondsMin, NotifyRtMillisecondsMax, NotifyRtMillisecondsAvg, NotifyRtMillisecondsSum, NotifyRtMillisecondsLast, metrics.GetApplicationLevel(), rc.regRegistry)
 	}).(metrics.TimeMetric)

--- a/metrics/util/aggregate/aggregator.go
+++ b/metrics/util/aggregate/aggregator.go
@@ -50,8 +50,8 @@ type Result struct {
 
 func NewResult() *Result {
 	return &Result{
-		Min: math.MaxFloat64,
-		Max: math.SmallestNonzeroFloat64,
+		Min:  math.MaxFloat64,
+		Max:  math.SmallestNonzeroFloat64,
 		Last: math.NaN(),
 	}
 }

--- a/metrics/util/aggregate/aggregator_test.go
+++ b/metrics/util/aggregate/aggregator_test.go
@@ -42,6 +42,7 @@ func TestTimeWindowAggregatorAddAndResult(t *testing.T) {
 				Max:   30,
 				Avg:   20,
 				Count: 3,
+				Last: 30,
 			},
 		},
 	}

--- a/metrics/util/aggregate/aggregator_test.go
+++ b/metrics/util/aggregate/aggregator_test.go
@@ -42,14 +42,15 @@ func TestTimeWindowAggregatorAddAndResult(t *testing.T) {
 				Max:   30,
 				Avg:   20,
 				Count: 3,
-				Last:  30,
 			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := timeWindowAggregator.Result(); !reflect.DeepEqual(got, tt.want) {
+			got := timeWindowAggregator.Result()
+			got.Last = 0 // NaN can not equal
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Result() = %v, want %v", got, tt.want)
 			}
 		})

--- a/metrics/util/aggregate/aggregator_test.go
+++ b/metrics/util/aggregate/aggregator_test.go
@@ -42,7 +42,7 @@ func TestTimeWindowAggregatorAddAndResult(t *testing.T) {
 				Max:   30,
 				Avg:   20,
 				Count: 3,
-				Last: 30,
+				Last:  30,
 			},
 		},
 	}


### PR DESCRIPTION
1. optimize rt calculation time
  The current implementation rt will be calculated every time the sample data is added, which is performance-intensive and unnecessary. 
  new implementation will only be calculated when Prometheus pulls data

2. add more unit tests for metrics
3. add Rt interface to `MetricRegisrty` simplfy  rt processing

  for example:
  ```go
  var MetricRegisrty registry
  registry.Rt(&MetricId{Name:"dubbo_request_rt", Desc: "Request RT"}).Observe(100)

  // next time also call it in this way, no need to manually cache it
  registry.Rt(&MetricId{Name:"dubbo_request_rt", Desc: "Request RT"}).Observe(100)
  ```
  it will produce 5 metrics in prometheus:
  ```plain
  # HELP dubbo_request_rt_avg Average request RT
  # TYPE dubbo_request_rt_avg gauge
  dubbo_request_rt_avg{app="dubbo",version="1.0.0"} 45
  # HELP dubbo_request_rt_last Last request RT
  # TYPE dubbo_request_rt_last gauge
  dubbo_request_rt_last{app="dubbo",version="1.0.0"} 90
  # HELP dubbo_request_rt_max Max request RT
  # TYPE dubbo_request_rt_max gauge
  dubbo_request_rt_max{app="dubbo",version="1.0.0"} 90
  # HELP dubbo_request_rt_min Min request RT
  # TYPE dubbo_request_rt_min gauge
  dubbo_request_rt_min{app="dubbo",version="1.0.0"} 0
  # HELP dubbo_request_rt_sum Sum request RT
  # TYPE dubbo_request_rt_sum gauge
  dubbo_request_rt_sum{app="dubbo",version="1.0.0"} 450
  ```
