### PR TITLE
Fix:modify router warn log

### DIFF
--- a/cluster/router/condition/dynamic_router.go
+++ b/cluster/router/condition/dynamic_router.go
@@ -124,7 +124,7 @@ func (s *ServiceRouter) Notify(invokers []protocol.Invoker) {
 
 	dynamicConfiguration := conf.GetEnvInstance().GetDynamicConfiguration()
 	if dynamicConfiguration == nil {
-		logger.Warnf("config center does not start, please check if the configuration center has been properly configured in dubbogo.yml")
+		logger.Infof("Config center does not start, Condition router will not be enabled")
 		return
 	}
 	key := strings.Join([]string{url.ColonSeparatedKey(), constant.ConditionRouterRuleSuffix}, "")
@@ -183,7 +183,7 @@ func (a *ApplicationRouter) Notify(invokers []protocol.Invoker) {
 	if providerApplicaton != a.application {
 		dynamicConfiguration := conf.GetEnvInstance().GetDynamicConfiguration()
 		if dynamicConfiguration == nil {
-			logger.Warnf("config center does not start, please check if the configuration center has been properly configured in dubbogo.yml")
+			logger.Infof("Config center does not start, Condition router will not be enabled")
 			return
 		}
 

--- a/cluster/router/tag/router.go
+++ b/cluster/router/tag/router.go
@@ -84,7 +84,7 @@ func (p *PriorityRouter) Notify(invokers []protocol.Invoker) {
 	}
 	dynamicConfiguration := conf.GetEnvInstance().GetDynamicConfiguration()
 	if dynamicConfiguration == nil {
-		logger.Warnf("config center does not start, please check if the configuration center has been properly configured in dubbogo.yml")
+		logger.Infof("Config center does not start, Tag router will not be enabled")
 		return
 	}
 	key := strings.Join([]string{application, constant.TagRouterRuleSuffix}, "")


### PR DESCRIPTION
related #2558
I think if users don't set config center ,we should print a info log rather than a warning, telling the user that the router will not be enabled