### PR TITLE
Fix/remove setdeadline

### DIFF
--- a/protocol/rest/client/client_impl/resty_client.go
+++ b/protocol/rest/client/client_impl/resty_client.go
@@ -22,13 +22,18 @@ import (
 	"net"
 	"net/http"
 	"path"
+)
 
+import (
 	"github.com/go-resty/resty/v2"
 
+	perrors "github.com/pkg/errors"
+)
+
+import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/protocol/rest/client"
-	perrors "github.com/pkg/errors"
 )
 
 func init() {

--- a/protocol/rest/client/client_impl/resty_client.go
+++ b/protocol/rest/client/client_impl/resty_client.go
@@ -22,19 +22,13 @@ import (
 	"net"
 	"net/http"
 	"path"
-	"time"
-)
 
-import (
 	"github.com/go-resty/resty/v2"
 
-	perrors "github.com/pkg/errors"
-)
-
-import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/protocol/rest/client"
+	perrors "github.com/pkg/errors"
 )
 
 func init() {
@@ -56,13 +50,11 @@ func NewRestyClient(restOption *client.RestOptions) client.RestClient {
 				if err != nil {
 					return nil, err
 				}
-				err = c.SetDeadline(time.Now().Add(restOption.RequestTimeout))
-				if err != nil {
-					return nil, err
-				}
 				return c, nil
 			},
+			IdleConnTimeout: restOption.KeppAliveTimeout,
 		})
+	client.SetTimeout(restOption.RequestTimeout)
 	return &RestyClient{
 		client: client,
 	}

--- a/protocol/rest/client/rest_client.go
+++ b/protocol/rest/client/rest_client.go
@@ -23,8 +23,9 @@ import (
 )
 
 type RestOptions struct {
-	RequestTimeout time.Duration
-	ConnectTimeout time.Duration
+	RequestTimeout   time.Duration
+	ConnectTimeout   time.Duration
+	KeppAliveTimeout time.Duration
 }
 
 type RestClientRequest struct {

--- a/protocol/rest/rest_protocol.go
+++ b/protocol/rest/rest_protocol.go
@@ -20,21 +20,22 @@ package rest
 import (
 	"sync"
 	"time"
+)
 
+import (
+	"github.com/dubbogo/gost/log/logger"
+)
+
+import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/protocol"
 	"dubbo.apache.org/dubbo-go/v3/protocol/rest/client"
-	"github.com/dubbogo/gost/log/logger"
-
 	_ "dubbo.apache.org/dubbo-go/v3/protocol/rest/client/client_impl"
-
 	rest_config "dubbo.apache.org/dubbo-go/v3/protocol/rest/config"
-
 	_ "dubbo.apache.org/dubbo-go/v3/protocol/rest/config/reader"
 	"dubbo.apache.org/dubbo-go/v3/protocol/rest/server"
-
 	_ "dubbo.apache.org/dubbo-go/v3/protocol/rest/server/server_impl"
 )
 

--- a/protocol/rest/rest_protocol.go
+++ b/protocol/rest/rest_protocol.go
@@ -20,22 +20,21 @@ package rest
 import (
 	"sync"
 	"time"
-)
 
-import (
-	"github.com/dubbogo/gost/log/logger"
-)
-
-import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/protocol"
 	"dubbo.apache.org/dubbo-go/v3/protocol/rest/client"
+	"github.com/dubbogo/gost/log/logger"
+
 	_ "dubbo.apache.org/dubbo-go/v3/protocol/rest/client/client_impl"
+
 	rest_config "dubbo.apache.org/dubbo-go/v3/protocol/rest/config"
+
 	_ "dubbo.apache.org/dubbo-go/v3/protocol/rest/config/reader"
 	"dubbo.apache.org/dubbo-go/v3/protocol/rest/server"
+
 	_ "dubbo.apache.org/dubbo-go/v3/protocol/rest/server/server_impl"
 )
 
@@ -93,6 +92,7 @@ func (rp *RestProtocol) Refer(url *common.URL) protocol.Invoker {
 	requestTimeout := time.Duration(3 * time.Second)
 	requestTimeoutStr := url.GetParam(constant.TimeoutKey, "3s")
 	connectTimeout := requestTimeout // config.GetConsumerConfig().ConnectTimeout
+	keepAliveTimeout := url.GetParamDuration(constant.KeepAliveTimeout, constant.DefaultKeepAliveTimeout)
 	// end
 	if t, err := time.ParseDuration(requestTimeoutStr); err == nil {
 		requestTimeout = t
@@ -103,7 +103,7 @@ func (rp *RestProtocol) Refer(url *common.URL) protocol.Invoker {
 		logger.Errorf("%s service doesn't has consumer config", url.Path)
 		return nil
 	}
-	restOptions := client.RestOptions{RequestTimeout: requestTimeout, ConnectTimeout: connectTimeout}
+	restOptions := client.RestOptions{RequestTimeout: requestTimeout, ConnectTimeout: connectTimeout, KeppAliveTimeout: keepAliveTimeout}
 	restClient := rp.getClient(restOptions, restServiceConfig.Client)
 	invoker := NewRestInvoker(url, &restClient, restServiceConfig.RestMethodConfigsMap)
 	rp.SetInvokers(invoker)


### PR DESCRIPTION
What this PR does

https://pkg.go.dev/net#Conn.SetDeadline

> *// SetDeadline sets the read and write deadlines associated*
>
> *// with the connection. It is equivalent to calling both*
>
> // SetReadDeadline and SetWriteDeadline.

Therefore, `SetDeadline` will cause the connection to be closed before the server returns completely, so `SetDeadline` is removed and `SetTimeout` is used instead. In addition, `IdleConnTimeout` is added to close idle connections after timeout to avoid invalid reuse.



Which issue(s) this PR fixes

https://github.com/apache/dubbo-go/issues/2302