### PR TITLE
fix: CallClientStream result has error

### DIFF
--- a/protocol/triple/server.go
+++ b/protocol/triple/server.go
@@ -270,7 +270,12 @@ func (s *Server) handleServiceWithInfo(interfaceName string, invoker protocol.In
 					ctx = context.WithValue(ctx, constant.AttachmentKey, attachments)
 					invo := invocation.NewRPCInvocation(m.Name, args, attachments)
 					res := invoker.Invoke(ctx, invo)
-					return res.Result().(*tri.Response), res.Error()
+					if triResp, ok := res.Result().(*tri.Response); ok {
+						return triResp, res.Error()
+					}
+					// please refer to proxy/proxy_factory/ProxyInvoker.Invoke
+					triResp := tri.NewResponse([]interface{}{res.Result()})
+					return triResp, res.Error()
 				},
 				opts...,
 			)


### PR DESCRIPTION
triple rpc server端对CallClientStream的handle处理, 当service return error的时候, 会result的Result()值会是nil, 这样会导致res.Result().(*tri.Response)出现panic