### PR TITLE
feat: add rpc exception metrics

### DIFF
--- a/metrics/rpc/collector.go
+++ b/metrics/rpc/collector.go
@@ -154,10 +154,10 @@ func (c *rpcCollector) incRequestsSucceedTotal(role string, labels map[string]st
 
 func (c *rpcCollector) incRequestsFailedTotal(role string, labels map[string]string) {
 	switch role {
-	case providerField:
+	case constant.SideProvider:
 		c.metricSet.provider.requestsFailedTotal.Inc(labels)
 		c.metricSet.provider.requestsFailedTotalAggregate.Inc(labels)
-	case consumerField:
+	case constant.SideConsumer:
 		c.metricSet.consumer.requestsFailedTotal.Inc(labels)
 		c.metricSet.consumer.requestsFailedTotalAggregate.Inc(labels)
 	}

--- a/metrics/rpc/collector.go
+++ b/metrics/rpc/collector.go
@@ -95,6 +95,9 @@ func (c *rpcCollector) afterInvokeHandler(event *metricsEvent) {
 	if event.result != nil {
 		if event.result.Error() == nil {
 			c.incRequestsSucceedTotal(role, labels)
+		} else {
+			// TODO: Breaking down RPC exceptions further
+			c.incRequestsFailedTotal(role, labels)
 		}
 	}
 	c.reportRTMilliseconds(role, labels, event.costTime.Milliseconds())
@@ -146,6 +149,17 @@ func (c *rpcCollector) incRequestsSucceedTotal(role string, labels map[string]st
 	case constant.SideConsumer:
 		c.metricSet.consumer.requestsSucceedTotal.Inc(labels)
 		c.metricSet.consumer.requestsSucceedTotalAggregate.Inc(labels)
+	}
+}
+
+func (c *rpcCollector) incRequestsFailedTotal(role string, labels map[string]string) {
+	switch role {
+	case providerField:
+		c.metricSet.provider.requestsFailedTotal.Inc(labels)
+		c.metricSet.provider.requestsFailedTotalAggregate.Inc(labels)
+	case consumerField:
+		c.metricSet.consumer.requestsFailedTotal.Inc(labels)
+		c.metricSet.consumer.requestsFailedTotalAggregate.Inc(labels)
 	}
 }
 

--- a/metrics/rpc/metric_set.go
+++ b/metrics/rpc/metric_set.go
@@ -43,6 +43,8 @@ type rpcCommonMetrics struct {
 	requestsProcessingTotal       metrics.GaugeVec
 	requestsSucceedTotal          metrics.CounterVec
 	requestsSucceedTotalAggregate metrics.AggregateCounterVec
+	requestsFailedTotal           metrics.CounterVec
+	requestsFailedTotalAggregate  metrics.AggregateCounterVec
 	rtMilliseconds                metrics.RtVec
 	rtMillisecondsQuantiles       metrics.QuantileMetricVec
 	rtMillisecondsAggregate       metrics.RtVec
@@ -66,6 +68,8 @@ func (pm *providerMetrics) init(registry metrics.MetricRegistry) {
 	pm.requestsProcessingTotal = metrics.NewGaugeVec(registry, metrics.NewMetricKey("dubbo_provider_requests_processing_total", "The number of received requests being processed by the provider"))
 	pm.requestsSucceedTotal = metrics.NewCounterVec(registry, metrics.NewMetricKey("dubbo_provider_requests_succeed_total", "The number of requests successfully received by the provider"))
 	pm.requestsSucceedTotalAggregate = metrics.NewAggregateCounterVec(registry, metrics.NewMetricKey("dubbo_provider_requests_succeed_total_aggregate", "The number of successful requests received by the provider under the sliding window"))
+	pm.requestsFailedTotal = metrics.NewCounterVec(registry, metrics.NewMetricKey("dubbo_provider_requests_failed_total", "Total Failed Requests"))
+	pm.requestsFailedTotalAggregate = metrics.NewAggregateCounterVec(registry, metrics.NewMetricKey("dubbo_provider_requests_failed_total_aggregate", "Total Failed Aggregate Requests"))
 	pm.rtMilliseconds = metrics.NewRtVec(registry,
 		metrics.NewMetricKey("dubbo_provider_rt_milliseconds", "response time among all requests processed by the provider"),
 		&metrics.RtOpts{Aggregate: false},
@@ -89,6 +93,8 @@ func (cm *consumerMetrics) init(registry metrics.MetricRegistry) {
 	cm.requestsProcessingTotal = metrics.NewGaugeVec(registry, metrics.NewMetricKey("dubbo_consumer_requests_processing_total", "The number of received requests being processed by the consumer"))
 	cm.requestsSucceedTotal = metrics.NewCounterVec(registry, metrics.NewMetricKey("dubbo_consumer_requests_succeed_total", "The number of successful requests sent by consumers"))
 	cm.requestsSucceedTotalAggregate = metrics.NewAggregateCounterVec(registry, metrics.NewMetricKey("dubbo_consumer_requests_succeed_total_aggregate", "The number of successful requests sent by consumers under the sliding window"))
+	cm.requestsFailedTotal = metrics.NewCounterVec(registry, metrics.NewMetricKey("dubbo_consumer_requests_failed_total", "Total Failed Requests"))
+	cm.requestsFailedTotalAggregate = metrics.NewAggregateCounterVec(registry, metrics.NewMetricKey("dubbo_consumer_requests_failed_total_aggregate", "Total Failed Aggregate Requests"))
 	cm.rtMilliseconds = metrics.NewRtVec(registry,
 		metrics.NewMetricKey("dubbo_consumer_rt_milliseconds", "response time among all requests from consumers"),
 		&metrics.RtOpts{Aggregate: false},

--- a/metrics/rpc/metric_set.go
+++ b/metrics/rpc/metric_set.go
@@ -75,7 +75,7 @@ func (pm *providerMetrics) init(registry metrics.MetricRegistry) {
 		&metrics.RtOpts{Aggregate: false},
 	)
 	pm.rtMillisecondsAggregate = metrics.NewRtVec(registry,
-		metrics.NewMetricKey("dubbo_provider_rt_milliseconds", "response time of the provider under the sliding window"),
+		metrics.NewMetricKey("dubbo_provider_rt", "response time of the provider under the sliding window"),
 		&metrics.RtOpts{Aggregate: true, BucketNum: metrics.DefaultBucketNum, TimeWindowSeconds: metrics.DefaultTimeWindowSeconds},
 	)
 	pm.rtMillisecondsQuantiles = metrics.NewQuantileMetricVec(registry, []*metrics.MetricKey{
@@ -100,7 +100,7 @@ func (cm *consumerMetrics) init(registry metrics.MetricRegistry) {
 		&metrics.RtOpts{Aggregate: false},
 	)
 	cm.rtMillisecondsAggregate = metrics.NewRtVec(registry,
-		metrics.NewMetricKey("dubbo_consumer_rt_milliseconds", "response time of the consumer under the sliding window"),
+		metrics.NewMetricKey("dubbo_consumer_rt", "response time of the consumer under the sliding window"),
 		&metrics.RtOpts{Aggregate: true, BucketNum: metrics.DefaultBucketNum, TimeWindowSeconds: metrics.DefaultTimeWindowSeconds},
 	)
 	cm.rtMillisecondsQuantiles = metrics.NewQuantileMetricVec(registry, []*metrics.MetricKey{


### PR DESCRIPTION
## Main changes
- implement new metrics: 
  - dubbo_provider_requests_failed_total
  - dubbo_consumer_requests_failed_total
  - dubbo_provider_requests_failed_total_aggregate
  - dubbo_consumer_requests_failed_total_aggregate
- fix a metrics naming error

## Next to do
According to the type of RPC exception, implement more detailed metrics to refine the granularity.
