### PR TITLE
fix reference conflict in triple

### DIFF
--- a/common/rpc_service.go
+++ b/common/rpc_service.go
@@ -52,10 +52,14 @@ type TriplePBService interface {
 }
 
 // GetReference return the reference id of the service.
-// If the service implemented the ReferencedRPCService interface,
+// If the service implemented the TriplePBService or ReferencedRPCService interface,
 // it will call the Reference method. If not, it will
 // return the struct name as the reference id.
 func GetReference(service RPCService) string {
+	if s, ok := service.(TriplePBService); ok {
+		return s.XXX_InterfaceName()
+	}
+
 	if s, ok := service.(ReferencedRPCService); ok {
 		return s.Reference()
 	}

--- a/common/rpc_service_test.go
+++ b/common/rpc_service_test.go
@@ -37,6 +37,7 @@ const (
 	testInterfaceName             = "testService"
 	testProtocol                  = "testprotocol"
 	testSuiteMethodExpectedString = "interface {}"
+	testTripleServiceName         = "com.test.TriplePath"
 )
 
 type TestService struct{}
@@ -88,6 +89,12 @@ type TestService1 struct{}
 
 func (s *TestService1) Reference() string {
 	return referenceTestPathDistinct
+}
+
+type TestTriplePBService struct{}
+
+func (s *TestTriplePBService) XXX_InterfaceName() string {
+	return testTripleServiceName
 }
 
 func TestServiceMapRegister(t *testing.T) {
@@ -250,4 +257,8 @@ func TestGetReference(t *testing.T) {
 	}{}
 	ref5 := GetReference(s5)
 	assert.Equal(t, expectedReference, ref5)
+
+	s6 := &TestTriplePBService{}
+	ref6 := GetReference(s6)
+	assert.Equal(t, testTripleServiceName, ref6)
 }


### PR DESCRIPTION
The `ReferencedRPCService` interface is not implemented when generating triple pb file. Multiple clients with the same service name but different packages will get conflicting ids through `GetReference`