### PR TITLE
fix: set baseinvoker's url to nil to address memory leak issues

### DIFF
--- a/common/url.go
+++ b/common/url.go
@@ -784,10 +784,9 @@ func (c *URL) MergeURL(anotherUrl *URL) *URL {
 	for key, value := range anotherUrl.GetParams() {
 		if _, ok := mergedURL.GetNonDefaultParam(key); !ok {
 			if len(value) > 0 {
-				params[key] = value
+				params[key] = make([]string, len(value))
+				copy(params[key], value)
 			}
-			params[key] = make([]string, len(value))
-			copy(params[key], value)
 		}
 	}
 

--- a/protocol/dubbo/dubbo_exporter.go
+++ b/protocol/dubbo/dubbo_exporter.go
@@ -46,9 +46,9 @@ func NewDubboExporter(key string, invoker protocol.Invoker, exporterMap *sync.Ma
 // Unexport unexport dubbo service exporter.
 func (de *DubboExporter) UnExport() {
 	interfaceName := de.GetInvoker().GetURL().GetParam(constant.InterfaceKey, "")
-	de.BaseExporter.UnExport()
 	err := common.ServiceMap.UnRegister(interfaceName, DUBBO, de.GetInvoker().GetURL().ServiceKey())
 	if err != nil {
 		logger.Errorf("[DubboExporter.UnExport] error: %v", err)
 	}
+	de.BaseExporter.UnExport()
 }

--- a/protocol/dubbo/dubbo_invoker.go
+++ b/protocol/dubbo/dubbo_invoker.go
@@ -193,7 +193,6 @@ func (di *DubboInvoker) IsAvailable() bool {
 // Destroy destroy dubbo client invoker.
 func (di *DubboInvoker) Destroy() {
 	di.quitOnce.Do(func() {
-		di.BaseInvoker.Destroy()
 		client := di.getClient()
 		if client != nil {
 			activeNumber := client.DecreaseActiveNumber()
@@ -203,6 +202,7 @@ func (di *DubboInvoker) Destroy() {
 				client.Close()
 			}
 		}
+		di.BaseInvoker.Destroy()
 	})
 }
 

--- a/protocol/dubbo3/dubbo3_exporter.go
+++ b/protocol/dubbo3/dubbo3_exporter.go
@@ -52,10 +52,10 @@ func NewDubboExporter(key string, invoker protocol.Invoker, exporterMap *sync.Ma
 func (de *DubboExporter) UnExport() {
 	url := de.GetInvoker().GetURL()
 	interfaceName := url.GetParam(constant.InterfaceKey, "")
-	de.BaseExporter.UnExport()
 	err := common.ServiceMap.UnRegister(interfaceName, tripleConstant.TRIPLE, url.ServiceKey())
 	if err != nil {
 		logger.Errorf("[DubboExporter.UnExport] error: %v", err)
 	}
 	de.serviceMap.Delete(interfaceName)
+	de.BaseExporter.UnExport()
 }

--- a/protocol/grpc/grpc_exporter.go
+++ b/protocol/grpc/grpc_exporter.go
@@ -46,9 +46,9 @@ func NewGrpcExporter(key string, invoker protocol.Invoker, exporterMap *sync.Map
 // Unexport and unregister gRPC service from registry and memory.
 func (gg *GrpcExporter) UnExport() {
 	interfaceName := gg.GetInvoker().GetURL().GetParam(constant.InterfaceKey, "")
-	gg.BaseExporter.UnExport()
 	err := common.ServiceMap.UnRegister(interfaceName, GRPC, gg.GetInvoker().GetURL().ServiceKey())
 	if err != nil {
 		logger.Errorf("[GrpcExporter.UnExport] error: %v", err)
 	}
+	gg.BaseExporter.UnExport()
 }

--- a/protocol/invoker.go
+++ b/protocol/invoker.go
@@ -88,7 +88,7 @@ func (bi *BaseInvoker) Invoke(context context.Context, invocation Invocation) Re
 	return &RPCResult{}
 }
 
-// Destroy changes available and destroyed flag
+// Destroy changes available and destroyed flag and release the url's allocated memory
 func (bi *BaseInvoker) Destroy() {
 	logger.Infof("Destroy invoker: %s", bi.GetURL())
 	bi.destroyed.Store(true)

--- a/protocol/invoker.go
+++ b/protocol/invoker.go
@@ -93,6 +93,7 @@ func (bi *BaseInvoker) Destroy() {
 	logger.Infof("Destroy invoker: %s", bi.GetURL())
 	bi.destroyed.Store(true)
 	bi.available.Store(false)
+	bi.url = nil
 }
 
 func (bi *BaseInvoker) String() string {

--- a/protocol/jsonrpc/jsonrpc_exporter.go
+++ b/protocol/jsonrpc/jsonrpc_exporter.go
@@ -46,9 +46,9 @@ func NewJsonrpcExporter(key string, invoker protocol.Invoker, exporterMap *sync.
 // Unexport exported JSON RPC service.
 func (je *JsonrpcExporter) UnExport() {
 	interfaceName := je.GetInvoker().GetURL().GetParam(constant.InterfaceKey, "")
-	je.BaseExporter.UnExport()
 	err := common.ServiceMap.UnRegister(interfaceName, JSONRPC, je.GetInvoker().GetURL().ServiceKey())
 	if err != nil {
 		logger.Errorf("[JsonrpcExporter.UnExport] error: %v", err)
 	}
+	je.BaseExporter.UnExport()
 }

--- a/protocol/rest/rest_exporter.go
+++ b/protocol/rest/rest_exporter.go
@@ -46,9 +46,9 @@ func NewRestExporter(key string, invoker protocol.Invoker, exporterMap *sync.Map
 // Unexport unexport the RestExporter
 func (re *RestExporter) UnExport() {
 	interfaceName := re.GetInvoker().GetURL().GetParam(constant.InterfaceKey, "")
-	re.BaseExporter.UnExport()
 	err := common.ServiceMap.UnRegister(interfaceName, REST, re.GetInvoker().GetURL().ServiceKey())
 	if err != nil {
 		logger.Errorf("[RestExporter.UnExport] error: %v", err)
 	}
+	re.BaseExporter.UnExport()
 }

--- a/protocol/triple/triple_exporter.go
+++ b/protocol/triple/triple_exporter.go
@@ -45,10 +45,10 @@ func NewTripleExporter(key string, invoker protocol.Invoker, exporterMap *sync.M
 // UnExport and unregister Triple service from registry and memory.
 func (te *TripleExporter) UnExport() {
 	interfaceName := te.GetInvoker().GetURL().GetParam(constant.InterfaceKey, "")
-	te.BaseExporter.UnExport()
 	// todo: move UnRegister logic to a better place
 	err := common.ServiceMap.UnRegister(interfaceName, TRIPLE, te.GetInvoker().GetURL().ServiceKey())
 	if err != nil {
 		logger.Errorf("[GrpcNewExporter.UnExport] error: %v", err)
 	}
+	te.BaseExporter.UnExport()
 }


### PR DESCRIPTION
Bssed on PR #2223 ,the main purpose of this PR is to fix the memory leak problem caused by the url pointer in baseinvoker not being released correctly. You can refer to the following issue：

FIXES: #2701 #2339 #2031 