### PR TITLE
refactor: migrate old RT metric impl to new RT impl

### DIFF
--- a/metrics/common.go
+++ b/metrics/common.go
@@ -66,7 +66,7 @@ func (m *ApplicationMetricLevel) Tags() map[string]string {
 	tags := make(map[string]string)
 	tags[constant.IpKey] = m.Ip
 	tags[constant.HostnameKey] = m.HostName
-	tags[constant.ApplicationKey] = m.ApplicationName
+	tags[constant.ApplicationNameKey] = m.ApplicationName
 	tags[constant.ApplicationVersionKey] = m.Version
 	tags[constant.GitCommitIdKey] = m.GitCommitId
 	return tags

--- a/metrics/metadata/collector.go
+++ b/metrics/metadata/collector.go
@@ -32,13 +32,13 @@ var ch = make(chan metrics.MetricsEvent, 10)
 
 func init() {
 	metrics.AddCollector("metadata", func(mr metrics.MetricRegistry, rc *metrics.ReporterConfig) {
-		l := &MetadataMetricCollector{r: mr}
+		l := &MetadataMetricCollector{metrics.BaseCollector{R: mr}}
 		l.start()
 	})
 }
 
 type MetadataMetricCollector struct {
-	r metrics.MetricRegistry
+	metrics.BaseCollector
 }
 
 func (c *MetadataMetricCollector) start() {
@@ -63,59 +63,26 @@ func (c *MetadataMetricCollector) start() {
 }
 
 func (c *MetadataMetricCollector) handleMetadataPush(event *MetadataMetricEvent) {
-	m := metrics.ComputeIfAbsentCache(dubboMetadataPush, func() interface{} {
-		return newStatesMetricFunc(metadataPushNum, metadataPushNumSucceed, metadataPushNumFailed, metrics.GetApplicationLevel(), c.r)
-	}).(metrics.StatesMetrics)
-	m.Inc(event.Succ)
-	metric := metrics.ComputeIfAbsentCache(dubboPushRt, func() interface{} {
-		return newTimeMetrics(pushRtMin, pushRtMax, pushRtAvg, pushRtSum, pushRtLast, metrics.GetApplicationLevel(), c.r)
-	}).(metrics.TimeMetric)
-	metric.Record(event.CostMs())
+	level := metrics.GetApplicationLevel()
+	c.StateCount(metadataPushNum, metadataPushSucceed, metadataPushFailed, level, event.Succ)
+	c.R.Rt(metrics.NewMetricId(pushRt, level), &metrics.RtOpts{}).Observe(event.CostMs())
 }
 
 func (c *MetadataMetricCollector) handleMetadataSub(event *MetadataMetricEvent) {
-	m := metrics.ComputeIfAbsentCache(dubboMetadataSubscribe, func() interface{} {
-		return newStatesMetricFunc(metadataSubNum, metadataSubNumSucceed, metadataSubNumFailed, metrics.GetApplicationLevel(), c.r)
-	}).(metrics.StatesMetrics)
-	m.Inc(event.Succ)
-	metric := metrics.ComputeIfAbsentCache(dubboSubscribeRt, func() interface{} {
-		return newTimeMetrics(subscribeRtMin, subscribeRtMax, subscribeRtAvg, subscribeRtSum, subscribeRtLast, metrics.GetApplicationLevel(), c.r)
-	}).(metrics.TimeMetric)
-	metric.Record(event.CostMs())
+	level := metrics.GetApplicationLevel()
+	c.StateCount(metadataSubNum, metadataSubSucceed, metadataSubFailed, level, event.Succ)
+	c.R.Rt(metrics.NewMetricId(subscribeRt, level), &metrics.RtOpts{}).Observe(event.CostMs())
 }
 
 func (c *MetadataMetricCollector) handleStoreProvider(event *MetadataMetricEvent) {
-	interfaceName := event.Attachment[constant.InterfaceKey]
-	m := metrics.ComputeIfAbsentCache(dubboMetadataStoreProvider+":"+interfaceName, func() interface{} {
-		return newStatesMetricFunc(metadataStoreProvider, metadataStoreProviderSucceed, metadataStoreProviderFailed,
-			metrics.NewServiceMetric(interfaceName), c.r)
-	}).(metrics.StatesMetrics)
-	m.Inc(event.Succ)
-	metric := metrics.ComputeIfAbsentCache(dubboStoreProviderInterfaceRt+":"+interfaceName, func() interface{} {
-		return newTimeMetrics(storeProviderInterfaceRtMin, storeProviderInterfaceRtMax, storeProviderInterfaceRtAvg,
-			storeProviderInterfaceRtSum, storeProviderInterfaceRtLast, metrics.NewServiceMetric(interfaceName), c.r)
-	}).(metrics.TimeMetric)
-	metric.Record(event.CostMs())
+	level := metrics.NewServiceMetric(event.Attachment[constant.InterfaceKey])
+	c.StateCount(metadataStoreProviderNum, metadataStoreProviderSucceed, metadataStoreProviderFailed, level, event.Succ)
+	c.R.Rt(metrics.NewMetricId(storeProviderInterfaceRt, level), &metrics.RtOpts{}).Observe(event.CostMs())
 }
 
 func (c *MetadataMetricCollector) handleSubscribeService(event *MetadataMetricEvent) {
-	interfaceName := event.Attachment[constant.InterfaceKey]
-	metric := metrics.ComputeIfAbsentCache(dubboSubscribeServiceRt+":"+interfaceName, func() interface{} {
-		return newTimeMetrics(subscribeServiceRtMin, subscribeServiceRtMax, subscribeServiceRtAvg, subscribeServiceRtSum,
-			subscribeServiceRtLast, metrics.NewServiceMetric(interfaceName), c.r)
-	}).(metrics.TimeMetric)
-	metric.Record(event.CostMs())
-}
-
-func newStatesMetricFunc(total *metrics.MetricKey, succ *metrics.MetricKey, fail *metrics.MetricKey,
-	level metrics.MetricLevel, reg metrics.MetricRegistry) metrics.StatesMetrics {
-	return metrics.NewStatesMetrics(metrics.NewMetricId(total, level), metrics.NewMetricId(succ, level),
-		metrics.NewMetricId(fail, level), reg)
-}
-
-func newTimeMetrics(min, max, avg, sum, last *metrics.MetricKey, level metrics.MetricLevel, mr metrics.MetricRegistry) metrics.TimeMetric {
-	return metrics.NewTimeMetric(metrics.NewMetricId(min, level), metrics.NewMetricId(max, level), metrics.NewMetricId(avg, level),
-		metrics.NewMetricId(sum, level), metrics.NewMetricId(last, level), mr)
+	level := metrics.NewServiceMetric(event.Attachment[constant.InterfaceKey])
+	c.R.Rt(metrics.NewMetricId(subscribeServiceRt, level), &metrics.RtOpts{}).Observe(event.CostMs())
 }
 
 type MetadataMetricEvent struct {

--- a/metrics/metadata/metric_set.go
+++ b/metrics/metadata/metric_set.go
@@ -47,34 +47,21 @@ const (
 	totalSuffix  = "_total"
 	succSuffix   = "_succeed_total"
 	failedSuffix = "_failed_total"
-	sumSuffix    = "_sum"
-	lastSuffix   = "_last"
-	minSuffix    = "_min"
-	maxSuffix    = "_max"
-	avgSuffix    = "_avg"
 )
 
 var (
 	// app level
-	metadataPushNum        = metrics.NewMetricKey(dubboMetadataPush+totalSuffix, "Total Num")
-	metadataPushNumSucceed = metrics.NewMetricKey(dubboMetadataPush+succSuffix, "Succeed Push Num")
-	metadataPushNumFailed  = metrics.NewMetricKey(dubboMetadataPush+failedSuffix, "Failed Push Num")
+	metadataPushNum     = metrics.NewMetricKey(dubboMetadataPush+totalSuffix, "Total Num")
+	metadataPushSucceed = metrics.NewMetricKey(dubboMetadataPush+succSuffix, "Succeed Push Num")
+	metadataPushFailed  = metrics.NewMetricKey(dubboMetadataPush+failedSuffix, "Failed Push Num")
 	// app level
-	metadataSubNum        = metrics.NewMetricKey(dubboMetadataSubscribe+totalSuffix, "Total Metadata Subscribe Num")
-	metadataSubNumSucceed = metrics.NewMetricKey(dubboMetadataSubscribe+succSuffix, "Succeed Metadata Subscribe Num")
-	metadataSubNumFailed  = metrics.NewMetricKey(dubboMetadataSubscribe+failedSuffix, "Failed Metadata Subscribe Num")
+	metadataSubNum     = metrics.NewMetricKey(dubboMetadataSubscribe+totalSuffix, "Total Metadata Subscribe Num")
+	metadataSubSucceed = metrics.NewMetricKey(dubboMetadataSubscribe+succSuffix, "Succeed Metadata Subscribe Num")
+	metadataSubFailed  = metrics.NewMetricKey(dubboMetadataSubscribe+failedSuffix, "Failed Metadata Subscribe Num")
 	// app level
-	pushRtSum  = metrics.NewMetricKey(dubboPushRt+sumSuffix, "Sum Response Time")
-	pushRtLast = metrics.NewMetricKey(dubboPushRt+lastSuffix, "Last Response Time")
-	pushRtMin  = metrics.NewMetricKey(dubboPushRt+minSuffix, "Min Response Time")
-	pushRtMax  = metrics.NewMetricKey(dubboPushRt+maxSuffix, "Max Response Time")
-	pushRtAvg  = metrics.NewMetricKey(dubboPushRt+avgSuffix, "Average Response Time")
+	pushRt = metrics.NewMetricKey(dubboPushRt, "Response Time")
 	// app level
-	subscribeRtSum  = metrics.NewMetricKey(dubboSubscribeRt+sumSuffix, "Sum Response Time")
-	subscribeRtLast = metrics.NewMetricKey(dubboSubscribeRt+lastSuffix, "Last Response Time")
-	subscribeRtMin  = metrics.NewMetricKey(dubboSubscribeRt+minSuffix, "Min Response Time")
-	subscribeRtMax  = metrics.NewMetricKey(dubboSubscribeRt+maxSuffix, "Max Response Time")
-	subscribeRtAvg  = metrics.NewMetricKey(dubboSubscribeRt+avgSuffix, "Average Response Time")
+	subscribeRt = metrics.NewMetricKey(dubboSubscribeRt, "Response Time")
 
 	/*
 	   # HELP dubbo_metadata_store_provider_succeed_total Succeed Store Provider Metadata
@@ -85,7 +72,7 @@ var (
 	// service level
 	metadataStoreProviderFailed  = metrics.NewMetricKey(dubboMetadataStoreProvider+failedSuffix, "Total Failed Provider Metadata Store")
 	metadataStoreProviderSucceed = metrics.NewMetricKey(dubboMetadataStoreProvider+succSuffix, "Total Succeed Provider Metadata Store")
-	metadataStoreProvider        = metrics.NewMetricKey(dubboMetadataStoreProvider+totalSuffix, "Total Provider Metadata Store")
+	metadataStoreProviderNum     = metrics.NewMetricKey(dubboMetadataStoreProvider+totalSuffix, "Total Provider Metadata Store")
 
 	/*
 	   # HELP dubbo_store_provider_interface_rt_milliseconds_avg Average Response Time
@@ -94,15 +81,7 @@ var (
 	   dubbo_store_provider_interface_rt_milliseconds_avg{application_name="metrics-provider",application_version="3.2.1",git_commit_id="20de8b22ffb2a23531f6d9494a4963fcabd52561",hostname="localhost",interface="org.apache.dubbo.samples.metrics.prometheus.api.DemoService2",ip="10.252.156.213",} 10837.0
 	*/
 	// service level
-	storeProviderInterfaceRtAvg  = metrics.NewMetricKey(dubboStoreProviderInterfaceRt+avgSuffix, "Average Store Provider Interface Time")
-	storeProviderInterfaceRtLast = metrics.NewMetricKey(dubboStoreProviderInterfaceRt+lastSuffix, "Last Store Provider Interface Time")
-	storeProviderInterfaceRtMax  = metrics.NewMetricKey(dubboStoreProviderInterfaceRt+maxSuffix, "Max Store Provider Interface Time")
-	storeProviderInterfaceRtMin  = metrics.NewMetricKey(dubboStoreProviderInterfaceRt+minSuffix, "Min Store Provider Interface Time")
-	storeProviderInterfaceRtSum  = metrics.NewMetricKey(dubboStoreProviderInterfaceRt+sumSuffix, "Sum Store Provider Interface Time")
+	storeProviderInterfaceRt = metrics.NewMetricKey(dubboStoreProviderInterfaceRt, "Store Provider Interface Time")
 
-	subscribeServiceRtLast = metrics.NewMetricKey(dubboSubscribeServiceRt+lastSuffix, "Last Subscribe Service Time")
-	subscribeServiceRtMax  = metrics.NewMetricKey(dubboSubscribeServiceRt+maxSuffix, "Max Subscribe Service Time")
-	subscribeServiceRtMin  = metrics.NewMetricKey(dubboSubscribeServiceRt+minSuffix, "Min Subscribe Service Time")
-	subscribeServiceRtSum  = metrics.NewMetricKey(dubboSubscribeServiceRt+sumSuffix, "Sum Subscribe Service Time")
-	subscribeServiceRtAvg  = metrics.NewMetricKey(dubboSubscribeServiceRt+avgSuffix, "Average Subscribe Service Time")
+	subscribeServiceRt = metrics.NewMetricKey(dubboSubscribeServiceRt, "Subscribe Service Time")
 )

--- a/metrics/registry/collector.go
+++ b/metrics/registry/collector.go
@@ -18,10 +18,6 @@
 package registry
 
 import (
-	"time"
-)
-
-import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/metrics"
 )
@@ -32,14 +28,14 @@ var (
 
 func init() {
 	metrics.AddCollector("registry", func(m metrics.MetricRegistry, c *metrics.ReporterConfig) {
-		rc := &registryCollector{regRegistry: m}
+		rc := &registryCollector{metrics.BaseCollector{R: m}}
 		go rc.start()
 	})
 }
 
 // registryCollector is the registry's metrics collector
 type registryCollector struct {
-	regRegistry metrics.MetricRegistry
+	metrics.BaseCollector
 }
 
 func (rc *registryCollector) start() {
@@ -63,49 +59,31 @@ func (rc *registryCollector) start() {
 	}
 }
 
-func newStatesMetricFunc(total *metrics.MetricKey, succ *metrics.MetricKey, fail *metrics.MetricKey,
-	level metrics.MetricLevel, reg metrics.MetricRegistry) metrics.StatesMetrics {
-	return metrics.NewStatesMetrics(metrics.NewMetricId(total, level), metrics.NewMetricId(succ, level),
-		metrics.NewMetricId(fail, level), reg)
-}
-
-func newTimeMetrics(min, max, avg, sum, last *metrics.MetricKey, level metrics.MetricLevel, mr metrics.MetricRegistry) metrics.TimeMetric {
-	return metrics.NewTimeMetric(metrics.NewMetricId(min, level), metrics.NewMetricId(max, level), metrics.NewMetricId(avg, level),
-		metrics.NewMetricId(sum, level), metrics.NewMetricId(last, level), mr)
-}
-
 // regHandler handles register metrics
 func (rc *registryCollector) regHandler(event *RegistryMetricsEvent) {
 	// Event is converted to metrics
 	// Save metrics to the MetricRegistry
-	m := metrics.ComputeIfAbsentCache(dubboRegNum, func() interface{} {
-		return newStatesMetricFunc(RegisterMetricRequests, RegisterMetricRequestsSucceed, RegisterMetricRequestsFailed, metrics.GetApplicationLevel(), rc.regRegistry)
-	}).(metrics.StatesMetrics)
-	m.Inc(event.Succ)
-	metric := metrics.ComputeIfAbsentCache(dubboRegRt, func() interface{} {
-		return newTimeMetrics(RegisterRtMillisecondsMin, RegisterRtMillisecondsMax, RegisterRtMillisecondsAvg, RegisterRtMillisecondsSum, RegisterRtMillisecondsLast, metrics.GetApplicationLevel(), rc.regRegistry)
-	}).(metrics.TimeMetric)
-	metric.Record(event.CostMs())
+	level := metrics.GetApplicationLevel()
+	rc.StateCount(RegisterMetricRequests, RegisterMetricRequestsSucceed, RegisterMetricRequestsFailed, level, event.Succ)
+	rc.R.Rt(metrics.NewMetricId(RegisterRt, level), &metrics.RtOpts{}).Observe(event.CostMs())
 }
 
 // subHandler handles subscribe metrics
 func (rc *registryCollector) subHandler(event *RegistryMetricsEvent) {
 	// Event is converted to metrics
 	// Save metrics to the MetricRegistry
-	m := newStatesMetricFunc(SubscribeMetricNum, SubscribeMetricNumSucceed, SubscribeMetricNumFailed, metrics.GetApplicationLevel(), rc.regRegistry)
-	m.Inc(event.Succ)
+	level := metrics.GetApplicationLevel()
+	rc.StateCount(SubscribeMetricNum, SubscribeMetricNumSucceed, SubscribeMetricNumFailed, level, event.Succ)
 }
 
 // notifyHandler handles notify metrics
 func (rc *registryCollector) notifyHandler(event *RegistryMetricsEvent) {
 	// Event is converted to metrics
 	// Save metrics to the MetricRegistry
-	rc.regRegistry.Counter(metrics.NewMetricId(NotifyMetricRequests, metrics.GetApplicationLevel())).Inc()
-	rc.regRegistry.Histogram(metrics.NewMetricId(NotifyMetricNumLast, metrics.GetApplicationLevel())).Observe(float64(event.End.UnixNano()) / float64(time.Second))
-	metric := metrics.ComputeIfAbsentCache(dubboNotifyRt, func() interface{} {
-		return newTimeMetrics(NotifyRtMillisecondsMin, NotifyRtMillisecondsMax, NotifyRtMillisecondsAvg, NotifyRtMillisecondsSum, NotifyRtMillisecondsLast, metrics.GetApplicationLevel(), rc.regRegistry)
-	}).(metrics.TimeMetric)
-	metric.Record(event.CostMs())
+	level := metrics.GetApplicationLevel()
+	rc.R.Counter(metrics.NewMetricId(NotifyMetricRequests, level)).Inc()
+	rc.R.Gauge(metrics.NewMetricId(NotifyMetricNumLast, level)).Set(event.CostMs())
+	rc.R.Rt(metrics.NewMetricId(NotifyRt, level), &metrics.RtOpts{}).Observe(event.CostMs())
 }
 
 // directoryHandler handles directory metrics
@@ -116,15 +94,15 @@ func (rc *registryCollector) directoryHandler(event *RegistryMetricsEvent) {
 	typ := event.Attachment["DirTyp"]
 	switch typ {
 	case NumAllInc:
-		rc.regRegistry.Counter(metrics.NewMetricId(DirectoryMetricNumAll, level)).Inc()
+		rc.R.Counter(metrics.NewMetricId(DirectoryMetricNumAll, level)).Inc()
 	case NumAllDec:
-		rc.regRegistry.Counter(metrics.NewMetricId(DirectoryMetricNumAll, level)).Add(-1)
+		rc.R.Counter(metrics.NewMetricId(DirectoryMetricNumAll, level)).Add(-1)
 	case NumDisableTotal:
-		rc.regRegistry.Counter(metrics.NewMetricId(DirectoryMetricNumDisable, level)).Inc()
+		rc.R.Counter(metrics.NewMetricId(DirectoryMetricNumDisable, level)).Inc()
 	case NumToReconnectTotal:
-		rc.regRegistry.Counter(metrics.NewMetricId(DirectoryMetricNumToReconnect, level)).Inc()
+		rc.R.Counter(metrics.NewMetricId(DirectoryMetricNumToReconnect, level)).Inc()
 	case NumValidTotal:
-		rc.regRegistry.Counter(metrics.NewMetricId(DirectoryMetricNumValid, level)).Inc()
+		rc.R.Counter(metrics.NewMetricId(DirectoryMetricNumValid, level)).Inc()
 	default:
 	}
 
@@ -134,20 +112,15 @@ func (rc *registryCollector) directoryHandler(event *RegistryMetricsEvent) {
 func (rc *registryCollector) serverRegHandler(event *RegistryMetricsEvent) {
 	// Event is converted to metrics
 	// Save metrics to the MetricRegistry
-	m := metrics.ComputeIfAbsentCache(dubboRegServerNum, func() interface{} {
-		return newStatesMetricFunc(ServiceRegisterMetricRequests, ServiceRegisterMetricRequestsSucceed, ServiceRegisterMetricRequestsFailed, metrics.GetApplicationLevel(), rc.regRegistry)
-	}).(metrics.StatesMetrics)
-	m.Inc(event.Succ)
-	metric := metrics.ComputeIfAbsentCache(dubboRegServerRt, func() interface{} {
-		return newTimeMetrics(RegisterServiceRtMillisecondsMin, RegisterServiceRtMillisecondsMax, RegisterServiceRtMillisecondsAvg, RegisterServiceRtMillisecondsSum, RegisterServiceRtMillisecondsLast, metrics.GetApplicationLevel(), rc.regRegistry)
-	}).(metrics.TimeMetric)
-	metric.Record(event.CostMs())
+	level := metrics.GetApplicationLevel()
+	rc.StateCount(ServiceRegisterMetricRequests, ServiceRegisterMetricRequestsSucceed, ServiceRegisterMetricRequestsFailed, level, event.Succ)
+	rc.R.Rt(metrics.NewMetricId(RegisterServiceRt, level), &metrics.RtOpts{}).Observe(event.CostMs())
 }
 
 // serverSubHandler handles server subscribe metrics
 func (rc *registryCollector) serverSubHandler(event *RegistryMetricsEvent) {
 	// Event is converted to metrics
 	// Save metrics to the MetricRegistry
-	m := newStatesMetricFunc(ServiceSubscribeMetricNum, ServiceSubscribeMetricNumSucceed, ServiceSubscribeMetricNumFailed, metrics.GetApplicationLevel(), rc.regRegistry)
-	m.Inc(event.Succ)
+	level := metrics.GetApplicationLevel()
+	rc.StateCount(ServiceSubscribeMetricNum, ServiceSubscribeMetricNumSucceed, ServiceSubscribeMetricNumFailed, level, event.Succ)
 }

--- a/metrics/registry/metric_set.go
+++ b/metrics/registry/metric_set.go
@@ -40,14 +40,6 @@ const (
 	NumValidTotal       = "numValidTotal"
 )
 
-const (
-	dubboRegNum       = "dubbo_registry_register_metrics_num"
-	dubboRegRt        = "dubbo_registry_register_metrics_rt"
-	dubboRegServerNum = "dubbo_registry_register_server_metrics_num"
-	dubboRegServerRt  = "dubbo_registry_register_server_metrics_rt"
-	dubboNotifyRt     = "dubbo_notify_rt"
-)
-
 var (
 	// register metrics key
 	RegisterMetricRequests        = metrics.NewMetricKey("dubbo_registry_register_requests_total", "Total Register Requests")
@@ -79,23 +71,11 @@ var (
 	ServiceSubscribeMetricNumFailed  = metrics.NewMetricKey("dubbo_registry_subscribe_service_num_failed_total", "Failed Service-Level Num")
 
 	// register metrics server rt key
-	RegisterServiceRtMillisecondsAvg  = metrics.NewMetricKey("dubbo_register_service_rt_milliseconds_avg", "Average Service Register Time")
-	RegisterServiceRtMillisecondsLast = metrics.NewMetricKey("dubbo_register_service_rt_milliseconds_last", "Last Service Register Time")
-	RegisterServiceRtMillisecondsMax  = metrics.NewMetricKey("dubbo_register_service_rt_milliseconds_max", "Max Service Register Time")
-	RegisterServiceRtMillisecondsMin  = metrics.NewMetricKey("dubbo_register_service_rt_milliseconds_min", "Min Service Register Time")
-	RegisterServiceRtMillisecondsSum  = metrics.NewMetricKey("dubbo_register_service_rt_milliseconds_sum", "Sum Service Register Time")
+	RegisterServiceRt = metrics.NewMetricKey("dubbo_register_service_rt_milliseconds", "Service Register Time")
 
 	// register metrics rt key
-	RegisterRtMillisecondsMax  = metrics.NewMetricKey("dubbo_register_rt_milliseconds_max", "Max Response Time")
-	RegisterRtMillisecondsLast = metrics.NewMetricKey("dubbo_register_rt_milliseconds_last", "Last Response Time")
-	RegisterRtMillisecondsAvg  = metrics.NewMetricKey("dubbo_register_rt_milliseconds_avg", "Average Response Time")
-	RegisterRtMillisecondsSum  = metrics.NewMetricKey("dubbo_register_rt_milliseconds_sum", "Sum Response Time")
-	RegisterRtMillisecondsMin  = metrics.NewMetricKey("dubbo_register_rt_milliseconds_min", "Min Response Time")
+	RegisterRt = metrics.NewMetricKey("dubbo_register_rt_milliseconds", "Response Time")
 
 	// notify rt key
-	NotifyRtMillisecondsAvg  = metrics.NewMetricKey("dubbo_notify_rt_milliseconds_avg", "Average Notify Time")
-	NotifyRtMillisecondsLast = metrics.NewMetricKey("dubbo_notify_rt_milliseconds_last", "Last Notify Time")
-	NotifyRtMillisecondsMax  = metrics.NewMetricKey("dubbo_notify_rt_milliseconds_max", "Max Notify Time")
-	NotifyRtMillisecondsMin  = metrics.NewMetricKey("dubbo_notify_rt_milliseconds_min", "Min Notify Time")
-	NotifyRtMillisecondsSum  = metrics.NewMetricKey("dubbo_notify_rt_milliseconds_sum", "Sum Notify Time")
+	NotifyRt = metrics.NewMetricKey("dubbo_notify_rt_milliseconds", "Notify Time")
 )


### PR DESCRIPTION
migrate old RT metric impl to new RT impl , related to #2376 

1. simplify rt usage
2. fix: metric tag `application` -> `application_name`
3. fix: `dubbo_registry_notify_num_last` to metric type `gauge`