### PR TITLE
feat: decode hessian from stream（#2840)

### DIFF
--- a/protocol/dubbo/hessian2/hessian_dubbo.go
+++ b/protocol/dubbo/hessian2/hessian_dubbo.go
@@ -64,9 +64,10 @@ type Service struct {
 
 // HessianCodec defines hessian codec
 type HessianCodec struct {
-	pkgType PackageType
-	reader  *bufio.Reader
-	bodyLen int
+	pkgType   PackageType
+	reader    *bufio.Reader
+	bodyLen   int
+	streaming bool
 }
 
 // NewHessianCodec generate a new hessian codec instance
@@ -82,6 +83,16 @@ func NewHessianCodecCustom(pkgType PackageType, reader *bufio.Reader, bodyLen in
 		pkgType: pkgType,
 		reader:  reader,
 		bodyLen: bodyLen,
+	}
+}
+
+// NewStreamingHessianCodecCustom generate a new hessian codec instance
+func NewStreamingHessianCodecCustom(pkgType PackageType, reader *bufio.Reader, bodyLen int) *HessianCodec {
+	return &HessianCodec{
+		pkgType:   pkgType,
+		reader:    reader,
+		bodyLen:   bodyLen,
+		streaming: true,
 	}
 }
 
@@ -109,17 +120,34 @@ func (h *HessianCodec) Write(service Service, header DubboHeader, body interface
 // ReadHeader uses hessian codec to read dubbo header
 func (h *HessianCodec) ReadHeader(header *DubboHeader) error {
 	var err error
+	var buf []byte
 
-	if h.reader.Size() < HEADER_LENGTH {
-		return ErrHeaderNotEnough
-	}
-	buf, err := h.reader.Peek(HEADER_LENGTH)
-	if err != nil { // this is impossible
-		return perrors.WithStack(err)
-	}
-	_, err = h.reader.Discard(HEADER_LENGTH)
-	if err != nil { // this is impossible
-		return perrors.WithStack(err)
+	if h.streaming {
+		buf = make([]byte, HEADER_LENGTH)
+		n, _ := h.reader.Read(buf)
+		if n < HEADER_LENGTH {
+			// just try once
+			_, err = h.reader.Peek(HEADER_LENGTH - n)
+			if err != nil {
+				return perrors.WithStack(err)
+			}
+			_, err = h.reader.Read(buf[n:])
+			if err != nil { // this is impossible
+				return perrors.WithStack(err)
+			}
+		}
+	} else {
+		if h.reader.Size() < HEADER_LENGTH {
+			return ErrHeaderNotEnough
+		}
+		buf, err = h.reader.Peek(HEADER_LENGTH)
+		if err != nil { // this is impossible
+			return perrors.WithStack(err)
+		}
+		_, err = h.reader.Discard(HEADER_LENGTH)
+		if err != nil { // this is impossible
+			return perrors.WithStack(err)
+		}
 	}
 
 	//// read header
@@ -164,7 +192,7 @@ func (h *HessianCodec) ReadHeader(header *DubboHeader) error {
 	h.pkgType = header.Type
 	h.bodyLen = header.BodyLen
 
-	if h.reader.Buffered() < h.bodyLen {
+	if h.reader.Buffered() < h.bodyLen && !h.streaming {
 		return ErrBodyNotEnough
 	}
 
@@ -173,16 +201,31 @@ func (h *HessianCodec) ReadHeader(header *DubboHeader) error {
 
 // ReadBody uses hessian codec to read response body
 func (h *HessianCodec) ReadBody(rspObj interface{}) error {
-	if h.reader.Buffered() < h.bodyLen {
-		return ErrBodyNotEnough
-	}
-	buf, err := h.reader.Peek(h.bodyLen)
-	if err != nil {
-		return perrors.WithStack(err)
-	}
-	_, err = h.reader.Discard(h.bodyLen)
-	if err != nil { // this is impossible
-		return perrors.WithStack(err)
+	var err error
+	var buf []byte
+
+	if h.streaming {
+		buf = make([]byte, h.bodyLen)
+		readLen, n := 0, 0
+		for readLen < h.bodyLen {
+			n, err = h.reader.Read(buf[readLen:])
+			if err != nil {
+				return perrors.WithStack(err)
+			}
+			readLen += n
+		}
+	} else {
+		if h.reader.Buffered() < h.bodyLen {
+			return ErrBodyNotEnough
+		}
+		buf, err = h.reader.Peek(h.bodyLen)
+		if err != nil {
+			return perrors.WithStack(err)
+		}
+		_, err = h.reader.Discard(h.bodyLen)
+		if err != nil { // this is impossible
+			return perrors.WithStack(err)
+		}
 	}
 
 	switch h.pkgType & PackageType_BitSize {
@@ -218,16 +261,30 @@ func (h *HessianCodec) ReadBody(rspObj interface{}) error {
 
 // ignore body, but only read attachments
 func (h *HessianCodec) ReadAttachments() (map[string]interface{}, error) {
-	if h.reader.Buffered() < h.bodyLen {
-		return nil, ErrBodyNotEnough
-	}
-	buf, err := h.reader.Peek(h.bodyLen)
-	if err != nil {
-		return nil, perrors.WithStack(err)
-	}
-	_, err = h.reader.Discard(h.bodyLen)
-	if err != nil { // this is impossible
-		return nil, perrors.WithStack(err)
+	var err error
+	var buf []byte
+	if h.streaming {
+		buf = make([]byte, h.bodyLen)
+		readLen, n := 0, 0
+		for readLen < h.bodyLen {
+			n, err = h.reader.Read(buf[readLen:])
+			if err != nil {
+				return nil, perrors.WithStack(err)
+			}
+			readLen += n
+		}
+	} else {
+		if h.reader.Buffered() < h.bodyLen {
+			return nil, ErrBodyNotEnough
+		}
+		buf, err = h.reader.Peek(h.bodyLen)
+		if err != nil {
+			return nil, perrors.WithStack(err)
+		}
+		_, err = h.reader.Discard(h.bodyLen)
+		if err != nil { // this is impossible
+			return nil, perrors.WithStack(err)
+		}
 	}
 
 	switch h.pkgType & PackageType_BitSize {

--- a/protocol/dubbo/hessian2/hessian_dubbo_test.go
+++ b/protocol/dubbo/hessian2/hessian_dubbo_test.go
@@ -245,3 +245,67 @@ type AttachTestObject struct {
 func (AttachTestObject) JavaClassName() string {
 	return "com.test.Test"
 }
+
+type CaseStream struct {
+	Payload string
+}
+
+func (CaseStream) JavaClassName() string {
+	return "com.test.CaseStream"
+}
+
+func TestDecodeFromTcpStream(t *testing.T) {
+	payload := make([]byte, 1024)
+	alphabet := "abcdefghijklmnopqrstuvwxyz"
+	for i, _ := range payload {
+		payload[i] = alphabet[i%26]
+	}
+	cs := &CaseStream{
+		Payload: string(payload),
+	}
+
+	hessian.RegisterPOJO(cs)
+	codecW := NewHessianCodec(nil)
+	service := Service{
+		Path:      "test",
+		Interface: "ITest",
+		Version:   "v1.0",
+		Method:    "test",
+		Timeout:   time.Second * 10,
+	}
+	header := DubboHeader{
+		SerialID:       2,
+		Type:           PackageRequest,
+		ID:             1,
+		ResponseStatus: Zero,
+	}
+	resp, err := codecW.Write(service, header, []interface{}{cs})
+
+	// set reader buffer = 1024 to split resp into two parts
+	codec := NewStreamingHessianCodecCustom(0, bufio.NewReaderSize(bytes.NewReader(resp), 1024), 0)
+	h := &DubboHeader{}
+	assert.NoError(t, codec.ReadHeader(h))
+	assert.Equal(t, h.SerialID, header.SerialID)
+	assert.Equal(t, h.Type, header.Type)
+	assert.Equal(t, h.ID, header.ID)
+	assert.Equal(t, h.ResponseStatus, header.ResponseStatus)
+
+	reqBody := make([]interface{}, 7)
+
+	err = codec.ReadBody(reqBody)
+	assert.NoError(t, err)
+	assert.Equal(t, reqBody[1], service.Path)
+	assert.Equal(t, reqBody[2], service.Version)
+	assert.Equal(t, reqBody[3], service.Method)
+
+	if list, ok := reqBody[5].([]interface{}); ok {
+		assert.Len(t, list, 1)
+		if infoPtr, ok2 := list[0].(*CaseStream); ok2 {
+			assert.Equal(t, len(infoPtr.Payload), 1024)
+		}
+	}
+
+	codec = NewHessianCodecCustom(0, bufio.NewReaderSize(bytes.NewReader(resp), 1024), 0)
+	err = codec.ReadHeader(h)
+	assert.ErrorIs(t, err, ErrBodyNotEnough)
+}


### PR DESCRIPTION
```
func NewStreamingHessianCodecCustom(pkgType PackageType, reader *bufio.Reader, bodyLen int) *HessianCodec {
	return &HessianCodec{
		pkgType:   pkgType,
		reader:    reader,
		bodyLen:   bodyLen,
		streaming: true,
	}
}
```
Add a `streaming` option for  `HessianCodec`, if true, keep reading the buffer of reader until `bodyLen` is reached