### PR TITLE
Design and implement new conditional rules V3.1

### DIFF
--- a/cluster/router/condition/dynamic_router.go
+++ b/cluster/router/condition/dynamic_router.go
@@ -188,10 +188,19 @@ func generateMultiConditionRoute(rawConfig string) (multiplyConditionRoute, bool
 		if err != nil {
 			return nil, false, false, err
 		}
+
 		url.SetAttribute(constant.RuleKey, conditionRule)
 		url.AddParam(constant.ForceKey, strconv.FormatBool(conditionRule.Force))
-		url.AddParam(constant.PriorityKey, strconv.FormatInt(int64(conditionRule.Priority), 10))
-		url.AddParam(constant.RatioKey, strconv.FormatInt(int64(conditionRule.Ratio), 10))
+		if conditionRule.Priority < 0 {
+			logger.Warnf("got conditionRouteConfig.conditions.priority (%d < 0) is invalid, ignore priority value, use defatult %d ", conditionRule.Priority, constant.DefaultRoutePriority)
+		} else {
+			url.AddParam(constant.PriorityKey, strconv.FormatInt(int64(conditionRule.Priority), 10))
+		}
+		if conditionRule.Ratio < 0 || conditionRule.Ratio > 100 {
+			logger.Warnf("got conditionRouteConfig.conditions.ratio (%d) is invalid, hope (0 - 100), ignore ratio value, use defatult %d ", conditionRule.Ratio, constant.DefaultRouteRatio)
+		} else {
+			url.AddParam(constant.RatioKey, strconv.FormatInt(int64(conditionRule.Ratio), 10))
+		}
 
 		conditionRoute, err := NewConditionMultiDestRouter(url)
 		if err != nil {

--- a/cluster/router/condition/route.go
+++ b/cluster/router/condition/route.go
@@ -18,6 +18,7 @@
 package condition
 
 import (
+	"math/rand"
 	"regexp"
 	"sort"
 	"strings"
@@ -48,9 +49,6 @@ var (
 )
 
 type StateRouter struct {
-	priority      int64
-	force         bool
-	url           *common.URL
 	whenCondition map[string]matcher.Matcher
 	thenCondition map[string]matcher.Matcher
 }
@@ -62,13 +60,7 @@ func NewConditionStateRouter(url *common.URL) (*StateRouter, error) {
 		return nil, errors.Errorf("No ConditionMatcherFactory exists")
 	}
 
-	force := url.GetParamBool(constant.ForceKey, false)
-	priority := url.GetParamInt(constant.PriorityKey, constant.DefaultPriority)
-	c := &StateRouter{
-		url:      url,
-		force:    force,
-		priority: priority,
-	}
+	c := &StateRouter{}
 
 	when, then, err := generateMatcher(url)
 	if err != nil {
@@ -83,18 +75,18 @@ func NewConditionStateRouter(url *common.URL) (*StateRouter, error) {
 // condition rule like `self_condition => peers_condition `
 //
 // @return active_peers_invokers, Is_self_condition_match_success
-func (s *StateRouter) Route(invokers []protocol.Invoker, url *common.URL, invocation protocol.Invocation) ([]protocol.Invoker, bool) {
+func (s *StateRouter) Route(invokers []protocol.Invoker, url *common.URL, invocation protocol.Invocation) []protocol.Invoker {
 	if len(invokers) == 0 {
-		return invokers, false
+		return invokers
 	}
 
 	if !s.matchWhen(url, invocation) {
-		return invokers, false
+		return invokers
 	}
 
 	if len(s.thenCondition) == 0 {
 		logger.Warn("condition state router thenCondition is empty")
-		return []protocol.Invoker{}, true
+		return []protocol.Invoker{}
 	}
 
 	var result = make([]protocol.Invoker, 0, len(invokers))
@@ -104,7 +96,7 @@ func (s *StateRouter) Route(invokers []protocol.Invoker, url *common.URL, invoca
 		}
 	}
 
-	return result, true
+	return result
 }
 
 func (s *StateRouter) matchWhen(url *common.URL, invocation protocol.Invocation) bool {
@@ -305,6 +297,146 @@ func parseConditionRoute(routeContent string) (*config.RouterConfig, error) {
 		return nil, err
 	}
 	return routerConfig, nil
+}
+
+// MultiDestRouter Multiply-Destination-Router
+type MultiDestRouter struct {
+	whenCondition map[string]matcher.Matcher
+	thenCondition []condSet
+	ratio         int // default 0, 0 to 100
+	priority      int
+	force         bool
+}
+
+type condSet struct {
+	cond         map[string]matcher.Matcher
+	subSetWeight int
+}
+
+func newCondSet(cond map[string]matcher.Matcher, subSetWeight int) *condSet {
+	if subSetWeight <= 0 {
+		subSetWeight = constant.DefaultConditionSubSetWeight
+	}
+	return &condSet{cond: cond, subSetWeight: subSetWeight}
+}
+
+type destSets struct {
+	dest []struct {
+		weight int
+		ivks   []protocol.Invoker
+	}
+	weightSum int
+}
+
+func newDestSets() *destSets {
+	return &destSets{
+		dest: make([]struct {
+			weight int
+			ivks   []protocol.Invoker
+		}, 0),
+		weightSum: 0,
+	}
+}
+
+func (s *destSets) addDest(weight int, ivks []protocol.Invoker) {
+	s.dest = append(s.dest, struct {
+		weight int
+		ivks   []protocol.Invoker
+	}{weight: weight, ivks: ivks})
+	s.weightSum += weight
+}
+
+func (s *destSets) roundDest() []protocol.Invoker {
+	if len(s.dest) == 1 {
+		return s.dest[0].ivks
+	}
+	sum := rand.Intn(s.weightSum)
+	for _, d := range s.dest {
+		sum -= d.weight
+		if sum < 0 {
+			return d.ivks
+		}
+	}
+	return nil
+}
+
+func (m MultiDestRouter) Route(invokers []protocol.Invoker, url *common.URL, invocation protocol.Invocation) ([]protocol.Invoker, bool) {
+	if len(invokers) == 0 {
+		return invokers, false
+	}
+
+	if !doMatch(url, nil, invocation, m.whenCondition, true) {
+		return invokers, false
+	}
+
+	if len(m.thenCondition) == 0 {
+		logger.Warn("condition state router thenCondition is empty")
+		return []protocol.Invoker{}, true
+	}
+
+	destinations := newDestSets()
+	for _, condition := range m.thenCondition {
+		res := make([]protocol.Invoker, 0)
+		for _, invoker := range invokers {
+			if doMatch(invoker.GetURL(), url, nil, condition.cond, false) {
+				res = append(res, invoker)
+			}
+		}
+		if len(res) != 0 {
+			destinations.addDest(condition.subSetWeight, res)
+		}
+	}
+	res := destinations.roundDest()
+
+	if len(invokers)*100/len(res) > m.ratio {
+		return res, true
+	}
+
+	return []protocol.Invoker{}, true
+}
+
+func NewConditionMultiDestRouter(url *common.URL) (*MultiDestRouter, error) {
+	once.Do(initMatcherFactories)
+
+	if len(matcherFactories) == 0 {
+		return nil, errors.Errorf("No ConditionMatcherFactory exists")
+	}
+
+	rawCondConf, ok := url.GetAttribute(constant.RuleKey)
+	if !ok {
+		return nil, errors.Errorf("Condition Router can't get the rule key")
+	}
+	condConf, ok := rawCondConf.(config.ConditionRule)
+	if !ok {
+		return nil, errors.Errorf("Condition Router get the rule key invaild , got %T", rawCondConf)
+	}
+
+	c := &MultiDestRouter{
+		whenCondition: make(map[string]matcher.Matcher),
+		thenCondition: make([]condSet, 0, len(condConf.To)),
+		ratio:         int(url.GetParamInt32(constant.RatioKey, 0)),
+		priority:      int(url.GetParamInt32(constant.PriorityKey, 0)),
+		force:         url.GetParamBool(constant.ForceKey, false),
+	}
+
+	m, err := parseRule(condConf.From.Match)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range m {
+		// if key same, cover
+		c.whenCondition[k] = v
+	}
+
+	for _, ruleTo := range condConf.To {
+		cond, err := parseRule(ruleTo.Match)
+		if err != nil {
+			return nil, err
+		}
+		c.thenCondition = append(c.thenCondition, *newCondSet(cond, ruleTo.Weight))
+	}
+
+	return c, nil
 }
 
 func parseMultiConditionRoute(routeContent string) (*config.ConditionRouter, error) {

--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -308,29 +308,31 @@ const (
 
 // Use for router module
 const (
-	ScriptRouterRuleSuffix           = ".script-router"
-	TagRouterRuleSuffix              = ".tag-router"
-	ConditionRouterRuleSuffix        = ".condition-router" // Specify condition router suffix
-	MeshRouteSuffix                  = ".MESHAPPRULE"      // Specify mesh router suffix
-	ForceUseTag                      = "dubbo.force.tag"   // the tag in attachment
-	ForceUseCondition                = "dubbo.force.condition"
-	Tagkey                           = "dubbo.tag" // key of tag
-	ConditionKey                     = "dubbo.condition"
-	AttachmentKey                    = DubboCtxKey("attachment") // key in context in invoker
-	TagRouterFactoryKey              = "tag"
-	ConditionAppRouterFactoryKey     = "provider.condition"
-	ConditionServiceRouterFactoryKey = "service.condition"
-	ScriptRouterFactoryKey           = "consumer.script"
-	ForceKey                         = "force"
-	PriorityKey                      = "priority"
-	RatioKey                         = "RatioKey"
-	Arguments                        = "arguments"
-	Attachments                      = "attachments"
-	Param                            = "param"
-	Scope                            = "scope"
-	Wildcard                         = "wildcard"
-	MeshRouterFactoryKey             = "mesh"
-	DefaultConditionSubSetWeight     = 100
+	ScriptRouterRuleSuffix            = ".script-router"
+	TagRouterRuleSuffix               = ".tag-router"
+	ConditionRouterRuleSuffix         = ".condition-router" // Specify condition router suffix
+	MeshRouteSuffix                   = ".MESHAPPRULE"      // Specify mesh router suffix
+	ForceUseTag                       = "dubbo.force.tag"   // the tag in attachment
+	ForceUseCondition                 = "dubbo.force.condition"
+	Tagkey                            = "dubbo.tag" // key of tag
+	ConditionKey                      = "dubbo.condition"
+	AttachmentKey                     = DubboCtxKey("attachment") // key in context in invoker
+	TagRouterFactoryKey               = "tag"
+	ConditionAppRouterFactoryKey      = "provider.condition"
+	ConditionServiceRouterFactoryKey  = "service.condition"
+	ScriptRouterFactoryKey            = "consumer.script"
+	ForceKey                          = "force"
+	PriorityKey                       = "priority"
+	RatioKey                          = "RatioKey"
+	Arguments                         = "arguments"
+	Attachments                       = "attachments"
+	Param                             = "param"
+	Scope                             = "scope"
+	Wildcard                          = "wildcard"
+	MeshRouterFactoryKey              = "mesh"
+	DefaultRouteRatio                 = 0
+	DefaultRouteConditionSubSetWeight = 100
+	DefaultRoutePriority              = 0
 )
 
 // Auth filter

--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -323,12 +323,14 @@ const (
 	ScriptRouterFactoryKey           = "consumer.script"
 	ForceKey                         = "force"
 	PriorityKey                      = "priority"
+	RatioKey                         = "RatioKey"
 	Arguments                        = "arguments"
 	Attachments                      = "attachments"
 	Param                            = "param"
 	Scope                            = "scope"
 	Wildcard                         = "wildcard"
 	MeshRouterFactoryKey             = "mesh"
+	DefaultConditionSubSetWeight     = 100
 )
 
 // Auth filter

--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -322,6 +322,7 @@ const (
 	ConditionServiceRouterFactoryKey  = "service.condition"
 	ScriptRouterFactoryKey            = "consumer.script"
 	ForceKey                          = "force"
+	TrafficDisableKey                 = "trafficDisable"
 	PriorityKey                       = "priority"
 	RatioKey                          = "RatioKey"
 	Arguments                         = "arguments"

--- a/config/router_config.go
+++ b/config/router_config.go
@@ -50,9 +50,20 @@ type Tag struct {
 }
 
 type ConditionRule struct {
-	Rule     string `validate:"required" yaml:"rule" json:"rule,omitempty" property:"rule"`
-	Priority int    `default:"0" yaml:"priority" json:"priority,omitempty" property:"priority"`
-	Force    bool   `default:"false" yaml:"force" json:"force,omitempty" property:"force"`
+	From     ConditionRuleFrom `yaml:"from" json:"from,omitempty" property:"from"`
+	To       []ConditionRuleTo `yaml:"to" json:"to,omitempty" property:"to"`
+	Priority int               `default:"0" yaml:"priority" json:"priority,omitempty" property:"priority"`
+	Ratio    int               `default:"0" yaml:"ratio" json:"ratio,omitempty" property:"priority"`
+	Force    bool              `default:"false" yaml:"force" json:"force,omitempty" property:"force"`
+}
+
+type ConditionRuleFrom struct {
+	Match string `yaml:"match" json:"match,omitempty" property:"match"`
+}
+
+type ConditionRuleTo struct {
+	Match  string `yaml:"match" json:"match,omitempty" property:"match"`
+	Weight int    `default:"100" yaml:"weight" json:"weight,omitempty" property:"weight"`
 }
 
 // ConditionRouter -- when RouteConfigVersion == v3.1, decode by this

--- a/config/router_config.go
+++ b/config/router_config.go
@@ -50,9 +50,10 @@ type Tag struct {
 }
 
 type ConditionRule struct {
-	From     ConditionRuleFrom `yaml:"from" json:"from,omitempty" property:"from"`
-	To       []ConditionRuleTo `yaml:"to" json:"to,omitempty" property:"to"`
 	Priority int               `default:"0" yaml:"priority" json:"priority,omitempty" property:"priority"`
+	From     ConditionRuleFrom `yaml:"from" json:"from,omitempty" property:"from"`
+	Disable  bool              `default:"false" yaml:"trafficDisable" json:"trafficDisable,omitempty" property:"trafficDisable"`
+	To       []ConditionRuleTo `yaml:"to" json:"to,omitempty" property:"to"`
 	Ratio    int               `default:"0" yaml:"ratio" json:"ratio,omitempty" property:"priority"`
 	Force    bool              `default:"false" yaml:"force" json:"force,omitempty" property:"force"`
 }


### PR DESCRIPTION
>   to support #2684 

# Doc for New Routing Configuration

## Configuration Format

This doc show how to set up condition-router configurations for your services/application. 

The configurations are defined in a YAML format and must adhere to specific rules and parameters to ensure proper functioning.

## Examples

```yaml
configVersion: v3.1 # be v3.1 or V3.1 to use this
scope: service      # must be 'service' or 'application'
key: org.apache.dubbo.samples.CommentService # [service name] or [application name]
force: false        # decide hole condition route an empty set, return err Or ignore this rule
runtime: true       # decide is use cache
enabled: true       # decide is the rule enabled 
conditions:         # contains by many conditions, sort by condition.priority

  - priority: 10    # default 0, expect > 0
    from:           # match consumer-side url, match fail jump next condition, match success to match provider-side urls
      match: region=$region & version=v1    # string, use '&' to separate rules
    trafficDisable: false # default true, if set true & from match successfully,
                          # it will ignore ./{'to','force','ratio'} value AND ../../{'force'} value, return empty.
    to:             # match provider-side urls, contains by many destination-subsets
      - match: env=$env & region=shanghai   # if match fail, ignore subset
        weight: 100                         # int, default 100, Max INT_MAX, Min 0
      - match: env=$env & region=beijing
        weight: 200
      - match: env=$env & region=hangzhou
        weight: 300
    force: false    # here [force] decide to jump next or return empty, when get empty peer-set or ratio check false
    ratio: 20       # default 0, Max 100, Min 0 -- e.g. expect $result/$all-peers >= 20% -- fail to jump next(or return empty [decide by key(force)])

# e.g. this condition rule will ban all traffic which sent from version=1
  - priority: 5     
    from:
      match: version=v1
    trafficDisable: true

# e.g. this condition rule will show how to set region priority
  - priority: 20
    from:
      match:
    to:
      - match: region=$region
    ratio: 20

```

## Configuration Structure

### Top-Level Structure

- **configVersion**: (Required) Specifies the version of the configuration. Must be `v3.1` or `V3.1` to use this configuration format.
- **scope**: (Required) Defines the scope of the configuration. Must be either `service` or `application`.
- **key**: (Required) Specifies the name of the service or application. For example, `org.apache.dubbo.samples.CommentService`.
- **force**: (Optional) Boolean value that determines the behavior when a condition results in an empty set. If `true`, it returns an error; if `false`, it ignores this rule.
- **runtime**: (Optional) Boolean value that indicates whether to use cache.
- **enabled**: (Optional) Boolean value that indicates whether the rule is enabled.
- **conditions**: (Required) A list of conditions. Each condition contains matching rules for consumer-side and provider-side URLs and it will sort by condition.priority.

### Conditions

Each condition block contains the following parameters:

- **priority**: (Optional) An integer that specifies the priority of the condition. Default is 0, with higher numbers indicating higher priority.
- **from**: (Required) Specifies the criteria for matching consumer-side URLs. If the match fails, it jumps to the next condition. If it matches successfully, it proceeds to match provider-side URLs.
  - **match**: (Required) A string that defines the matching rules using '&' to separate multiple rules. For example, `region=$region & version=v1`.
- **trafficDisable**: (Optional) Boolean value that defaults to `true`. If set to `true` and `from` matches successfully, it ignores the `to`, `force`, and `ratio` values within the condition, and the `force` value at the top level, returning empty.
- **to**: (Required) Specifies the criteria for matching provider-side URLs. It can contain multiple destination subsets.
  - **match**: (Required) A string that defines the matching rules for each subset.
  - **weight**: (Optional) An integer that specifies the weight of the subset. Default is 100, with a maximum of `INT_MAX` and a minimum of 0.
- **force**: (Optional) Boolean value that determines the behavior when a subset results in an empty set or fails a ratio check. If `true`, it returns empty; if `false`, it jumps to the next subset.
- **ratio**: (Optional) An integer that specifies the expected ratio of the result to all peers. Default is 0, with a maximum of 100 and a minimum of 0. For example, `20` means `result/all-peers >= 20%`.

### Matching and Filtering Conditions

#### Supported Parameters

- **Service Invocation Context**: Such as `interface`, `method`, `group`, `version`.
- **Request Context**: Such as `attachments[key] = value`.
- **Method Parameters**: Such as `arguments[0] = tom`.
- **URL Fields**: Such as `protocol`, `host`, `port`.
- **URL Extended Parameters**: Such as `application`, `organization`.
- **Custom Extensions**: Developers can define custom extensions as needed.

#### Condition Operators

- **Equal (=)**: Indicates a match. For example, `method = getComment`.
- **Not Equal (!=)**: Indicates a mismatch. For example, `method != getComment`.

#### Value Support

- **Comma-Separated Values**: Multiple values separated by commas. For example, `host != 10.20.153.10,10.20.153.11`.
- **Wildcard**: Values ending with an asterisk (*) indicate a wildcard match. For example, `host != 10.20.*`.
- **Parameter Reference**: Values starting with a dollar sign ($) reference consumer parameters. For example, `region = $region`.
- **Integer Range**: Integer value ranges. For example, `userId = 1~100` or `userId = 101~`.
- **Custom Extensions**: Developers can define custom extensions as needed.
