### PR TITLE
feat: modularize Graceful_Shutdown functionality

### DIFF
--- a/graceful_shutdown/common.go
+++ b/graceful_shutdown/common.go
@@ -18,24 +18,17 @@
 package graceful_shutdown
 
 import (
-	"dubbo.apache.org/dubbo-go/v3/config"
-	"dubbo.apache.org/dubbo-go/v3/global"
-	"go.uber.org/atomic"
+	"github.com/dubbogo/gost/log/logger"
+	"time"
 )
 
-func compatShutdownConfig(c *global.ShutdownConfig) *config.ShutdownConfig {
-	if c == nil {
-		return nil
+func parseDuration(timeout string, desc string, def time.Duration) time.Duration {
+	res, err := time.ParseDuration(timeout)
+	if err != nil {
+		logger.Errorf("The %s configuration is invalid: %s, and we will use the default value: %s, err: %v",
+			desc, timeout, def.String(), err)
+		res = def
 	}
-	cfg := &config.ShutdownConfig{
-		Timeout:                     c.Timeout,
-		StepTimeout:                 c.StepTimeout,
-		ConsumerUpdateWaitTime:      c.ConsumerUpdateWaitTime,
-		RejectRequestHandler:        c.RejectRequestHandler,
-		InternalSignal:              c.InternalSignal,
-		OfflineRequestWindowTimeout: c.OfflineRequestWindowTimeout,
-		RejectRequest:               atomic.Bool{},
-	}
-	cfg.RejectRequest.Store(c.RejectRequest.Load())
-	return cfg
+
+	return res
 }

--- a/graceful_shutdown/compat.go
+++ b/graceful_shutdown/compat.go
@@ -1,0 +1,24 @@
+package graceful_shutdown
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/config"
+	"dubbo.apache.org/dubbo-go/v3/global"
+	"go.uber.org/atomic"
+)
+
+func compatShutdownConfig(c *global.ShutdownConfig) *config.ShutdownConfig {
+	if c == nil {
+		return nil
+	}
+	cfg := &config.ShutdownConfig{
+		Timeout:                     c.Timeout,
+		StepTimeout:                 c.StepTimeout,
+		ConsumerUpdateWaitTime:      c.ConsumerUpdateWaitTime,
+		RejectRequestHandler:        c.RejectRequestHandler,
+		InternalSignal:              c.InternalSignal,
+		OfflineRequestWindowTimeout: c.OfflineRequestWindowTimeout,
+		RejectRequest:               atomic.Bool{},
+	}
+	cfg.RejectRequest.Store(c.RejectRequest.Load())
+	return cfg
+}

--- a/graceful_shutdown/graceful_shutdown_signal_darwin.go
+++ b/graceful_shutdown/graceful_shutdown_signal_darwin.go
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graceful_shutdown
+
+import (
+	"os"
+	"syscall"
+)
+
+var (
+	// ShutdownSignals receives shutdown signals to process
+	ShutdownSignals = []os.Signal{
+		os.Interrupt, os.Kill, syscall.SIGKILL, syscall.SIGSTOP,
+		syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGILL, syscall.SIGTRAP,
+		syscall.SIGABRT, syscall.SIGSYS, syscall.SIGTERM,
+	}
+
+	// DumpHeapShutdownSignals receives shutdown signals to process
+	DumpHeapShutdownSignals = []os.Signal{
+		syscall.SIGQUIT, syscall.SIGILL,
+		syscall.SIGTRAP, syscall.SIGABRT, syscall.SIGSYS,
+	}
+)

--- a/graceful_shutdown/graceful_shutdown_signal_linux.go
+++ b/graceful_shutdown/graceful_shutdown_signal_linux.go
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graceful_shutdown
+
+import (
+	"os"
+	"syscall"
+)
+
+var (
+	// ShutdownSignals receives shutdown signals to process
+	ShutdownSignals = []os.Signal{
+		os.Interrupt, os.Kill, syscall.SIGKILL, syscall.SIGSTOP,
+		syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGILL, syscall.SIGTRAP,
+		syscall.SIGABRT, syscall.SIGSYS, syscall.SIGTERM,
+	}
+
+	// DumpHeapShutdownSignals receives shutdown signals to process
+	DumpHeapShutdownSignals = []os.Signal{
+		syscall.SIGQUIT, syscall.SIGILL,
+		syscall.SIGTRAP, syscall.SIGABRT, syscall.SIGSYS,
+	}
+)

--- a/graceful_shutdown/graceful_shutdown_signal_windows.go
+++ b/graceful_shutdown/graceful_shutdown_signal_windows.go
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package graceful_shutdown
+
+import (
+	"os"
+	"syscall"
+)
+
+var (
+	// ShutdownSignals receives shutdown signals to process
+	ShutdownSignals = []os.Signal{
+		os.Interrupt, os.Kill, syscall.SIGKILL,
+		syscall.SIGHUP, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGILL, syscall.SIGTRAP,
+		syscall.SIGABRT, syscall.SIGTERM,
+	}
+
+	// DumpHeapShutdownSignals receives shutdown signals to process
+	DumpHeapShutdownSignals = []os.Signal{syscall.SIGQUIT, syscall.SIGILL, syscall.SIGTRAP, syscall.SIGABRT}
+)

--- a/graceful_shutdown/options.go
+++ b/graceful_shutdown/options.go
@@ -1,9 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package graceful_shutdown
 
 import "dubbo.apache.org/dubbo-go/v3/global"
 
+var (
+	defOpts = &Options{
+		shutdown: global.DefaultShutdownConfig(),
+	}
+)
+
 type Options struct {
 	shutdown *global.ShutdownConfig
+}
+
+func defaultOptions() *Options {
+	return defOpts
 }
 
 type Option func(*Options)

--- a/graceful_shutdown/options.go
+++ b/graceful_shutdown/options.go
@@ -1,0 +1,15 @@
+package graceful_shutdown
+
+import "dubbo.apache.org/dubbo-go/v3/global"
+
+type Options struct {
+	shutdown *global.ShutdownConfig
+}
+
+type Option func(*Options)
+
+func WithShutdown_Config(cfg *global.ShutdownConfig) Option {
+	return func(opts *Options) {
+		opts.shutdown = cfg
+	}
+}

--- a/graceful_shutdown/shutdown.go
+++ b/graceful_shutdown/shutdown.go
@@ -1,0 +1,203 @@
+package graceful_shutdown
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/common/extension"
+	"dubbo.apache.org/dubbo-go/v3/config"
+	"dubbo.apache.org/dubbo-go/v3/global"
+	"github.com/dubbogo/gost/log/logger"
+	"os"
+	"os/signal"
+	"runtime/debug"
+	"sync"
+	"time"
+)
+
+const (
+	defaultTimeout                     = 60 * time.Second
+	defaultStepTimeout                 = 3 * time.Second
+	defaultConsumerUpdateWaitTime      = 3 * time.Second
+	defaultOfflineRequestWindowTimeout = 3 * time.Second
+)
+
+var (
+	initOnce       sync.Once
+	compatShutdown *config.ShutdownConfig
+
+	proMu     sync.Mutex
+	protocols map[string]struct{}
+)
+
+func Init(cfg *global.ShutdownConfig) {
+	compatShutdown = compatShutdownConfig(cfg)
+	// retrieve ShutdownConfig for gracefulShutdownFilter
+	cGracefulShutdownFilter, existcGracefulShutdownFilter := extension.GetFilter(constant.GracefulShutdownConsumerFilterKey)
+	if !existcGracefulShutdownFilter {
+		return
+	}
+	sGracefulShutdownFilter, existsGracefulShutdownFilter := extension.GetFilter(constant.GracefulShutdownProviderFilterKey)
+	if !existsGracefulShutdownFilter {
+		return
+	}
+	if filter, ok := cGracefulShutdownFilter.(config.Setter); ok {
+		filter.Set(constant.GracefulShutdownFilterShutdownConfig, compatShutdown)
+	}
+
+	if filter, ok := sGracefulShutdownFilter.(config.Setter); ok {
+		filter.Set(constant.GracefulShutdownFilterShutdownConfig, compatShutdown)
+	}
+
+	if compatShutdown.InternalSignal != nil && *compatShutdown.InternalSignal {
+		signals := make(chan os.Signal, 1)
+		signal.Notify(signals, ShutdownSignals...)
+
+		go func() {
+			select {
+			case sig := <-signals:
+				logger.Infof("get signal %s, applicationConfig will shutdown.", sig)
+				// gracefulShutdownOnce.Do(func() {
+				time.AfterFunc(totalTimeout(), func() {
+					logger.Warn("Shutdown gracefully timeout, applicationConfig will shutdown immediately. ")
+					os.Exit(0)
+				})
+				beforeShutdown()
+				// those signals' original behavior is exit with dump ths stack, so we try to keep the behavior
+				for _, dumpSignal := range DumpHeapShutdownSignals {
+					if sig == dumpSignal {
+						debug.WriteHeapDump(os.Stdout.Fd())
+					}
+				}
+				os.Exit(0)
+			}
+		}()
+	}
+}
+
+// RegisterProtocol registers protocol which would be destroyed before shutdown
+func RegisterProtocol(name string) {
+	proMu.Lock()
+	protocols[name] = struct{}{}
+	proMu.Unlock()
+}
+
+func totalTimeout() time.Duration {
+	result, err := time.ParseDuration(compatShutdown.Timeout)
+	if err != nil {
+		logger.Errorf("The Timeout configuration is invalid: %s, and we will use the default value: %s, err: %v",
+			compatShutdown.Timeout, defaultTimeout.String(), err)
+		result = defaultTimeout
+	}
+	if result <= defaultTimeout {
+		result = defaultTimeout
+	}
+
+	return result
+}
+
+func beforeShutdown() {
+	destroyRegistries()
+	// waiting for a short time so that the clients have enough time to get the notification that server shutdowns
+	// The value of configuration depends on how long the clients will get notification.
+	waitAndAcceptNewRequests()
+
+	// reject sending/receiving the new request, but keeping waiting for accepting requests
+	waitForSendingAndReceivingRequests()
+
+	// destroy all protocols
+	destroyProtocols()
+
+	logger.Info("Graceful shutdown --- Execute the custom callbacks.")
+	customCallbacks := extension.GetAllCustomShutdownCallbacks()
+	for callback := customCallbacks.Front(); callback != nil; callback = callback.Next() {
+		callback.Value.(func())()
+	}
+}
+
+// destroyRegistries destroys RegistryProtocol directly.
+func destroyRegistries() {
+	logger.Info("Graceful shutdown --- Destroy all registriesConfig. ")
+	registryProtocol := extension.GetProtocol(constant.RegistryProtocol)
+	registryProtocol.Destroy()
+}
+
+func waitAndAcceptNewRequests() {
+	logger.Info("Graceful shutdown --- Keep waiting and accept new requests for a short time. ")
+
+	waitTime, err := time.ParseDuration(compatShutdown.ConsumerUpdateWaitTime)
+	if err != nil {
+		logger.Errorf("The ConsumerUpdateTimeout configuration is invalid: %s, and we will use the default value: %s, err: %v",
+			compatShutdown.ConsumerActiveCount.Load(), defaultConsumerUpdateWaitTime.String(), err)
+		waitTime = defaultConsumerUpdateWaitTime
+	}
+	time.Sleep(waitTime)
+
+	timeout, err := time.ParseDuration(compatShutdown.StepTimeout)
+	if err != nil {
+		logger.Errorf("The StepTimeout configuration is invalid: %s, and we will use the default value: %s, err: %v",
+			compatShutdown.StepTimeout, defaultStepTimeout.String(), err)
+		timeout = defaultStepTimeout
+	}
+
+	// ignore this step
+	if timeout < 0 {
+		return
+	}
+	waitingProviderProcessedTimeout(timeout)
+}
+
+func waitingProviderProcessedTimeout(timeout time.Duration) {
+	deadline := time.Now().Add(timeout)
+
+	offlineRequestWindowTimeout, err := time.ParseDuration(compatShutdown.OfflineRequestWindowTimeout)
+	if err != nil {
+		logger.Errorf("The OfflineRequestWindowTimeout configuration is invalid: %s, and we will use the default value: %s, err: %v",
+			compatShutdown.OfflineRequestWindowTimeout, defaultOfflineRequestWindowTimeout.String(), err)
+		offlineRequestWindowTimeout = defaultOfflineRequestWindowTimeout
+	}
+
+	for time.Now().Before(deadline) &&
+		(compatShutdown.ProviderActiveCount.Load() > 0 || time.Now().Before(compatShutdown.ProviderLastReceivedRequestTime.Load().Add(offlineRequestWindowTimeout))) {
+		// sleep 10 ms and then we check it again
+		time.Sleep(10 * time.Millisecond)
+		logger.Infof("waiting for provider active invocation count = %d, provider last received request time: %v",
+			compatShutdown.ProviderActiveCount.Load(), compatShutdown.ProviderLastReceivedRequestTime.Load())
+	}
+}
+
+// for provider. It will wait for processing receiving requests
+func waitForSendingAndReceivingRequests() {
+	logger.Info("Graceful shutdown --- Keep waiting until sending/accepting requests finish or timeout. ")
+	compatShutdown.RejectRequest.Store(true)
+	waitingConsumerProcessedTimeout()
+}
+
+func waitingConsumerProcessedTimeout() {
+	timeout, err := time.ParseDuration(compatShutdown.StepTimeout)
+	if err != nil {
+		logger.Errorf("The StepTimeout configuration is invalid: %s, and we will use the default value: %s, err: %v",
+			compatShutdown.StepTimeout, defaultStepTimeout.String(), err)
+		timeout = defaultStepTimeout
+	}
+	if timeout <= 0 {
+		return
+	}
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) && compatShutdown.ConsumerActiveCount.Load() > 0 {
+		// sleep 10 ms and then we check it again
+		time.Sleep(10 * time.Millisecond)
+		logger.Infof("waiting for consumer active invocation count = %d", compatShutdown.ConsumerActiveCount.Load())
+	}
+}
+
+// destroyProtocols destroys protocols that have been registered.
+func destroyProtocols() {
+	logger.Info("Graceful shutdown --- Destroy protocols. ")
+
+	proMu.Lock()
+	// extension.GetProtocol might panic
+	defer proMu.Unlock()
+	for name := range protocols {
+		extension.GetProtocol(name).Destroy()
+	}
+}


### PR DESCRIPTION
In the original implementation of Graceful_Shutdown, all the processing logics exist in **RootConfig.Start()** (**gracefulShutdownInit**). As shown below:
```go
func (rc *RootConfig) Start() {
	startOnce.Do(func() {
		gracefulShutdownInit()
		rc.Consumer.Load()
		rc.Provider.Load()
		exportMetadataService()
		registerServiceInstance()
	})
}
```
It is not convenient for just creating a **Client** because this behavior is global and embedded in **config** package.
After modularizing Graceful_Shutdown functionality, **Client** and **Server** modules could invoke **Init** and **RegisterProtocol** directly. Here is the code sample:
```go
graceful_shutdown.Init(&global.ShutdownConfig{
    Timeout: "300ms"
})
// iterate protocols configured
for protocolName... {
    graceful_shutdown.RegisterProtocol(protocolName)
}
```
About extensibility, we can add RegisterXXX functions and XXX represents certain resource that need to be destroyed.