### PR TITLE
Fix: Ensure Subscribe Waits for Register Completion or Timeout

### DIFF
--- a/registry/directory/directory.go
+++ b/registry/directory/directory.go
@@ -137,8 +137,6 @@ func (dir *RegistryDirectory) Subscribe(url *common.URL) error {
 		timeout, _ = time.ParseDuration(constant.DefaultRegTimeout)
 	}
 
-	fmt.Println("timeout:\n\n", timeout)
-
 	done := make(chan struct{})
 
 	go func() {


### PR DESCRIPTION
## What this PR does

- Ensure that Subscribe only returns after the Register operation has either completed successfully or timed out.
- allowing the caller to be informed about the registration status.

## Which issue(s) this PR fixes

Fixes #2591

## Error cause description

- The primary reason for the failure of the first invocation was that the consumer's registration and subscription process was asynchronous, resulting in the consumer not having received the available provider information from the registry when the Invoke method was called.
