### PR TITLE
Fix typos: serivce->service, balancce->balance

### DIFF
--- a/config/provider_config.go
+++ b/config/provider_config.go
@@ -104,7 +104,7 @@ func (c *ProviderConfig) Init(rc *RootConfig) error {
 		if serviceConfig.Interface == "" {
 			service := GetProviderService(key)
 			// try to use interface name defined by pb
-			supportPBPackagerNameSerivce, ok := service.(common.TriplePBService)
+			supportPBPackagerNameService, ok := service.(common.TriplePBService)
 			if !ok {
 				logger.Errorf("Service with reference = %s is not support read interface name from it."+
 					"Please run go install github.com/dubbogo/dubbogo-cli/cmd/protoc-gen-go-triple@latest to update your "+
@@ -113,7 +113,7 @@ func (c *ProviderConfig) Init(rc *RootConfig) error {
 				continue
 			} else {
 				// use interface name defined by pb
-				serviceConfig.Interface = supportPBPackagerNameSerivce.XXX_InterfaceName()
+				serviceConfig.Interface = supportPBPackagerNameService.XXX_InterfaceName()
 			}
 		}
 		if err := serviceConfig.Init(rc); err != nil {
@@ -177,7 +177,7 @@ func (c *ProviderConfig) Load() {
 				continue
 			}
 			// service doesn't config in config file, create one with default
-			supportPBPackagerNameSerivce, ok := service.(common.TriplePBService)
+			supportPBPackagerNameService, ok := service.(common.TriplePBService)
 			if !ok {
 				logger.Warnf(
 					"The provider service %s is ignored: neither the config is found, nor it is a valid Triple service.",
@@ -186,9 +186,9 @@ func (c *ProviderConfig) Load() {
 			}
 			serviceConfig = NewServiceConfigBuilder().Build()
 			// use interface name defined by pb
-			serviceConfig.Interface = supportPBPackagerNameSerivce.XXX_InterfaceName()
+			serviceConfig.Interface = supportPBPackagerNameService.XXX_InterfaceName()
 			if err := serviceConfig.Init(rootConfig); err != nil {
-				logger.Errorf("Service with refKey = %s init failed with error = %s")
+				logger.Errorf("Service with registeredTypeName = %s init failed with error = %#v", registeredTypeName, err)
 			}
 			serviceConfig.adaptiveService = c.AdaptiveService
 		}

--- a/config/service_config.go
+++ b/config/service_config.go
@@ -539,7 +539,7 @@ func (pcb *ServiceConfigBuilder) SetMetadataType(setMetadataType string) *Servic
 	return pcb
 }
 
-func (pcb *ServiceConfigBuilder) SetLoadBalancce(lb string) *ServiceConfigBuilder {
+func (pcb *ServiceConfigBuilder) SetLoadBalance(lb string) *ServiceConfigBuilder {
 	pcb.serviceConfig.Loadbalance = lb
 	return pcb
 }

--- a/config/service_config_test.go
+++ b/config/service_config_test.go
@@ -63,7 +63,7 @@ func TestNewServiceConfigBuilder(t *testing.T) {
 			SetProtocolIDs("dubbo").
 			SetInterface("org.apache.dubbo.HelloService").
 			SetMetadataType("local").
-			SetLoadBalancce("random").
+			SetLoadBalance("random").
 			SetWarmUpTie("warmup").
 			SetCluster("cluster").
 			AddRCRegistry("nacos", registryConfig).


### PR DESCRIPTION
fix typos:

`serivce`->`service`
`balancce` -> `balance`


skip changelog