### PR TITLE
Fix: Triple protocol streaming does not correctly handle context ctx attachments errors

### DIFF
--- a/protocol/triple/triple_protocol/interceptor.go
+++ b/protocol/triple/triple_protocol/interceptor.go
@@ -16,7 +16,6 @@ package triple_protocol
 
 import (
 	"context"
-	"fmt"
 )
 
 // UnaryFunc is the generic signature of a unary RPC. Interceptors may wrap
@@ -118,7 +117,6 @@ func (c *chain) WrapStreamingClient(next StreamingClientFunc) StreamingClientFun
 }
 
 func (c *chain) WrapStreamingHandler(next StreamingHandlerFunc) StreamingHandlerFunc {
-	fmt.Printf("33333333\n\n\n")
 	for _, interceptor := range c.interceptors {
 		next = interceptor.WrapStreamingHandler(next)
 	}

--- a/protocol/triple/triple_protocol/recover.go
+++ b/protocol/triple/triple_protocol/recover.go
@@ -16,7 +16,6 @@ package triple_protocol
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 )
 
@@ -81,7 +80,6 @@ func (i *recoverHandlerInterceptor) WrapUnaryHandler(next UnaryHandlerFunc) Unar
 }
 
 func (i *recoverHandlerInterceptor) WrapStreamingHandler(next StreamingHandlerFunc) StreamingHandlerFunc {
-	fmt.Printf("22222222\n\n\n")
 	return func(ctx context.Context, conn StreamingHandlerConn) (retErr error) {
 		panicked := true
 		defer func() {


### PR DESCRIPTION
Fix：https://github.com/apache/dubbo-go/issues/2808

Error cause description：
The context data transfer is not handled correctly in triple streaming, resulting in the conversion of the null value (nil) of the interface{} type to the []string type, but it fails.