### PR TITLE
Fix router rule parsing log error

### DIFF
--- a/cluster/router/condition/dynamic_router.go
+++ b/cluster/router/condition/dynamic_router.go
@@ -308,6 +308,10 @@ func (s *ServiceRouter) Notify(invokers []protocol.Invoker) {
 		logger.Errorf("Failed to query condition rule, key=%s, err=%v", key, err)
 		return
 	}
+	if value == "" {
+		logger.Infof("Condition rule is empty, key=%s", key)
+		return
+	}
 	s.Process(&config_center.ConfigChangeEvent{Key: key, Value: value, ConfigType: remoting.EventTypeAdd})
 }
 
@@ -368,6 +372,10 @@ func (a *ApplicationRouter) Notify(invokers []protocol.Invoker) {
 		value, err := dynamicConfiguration.GetRule(key)
 		if err != nil {
 			logger.Errorf("Failed to query condition rule, key=%s, err=%v", key, err)
+			return
+		}
+		if value == "" {
+			logger.Infof("Condition rule is empty, key=%s", key)
 			return
 		}
 		a.Process(&config_center.ConfigChangeEvent{Key: key, Value: value, ConfigType: remoting.EventTypeUpdate})

--- a/cluster/router/condition/factory.go
+++ b/cluster/router/condition/factory.go
@@ -19,12 +19,13 @@ package condition
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/cluster/router"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/common/extension"
 )
 
 func init() {
-	// TODO(finalt) Temporarily removed until fixed
-	//extension.SetRouterFactory(constant.ConditionServiceRouterFactoryKey, NewServiceConditionRouterFactory)
-	//extension.SetRouterFactory(constant.ConditionAppRouterFactoryKey, NewAppConditionRouterFactory)
+	extension.SetRouterFactory(constant.ConditionServiceRouterFactoryKey, NewServiceConditionRouterFactory)
+	extension.SetRouterFactory(constant.ConditionAppRouterFactoryKey, NewAppConditionRouterFactory)
 }
 
 // ServiceRouteFactory router factory

--- a/cluster/router/tag/factory.go
+++ b/cluster/router/tag/factory.go
@@ -19,6 +19,8 @@ package tag
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/cluster/router"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/common/extension"
 )
 
 func init() {
@@ -27,8 +29,7 @@ func init() {
 		and cause warning if config center is empty.
 		User can import this package and config config center to use tag router.
 	*/
-	// TODO(finalt) Temporarily removed until fixed
-	//extension.SetRouterFactory(constant.TagRouterFactoryKey, NewTagRouterFactory)
+	extension.SetRouterFactory(constant.TagRouterFactoryKey, NewTagRouterFactory)
 }
 
 // RouteFactory router factory

--- a/cluster/router/tag/router.go
+++ b/cluster/router/tag/router.go
@@ -94,6 +94,10 @@ func (p *PriorityRouter) Notify(invokers []protocol.Invoker) {
 		logger.Errorf("query router rule fail,key=%s,err=%v", key, err)
 		return
 	}
+	if value == "" {
+		logger.Infof("router rule is empty,key=%s", key)
+		return
+	}
 	p.Process(&config_center.ConfigChangeEvent{Key: key, Value: value, ConfigType: remoting.EventTypeAdd})
 }
 

--- a/protocol/triple/triple_invoker.go
+++ b/protocol/triple/triple_invoker.go
@@ -145,7 +145,7 @@ func (ti *TripleInvoker) Invoke(ctx context.Context, invocation protocol.Invocat
 func mergeAttachmentToOutgoing(ctx context.Context, inv protocol.Invocation) (context.Context, error) {
 	// Todo(finalt) Temporarily solve the problem that the timeout time is not valid
 	if timeout, ok := inv.GetAttachment(constant.TimeoutKey); ok {
-		ctx = context.WithValue(ctx, "dubbo.timeout.key", timeout)
+		ctx = context.WithValue(ctx, tri.TimeoutKey{}, timeout)
 	}
 	for key, valRaw := range inv.Attachments() {
 		if str, ok := valRaw.(string); ok {

--- a/protocol/triple/triple_protocol/client.go
+++ b/protocol/triple/triple_protocol/client.go
@@ -25,6 +25,8 @@ import (
 	"time"
 )
 
+type TimeoutKey struct{}
+
 // Client is a reusable, concurrency-safe client for a single procedure.
 // Depending on the procedure's type, use the CallUnary, CallClientStream,
 // CallServerStream, or CallBidiStream method.
@@ -282,7 +284,7 @@ func applyDefaultTimeout(ctx context.Context, timeout time.Duration) (context.Co
 
 	// Todo(finalt) Temporarily solve the problem that the timeout time is not valid
 	if !ok {
-		timeoutVal := ctx.Value("dubbo.timeout.key")
+		timeoutVal := ctx.Value(TimeoutKey{})
 		if timeoutVal != nil {
 			if s, exist := timeoutVal.(string); exist && s != "" {
 				if newTimeout, err := time.ParseDuration(s); err == nil {


### PR DESCRIPTION
If the router rule is empty, a parsing error occurs.