### PR TITLE
Multi registry verification and Use LoadOrStore instead

### DIFF
--- a/config/root_config.go
+++ b/config/root_config.go
@@ -386,9 +386,9 @@ func validateRegistryAddresses(registries map[string]*RegistryConfig) error {
 		}
 
 		if existingID, exists := cacheKeyMap[cacheKey]; exists {
-			logger.Errorf("Registry %s is already in use by %s", id, existingID)
-			return fmt.Errorf("duplicate registry cache key detected: %s is used by both %s and %s registries",
-				cacheKey, existingID, id)
+			err := fmt.Errorf("duplicate registry address: [%s] used by both [%s] and [%s]", cacheKey, existingID, id)
+			logger.Error(err)
+			return err
 		}
 
 		cacheKeyMap[cacheKey] = id

--- a/config/root_config.go
+++ b/config/root_config.go
@@ -373,8 +373,9 @@ func (rc *RootConfig) Process(event *config_center.ConfigChangeEvent) {
 	rc.Metrics.DynamicUpdateProperties(updateRootConfig.Metrics)
 }
 
+// validateRegistryAddresses Checks whether there are duplicate registry addresses
 func validateRegistryAddresses(registries map[string]*RegistryConfig) error {
-	cacheKeyMap := make(map[string]string)
+	cacheKeyMap := make(map[string]string, len(registries))
 
 	for id, reg := range registries {
 		address := reg.Address
@@ -387,7 +388,7 @@ func validateRegistryAddresses(registries map[string]*RegistryConfig) error {
 
 		if existingID, exists := cacheKeyMap[cacheKey]; exists {
 			err := fmt.Errorf("duplicate registry address: [%s] used by both [%s] and [%s]", cacheKey, existingID, id)
-			logger.Error(err)
+			logger.Errorf("duplicate registry address: [%s] used by both [%s] and [%s]", cacheKey, existingID, id)
 			return err
 		}
 

--- a/config/root_config.go
+++ b/config/root_config.go
@@ -167,6 +167,7 @@ func (rc *RootConfig) Init() error {
 		}
 	}
 
+	// TODO：When config is migrated later, the impact of this will be migrated to the global module
 	if err := validateRegistryAddresses(rc.Registries); err != nil {
 		return err
 	}
@@ -373,6 +374,7 @@ func (rc *RootConfig) Process(event *config_center.ConfigChangeEvent) {
 	rc.Metrics.DynamicUpdateProperties(updateRootConfig.Metrics)
 }
 
+// TODO：When config is migrated later, the impact of this will be migrated to the global module
 // validateRegistryAddresses Checks whether there are duplicate registry addresses
 func validateRegistryAddresses(registries map[string]*RegistryConfig) error {
 	cacheKeyMap := make(map[string]string, len(registries))

--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -79,23 +79,20 @@ func newRegistryProtocol() *registryProtocol {
 }
 
 func (proto *registryProtocol) getRegistry(registryUrl *common.URL) registry.Registry {
-	var err error
-
 	namespace := registryUrl.GetParam(constant.RegistryNamespaceKey, "")
 	cacheKey := registryUrl.PrimitiveURL
 	if namespace != "" {
 		cacheKey = cacheKey + "?" + constant.NacosNamespaceID + "=" + namespace
 	}
-	reg, loaded := proto.registries.Load(cacheKey)
-	if !loaded {
-		reg, err = extension.GetRegistry(registryUrl.Protocol, registryUrl)
+	actualReg, _ := proto.registries.LoadOrStore(cacheKey, func() any {
+		reg, err := extension.GetRegistry(registryUrl.Protocol, registryUrl)
 		if err != nil {
-			logger.Errorf("Registry can not connect success, program is going to panic.Error message is %s", err.Error())
+			logger.Errorf("Registry cannot connect successfully. Error: %s", err.Error())
 			panic(err)
 		}
-		proto.registries.Store(cacheKey, reg)
-	}
-	return reg.(registry.Registry)
+		return reg
+	}())
+	return actualReg.(registry.Registry)
 }
 
 func getCacheKey(invoker protocol.Invoker) string {


### PR DESCRIPTION
fix：https://github.com/apache/dubbo-go/issues/2094 Multi registry Address verification 

Rewriting with LoadOrStore here can avoid the problem of duplicate creation under multi-threaded concurrency.
