### PR TITLE
feat: simplify registry and protocol configuration

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -169,25 +169,19 @@ func WithRegistryIDs(registryIDs []string) ClientOption {
 	}
 }
 
-func WithRegistry(key string, opts ...registry.Option) ClientOption {
-	regOpts := registry.DefaultOptions()
-	for _, opt := range opts {
-		opt(regOpts)
-	}
+func WithRegistry(opts ...registry.Option) ClientOption {
+	regOpts := registry.NewOptions(opts...)
 
 	return func(cliOpts *ClientOptions) {
 		if cliOpts.Registries == nil {
 			cliOpts.Registries = make(map[string]*global.RegistryConfig)
 		}
-		cliOpts.Registries[key] = regOpts.Registry
+		cliOpts.Registries[regOpts.ID] = regOpts.Registry
 	}
 }
 
 func WithShutdown(opts ...graceful_shutdown.Option) ClientOption {
-	sdOpts := graceful_shutdown.DefaultOptions()
-	for _, opt := range opts {
-		opt(sdOpts)
-	}
+	sdOpts := graceful_shutdown.NewOptions(opts...)
 
 	return func(cliOpts *ClientOptions) {
 		cliOpts.Shutdown = sdOpts.Shutdown

--- a/graceful_shutdown/options.go
+++ b/graceful_shutdown/options.go
@@ -25,17 +25,22 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/global"
 )
 
-var (
-	defOpts = &Options{
-		Shutdown: global.DefaultShutdownConfig(),
-	}
-)
-
 type Options struct {
 	Shutdown *global.ShutdownConfig
 }
 
-func DefaultOptions() *Options {
+func defaultOptions() *Options {
+	return &Options{
+		Shutdown: global.DefaultShutdownConfig(),
+	}
+}
+
+func NewOptions(opts ...Option) *Options {
+	defOpts := defaultOptions()
+	for _, opt := range opts {
+		opt(defOpts)
+	}
+
 	return defOpts
 }
 

--- a/graceful_shutdown/shutdown.go
+++ b/graceful_shutdown/shutdown.go
@@ -59,7 +59,7 @@ var (
 func Init(opts ...Option) {
 	initOnce.Do(func() {
 		protocols = make(map[string]struct{})
-		newOpts := DefaultOptions()
+		newOpts := defaultOptions()
 		for _, opt := range opts {
 			opt(newOpts)
 		}

--- a/options.go
+++ b/options.go
@@ -220,31 +220,25 @@ func WithTag(tag string) InstanceOption {
 	}
 }
 
-func WithProtocol(key string, opts ...protocol.Option) InstanceOption {
-	proOpts := protocol.DefaultOptions()
-	for _, opt := range opts {
-		opt(proOpts)
-	}
+func WithProtocol(opts ...protocol.Option) InstanceOption {
+	proOpts := protocol.NewOptions(opts...)
 
 	return func(insOpts *InstanceOptions) {
 		if insOpts.Protocols == nil {
 			insOpts.Protocols = make(map[string]*global.ProtocolConfig)
 		}
-		insOpts.Protocols[key] = proOpts.Protocol
+		insOpts.Protocols[proOpts.ID] = proOpts.Protocol
 	}
 }
 
-func WithRegistry(key string, opts ...registry.Option) InstanceOption {
-	regOpts := registry.DefaultOptions()
-	for _, opt := range opts {
-		opt(regOpts)
-	}
+func WithRegistry(opts ...registry.Option) InstanceOption {
+	regOpts := registry.NewOptions(opts...)
 
 	return func(insOpts *InstanceOptions) {
 		if insOpts.Registries == nil {
 			insOpts.Registries = make(map[string]*global.RegistryConfig)
 		}
-		insOpts.Registries[key] = regOpts.Registry
+		insOpts.Registries[regOpts.ID] = regOpts.Registry
 	}
 }
 
@@ -318,10 +312,7 @@ func WithRegistry(key string, opts ...registry.Option) InstanceOption {
 //}
 
 func WithShutdown(opts ...graceful_shutdown.Option) InstanceOption {
-	sdOpts := graceful_shutdown.DefaultOptions()
-	for _, opt := range opts {
-		opt(sdOpts)
-	}
+	sdOpts := graceful_shutdown.NewOptions(opts...)
 
 	return func(insOpts *InstanceOptions) {
 		insOpts.Shutdown = sdOpts.Shutdown

--- a/protocol/options.go
+++ b/protocol/options.go
@@ -18,6 +18,7 @@
 package protocol
 
 import (
+	"fmt"
 	"strconv"
 )
 
@@ -27,10 +28,28 @@ import (
 
 type Options struct {
 	Protocol *global.ProtocolConfig
+
+	ID string
 }
 
-func DefaultOptions() *Options {
+func defaultOptions() *Options {
 	return &Options{Protocol: global.DefaultProtocolConfig()}
+}
+
+func NewOptions(opts ...Option) *Options {
+	defOpts := defaultOptions()
+	for _, opt := range opts {
+		opt(defOpts)
+	}
+
+	if defOpts.Protocol.Name == "" {
+		panic(fmt.Sprintf("Please specify registry, eg. WithTriple()"))
+	}
+	if defOpts.ID == "" {
+		defOpts.ID = defOpts.Protocol.Name
+	}
+
+	return defOpts
 }
 
 type Option func(*Options)
@@ -62,6 +81,14 @@ func WithREST() Option {
 func WithTriple() Option {
 	return func(opts *Options) {
 		opts.Protocol.Name = "tri"
+	}
+}
+
+// WithID specifies the id of protocol.Options. Then you could configure server.WithProtocolIDs and
+// server.WithServer_ProtocolIDs to specify which protocol you need to use in multi-protocols scenario.
+func WithID(id string) Option {
+	return func(opts *Options) {
+		opts.ID = id
 	}
 }
 

--- a/protocol/triple/internal/client/cmd_client_with_registry/main.go
+++ b/protocol/triple/internal/client/cmd_client_with_registry/main.go
@@ -29,7 +29,7 @@ func main() {
 	// for the most brief RPC case with Registry
 
 	cli, err := client.NewClient(
-		client.WithRegistry("zk",
+		client.WithRegistry(
 			registry.WithZookeeper(),
 			registry.WithAddress("127.0.0.1:2181"),
 		),

--- a/protocol/triple/internal/client/cmd_instance_with_registry/main.go
+++ b/protocol/triple/internal/client/cmd_instance_with_registry/main.go
@@ -31,7 +31,8 @@ func main() {
 	// configure global configurations and common modules
 	ins, err := dubbo.NewInstance(
 		dubbo.WithName("dubbo_test"),
-		dubbo.WithRegistry("zk",
+		dubbo.WithRegistry(
+			registry.WithID("zk"),
 			registry.WithZookeeper(),
 			registry.WithAddress("127.0.0.1:2181"),
 		),

--- a/protocol/triple/internal/server/cmd_instance/main.go
+++ b/protocol/triple/internal/server/cmd_instance/main.go
@@ -30,7 +30,7 @@ func main() {
 	// configure global configurations and common modules
 	ins, err := dubbo.NewInstance(
 		dubbo.WithName("dubbo_test"),
-		dubbo.WithProtocol("tri",
+		dubbo.WithProtocol(
 			protocol.WithTriple(),
 			protocol.WithPort(20000),
 		),

--- a/protocol/triple/internal/server/cmd_instance_with_registry/main.go
+++ b/protocol/triple/internal/server/cmd_instance_with_registry/main.go
@@ -31,11 +31,11 @@ func main() {
 	// configure global configurations and common modules
 	ins, err := dubbo.NewInstance(
 		dubbo.WithName("dubbo_test"),
-		dubbo.WithRegistry("zk",
+		dubbo.WithRegistry(
 			registry.WithZookeeper(),
 			registry.WithAddress("127.0.0.1:2181"),
 		),
-		dubbo.WithProtocol("tri",
+		dubbo.WithProtocol(
 			protocol.WithTriple(),
 			protocol.WithPort(20000),
 		),

--- a/protocol/triple/internal/server/cmd_server/main.go
+++ b/protocol/triple/internal/server/cmd_server/main.go
@@ -27,7 +27,7 @@ import (
 
 func main() {
 	srv, err := server.NewServer(
-		server.WithServer_Protocol("tri",
+		server.WithServer_Protocol(
 			protocol.WithTriple(),
 			protocol.WithPort(20000),
 		),

--- a/protocol/triple/internal/server/cmd_server_with_registry/main.go
+++ b/protocol/triple/internal/server/cmd_server_with_registry/main.go
@@ -28,11 +28,11 @@ import (
 
 func main() {
 	srv, err := server.NewServer(
-		server.WithServer_Registry("zk",
+		server.WithServer_Registry(
 			registry.WithZookeeper(),
 			registry.WithAddress("127.0.0.1:2181"),
 		),
-		server.WithServer_Protocol("tri",
+		server.WithServer_Protocol(
 			protocol.WithTriple(),
 			protocol.WithPort(20000),
 		),

--- a/server/options.go
+++ b/server/options.go
@@ -128,17 +128,14 @@ func WithServer_RegistryIDs(registryIDs []string) ServerOption {
 	}
 }
 
-func WithServer_Registry(key string, opts ...registry.Option) ServerOption {
-	regOpts := registry.DefaultOptions()
-	for _, opt := range opts {
-		opt(regOpts)
-	}
+func WithServer_Registry(opts ...registry.Option) ServerOption {
+	regOpts := registry.NewOptions(opts...)
 
 	return func(srvOpts *ServerOptions) {
 		if srvOpts.Registries == nil {
 			srvOpts.Registries = make(map[string]*global.RegistryConfig)
 		}
-		srvOpts.Registries[key] = regOpts.Registry
+		srvOpts.Registries[regOpts.ID] = regOpts.Registry
 	}
 }
 
@@ -149,17 +146,14 @@ func WithServer_ProtocolIDs(protocolIDs []string) ServerOption {
 	}
 }
 
-func WithServer_Protocol(key string, opts ...protocol.Option) ServerOption {
-	proOpts := protocol.DefaultOptions()
-	for _, opt := range opts {
-		opt(proOpts)
-	}
+func WithServer_Protocol(opts ...protocol.Option) ServerOption {
+	proOpts := protocol.NewOptions(opts...)
 
 	return func(srvOpts *ServerOptions) {
 		if srvOpts.Protocols == nil {
 			srvOpts.Protocols = make(map[string]*global.ProtocolConfig)
 		}
-		srvOpts.Protocols[key] = proOpts.Protocol
+		srvOpts.Protocols[proOpts.ID] = proOpts.Protocol
 	}
 }
 


### PR DESCRIPTION
This PR aims to solve issue(https://github.com/apache/dubbo-go/issues/2444) and unify options design.
For instance, in former implementation, we use DefaultOptions and apply those Option to DefaultOptions directly.
```go
// dubbo.WithRegistry
func WithRegistry(key string, opts ...registry.Option) ClientOption {
	regOpts := registry.DefaultOptions()
	for _, opt := range opts {
		opt(regOpts)
	}

	return func(cliOpts *ClientOptions) {
		if cliOpts.Registries == nil {
			cliOpts.Registries = make(map[string]*global.RegistryConfig)
		}
		cliOpts.Registries[key] = regOpts.Registry
		cliOpts.Registries[regOpts.ID] = regOpts.Registry
	}
}
```
We should move this logic to registry module so that extensions would be easy to add. As a result, introducing  ```NewOptions(opts ...Option) *Options```  in each module. Then **dubbo.WithRegistry** would become:
```go
func WithRegistry(opts ...registry.Option) InstanceOption {
	regOpts := registry.NewOptions(opts...)

	return func(insOpts *InstanceOptions) {
		if insOpts.Registries == nil {
			insOpts.Registries = make(map[string]*global.RegistryConfig)
		}
		insOpts.Registries[regOpts.ID] = regOpts.Registry
	}
}
```
We could add some logics into NewOptions and do not expose these details to other modules.
```go
func NewOptions(opts ...Option) *Options {
	defOpts := defaultOptions()
	for _, opt := range opts {
		opt(defOpts)
	}

	if defOpts.Registry.Protocol == "" {
		panic(fmt.Sprintf("Please specify registry, eg. WithZookeeper()"))
	}
	if defOpts.ID == "" {
		defOpts.ID = defOpts.Registry.Protocol
	}

	return defOpts
}
```