### PR TITLE
fix issue 2683: defeat memory leak

### DIFF
--- a/config/reference_config.go
+++ b/config/reference_config.go
@@ -378,7 +378,7 @@ func (rc *ReferenceConfig) getURLMap() url.Values {
 
 // GenericLoad ...
 func (rc *ReferenceConfig) GenericLoad(id string) {
-	genericService := generic.NewGenericService(rc.id)
+	genericService := generic.NewGenericService(id)
 	SetConsumerService(genericService)
 	rc.id = id
 	rc.Refer(genericService)

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5
 	github.com/alibaba/sentinel-golang v1.0.4
 	github.com/apache/dubbo-getty v1.4.10
-	github.com/apache/dubbo-go-hessian2 v1.12.2
+	github.com/apache/dubbo-go-hessian2 v1.12.5
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4
 	github.com/cncf/xds/go v0.0.0-20220314180256-7f1daf1720fc

--- a/go.sum
+++ b/go.sum
@@ -73,8 +73,8 @@ github.com/apache/dubbo-getty v1.4.10 h1:ZmkpHJa/qgS0evX2tTNqNCz6rClI/9Wwp7ctyMm
 github.com/apache/dubbo-getty v1.4.10/go.mod h1:V64WqLIxksEgNu5aBJBOxNIvpOZyfUJ7J/DXBlKSUoA=
 github.com/apache/dubbo-go-hessian2 v1.9.1/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
 github.com/apache/dubbo-go-hessian2 v1.9.3/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
-github.com/apache/dubbo-go-hessian2 v1.12.2 h1:2/56JRPng2lnLziJF3fqmSgsg28Yt1a5YZ5RX+jHDGs=
-github.com/apache/dubbo-go-hessian2 v1.12.2/go.mod h1:QP9Tc0w/B/mDopjusebo/c7GgEfl6Lz8jeuFg8JA6yw=
+github.com/apache/dubbo-go-hessian2 v1.12.5 h1:19lJz2Md0EYF2bOtEvFqXEQRYvLz04GfsoocsBWlLWQ=
+github.com/apache/dubbo-go-hessian2 v1.12.5/go.mod h1:QP9Tc0w/B/mDopjusebo/c7GgEfl6Lz8jeuFg8JA6yw=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=


### PR DESCRIPTION
There is a memory leak when using the dubbo-go-hessian2 protocol(https://github.com/apache/dubbo-go/issues/2683). Since the dubbo-go-hessian2 already fixed in (https://github.com/apache/dubbo-go-hessian2/pull/374) and released a new version with tag v1.12.5. So update the version in dubbo-go.