### PR TITLE
fix(config): Random ports can't be assgined

### DIFF
--- a/config/service_config.go
+++ b/config/service_config.go
@@ -209,7 +209,12 @@ func (s *ServiceConfig) IsExport() bool {
 func getRandomPort(protocolConfigs []*ProtocolConfig) *list.List {
 	ports := list.New()
 	for _, proto := range protocolConfigs {
-		if len(proto.Port) > 0 {
+		if port, err := strconv.Atoi(proto.Port); err != nil {
+			logger.Infof(
+				"%s will be assgined to a random port, since the port is an invalid number",
+				proto.Name,
+			)
+		} else if port > 0 {
 			continue
 		}
 


### PR DESCRIPTION
The condition of assigning a random port for protocols should be that port
is less than or equal to 0, not the length of the port string.

Fixes: #2382