### PR TITLE
fix: fix miss makezero bug

### DIFF
--- a/protocol/dubbo3/dubbo3_protocol.go
+++ b/protocol/dubbo3/dubbo3_protocol.go
@@ -147,7 +147,7 @@ func (dp *DubboProtocol) Refer(url *common.URL) protocol.Invoker {
 // Destroy destroy dubbo3 service.
 func (dp *DubboProtocol) Destroy() {
 	dp.BaseProtocol.Destroy()
-	keyList := make([]string, 16)
+	keyList := make([]string, 0, 16)
 
 	dp.serverLock.Lock()
 	defer dp.serverLock.Unlock()

--- a/registry/servicediscovery/service_instances_changed_listener_impl.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl.go
@@ -114,7 +114,7 @@ func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error
 			}
 			subInstances := revisionToInstances[revision]
 			if subInstances == nil {
-				subInstances = make([]registry.ServiceInstance, 8)
+				subInstances = make([]registry.ServiceInstance, 0, 8)
 			}
 			revisionToInstances[revision] = append(subInstances, instance)
 			metadataInfo := lstn.revisionToMetadata[revision]

--- a/xds/client/resource/filter_chain.go
+++ b/xds/client/resource/filter_chain.go
@@ -110,7 +110,7 @@ type RouteWithInterceptors struct {
 // ConstructUsableRouteConfiguration takes Route Configuration and converts it
 // into matchable route configuration, with instantiated HTTP Filters per route.
 func (f *FilterChain) ConstructUsableRouteConfiguration(config RouteConfigUpdate) ([]VirtualHostWithInterceptors, error) {
-	vhs := make([]VirtualHostWithInterceptors, len(config.VirtualHosts))
+	vhs := make([]VirtualHostWithInterceptors, 0, len(config.VirtualHosts))
 	for _, vh := range config.VirtualHosts {
 		vhwi, err := f.convertVirtualHost(vh)
 		if err != nil {


### PR DESCRIPTION
I was running github actions to run linter [makezero](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1

and the github actions output https://github.com/alingse/go-linter-runner/actions/runs/9242652074/job/25425741161

```
====================================================================================================
append to slice `vhs` with non-zero initialized length at https://github.com/apache/dubbo-go/blob/main/xds/client/resource/filter_chain.go#L119:9
append to slice `keyList` with non-zero initialized length at https://github.com/apache/dubbo-go/blob/main/protocol/dubbo3/dubbo3_protocol.go#L156:13
append to slice `in` with non-zero initialized length at https://github.com/apache/dubbo-go/blob/main/proxy/proxy_factory/pass_through.go#L[10](https://github.com/alingse/go-linter-runner/actions/runs/9242652074/job/25425741161#step:4:11)5:7
append to slice `in` with non-zero initialized length at https://github.com/apache/dubbo-go/blob/main/proxy/proxy_factory/pass_through.go#L106:7
append to slice `in` with non-zero initialized length at https://github.com/apache/dubbo-go/blob/main/proxy/proxy_factory/pass_through.go#L107:7
append to slice `in` with non-zero initialized length at https://github.com/apache/dubbo-go/blob/main/proxy/proxy_factory/pass_through.go#L108:7
append to slice `in` with non-zero initialized length at https://github.com/apache/dubbo-go/blob/main/proxy/proxy_factory/pass_through.go#L109:7
append to slice `subInstances` with non-zero initialized length at https://github.com/apache/dubbo-go/blob/main/registry/servicediscovery/service_instances_changed_listener_impl.go#L[11](https://github.com/alingse/go-linter-runner/actions/runs/9242652074/job/25425741161#step:4:12)9:36
====================================================================================================
```
the `vhs` , `keyList` , `subInstances`  is easy to check that they are bugs and they need make the slice to zero length.


but the other lines has var `in`  that linter reported,  I don't know if they are some special usage, so I  wasn't commit them.

```go
	in := make([]reflect.Value, 5) // maybe should replace with  in := make([]reflect.Value, 0, 5)
	in = append(in, srv.Rcvr())
	in = append(in, reflect.ValueOf(invocation.MethodName()))
	in = append(in, reflect.ValueOf(invocation.GetAttachmentInterface(constant.ParamsTypeKey)))
	in = append(in, reflect.ValueOf(args))
	in = append(in, reflect.ValueOf(invocation.Attachments()))
```

