### PR TITLE
[3.0] ci: Clone from target branch

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -2,7 +2,9 @@ name: CI
 
 on:
   push:
-    branches: "*"
+    branches:
+      - main
+      - 'release-*'
   pull_request:
     branches: "*"
 
@@ -66,7 +68,6 @@ jobs:
     - name: Format code
       run: |
         go fmt ./... && git status && [[ -z `git status -s` ]]
-        # diff -u <(echo -n) <(gofmt -d -s .)
 
     - name: Verify
       run: |

--- a/integrate_test.sh
+++ b/integrate_test.sh
@@ -36,7 +36,7 @@ echo "github pull request base branch -> $3"
 echo "github pull request head branch -> ${GITHUB_HEAD_REF}"
 
 echo "use dubbo-go-samples $3 branch for integration testing"
-git clone -b master https://github.com/apache/dubbo-go-samples.git samples && cd samples
+git clone -b $3 https://github.com/apache/dubbo-go-samples.git samples && cd samples
 
 # update dubbo-go to current commit id
 go mod edit -replace=dubbo.apache.org/dubbo-go/v3=github.com/"$1"/v3@"$2"


### PR DESCRIPTION
We are maintaining several branches at this time, e.g. release-3.0 and
main. However, cloning dubbo-go-samples for integrate testing is still from
master. This leads to CI failure on old branch, like release-3.0, when the
master branch have received some breaking changes. Therefore, the
dubbo-go-samples' branch is required to keep same as the target branch.