### PR TITLE
[3.0] ci: Fix CI testing failure on push

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -77,12 +77,10 @@ jobs:
       run: |
         if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
           chmod +x integrate_test.sh \
-            && [[ -n "${{github.event.pull_request.head.repo.full_name}}" ]] \
-            && [[ -n "${{github.event.pull_request.head.sha}}" ]] \
-            && [[ -n "${{github.base_ref}}" ]] \
             && ./integrate_test.sh ${{github.event.pull_request.head.repo.full_name}} ${{github.event.pull_request.head.sha}} ${{github.base_ref}}
         elif [ "$GITHUB_EVENT_NAME" == "push" ]; then
-          chmod +x integrate_test.sh && ./integrate_test.sh $GITHUB_REPOSITORY $GITHUB_SHA $GITHUB_BASE_REF
+          chmod +x integrate_test.sh  \
+            && ./integrate_test.sh $GITHUB_REPOSITORY $GITHUB_SHA $GITHUB_REF_NAME
         else
           echo "$GITHUB_EVENT_NAME is an unsupported event type."
           exit 1

--- a/integrate_test.sh
+++ b/integrate_test.sh
@@ -17,29 +17,22 @@
 #!/bin/bash
 
 set -e
-set -x
 
-echo 'start integrate-test'
+echo "start integrate-test: repo = $1, SHA = $2, branch = $3"
 
 # set root workspace
 ROOT_DIR=$(pwd)
 echo "integrate-test root work-space -> ${ROOT_DIR}"
 
-# show all github-env
-echo "github current commit id  -> $2"
-echo "github pull request branch -> ${GITHUB_REF}"
-echo "github pull request slug -> ${GITHUB_REPOSITORY}"
-echo "github pull request repo slug -> ${GITHUB_REPOSITORY}"
-echo "github pull request actor -> ${GITHUB_ACTOR}"
-echo "github pull request repo param -> $1"
-echo "github pull request base branch -> $3"
-echo "github pull request head branch -> ${GITHUB_HEAD_REF}"
-
 echo "use dubbo-go-samples $3 branch for integration testing"
 git clone -b $3 https://github.com/apache/dubbo-go-samples.git samples && cd samples
 
 # update dubbo-go to current commit id
-go mod edit -replace=dubbo.apache.org/dubbo-go/v3=github.com/"$1"/v3@"$2"
+if [ "$1" == "apache/dubbo-go" ]; then
+    go mod edit -replace=dubbo.apache.org/dubbo-go/v3=dubbo.apache.org/dubbo-go/v3@"$2"
+else
+    go mod edit -replace=dubbo.apache.org/dubbo-go/v3=github.com/"$1"/v3@"$2"
+fi
 
 go mod tidy
 


### PR DESCRIPTION
`$GITHUB_BASE_NAME` is an invalid variable, and is replaced with
`$GITHUB_REF_NAME` to acquire target branch of push.

Replacing mod name in `integrate_test.sh` adapts a case of
"apache/dubbo-go". It ensures that its mod name isn't changed to
"github.com/apache/dubbo-go".