### PR TITLE
fix: propagate encoding errors in marshalRequest (fixes #2517)

### DIFF
--- a/protocol/dubbo/impl/hessian.go
+++ b/protocol/dubbo/impl/hessian.go
@@ -136,7 +136,9 @@ func marshalRequest(encoder *hessian.Encoder, p DubboPackage) ([]byte, error) {
 	}
 	_ = encoder.Encode(types)
 	for _, v := range args {
-		_ = encoder.Encode(v)
+		if err := encoder.Encode(v); err != nil {
+			return nil, perrors.Wrapf(err, "failed to encode argument: %v", v)
+		}
 	}
 
 	request.Attachments[PATH_KEY] = service.Path

--- a/protocol/dubbo/impl/hessian_test.go
+++ b/protocol/dubbo/impl/hessian_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 import (
+	"github.com/apache/dubbo-go-hessian2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -57,4 +58,47 @@ func TestGetArgType(t *testing.T) {
 	t.Run("param", func(t *testing.T) {
 		assert.Equal(t, dubboParam, getArgType(&Param{}))
 	})
+}
+
+func TestMarshalRequestWithTypedNilPointer(t *testing.T) {
+	encoder := hessian.NewEncoder()
+	pkg := DubboPackage{
+		Service: Service{
+			Path:    "test.Path",
+			Version: "1.0.0",
+			Method:  "Echo",
+		},
+		Body: &RequestPayload{
+			Params: []interface{}{(*int32)(nil)},
+			Attachments: map[string]interface{}{
+				"key": "value",
+			},
+		},
+	}
+
+	data, err := marshalRequest(encoder, pkg)
+	assert.NoError(t, err)
+	assert.NotNil(t, data)
+}
+
+func TestMarshalRequestWithNonNilPointer(t *testing.T) {
+	val := int32(42)
+	encoder := hessian.NewEncoder()
+	pkg := DubboPackage{
+		Service: Service{
+			Path:    "test.Path",
+			Version: "1.0.0",
+			Method:  "Echo",
+		},
+		Body: &RequestPayload{
+			Params: []interface{}{&val},
+			Attachments: map[string]interface{}{
+				"key": "value",
+			},
+		},
+	}
+
+	data, err := marshalRequest(encoder, pkg)
+	assert.NoError(t, err)
+	assert.NotNil(t, data)
 }


### PR DESCRIPTION
This PR fixes the issue where encoding errors in marshalRequest were not properly propagated, which could lead to issues with typed nil pointers (e.g., (*int32)(nil)). The changes ensure that encoding errors are returned and handled appropriately.

Changes:
- Updated marshalRequest in hessian.go to propagate encoding errors.
- Added tests in hessian_test.go to verify the behavior with typed nil pointers and non-nil pointers.

Fixes #2517

**Note for Maintainers**:
This PR depends on the changes in apache/dubbo-go-hessian2#376 . After merging the changes in dubbo-go-hessian2, please update the go.mod file in this repository to point to the latest version of dubbo-go-hessian2 (remove the replace directive and update the version if required).