### PR TITLE
fix: update go version & golangci lint

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -20,7 +20,7 @@ jobs:
       # If you want to matrix build , you can append the following list.
       matrix:
         go_version:
-          - '1.20'
+          - '1.23'
         os:
           - ubuntu-latest
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,15 +18,14 @@ jobs:
     strategy:
       matrix:
         golang:
-          - '1.20'
+          - '1.23'
     steps:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.golang }}
       - uses: actions/checkout@v4
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: v1.54
+          version: v2.0.0
           args: --timeout=10m
-          skip-go-installation: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,63 +1,71 @@
-linters-settings:
-  govet:
-    check-shadowing: true
-  golint:
-    min-confidence: 0
-  gocyclo:
-    min-complexity: 10
-  maligned:
-    suggest-new: true
-  dupl:
-    threshold: 100
-  goconst:
-    min-len: 2
-    min-occurrences: 2
-  depguard:
-    list-type: blacklist
-    packages:
-      # logging is allowed only by logutils.Log, logrus
-      # is allowed to use only in logutils package
-      - github.com/sirupsen/logrus
-  misspell:
-    locale: US
-  lll:
-    line-length: 140
-  goimports:
-    local-prefixes: github.com/golangci/golangci-lint
-  gocritic:
-    enabled-tags:
-      - performance
-      - style
-      - experimental
-    disabled-checks:
-      - wrapperFunc
-
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - govet
-    - staticcheck
     - ineffassign
     - misspell
-
-run:
-  skip-dirs:
-    - test/testdata_etc
-    - pkg/golinters/goanalysis/(checker|passes)
-
-issues:
-  exclude-rules:
-    - text: "weak cryptographic primitive"
-      linters:
-        - gosec
-    - linters:
-        - staticcheck
-      text: "SA1019:"
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.15.x # use the fixed version to not introduce new linters unexpectedly
-  prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"
-
+  disable:
+    - staticcheck
+  settings:
+    dupl:
+      threshold: 100
+    goconst:
+      min-len: 2
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+      enabled-tags:
+        - performance
+        - style
+        - experimental
+    gocyclo:
+      min-complexity: 10
+    lll:
+      line-length: 140
+    misspell:
+      locale: US
+      ignore-rules:
+        - nto
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - gosec
+        text: weak cryptographic primitive
+      - linters:
+          - staticcheck
+        text: "S1009:"
+      - linters:
+          - staticcheck
+        text: "S1034:"
+      - linters:
+          - staticcheck
+        text: "SA1019:"
+      - linters:
+          - staticcheck
+        text: "ST1001:"
+      - linters:
+          - staticcheck
+        text: "ST1017:"
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/golangci/golangci-lint
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/client/action.go
+++ b/client/action.go
@@ -193,7 +193,7 @@ func processURL(ref *global.ReferenceConfig, regsCompat map[string]*config.Regis
 		for _, urlStr := range urlStrings {
 			serviceURL, err := common.NewURL(urlStr, common.WithProtocol(ref.Protocol))
 			if err != nil {
-				return nil, fmt.Errorf(fmt.Sprintf("url configuration error,  please check your configuration, user specified URL %v refer error, error message is %v ", urlStr, err.Error()))
+				return nil, fmt.Errorf("url configuration error,  please check your configuration, user specified URL %v refer error, error message is %v ", urlStr, err.Error())
 			}
 			if serviceURL.Protocol == constant.RegistryProtocol { // serviceURL in this branch is a registry protocol
 				serviceURL.SubURL = cfgURL

--- a/client/client.go
+++ b/client/client.go
@@ -144,9 +144,7 @@ func (cli *Client) dial(interfaceName string, info *ClientInfo, opts ...Referenc
 
 func generateInvocation(methodName string, reqs []interface{}, resp interface{}, callType string, opts *CallOptions) (protocol.Invocation, error) {
 	var paramsRawVals []interface{}
-	for _, req := range reqs {
-		paramsRawVals = append(paramsRawVals, req)
-	}
+	paramsRawVals = append(paramsRawVals, reqs...)
 	if resp != nil {
 		paramsRawVals = append(paramsRawVals, resp)
 	}

--- a/cluster/router/condition/matcher/argument.go
+++ b/cluster/router/condition/matcher/argument.go
@@ -34,7 +34,7 @@ import (
 )
 
 var (
-	argumentsPattern      = regexp.MustCompile("arguments\\[([0-9]+)\\]")
+	argumentsPattern      = regexp.MustCompile(`arguments\[([0-9]+)\]`)
 	notFoundArgumentValue = "dubbo internal not found argument condition value"
 )
 

--- a/cluster/router/condition/matcher/attachment.go
+++ b/cluster/router/condition/matcher/attachment.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	attachmentPattern       = regexp.MustCompile("attachments\\[([a-zA-Z0-9_]+)\\]")
+	attachmentPattern       = regexp.MustCompile(`attachments\[([a-zA-Z0-9_]+)\]`)
 	notFoundAttachmentValue = "dubbo internal not found attachment condition value"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module dubbo.apache.org/dubbo-go/v3
 
-go 1.20
+go 1.23
 
 require (
 	github.com/RoaringBitmap/roaring v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,7 @@ github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNI
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
@@ -882,6 +883,7 @@ go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
+go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=


### PR DESCRIPTION
#2825 has mentioned the problem caused by outdated go version, upgradation of ci will cause many staticcheck errors, a temporary solution is to disable the staticcheck linter or declare some exclusion rules.