### PR TITLE
Fix/retry opt (#2598)

### DIFF
--- a/cluster/cluster/failback/cluster_invoker.go
+++ b/cluster/cluster/failback/cluster_invoker.go
@@ -22,21 +22,15 @@ import (
 	"strconv"
 	"sync"
 	"time"
-)
 
-import (
-	"github.com/Workiva/go-datastructures/queue"
-
-	"github.com/dubbogo/gost/log/logger"
-)
-
-import (
 	"dubbo.apache.org/dubbo-go/v3/cluster/cluster/base"
 	"dubbo.apache.org/dubbo-go/v3/cluster/directory"
 	"dubbo.apache.org/dubbo-go/v3/cluster/loadbalance"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/protocol"
+	"github.com/Workiva/go-datastructures/queue"
+	"github.com/dubbogo/gost/log/logger"
 )
 
 /**
@@ -212,7 +206,7 @@ func newRetryTimerTask(loadbalance loadbalance.LoadBalance, invocation protocol.
 		clusterInvoker: cInvoker,
 	}
 
-	if retries, ok := invocation.GetAttachment(constant.RetriesKey); ok {
+	if retries, ok := invocation.GetAttachment(constant.RetriesKey); ok && retries != "" {
 		rInt, _ := strconv.Atoi(retries)
 		task.maxRetries = int64(rInt)
 	} else {

--- a/cluster/cluster/failover/cluster_invoker.go
+++ b/cluster/cluster/failover/cluster_invoker.go
@@ -116,8 +116,7 @@ func getRetries(invokers []protocol.Invoker, invocation protocol.Invocation, met
 	// Get CallOpt first
 	if callRetries, ok := invocation.GetAttachment(constant.RetriesKey); ok {
 		retries, _ = strconv.Atoi(callRetries)
-		//
-		if retries < 0 {
+		if retries < 0 || callRetries == "" {
 			retries = clientRetries
 		}
 	}

--- a/cluster/cluster/failover/cluster_invoker.go
+++ b/cluster/cluster/failover/cluster_invoker.go
@@ -20,6 +20,7 @@ package failover
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/dubbogo/gost/log/logger"
 	perrors "github.com/pkg/errors"
@@ -55,7 +56,7 @@ func (invoker *failoverClusterInvoker) Invoke(ctx context.Context, invocation pr
 	}
 
 	methodName := invocation.ActualMethodName()
-	retries := getRetries(invokers, methodName)
+	retries := getRetries(invokers, invocation, methodName)
 	loadBalance := base.GetLoadBalance(invokers[0], methodName)
 
 	for i := 0; i <= retries; i++ {
@@ -104,17 +105,26 @@ func (invoker *failoverClusterInvoker) Invoke(ctx context.Context, invocation pr
 	}
 }
 
-func getRetries(invokers []protocol.Invoker, methodName string) int {
+func getRetries(invokers []protocol.Invoker, invocation protocol.Invocation, methodName string) int {
 	if len(invokers) <= 0 {
 		return constant.DefaultRetriesInt
 	}
 	url := invokers[0].GetURL()
-
-	retries := url.GetMethodParamIntValue(methodName, constant.RetriesKey,
+	clientRetries := url.GetMethodParamIntValue(methodName, constant.RetriesKey,
 		url.GetParamByIntValue(constant.RetriesKey, constant.DefaultRetriesInt))
+	retries := clientRetries
+	// Get CallOpt first
+	if callRetries, ok := invocation.GetAttachment(constant.RetriesKey); ok {
+		retries, _ = strconv.Atoi(callRetries)
+		//
+		if retries < 0 {
+			retries = clientRetries
+		}
+	}
 
 	if retries < 0 {
 		return constant.DefaultRetriesInt
 	}
+
 	return retries
 }

--- a/cluster/cluster/failover/cluster_test.go
+++ b/cluster/cluster/failover/cluster_test.go
@@ -22,13 +22,7 @@ import (
 	"fmt"
 	"net/url"
 	"testing"
-)
 
-import (
-	"github.com/stretchr/testify/assert"
-)
-
-import (
 	clusterpkg "dubbo.apache.org/dubbo-go/v3/cluster/cluster"
 	"dubbo.apache.org/dubbo-go/v3/cluster/directory/static"
 	"dubbo.apache.org/dubbo-go/v3/cluster/loadbalance/random"
@@ -37,6 +31,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/protocol"
 	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
+	"github.com/stretchr/testify/assert"
 )
 
 // nolint
@@ -75,7 +70,8 @@ func TestFailoverInvokeFail(t *testing.T) {
 }
 
 // nolint
-func TestFailoverInvoke1(t *testing.T) {
+// Test client retries opt
+func TestFailoverRetries1(t *testing.T) {
 	urlParams := url.Values{}
 	urlParams.Set(constant.RetriesKey, "3")
 	result := normalInvoke(4, urlParams)
@@ -84,13 +80,27 @@ func TestFailoverInvoke1(t *testing.T) {
 }
 
 // nolint
-func TestFailoverInvoke2(t *testing.T) {
+// Test client retries opt
+func TestFailoverRetries2(t *testing.T) {
 	urlParams := url.Values{}
 	urlParams.Set(constant.RetriesKey, "2")
 	urlParams.Set("methods.test."+constant.RetriesKey, "3")
 
 	ivc := invocation.NewRPCInvocationWithOptions(invocation.WithMethodName("test"))
 	result := normalInvoke(4, urlParams, ivc)
+	assert.NoError(t, result.Error())
+	clusterpkg.Count = 0
+}
+
+// nolint
+// Test call retries opt
+func TestFailoverRetries3(t *testing.T) {
+	urlParams := url.Values{}
+	urlParams.Set(constant.RetriesKey, "2")
+	urlParams.Set("methods.test."+constant.RetriesKey, "3")
+
+	ivc := invocation.NewRPCInvocationWithOptions(invocation.WithMethodName("test"), invocation.WithAttachment(constant.RetriesKey, "4"))
+	result := normalInvoke(5, urlParams, ivc)
 	assert.NoError(t, result.Error())
 	clusterpkg.Count = 0
 }


### PR DESCRIPTION
fix https://github.com/apache/dubbo-go/issues/2598
Currently, failover has been fixed, and failback will be fixed later.