### PR TITLE
Fix the log that outputs inappropriate file names, function names, and line

### DIFF
--- a/logger/zap/zap.go
+++ b/logger/zap/zap.go
@@ -99,7 +99,7 @@ func NewDefault() *Logger {
 	}
 	encoder := zapcore.NewConsoleEncoder(encoderConfig())
 	lg = zap.New(zapcore.NewCore(encoder, zapcore.AddSync(os.Stdout), lv),
-		zap.AddCaller(), zap.AddCallerSkip(1)).Sugar()
+		zap.AddCaller(), zap.AddCallerSkip(2)).Sugar()
 	return &Logger{lg: lg}
 }
 


### PR DESCRIPTION
#2743 
Because the logger was encapsulated once in gost, and then encapsulated again in dubbo, it needs to be skiped twice.

such as
![image](https://github.com/user-attachments/assets/1e0e0c2a-3be2-4e57-94dc-7bf4918f7413)

