### PR TITLE
feat(metrics): add switch for metric collector

### DIFF
--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -404,6 +404,10 @@ const (
 
 // metrics key
 const (
+	MetadataEnabledKey                   = "metrics.metadata.enabled"
+	RegistryEnabledKey                   = "metrics.registry.enabled"
+	ConfigCenterEnabledKey               = "metrics.config-center.enabled"
+	RpcEnabledKey                        = "metrics.rpc.enabled"
 	AggregationEnabledKey                = "aggregation.enabled"
 	AggregationBucketNumKey              = "aggregation.bucket.num"
 	AggregationTimeWindowSecondsKey      = "aggregation.time.window.seconds"

--- a/config/metric_config_test.go
+++ b/config/metric_config_test.go
@@ -26,9 +26,17 @@ import (
 )
 
 func TestMetricConfigBuilder(t *testing.T) {
-	config := NewMetricConfigBuilder().Build()
-	err := config.Init(&RootConfig{Application: &ApplicationConfig{Name: "dubbo", Version: "1.0.0"}})
-	assert.NoError(t, err)
-	reporterConfig := config.ToReporterConfig()
-	assert.Equal(t, string(reporterConfig.Mode), "pull")
+	config := NewMetricConfigBuilder().
+		SetConfigCenterEnabled(false).
+		SetMetadataEnabled(false).
+		SetRegistryEnabled(false).
+		SetRpcEnabled(false).
+		Build()
+	enable := false
+	assert.Equal(t, &MetricConfig{
+		EnableConfigCenter: &enable,
+		EnableMetadata:     &enable,
+		EnableRegistry:     &enable,
+		EnableRpc:          &enable,
+	}, config)
 }

--- a/metrics/config_center/collector.go
+++ b/metrics/config_center/collector.go
@@ -30,9 +30,11 @@ var ch = make(chan metrics.MetricsEvent, 10)
 var info = metrics.NewMetricKey("dubbo_configcenter_total", "Config Changed Total")
 
 func init() {
-	metrics.AddCollector("config_center", func(mr metrics.MetricRegistry, _ *common.URL) {
-		c := &configCenterCollector{r: mr}
-		c.start()
+	metrics.AddCollector("config_center", func(mr metrics.MetricRegistry, url *common.URL) {
+		if url.GetParamBool(constant.ConfigCenterEnabledKey, true) {
+			c := &configCenterCollector{r: mr}
+			c.start()
+		}
 	})
 }
 

--- a/metrics/metadata/collector.go
+++ b/metrics/metadata/collector.go
@@ -32,9 +32,11 @@ const eventType = constant.MetricsMetadata
 var ch = make(chan metrics.MetricsEvent, 10)
 
 func init() {
-	metrics.AddCollector("metadata", func(mr metrics.MetricRegistry, _ *common.URL) {
-		l := &MetadataMetricCollector{metrics.BaseCollector{R: mr}}
-		l.start()
+	metrics.AddCollector("metadata", func(mr metrics.MetricRegistry, url *common.URL) {
+		if url.GetParamBool(constant.MetadataEnabledKey, true) {
+			l := &MetadataMetricCollector{metrics.BaseCollector{R: mr}}
+			l.start()
+		}
 	})
 }
 

--- a/metrics/registry/collector.go
+++ b/metrics/registry/collector.go
@@ -28,9 +28,11 @@ var (
 )
 
 func init() {
-	metrics.AddCollector("registry", func(m metrics.MetricRegistry, _ *common.URL) {
-		rc := &registryCollector{metrics.BaseCollector{R: m}}
-		go rc.start()
+	metrics.AddCollector("registry", func(m metrics.MetricRegistry, url *common.URL) {
+		if url.GetParamBool(constant.RegistryEnabledKey, true) {
+			rc := &registryCollector{metrics.BaseCollector{R: m}}
+			go rc.start()
+		}
 	})
 }
 

--- a/metrics/rpc/collector.go
+++ b/metrics/rpc/collector.go
@@ -33,12 +33,14 @@ var (
 
 // init will add the rpc collectorFunc to metrics.collectors slice, and lazy start the rpc collector goroutine
 func init() {
-	collectorFunc := func(registry metrics.MetricRegistry, c *common.URL) {
-		rc := &rpcCollector{
-			registry:  registry,
-			metricSet: buildMetricSet(registry),
+	collectorFunc := func(registry metrics.MetricRegistry, url *common.URL) {
+		if url.GetParamBool(constant.RpcEnabledKey, true) {
+			rc := &rpcCollector{
+				registry:  registry,
+				metricSet: buildMetricSet(registry),
+			}
+			go rc.start()
 		}
-		go rc.start()
 	}
 
 	metrics.AddCollector("rpc", collectorFunc)


### PR DESCRIPTION
add switch for metric collector, include metadata、registry、config-center、rpc

split `PrometheusRegistry.Export` method into two method to avoid large method body