### PR TITLE
Fix nacos service discovery issue

### DIFF
--- a/registry/nacos/service_discovery.go
+++ b/registry/nacos/service_discovery.go
@@ -261,7 +261,7 @@ func (n *nacosServiceDiscovery) AddListener(listener registry.ServiceInstancesCh
 
 					instances = append(instances, &registry.DefaultServiceInstance{
 						ID:          id,
-						ServiceName: service.ServiceName,
+						ServiceName: serviceName,
 						Host:        service.Ip,
 						Port:        int(service.Port),
 						Enable:      service.Enable,

--- a/registry/servicediscovery/service_discovery_registry.go
+++ b/registry/servicediscovery/service_discovery_registry.go
@@ -210,18 +210,19 @@ func (s *ServiceDiscoveryRegistry) Subscribe(url *common.URL, notify registry.No
 	}
 	_, err := s.metaDataService.SubscribeURL(url)
 	if err != nil {
-		return perrors.WithMessage(err, "subscribe url error: "+url.String())
+		return perrors.WithMessage(err, "save subscribe url error: "+url.String())
 	}
 
 	mappingListener := NewMappingListener(s.url, url, s.subscribedServices, notify)
 	services := s.getServices(url, mappingListener)
 	if services.Empty() {
-		return perrors.Errorf("Should has at least one way to know which services this interface belongs to,"+
+		logger.Infof("Should has at least one way to know which services this interface belongs to,"+
 			" either specify 'provided-by' for reference or enable metadata-report center subscription url:%s", url.String())
+	} else {
+		logger.Infof("Find initial mapping applications %q for service %s.", services, url.ServiceKey())
+		// first notify
+		err = mappingListener.OnEvent(registry.NewServiceMappingChangedEvent(url.ServiceKey(), services))
 	}
-	logger.Infof("Find initial mapping applications %q for service %s.", services, url.ServiceKey())
-	// first notify
-	err = mappingListener.OnEvent(registry.NewServiceMappingChangedEvent(url.ServiceKey(), services))
 	if err != nil {
 		logger.Errorf("[ServiceDiscoveryRegistry] ServiceInstancesChangedListenerImpl handle error:%v", err)
 	}

--- a/registry/servicediscovery/service_instances_changed_listener_impl.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl.go
@@ -159,20 +159,21 @@ func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error
 				newServiceURLs[serviceInfo.GetMatchKey()] = urls
 			}
 		}
-		lstn.serviceUrls = newServiceURLs
-
-		for key, notifyListener := range lstn.listeners {
-			urls := lstn.serviceUrls[key]
-			events := make([]*registry.ServiceEvent, 0, len(urls))
-			for _, url := range urls {
-				events = append(events, &registry.ServiceEvent{
-					Action:  remoting.EventTypeAdd,
-					Service: url,
-				})
-			}
-			notifyListener.NotifyAll(events, func() {})
-		}
 	}
+
+	lstn.serviceUrls = newServiceURLs
+	for key, notifyListener := range lstn.listeners {
+		urls := lstn.serviceUrls[key]
+		events := make([]*registry.ServiceEvent, 0, len(urls))
+		for _, url := range urls {
+			events = append(events, &registry.ServiceEvent{
+				Action:  remoting.EventTypeAdd,
+				Service: url,
+			})
+		}
+		notifyListener.NotifyAll(events, func() {})
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
1. fix wrong service name `DEFAULT_GROUP@@app_name` issue, happens when client starts before provider registers `mapping`
2. fix service discovery issue  when an interface is exported by different apps.