### PR TITLE
Fix:Initialize the correct otel-grpc exporter (#2666)

### DIFF
--- a/otel/trace/otlp/exporter.go
+++ b/otel/trace/otlp/exporter.go
@@ -45,7 +45,7 @@ var (
 
 func init() {
 	extension.SetTraceExporter("otlp-http", newHttpExporter)
-	extension.SetTraceExporter("otlp-grpc", newHttpExporter)
+	extension.SetTraceExporter("otlp-grpc", newGrpcExporter)
 }
 
 type Exporter struct {


### PR DESCRIPTION
backport #2666 to 3.1

Co-authored-by: yunfei <qiuyunfei@kiwiing.com>
(cherry picked from commit 1bd6abc9110f07daec24ec0c09dac9c987e20593)