### PR TITLE
feat: support configuring client.WithURL without protocol prefix

### DIFF
--- a/client/options_test.go
+++ b/client/options_test.go
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package client
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestWithURL(t *testing.T) {
+	tests := []struct {
+		opts    []ClientOption
+		justify func(t *testing.T, opts *ClientOptions)
+	}{
+		{
+			opts: []ClientOption{
+				WithURL("127.0.0.1:20000"),
+			},
+			justify: func(t *testing.T, opts *ClientOptions) {
+				urls := opts.urls
+				assert.Equal(t, 1, len(urls))
+				assert.Equal(t, "tri", urls[0].Protocol)
+			},
+		},
+		{
+			opts: []ClientOption{
+				WithURL("tri://127.0.0.1:20000"),
+			},
+			justify: func(t *testing.T, opts *ClientOptions) {
+				urls := opts.urls
+				assert.Equal(t, 1, len(urls))
+				assert.Equal(t, "tri", urls[0].Protocol)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		newOpts := defaultClientOptions()
+		assert.Nil(t, newOpts.init(test.opts...))
+		assert.Nil(t, newOpts.processURL(&common.URL{}))
+		test.justify(t, newOpts)
+	}
+}

--- a/dubbo.go
+++ b/dubbo.go
@@ -23,7 +23,6 @@ import (
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/client"
-	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/server"
 )
 
@@ -61,17 +60,16 @@ func (ins *Instance) NewClient(opts ...client.ClientOption) (*client.Client, err
 	regsCfg := ins.insOpts.Registries
 	sdCfg := ins.insOpts.Shutdown
 	if conCfg != nil {
-		refCfg := &global.ReferenceConfig{
-			Check:       &conCfg.Check,
-			Filter:      conCfg.Filter,
-			Protocol:    conCfg.Protocol,
-			RegistryIDs: conCfg.RegistryIDs,
-			TracingKey:  conCfg.TracingKey,
+		if conCfg.Check {
+			cliOpts = append(cliOpts, client.WithCheck())
 		}
 		// these options come from Consumer and Root.
 		// for dubbo-go developers, referring config/ConsumerConfig.Init and config/ReferenceConfig
 		cliOpts = append(cliOpts,
-			client.SetReference(refCfg),
+			client.WithFilter(conCfg.Filter),
+			// todo(DMwangnima): deal with Protocol
+			client.WithRegistryIDs(conCfg.RegistryIDs),
+			// todo(DMwangnima): deal with TracingKey
 			client.SetConsumer(conCfg),
 		)
 	}

--- a/protocol/triple/internal/client/cmd_client/main.go
+++ b/protocol/triple/internal/client/cmd_client/main.go
@@ -27,7 +27,7 @@ import (
 func main() {
 	// for the most brief RPC case
 	cli, err := client.NewClient(
-		client.WithURL("tri://127.0.0.1:20000"),
+		client.WithURL("127.0.0.1:20000"),
 	)
 	if err != nil {
 		panic(err)

--- a/protocol/triple/internal/client/cmd_instance/main.go
+++ b/protocol/triple/internal/client/cmd_instance/main.go
@@ -36,7 +36,7 @@ func main() {
 	}
 	// configure the params that only client layer cares
 	cli, err := ins.NewClient(
-		client.WithURL("tri://127.0.0.1:20000"),
+		client.WithURL("127.0.0.1:20000"),
 	)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This PR aims to support another type of configuring ```client.WithURL```:
```go
client.WithURL("127.0.0.1:20000")

client.WithURL("tri://127.0.0.1:20000")
```
Both of them could work well.