### PR TITLE
refactor(root_config): remove redundant nil check in `Init`

### DIFF
--- a/config/root_config.go
+++ b/config/root_config.go
@@ -167,12 +167,9 @@ func (rc *RootConfig) Init() error {
 	}
 
 	// init registry
-	registries := rc.Registries
-	if registries != nil {
-		for _, reg := range registries {
-			if err := reg.Init(); err != nil {
-				return err
-			}
+	for _, reg := range rc.Registries {
+		if err := reg.Init(); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
From the Go specification:

> "3. If the map is nil, the number of iterations is 0." https://go.dev/ref/spec#For_range

Therefore, an additional nil check for before the loop is unnecessary. Example: https://go.dev/play/p/7FQ6fOesRuY