### PR TITLE
fix:call offline services

### DIFF
--- a/registry/directory/directory.go
+++ b/registry/directory/directory.go
@@ -142,7 +142,7 @@ func (dir *RegistryDirectory) Notify(event *registry.ServiceEvent) {
 // NotifyAll notify the events that are complete Service Event List.
 // After notify the address, the callback func will be invoked.
 func (dir *RegistryDirectory) NotifyAll(events []*registry.ServiceEvent, callback func()) {
-	go dir.refreshAllInvokers(events, callback)
+	dir.refreshAllInvokers(events, callback)
 }
 
 // refreshInvokers refreshes service's events.


### PR DESCRIPTION
refer #2430
In the case that a large number of services go offline in a short period of time, the dubbo service will call the offline service
This is a temporary solution, we will later reproduce the scenario and test its performance