### PR TITLE
chore: Update golang v1.23 and golangci-lint to v1.64

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -20,7 +20,7 @@ jobs:
       # If you want to matrix build , you can append the following list.
       matrix:
         go_version:
-          - '1.20'
+          - '1.23'
         os:
           - ubuntu-latest
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         golang:
-          - '1.20'
+          - '1.23'
     steps:
       - uses: actions/setup-go@v5
         with:
@@ -27,6 +27,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.54
+          install-mode: goinstall
+          version: v1.64
           args: --timeout=10m
           skip-go-installation: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,23 +1,11 @@
 linters-settings:
-  govet:
-    check-shadowing: true
-  golint:
-    min-confidence: 0
   gocyclo:
     min-complexity: 10
-  maligned:
-    suggest-new: true
   dupl:
     threshold: 100
   goconst:
     min-len: 2
     min-occurrences: 2
-  depguard:
-    list-type: blacklist
-    packages:
-      # logging is allowed only by logutils.Log, logrus
-      # is allowed to use only in logutils package
-      - github.com/sirupsen/logrus
   misspell:
     locale: US
   lll:
@@ -40,12 +28,10 @@ linters:
     - ineffassign
     - misspell
 
-run:
-  skip-dirs:
+issues:
+  exclude-dirs:
     - test/testdata_etc
     - pkg/golinters/goanalysis/(checker|passes)
-
-issues:
   exclude-rules:
     - text: "weak cryptographic primitive"
       linters:
@@ -53,11 +39,4 @@ issues:
     - linters:
         - staticcheck
       text: "SA1019:"
-
-# golangci.com configuration
-# https://github.com/golangci/golangci/wiki/Configuration
-service:
-  golangci-lint-version: 1.15.x # use the fixed version to not introduce new linters unexpectedly
-  prepare:
-    - echo "here I can run custom commands, but no preparation needed for this repo"
 

--- a/client/action.go
+++ b/client/action.go
@@ -18,21 +18,18 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
 	"strconv"
 	"time"
-)
 
-import (
 	"github.com/dubbogo/gost/log/logger"
+
 	gxstrings "github.com/dubbogo/gost/strings"
-
 	constant2 "github.com/dubbogo/triple/pkg/common/constant"
-)
 
-import (
 	"dubbo.apache.org/dubbo-go/v3/cluster/directory/static"
 	"dubbo.apache.org/dubbo-go/v3/common"
 	commonCfg "dubbo.apache.org/dubbo-go/v3/common/config"
@@ -193,7 +190,7 @@ func processURL(ref *global.ReferenceConfig, regsCompat map[string]*config.Regis
 		for _, urlStr := range urlStrings {
 			serviceURL, err := common.NewURL(urlStr, common.WithProtocol(ref.Protocol))
 			if err != nil {
-				return nil, fmt.Errorf(fmt.Sprintf("url configuration error,  please check your configuration, user specified URL %v refer error, error message is %v ", urlStr, err.Error()))
+				return nil, errors.New(fmt.Sprintf("url configuration error,  please check your configuration, user specified URL %v refer error, error message is %v ", urlStr, err.Error()))
 			}
 			if serviceURL.Protocol == constant.RegistryProtocol { // serviceURL in this branch is a registry protocol
 				serviceURL.SubURL = cfgURL

--- a/common/url_test.go
+++ b/common/url_test.go
@@ -21,14 +21,9 @@ import (
 	"encoding/base64"
 	"net/url"
 	"testing"
-)
 
-import (
-	"github.com/stretchr/testify/assert"
-)
-
-import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -89,7 +84,7 @@ func TestURL(t *testing.T) {
 		"provider-golang-1.0.0&environment=dev&interface=com.ikurento.user.UserProvider&ip=192.168.56.1&methods=GetUser%"+
 		"2C&module=dubbogo+user-info+server&org=ikurento.com&owner=ZX&pid=1447&revision=0.0.1&side=provider&timeout=3000&t"+
 		"imestamp=1556509797245", u.params.Encode())
-
+	//nolint:misspell
 	assert.Equal(t, "dubbo://127.0.0.1:20000/com.ikurento.user.UserProvider?anyhost=true&application=BDTServi"+
 		"ce&category=providers&default.timeout=10000&dubbo=dubbo-provider-golang-1.0.0&environment=dev&interface=com.ikure"+
 		"nto.user.UserProvider&ip=192.168.56.1&methods=GetUser%2C&module=dubbogo+user-info+server&org=ikurento.com&owner="+
@@ -116,7 +111,7 @@ func TestURLWithoutSchema(t *testing.T) {
 		"provider-golang-1.0.0&environment=dev&interface=com.ikurento.user.UserProvider&ip=192.168.56.1&methods=GetUser%"+
 		"2C&module=dubbogo+user-info+server&org=ikurento.com&owner=ZX&pid=1447&revision=0.0.1&side=provider&timeout=3000&t"+
 		"imestamp=1556509797245", u.params.Encode())
-
+	//nolint:misspell
 	assert.Equal(t, "dubbo://127.0.0.1:20000/com.ikurento.user.UserProvider?anyhost=true&application=BDTServi"+
 		"ce&category=providers&default.timeout=10000&dubbo=dubbo-provider-golang-1.0.0&environment=dev&interface=com.ikure"+
 		"nto.user.UserProvider&ip=192.168.56.1&methods=GetUser%2C&module=dubbogo+user-info+server&org=ikurento.com&owner="+

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module dubbo.apache.org/dubbo-go/v3
 
-go 1.20
+go 1.23
 
 require (
 	github.com/RoaringBitmap/roaring v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -262,6 +262,7 @@ github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNI
 github.com/go-ole/go-ole v1.2.6 h1:/Fpf6oFPoeFik9ty7siob0G6Ke8QvQEuVcuChpwXzpY=
 github.com/go-ole/go-ole v1.2.6/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
+github.com/go-playground/assert/v2 v2.2.0/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
@@ -882,6 +883,7 @@ go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
+go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.5.0/go.mod h1:FeouvMocqHpRaaGuG9EjoKcStLC43Zu/fmqdUMPcKYU=


### PR DESCRIPTION
```
Run if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
start integrate-test: repo = apache/dubbo-go, SHA = 03ad5e326f94e0c8cf952a7f16b3552230d3d82d, branch = main
integrate-test root work-space -> /home/runner/work/dubbo-go/dubbo-go
use dubbo-go-samples main branch for integration testing
Cloning into 'samples'...
go: go.mod file indicates go 1.23, but maximum version supported by tidy is 1.20
```
ref:  https://github.com/apache/dubbo-go/actions/runs/14289442729/job/40048715934

Since the golang version of the dependent dubbo-go-samples has been upgraded to v1.23, keep it consistent:
https://github.com/apache/dubbo-go-samples/blob/04455d8b548ec54350f0c86c49b05e5524286cdd/go.mod#L173

