### PR TITLE
support conditional routing with multiple destinations, customize conditional routing priorities and operation in route fail

### DIFF
--- a/cluster/router/condition/dynamic_router.go
+++ b/cluster/router/condition/dynamic_router.go
@@ -18,9 +18,7 @@
 package condition
 
 import (
-	"dubbo.apache.org/dubbo-go/v3/cluster/utils"
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"sort"
 	"strconv"
 	"strings"
@@ -28,10 +26,7 @@ import (
 )
 
 import (
-	"github.com/dubbogo/gost/log/logger"
-)
-
-import (
+	"dubbo.apache.org/dubbo-go/v3/cluster/utils"
 	"dubbo.apache.org/dubbo-go/v3/common"
 	conf "dubbo.apache.org/dubbo-go/v3/common/config"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
@@ -39,6 +34,10 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/config_center"
 	"dubbo.apache.org/dubbo-go/v3/protocol"
 	"dubbo.apache.org/dubbo-go/v3/remoting"
+
+	"github.com/dubbogo/gost/log/logger"
+
+	"gopkg.in/yaml.v2"
 )
 
 type conditionRoute []*StateRouter

--- a/cluster/router/condition/dynamic_router.go
+++ b/cluster/router/condition/dynamic_router.go
@@ -148,7 +148,7 @@ func generateCondition(rawConfig string) (condRouter, bool, bool, error) {
 	rawVersion, ok := m["configVersion"]
 	if !ok {
 		return nil, false, false, fmt.Errorf("miss `ConfigVersion` in %s", rawConfig)
-	} else if version, ok := rawVersion.(string); ok {
+	} else if version, ok := rawVersion.(string); !ok {
 		return nil, false, false, fmt.Errorf("`ConfigVersion should be `string` got %v`", rawVersion)
 	} else {
 		var (
@@ -162,9 +162,9 @@ func generateCondition(rawConfig string) (condRouter, bool, bool, error) {
 			switch mode {
 			case utils.VersionEqual:
 				cr, force, enable, err = generateMultiConditionRoute(rawConfig)
-			case utils.VersionLess:
-				cr, force, enable, err = generateConditionsRoute(rawConfig)
 			case utils.VersionGreater:
+				cr, force, enable, err = generateConditionsRoute(rawConfig)
+			case utils.VersionLess:
 				err = fmt.Errorf("config version %s is greater than %s", rawVersion, constant.RouteVersion)
 			default:
 				panic("invalid version compare return")

--- a/cluster/router/condition/dynamic_router.go
+++ b/cluster/router/condition/dynamic_router.go
@@ -206,7 +206,7 @@ func generateMultiConditionRoute(rawConfig string) (multiplyConditionRoute, bool
 	}
 
 	sort.Slice(conditionRouters, func(i, j int) bool {
-		return conditionRouters[i].priority < conditionRouters[j].priority
+		return conditionRouters[i].priority > conditionRouters[j].priority
 	})
 	return conditionRouters, force, enable, nil
 }

--- a/cluster/router/condition/route.go
+++ b/cluster/router/condition/route.go
@@ -41,13 +41,10 @@ import (
 )
 
 var (
-	routePattern = regexp.MustCompile("([&!=,]*)\\s*([^&!=,\\s]+)")
-
-	illegalMsg = "Illegal route rule \"%s\", The error char '%s' before '%s'"
-
+	routePattern     = regexp.MustCompile("([&!=,]*)\\s*([^&!=,\\s]+)")
+	illegalMsg       = "Illegal route rule \"%s\", The error char '%s' before '%s'"
 	matcherFactories = make([]matcher.ConditionMatcherFactory, 0, 8)
-
-	once sync.Once
+	once             sync.Once
 )
 
 type StateRouter struct {

--- a/cluster/router/condition/router_test.go
+++ b/cluster/router/condition/router_test.go
@@ -213,7 +213,7 @@ func TestRouteMatchFilter(t *testing.T) {
 			router, err := NewConditionStateRouter(url)
 			assert.Nil(t, err)
 
-			filteredInvokers := router.Route(invokerList, data.comsumerURL, rpcInvocation)
+			filteredInvokers, _ := router.Route(invokerList, data.comsumerURL, rpcInvocation)
 			resVal := len(filteredInvokers)
 			assert.Equal(t, data.wantVal, resVal)
 		})
@@ -239,7 +239,7 @@ func TestRouterMethodRoute(t *testing.T) {
 			wantVal: true,
 		},
 		{
-			name:        "Exactly one method, match",
+			name:        "Exactly one method, Route",
 			consumerURL: remoteConsumerAddr + "?methods=getFoo",
 			rule:        "methods=getFoo => host = 1.2.3.4",
 
@@ -406,7 +406,7 @@ func TestRouteReturn(t *testing.T) {
 			router, err := NewConditionStateRouter(url)
 			assert.Nil(t, err)
 
-			filterInvokers := router.Route(invokers, consumerURL, rpcInvocation)
+			filterInvokers, _ := router.Route(invokers, consumerURL, rpcInvocation)
 			resVal := len(filterInvokers)
 
 			assert.Equal(t, data.wantVal, resVal)
@@ -478,7 +478,7 @@ func TestRouteArguments(t *testing.T) {
 
 			rpcInvocation := invocation.NewRPCInvocation("getBar", arguments, nil)
 
-			filterInvokers := router.Route(invokerList, consumerURL, rpcInvocation)
+			filterInvokers, _ := router.Route(invokerList, consumerURL, rpcInvocation)
 			resVal := len(filterInvokers)
 			assert.Equal(t, data.wantVal, resVal)
 
@@ -558,7 +558,7 @@ func TestRouteAttachments(t *testing.T) {
 			router, err := NewConditionStateRouter(url)
 			assert.Nil(t, err)
 
-			filterInvokers := router.Route(invokerList, consumerURL, rpcInvocation)
+			filterInvokers, _ := router.Route(invokerList, consumerURL, rpcInvocation)
 
 			resVal := len(filterInvokers)
 			assert.Equal(t, data.wantVal, resVal)
@@ -647,7 +647,7 @@ func TestRouteRangePattern(t *testing.T) {
 			router, err := NewConditionStateRouter(url)
 			assert.Nil(t, err)
 
-			filterInvokers := router.Route(invokerList, consumerURL, rpcInvocation)
+			filterInvokers, _ := router.Route(invokerList, consumerURL, rpcInvocation)
 
 			resVal := len(filterInvokers)
 			assert.Equal(t, data.wantVal, resVal)
@@ -678,7 +678,7 @@ func TestRouteMultipleConditions(t *testing.T) {
 		wantVal int
 	}{
 		{
-			name:        "All conditions match",
+			name:        "All conditions Route",
 			argument:    "a",
 			consumerURL: localConsumerAddr + "?application=consumer_app",
 			rule:        "application=consumer_app&arguments[0]=a => host = 127.0.0.1",
@@ -686,7 +686,7 @@ func TestRouteMultipleConditions(t *testing.T) {
 			wantVal: 2,
 		},
 		{
-			name:        "One of the conditions does not match",
+			name:        "One of the conditions does not Route",
 			argument:    "a",
 			consumerURL: localConsumerAddr + "?application=another_consumer_app",
 			rule:        "application=consumer_app&arguments[0]=a => host = 127.0.0.1",
@@ -711,7 +711,7 @@ func TestRouteMultipleConditions(t *testing.T) {
 
 			rpcInvocation := invocation.NewRPCInvocation(method, arguments, nil)
 
-			filterInvokers := router.Route(invokerList, consumerUrl, rpcInvocation)
+			filterInvokers, _ := router.Route(invokerList, consumerUrl, rpcInvocation)
 			resVal := len(filterInvokers)
 			assert.Equal(t, data.wantVal, resVal)
 		})

--- a/cluster/router/condition/router_test.go
+++ b/cluster/router/condition/router_test.go
@@ -739,6 +739,7 @@ func TestServiceRouter(t *testing.T) {
 	ccURL, _ := common.NewURL("mock://127.0.0.1:1111")
 	mockFactory := &config_center.MockDynamicConfigurationFactory{
 		Content: `
+configVersion: v3.0
 scope: service
 force: true
 enabled: true
@@ -783,6 +784,7 @@ func TestApplicationRouter(t *testing.T) {
 	ccURL, _ := common.NewURL("mock://127.0.0.1:1111")
 	mockFactory := &config_center.MockDynamicConfigurationFactory{
 		Content: `
+configVersion: V3.0
 scope: application
 force: true
 enabled: true

--- a/cluster/utils/version.go
+++ b/cluster/utils/version.go
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package utils
 
 import (

--- a/cluster/utils/version.go
+++ b/cluster/utils/version.go
@@ -1,0 +1,80 @@
+package utils
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var parseVersionRe = regexp.MustCompile(`^[Vv](\d+(\.\d+)*)$`)
+
+func parseVersion(versionStr string) ([]int, error) {
+	if versionContainsIllegalCharacters(versionStr) {
+		return nil, fmt.Errorf("illegal version string: %s , parse fail ", versionStr)
+	}
+	matches := parseVersionRe.FindStringSubmatch(versionStr)
+	if matches == nil {
+		return nil, fmt.Errorf("invalid version string format")
+	}
+
+	versionParts := strings.Split(matches[1], ".")
+	version := make([]int, len(versionParts))
+
+	for i, part := range versionParts {
+		number, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, fmt.Errorf("invalid version number part: %s", part)
+		}
+		version[i] = number
+	}
+
+	return version, nil
+}
+
+const (
+	VersionEqual   = 0
+	VersionLess    = -1
+	VersionGreater = 1
+)
+
+func CompareVersions(src, target string) (int, error) {
+	version1, err := parseVersion(src)
+	if err != nil {
+		return 0, err
+	}
+	version2, err := parseVersion(target)
+	if err != nil {
+		return 0, err
+	}
+
+	for i := 0; i < len(version1) || i < len(version2); i++ {
+		v1 := 0
+		if i < len(version1) {
+			v1 = version1[i]
+		}
+		v2 := 0
+		if i < len(version2) {
+			v2 = version2[i]
+		}
+		if v1 > v2 {
+			return VersionGreater, nil
+		} else if v1 < v2 {
+			return VersionLess, nil
+		}
+	}
+
+	if len(version1) > len(version2) {
+		return VersionGreater, nil
+	} else if len(version1) < len(version2) {
+		return VersionLess, nil
+	} else {
+		return VersionEqual, nil
+	}
+}
+
+var versionContainsIllegalCharactersRe = regexp.MustCompile(`^[Vv0-9.]+$`)
+
+func versionContainsIllegalCharacters(s string) bool {
+	return !versionContainsIllegalCharactersRe.MatchString(s)
+}

--- a/cluster/utils/version.go
+++ b/cluster/utils/version.go
@@ -24,9 +24,14 @@ import (
 	"strings"
 )
 
-var parseVersionRe = regexp.MustCompile(`^[Vv](\d+(\.\d+)*)$`)
+type Version []int
 
-func parseVersion(versionStr string) ([]int, error) {
+var (
+	parseVersionRe = regexp.MustCompile(`^[Vv](\d+(\.\d+)*)$`)
+	V3_1, _        = ParseVersion("v3.1")
+)
+
+func ParseVersion(versionStr string) (Version, error) {
 	if versionContainsIllegalCharacters(versionStr) {
 		return nil, fmt.Errorf("illegal version string: %s , parse fail ", versionStr)
 	}
@@ -50,43 +55,44 @@ func parseVersion(versionStr string) ([]int, error) {
 }
 
 const (
-	VersionEqual   = 0
-	VersionLess    = -1
-	VersionGreater = 1
+	versionEqual   = 0
+	versionLess    = -1
+	versionGreater = 1
 )
 
-func CompareVersions(src, target string) (int, error) {
-	version1, err := parseVersion(src)
-	if err != nil {
-		return 0, err
-	}
-	version2, err := parseVersion(target)
-	if err != nil {
-		return 0, err
-	}
+func (v Version) Equal(target Version) bool {
+	return v.compareVersions(target) == versionEqual
+}
+func (v Version) Less(target Version) bool {
+	return v.compareVersions(target) == versionLess
+}
+func (v Version) Greater(target Version) bool {
+	return v.compareVersions(target) == versionGreater
+}
 
-	for i := 0; i < len(version1) || i < len(version2); i++ {
+func (v Version) compareVersions(target Version) int {
+	for i := 0; i < len(v) || i < len(target); i++ {
 		v1 := 0
-		if i < len(version1) {
-			v1 = version1[i]
+		if i < len(v) {
+			v1 = v[i]
 		}
 		v2 := 0
-		if i < len(version2) {
-			v2 = version2[i]
+		if i < len(target) {
+			v2 = target[i]
 		}
 		if v1 > v2 {
-			return VersionGreater, nil
+			return versionGreater
 		} else if v1 < v2 {
-			return VersionLess, nil
+			return versionLess
 		}
 	}
 
-	if len(version1) > len(version2) {
-		return VersionGreater, nil
-	} else if len(version1) < len(version2) {
-		return VersionLess, nil
+	if len(v) > len(target) {
+		return versionGreater
+	} else if len(v) < len(target) {
+		return versionLess
 	} else {
-		return VersionEqual, nil
+		return versionEqual
 	}
 }
 

--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -322,6 +322,7 @@ const (
 	ConditionServiceRouterFactoryKey = "service.condition"
 	ScriptRouterFactoryKey           = "consumer.script"
 	ForceKey                         = "force"
+	PriorityKey                      = "priority"
 	Arguments                        = "arguments"
 	Attachments                      = "attachments"
 	Param                            = "param"

--- a/common/constant/version.go
+++ b/common/constant/version.go
@@ -18,7 +18,8 @@
 package constant
 
 const (
-	Version = "3.2.0"     // apache/dubbo-go version
-	Name    = "dubbogo"   // module name
-	DATE    = "2024/1/10" // release date
+	Version      = "3.2.0"     // apache/dubbo-go version
+	Name         = "dubbogo"   // module name
+	DATE         = "2024/1/10" // release date
+	RouteVersion = "3.1"
 )

--- a/common/constant/version.go
+++ b/common/constant/version.go
@@ -21,5 +21,5 @@ const (
 	Version      = "3.2.0"     // apache/dubbo-go version
 	Name         = "dubbogo"   // module name
 	DATE         = "2024/1/10" // release date
-	RouteVersion = "3.1"
+	RouteVersion = "v3.1"
 )

--- a/config/router_config.go
+++ b/config/router_config.go
@@ -49,6 +49,22 @@ type Tag struct {
 	Addresses []string             `yaml:"addresses" json:"addresses,omitempty" property:"addresses"`
 }
 
+type ConditionRule struct {
+	Rule     string `validate:"required" yaml:"rule" json:"rule,omitempty" property:"rule"`
+	Priority int    `default:"0" yaml:"priority" json:"priority,omitempty" property:"priority"`
+	Force    bool   `default:"false" yaml:"force" json:"force,omitempty" property:"force"`
+}
+
+// ConditionRouter -- when RouteConfigVersion == v3.1, decode by this
+type ConditionRouter struct {
+	Scope      string          `validate:"required" yaml:"scope" json:"scope,omitempty" property:"scope"` // must be chosen from `service` and `application`.
+	Key        string          `validate:"required" yaml:"key" json:"key,omitempty" property:"key"`       // specifies which service or application the rule body acts on.
+	Force      bool            `default:"false" yaml:"force" json:"force,omitempty" property:"force"`
+	Runtime    bool            `default:"false" yaml:"runtime" json:"runtime,omitempty" property:"runtime"`
+	Enabled    bool            `default:"true" yaml:"enabled" json:"enabled,omitempty" property:"enabled"`
+	Conditions []ConditionRule `yaml:"conditions" json:"conditions,omitempty" property:"conditions"`
+}
+
 // Prefix dubbo.router
 func (RouterConfig) Prefix() string {
 	return constant.RouterConfigPrefix


### PR DESCRIPTION
to support #2684 

new condition-rule config like this
```yaml
configVersion: v3.1
scope: service
force: true
runtime: true
enabled: true
key: org.apache.dubbo.samples.CommentService
conditions:
  - rule: method=getComment & env=gray & region=beijing => region=beijing & env=gray
    force: fasle
    priority: 10
  - rule: method=getComment => region=Hangzhou
    force: false
    priority: 10
  - rule: method=echo =>
    force: true
    priority: 15
```
| Condition Field | Type   | Required | DefaultValue |
|-----------------|--------|---------|---------|
| Rule            | String |   &#10003;    |         |
| Force           | Bool   |         | False   |
| Priority        | Int64  |         | 0       |


through `configVersion` to choose parse and load logic. 
set `configVersion: v3.1` to use new feature.
