### PR TITLE
Check and set client level registry if reference level is empty.

### DIFF
--- a/client/options.go
+++ b/client/options.go
@@ -114,7 +114,13 @@ func (refOpts *ReferenceOptions) init(cli *Client, opts ...ReferenceOption) erro
 	if ref.RegistryIDs == nil || len(ref.RegistryIDs) <= 0 {
 		emptyRegIDsFlag = true
 	}
+
+	// set client level as default registry
 	regs := refOpts.Registries
+	if regs == nil {
+		regs = cli.cliOpts.Registries
+	}
+
 	if regs != nil {
 		refOpts.registriesCompat = make(map[string]*config.RegistryConfig)
 		for key, reg := range regs {


### PR DESCRIPTION
Registries can be set at client and reference level, check and set client level registry if reference level is empty.