### PR TITLE
fix: fix weight configuration for loadbalance with nacos (#2864)

### DIFF
--- a/global/service_config.go
+++ b/global/service_config.go
@@ -17,6 +17,8 @@
 
 package global
 
+import "dubbo.apache.org/dubbo-go/v3/common/constant"
+
 // ServiceConfig is the configuration of the service provider
 type ServiceConfig struct {
 	Filter                      string            `yaml:"filter" json:"filter,omitempty" property:"filter"`
@@ -46,6 +48,7 @@ type ServiceConfig struct {
 	ParamSign                   string            `yaml:"param.sign" json:"param.sign,omitempty" property:"param.sign"`
 	Tag                         string            `yaml:"tag" json:"tag,omitempty" property:"tag"`
 	TracingKey                  string            `yaml:"tracing-key" json:"tracing-key,omitempty" propertiy:"tracing-key"`
+	Weight                      int64             `yaml:"weight" json:"weight,omitempty" property:"weight"`
 
 	RCProtocolsMap  map[string]*ProtocolConfig
 	RCRegistriesMap map[string]*RegistryConfig
@@ -60,6 +63,7 @@ func DefaultServiceConfig() *ServiceConfig {
 		Params:          make(map[string]string, 8),
 		RCProtocolsMap:  make(map[string]*ProtocolConfig),
 		RCRegistriesMap: make(map[string]*RegistryConfig),
+		Weight:          constant.DefaultWeight,
 	}
 }
 
@@ -126,5 +130,6 @@ func (c *ServiceConfig) Clone() *ServiceConfig {
 		ParamSign:                   c.ParamSign,
 		Tag:                         c.Tag,
 		TracingKey:                  c.TracingKey,
+		Weight:                      c.Weight,
 	}
 }

--- a/metadata/info/metadata_info.go
+++ b/metadata/info/metadata_info.go
@@ -212,6 +212,7 @@ type ServiceInfo struct {
 	Port     int               `json:"port,omitempty" hessian:"port"`
 	Path     string            `json:"path,omitempty" hessian:"path"`
 	Params   map[string]string `json:"params,omitempty" hessian:"params"`
+	Weight   int64             `json:"weight,omitempty" hessian:"weight"`
 
 	ServiceKey string      `json:"-" hessian:"-"`
 	MatchKey   string      `json:"-" hessian:"-"`

--- a/registry/nacos/service_discovery.go
+++ b/registry/nacos/service_discovery.go
@@ -20,7 +20,6 @@ package nacos
 import (
 	"fmt"
 	"regexp"
-	"strconv"
 	"sync"
 )
 
@@ -184,6 +183,7 @@ func (n *nacosServiceDiscovery) GetInstances(serviceName string) []registry.Serv
 			Healthy:     ins.Healthy,
 			Metadata:    metadata,
 			GroupName:   n.group,
+			Weight:      int64(ins.Weight),
 		})
 	}
 	return res
@@ -315,13 +315,12 @@ func (n *nacosServiceDiscovery) toRegisterInstance(instance registry.ServiceInst
 		metadata = make(map[string]string, 1)
 	}
 
-	weightStr := n.registryURL.GetParam(constant.RegistryKey+"."+constant.WeightKey, "1.0")
-	weight, err := strconv.ParseFloat(weightStr, 64)
-	if err != nil || weight <= constant.MinNacosWeight {
-		logger.Warnf("Invalid weight value %q, using default 1.0. err: %v", weightStr, err)
+	weight := n.registryURL.SubURL.GetParamInt(constant.WeightKey, constant.DefaultWeight)
+	if weight <= constant.MinNacosWeight {
+		logger.Warnf("Invalid weight value %d, using default weight %d.", weight, constant.DefaultWeight)
 		weight = constant.DefaultNacosWeight
 	} else if weight > constant.MaxNacosWeight {
-		logger.Warnf("Weight %f exceeds Nacos maximum 10000, setting to 10000", weight)
+		logger.Warnf("Weight %d exceeds Nacos maximum 10000, setting to 10000", weight)
 		weight = constant.MaxNacosWeight
 	}
 
@@ -332,7 +331,7 @@ func (n *nacosServiceDiscovery) toRegisterInstance(instance registry.ServiceInst
 		Port:        uint64(instance.GetPort()),
 		Metadata:    metadata,
 		// We must specify the weight since Java nacos namingClient will ignore the instance whose weight is 0
-		Weight:    weight,
+		Weight:    float64(weight),
 		Enable:    instance.IsEnable(),
 		Healthy:   instance.IsHealthy(),
 		GroupName: n.group,

--- a/registry/service_instance.go
+++ b/registry/service_instance.go
@@ -76,6 +76,7 @@ type ServiceInstance interface {
 
 	// GetTag will return the tag of the instance
 	GetTag() string
+	GetWeight() int64
 }
 
 // nolint
@@ -99,6 +100,7 @@ type DefaultServiceInstance struct {
 	GroupName       string
 	endpoints       []*Endpoint `json:"-"`
 	Tag             string
+	Weight          int64
 }
 
 // GetID will return this instance's id. It should be unique.
@@ -130,6 +132,8 @@ func (d *DefaultServiceInstance) IsEnable() bool {
 func (d *DefaultServiceInstance) IsHealthy() bool {
 	return d.Healthy
 }
+
+func (d *DefaultServiceInstance) GetWeight() int64 { return d.Weight }
 
 // GetAddress will return the ip:Port
 func (d *DefaultServiceInstance) GetAddress() string {

--- a/registry/servicediscovery/service_instances_changed_listener_impl.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl.go
@@ -20,6 +20,7 @@ package servicediscovery
 import (
 	"encoding/gob"
 	"reflect"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -156,6 +157,9 @@ func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error
 							urls = append(urls, i.ToURLs(serviceInfo)...)
 						}
 					}
+				}
+				for i, url := range urls {
+					url.SetParam(constant.WeightKey, strconv.FormatInt(ce.Instances[i].GetWeight(), 10))
 				}
 				revisionsToUrls[revisions] = urls
 				newServiceURLs[serviceInfo.GetMatchKey()] = urls

--- a/server/action.go
+++ b/server/action.go
@@ -381,6 +381,9 @@ func (svcOpts *ServiceOptions) getUrlMap() url.Values {
 	urlMap.Set(constant.ExportKey, strconv.FormatBool(svcOpts.needExport))
 	urlMap.Set(constant.PIDKey, fmt.Sprintf("%d", os.Getpid()))
 
+	// fix issue #2864, align with the implementation in Dubbo-Java
+	urlMap.Set(constant.WeightKey, strconv.FormatInt(svcOpts.Provider.Weight, 10))
+
 	for _, v := range srv.Methods {
 		prefix := "methods." + v.Name + "."
 		urlMap.Set(prefix+constant.LoadbalanceKey, v.LoadBalance)

--- a/server/options.go
+++ b/server/options.go
@@ -150,6 +150,12 @@ func WithServerLoadBalance(lb string) ServerOption {
 	}
 }
 
+func WithServerWeight(weight int64) ServerOption {
+	return func(opts *ServerOptions) {
+		opts.Provider.Weight = weight
+	}
+}
+
 // warmUp is in seconds
 func WithServerWarmUp(warmUp time.Duration) ServerOption {
 	return func(opts *ServerOptions) {


### PR DESCRIPTION
Fix: fixed Nacos weight-based load balancing (issue #2864). Users can now use `WithServerWeight` to configure server weights and `WithClientLoadBalance` to specify the load balancing strategy.

**Client Configuration:**
![Client Configuration](https://github.com/user-attachments/assets/13e11f72-9882-4c10-97f1-b6332c88a3bf)

**Server 1 Configuration:**
![Server 1 Configuration](https://github.com/user-attachments/assets/2357e506-ac04-4178-876f-79ebfc026cda)

**Server 2 Configuration:**
![Server 2 Configuration](https://github.com/user-attachments/assets/c9d23a97-e838-4367-afa4-6f87a034a37d)

**Result**

**Nacos Weight:**
![Nacos Weight Configuration](https://github.com/user-attachments/assets/23fc8a26-f91c-447f-b046-65e0adeb1bd8)

**Random Load Balance Strategy:**
![Random Load Balancing](https://github.com/user-attachments/assets/f18030f6-e6fd-40df-bf7b-7476bef630bb)

**Round Robin Load Balance Strategy:**
![Round Robin Load Balancing](https://github.com/user-attachments/assets/b14abd9a-c4f2-4e72-9087-3c6367122005)
*(Every 5 requests hit server2, and 1 request hits server1)*

**Exported URL Format:**
![Exported URL Format](https://github.com/user-attachments/assets/8e695941-b188-417a-b028-37aafaf9c204)

**Comparison with Dubbo Java:**
![Dubbo Java Configuration 1](https://github.com/user-attachments/assets/4c25cd61-cddd-4e47-9b0a-81b666d4738e)
![Dubbo Java Configuration 2](https://github.com/user-attachments/assets/dbec2389-c353-44ee-a0b7-a79ca539d33b)
