### PR TITLE
Replace copier.Copy with optimized manual deep copy in URL.Clone (#2678)

### DIFF
--- a/common/url.go
+++ b/common/url.go
@@ -21,9 +21,11 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
+	"maps"
 	"math"
 	"net"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -838,29 +840,25 @@ func (c *URL) Clone() *URL {
 		Path:         c.Path,
 		Username:     c.Username,
 		Password:     c.Password,
-		Methods:      append([]string(nil), c.Methods...),
+		Methods:      slices.Clone(c.Methods),
 	}
+
 	c.paramsLock.RLock()
-	defer c.paramsLock.RUnlock()
 	if c.params != nil {
-		newURL.params = make(url.Values, len(c.params))
-		for key, values := range c.params {
-			newValues := make([]string, len(values))
-			copy(newValues, values)
-			newURL.params[key] = newValues
-		}
+		newURL.params = maps.Clone(c.params)
 	}
+	c.paramsLock.RUnlock()
+
 	c.attributesLock.RLock()
-	defer c.attributesLock.RUnlock()
 	if c.attributes != nil {
-		newURL.attributes = make(map[string]interface{}, len(c.attributes))
-		for key, value := range c.attributes {
-			newURL.attributes[key] = value
-		}
+		newURL.attributes = maps.Clone(c.attributes)
 	}
+	c.attributesLock.RUnlock()
+
 	if c.SubURL != nil {
 		newURL.SubURL = c.SubURL.Clone()
 	}
+
 	return newURL
 }
 

--- a/common/url.go
+++ b/common/url.go
@@ -838,23 +838,26 @@ func (c *URL) Clone() *URL {
 		Path:         c.Path,
 		Username:     c.Username,
 		Password:     c.Password,
-		Methods:      make([]string, len(c.Methods)),
+		Methods:      append([]string(nil), c.Methods...),
+		params:       make(url.Values, len(c.params)),
+		attributes:   make(map[string]interface{}, len(c.attributes)),
 	}
-	copy(newURL.Methods, c.Methods)
-	newURL.params = make(url.Values, len(c.params))
 	c.paramsLock.RLock()
-	for key, values := range c.params {
-		newValues := make([]string, len(values))
-		copy(newValues, values)
-		newURL.params[key] = newValues
+	defer c.paramsLock.RUnlock()
+	if c.params != nil {
+		for key, values := range c.params {
+			newValues := make([]string, len(values))
+			copy(newValues, values)
+			newURL.params[key] = newValues
+		}
 	}
-	c.paramsLock.RUnlock()
-	newURL.attributes = make(map[string]interface{}, len(c.attributes))
 	c.attributesLock.RLock()
-	for key, value := range c.attributes {
-		newURL.attributes[key] = value
+	defer c.attributesLock.RUnlock()
+	if c.attributes != nil {
+		for key, value := range c.attributes {
+			newURL.attributes[key] = value
+		}
 	}
-	c.attributesLock.RUnlock()
 	if c.SubURL != nil {
 		newURL.SubURL = c.SubURL.Clone()
 	}

--- a/common/url.go
+++ b/common/url.go
@@ -839,12 +839,11 @@ func (c *URL) Clone() *URL {
 		Username:     c.Username,
 		Password:     c.Password,
 		Methods:      append([]string(nil), c.Methods...),
-		params:       make(url.Values, len(c.params)),
-		attributes:   make(map[string]interface{}, len(c.attributes)),
 	}
 	c.paramsLock.RLock()
 	defer c.paramsLock.RUnlock()
 	if c.params != nil {
+		newURL.params = make(url.Values, len(c.params))
 		for key, values := range c.params {
 			newValues := make([]string, len(values))
 			copy(newValues, values)
@@ -854,6 +853,7 @@ func (c *URL) Clone() *URL {
 	c.attributesLock.RLock()
 	defer c.attributesLock.RUnlock()
 	if c.attributes != nil {
+		newURL.attributes = make(map[string]interface{}, len(c.attributes))
 		for key, value := range c.attributes {
 			newURL.attributes[key] = value
 		}

--- a/common/url_test.go
+++ b/common/url_test.go
@@ -19,6 +19,7 @@ package common
 
 import (
 	"encoding/base64"
+	"fmt"
 	"net/url"
 	"testing"
 )
@@ -572,5 +573,33 @@ func TestIsAnyCondition(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equalf(t, tt.want, IsAnyCondition(tt.args.intf, tt.args.group, tt.args.version, tt.args.serviceURL), "IsAnyCondition(%v, %v, %v, %v)", tt.args.intf, tt.args.group, tt.args.version, tt.args.serviceURL)
 		})
+	}
+}
+
+func TestSubURLCopy(t *testing.T) {
+	original := &URL{SubURL: &URL{Protocol: "test"}}
+	cloned := original.Clone()
+	cloned.SubURL.Protocol = "modified"
+	if original.SubURL.Protocol == "modified" {
+		t.Errorf("SubURL was shallow-copied; expected deep copy")
+	}
+}
+
+func BenchmarkClone(b *testing.B) {
+	u := &URL{
+		Protocol:   "dubbo",
+		Ip:         "127.0.0.1",
+		Port:       "8080",
+		params:     make(url.Values),
+		attributes: make(map[string]interface{}),
+	}
+	for i := 0; i < 1000; i++ {
+		u.params.Set(fmt.Sprintf("key%d", i), fmt.Sprintf("value%d", i))
+		u.attributes[fmt.Sprintf("attr%d", i)] = i
+	}
+	u.SubURL = &URL{Protocol: "nested"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		u.Clone()
 	}
 }


### PR DESCRIPTION
Fixes by replacing `copier.Copy` with a manual deep copy in `URL.Clone()`, optimized with pre-allocated maps for `params` and `attributes`. This reduces memory and CPU overhead, especially for large data volumes. 
Key changes:
- Replaced `copier.Copy` with manual implementation in `URL.Clone()`.
- Removed `github.com/jinzhu/copier` import from `url.go` and dependency from `go.mod` via `go mod tidy`.
- Added `TestSubURLCopy` to verify deep-copy behavior.
- Updated `BenchmarkClone` to test the new implementation.

Benchmarks:
- 100 params/attributes:
  - Old (copier): 51 µs/op, 23.74 KB/op, 222 allocs/op
  - New (manual): 26 µs/op, 14.12 KB/op, 112 allocs/op
- 1,000 params/attributes:
  - Old (copier): 428 µs/op, 228 KB/op, 1,142 allocs/op
  - New (manual): 270 µs/op, 197 KB/op, 1,010 allocs/op

The new implementation is faster (~1.6x at 1,000 entries, ~2x at 100), uses less memory (~14% at 1,000, ~40% at 100), and reduces allocations (~12% at 1,000, ~50% at 100).

Note: Unrelated test failures in `rpc_service_test.go` (e.g., unexported `testService`) were observed but pre-exist this change and are outside this PR’s scope.

Fixes: #2678 

Tested with:
- `go test -v -run TestSubURLCopy`: Passed
- `go test -bench=BenchmarkClone -benchmem`: Confirmed performance