### PR TITLE
fix: remove unused fuction

### DIFF
--- a/protocol/triple/triple.go
+++ b/protocol/triple/triple.go
@@ -70,20 +70,6 @@ func (tp *TripleProtocol) Export(invoker protocol.Invoker) protocol.Exporter {
 	return exporter
 }
 
-// *Important*. This function is only for testing. When server package is finished, remove this function
-// and modify related tests.
-func (tp *TripleProtocol) exportForTest(invoker protocol.Invoker, info *common.ServiceInfo) protocol.Exporter {
-	url := invoker.GetURL()
-	serviceKey := url.ServiceKey()
-	// todo: retrieve this info from url
-	exporter := NewTripleExporter(serviceKey, invoker, tp.ExporterMap())
-	tp.SetExporterMap(serviceKey, exporter)
-	logger.Infof("[TRIPLE Protocol] Export service: %s", url.String())
-	tp.openServer(invoker, info)
-	internal.HealthSetServingStatusServing(url.Service())
-	return exporter
-}
-
 func (tp *TripleProtocol) openServer(invoker protocol.Invoker, info *common.ServiceInfo) {
 	url := invoker.GetURL()
 	tp.serverLock.Lock()


### PR DESCRIPTION
exportForTest is unused after remove Internal dir[#2794](https://github.com/apache/dubbo-go/pull/2794).