### PR TITLE
fix: log

### DIFF
--- a/registry/servicediscovery/service_instances_changed_listener_impl.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl.go
@@ -99,7 +99,7 @@ func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error
 	protocolRevisionsToUrls := make(map[string]map[*gxset.HashSet][]*common.URL)
 	newServiceURLs := make(map[string][]*common.URL)
 
-	logger.Infof("Received instance notification event of service %s, instance list size %s", ce.ServiceName, len(ce.Instances))
+	logger.Infof("Received instance notification event of service %s, instance list size %d", ce.ServiceName, len(ce.Instances))
 
 	for _, instances := range lstn.allInstances {
 		for _, instance := range instances {


### PR DESCRIPTION
When I was writing the example of dubbo-go-samples, I found that there was a problem with printing log.
![image](https://github.com/apache/dubbo-go/assets/102770919/68d42bac-7886-47c0-8afe-2bfb6c01936e)

