### PR TITLE
Fix CacheListener to use thread-safe ListenerSet for managing listeners

### DIFF
--- a/metadata/report/zookeeper/listener.go
+++ b/metadata/report/zookeeper/listener.go
@@ -102,14 +102,9 @@ func (l *CacheListener) AddListener(key string, listener registry.MappingListene
 	if err != nil {
 		return
 	}
-	// create new set with the listener
-	listenerSet := NewListenerSet()
-	listenerSet.Add(listener)
 	// try to store the new set. If key exists, add listener to existing set
-	listeners, loaded := l.keyListeners.LoadOrStore(key, listenerSet)
-	if loaded {
-		listeners.(*ListenerSet).Add(listener)
-	}
+	listeners, _ := l.keyListeners.LoadOrStore(key, NewListenerSet())
+	listeners.(*ListenerSet).Add(listener)
 }
 
 // RemoveListener will delete a listener if loaded


### PR DESCRIPTION
**What this PR does**:

- Replaces the `map[registry.MappingListener]struct{}` with a thread-safe `ListenerSet` for managing listeners. 
- Ensures safe concurrent access by using `sync.RWMutex` in the `ListenerSet`.

**Which issue(s) this PR fixes**:

Fixes #2759

**Special notes for your reviewer**:

- This refactor improves thread safety but may require additional performance testing to ensure there is no negative impact on listener management.
- No change in external functionality, this is an internal improvement.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```