### PR TITLE
feat: TLS new API design and replace the TLSconfig of config package

### DIFF
--- a/client/action.go
+++ b/client/action.go
@@ -135,6 +135,10 @@ func (refOpts *ReferenceOptions) refer(srv common.RPCService, info *ClientInfo) 
 		cfgURL.SetAttribute(constant.ClientInfoKey, info)
 	}
 
+	if refOpts.TLS != nil {
+		cfgURL.SetAttribute(constant.TLSConfigKey, refOpts.TLS)
+	}
+
 	if ref.ForceTag {
 		cfgURL.AddParam(constant.ForceUseTag, "true")
 	}

--- a/client/action.go
+++ b/client/action.go
@@ -130,13 +130,10 @@ func (refOpts *ReferenceOptions) refer(srv common.RPCService, info *ClientInfo) 
 		common.WithParamsValue(constant.TimeoutKey, refOpts.Consumer.RequestTimeout),
 		common.WithParamsValue(constant.KeepAliveInterval, ref.KeepAliveInterval),
 		common.WithParamsValue(constant.KeepAliveTimeout, ref.KeepAliveTimeout),
+		common.WithAttribute(constant.TLSConfigKey, refOpts.TLS),
 	)
 	if info != nil {
 		cfgURL.SetAttribute(constant.ClientInfoKey, info)
-	}
-
-	if refOpts.TLS != nil {
-		cfgURL.SetAttribute(constant.TLSConfigKey, refOpts.TLS)
 	}
 
 	if ref.ForceTag {

--- a/client/client.go
+++ b/client/client.go
@@ -130,6 +130,7 @@ func (cli *Client) dial(interfaceName string, info *ClientInfo, opts ...Referenc
 		setConsumer(cli.cliOpts.Consumer),
 		setMetrics(cli.cliOpts.Metrics),
 		setOtel(cli.cliOpts.Otel),
+		setTLS(cli.cliOpts.TLS),
 		// this config must be set after Reference initialized
 		setInterfaceName(interfaceName),
 	}

--- a/client/options.go
+++ b/client/options.go
@@ -75,22 +75,21 @@ func (refOpts *ReferenceOptions) init(opts ...ReferenceOption) error {
 		return err
 	}
 
-	// TODO: rename ref to refConf
-	ref := refOpts.Reference
+	refConf := refOpts.Reference
 
 	app := refOpts.applicationCompat
 	if app != nil {
 		refOpts.metaDataType = app.MetadataType
-		if ref.Group == "" {
-			ref.Group = app.Group
+		if refConf.Group == "" {
+			refConf.Group = app.Group
 		}
-		if ref.Version == "" {
-			ref.Version = app.Version
+		if refConf.Version == "" {
+			refConf.Version = app.Version
 		}
 	}
 
 	// init method
-	methods := ref.Methods
+	methods := refConf.Methods
 	if length := len(methods); length > 0 {
 		refOpts.methodsCompat = make([]*config.MethodConfig, length)
 		for i, method := range methods {
@@ -102,23 +101,23 @@ func (refOpts *ReferenceOptions) init(opts ...ReferenceOption) error {
 	}
 
 	// init cluster
-	if ref.Cluster == "" {
-		ref.Cluster = "failover"
+	if refConf.Cluster == "" {
+		refConf.Cluster = "failover"
 	}
 
 	// init registries
 	if len(refOpts.registriesCompat) > 0 {
 		regs := refOpts.registriesCompat
-		if len(ref.RegistryIDs) <= 0 {
-			ref.RegistryIDs = make([]string, len(regs))
+		if len(refConf.RegistryIDs) <= 0 {
+			refConf.RegistryIDs = make([]string, len(regs))
 			for key := range regs {
-				ref.RegistryIDs = append(ref.RegistryIDs, key)
+				refConf.RegistryIDs = append(refConf.RegistryIDs, key)
 			}
 		}
-		ref.RegistryIDs = commonCfg.TranslateIds(ref.RegistryIDs)
+		refConf.RegistryIDs = commonCfg.TranslateIds(refConf.RegistryIDs)
 
 		newRegs := make(map[string]*config.RegistryConfig)
-		for _, id := range ref.RegistryIDs {
+		for _, id := range refConf.RegistryIDs {
 			if reg, ok := regs[id]; ok {
 				newRegs[id] = reg
 			}
@@ -127,16 +126,16 @@ func (refOpts *ReferenceOptions) init(opts ...ReferenceOption) error {
 	}
 
 	// init protocol
-	if ref.Protocol == "" {
-		ref.Protocol = constant.TriProtocol
+	if refConf.Protocol == "" {
+		refConf.Protocol = constant.TriProtocol
 		if refOpts.Consumer != nil && refOpts.Consumer.Protocol != "" {
-			ref.Protocol = refOpts.Consumer.Protocol
+			refConf.Protocol = refOpts.Consumer.Protocol
 		}
 	}
 
 	// init serialization
-	if ref.Serialization == "" {
-		ref.Serialization = constant.ProtobufSerialization
+	if refConf.Serialization == "" {
+		refConf.Serialization = constant.ProtobufSerialization
 	}
 
 	return commonCfg.Verify(refOpts)
@@ -486,8 +485,7 @@ func (cliOpts *ClientOptions) init(opts ...ClientOption) error {
 		return err
 	}
 
-	// TODO: rename con to consumerConf
-	con := cliOpts.Consumer
+	consumerConf := cliOpts.Consumer
 
 	// init application
 	application := cliOpts.Application
@@ -502,15 +500,15 @@ func (cliOpts *ClientOptions) init(opts ...ClientOption) error {
 	regs := cliOpts.Registries
 	if regs != nil {
 		cliOpts.registriesCompat = make(map[string]*config.RegistryConfig)
-		if len(con.RegistryIDs) <= 0 {
-			con.RegistryIDs = make([]string, len(regs))
+		if len(consumerConf.RegistryIDs) <= 0 {
+			consumerConf.RegistryIDs = make([]string, len(regs))
 			for key := range regs {
-				con.RegistryIDs = append(con.RegistryIDs, key)
+				consumerConf.RegistryIDs = append(consumerConf.RegistryIDs, key)
 			}
 		}
-		con.RegistryIDs = commonCfg.TranslateIds(con.RegistryIDs)
+		consumerConf.RegistryIDs = commonCfg.TranslateIds(consumerConf.RegistryIDs)
 
-		for _, id := range con.RegistryIDs {
+		for _, id := range consumerConf.RegistryIDs {
 			if reg, ok := regs[id]; ok {
 				cliOpts.registriesCompat[id] = compatRegistryConfig(reg)
 				if err := cliOpts.registriesCompat[id].Init(); err != nil {

--- a/client/options.go
+++ b/client/options.go
@@ -587,18 +587,14 @@ func WithClientShutdown(opts ...graceful_shutdown.Option) ClientOption {
 	}
 }
 
-func WithClientTLSOption(opts ...tls.TLSOption) ClientOption {
-	// TODO: tls.NewOptions(opts...) implement
-	// avoid to use loop to apply options
-	// ref: WithServerProtocol func
+func WithClientTLSOption(opts ...tls.Option) ClientOption {
+	tlsOpts := tls.NewOptions(opts...)
 
 	return func(cliOpts *ClientOptions) {
 		if cliOpts.TLS == nil {
-			cliOpts.TLS = &global.TLSConfig{}
+			cliOpts.TLS = new(global.TLSConfig)
 		}
-		for _, opt := range opts {
-			opt(cliOpts.TLS)
-		}
+		cliOpts.TLS = tlsOpts.TLSConf
 	}
 }
 

--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -150,6 +150,7 @@ const (
 	ServiceInfoKey                     = "service-info"
 	RpcServiceKey                      = "rpc-service"
 	ClientInfoKey                      = "client-info"
+	TLSConfigKey                       = "tls-config"
 )
 
 const (

--- a/compat.go
+++ b/compat.go
@@ -56,7 +56,6 @@ func compatRootConfig(c *InstanceOptions) *config.RootConfig {
 		CacheFile:           c.CacheFile,
 		Custom:              compatCustomConfig(c.Custom),
 		Profiles:            compatProfilesConfig(c.Profiles),
-		TLSConfig:           compatTLSConfig(c.TLSConfig),
 	}
 }
 
@@ -361,18 +360,6 @@ func compatProfilesConfig(c *global.ProfilesConfig) *config.ProfilesConfig {
 	}
 }
 
-func compatTLSConfig(c *global.TLSConfig) *config.TLSConfig {
-	if c == nil {
-		return nil
-	}
-	return &config.TLSConfig{
-		CACertFile:    c.CACertFile,
-		TLSCertFile:   c.TLSCertFile,
-		TLSKeyFile:    c.TLSKeyFile,
-		TLSServerName: c.TLSServerName,
-	}
-}
-
 func compatMetricAggregationConfig(a *global.AggregateConfig) *config.AggregateConfig {
 	if a == nil {
 		return nil
@@ -446,7 +433,6 @@ func compatInstanceOptions(cr *config.RootConfig, rc *InstanceOptions) {
 	rc.CacheFile = cr.CacheFile
 	rc.Custom = compatGlobalCustomConfig(cr.Custom)
 	rc.Profiles = compatGlobalProfilesConfig(cr.Profiles)
-	rc.TLSConfig = compatGlobalTLSConfig(cr.TLSConfig)
 }
 
 func compatGlobalProtocolConfig(c *config.ProtocolConfig) *global.ProtocolConfig {
@@ -845,17 +831,5 @@ func compatGlobalProfilesConfig(c *config.ProfilesConfig) *global.ProfilesConfig
 	}
 	return &global.ProfilesConfig{
 		Active: c.Active,
-	}
-}
-
-func compatGlobalTLSConfig(c *config.TLSConfig) *global.TLSConfig {
-	if c == nil {
-		return nil
-	}
-	return &global.TLSConfig{
-		CACertFile:    c.CACertFile,
-		TLSCertFile:   c.TLSCertFile,
-		TLSKeyFile:    c.TLSKeyFile,
-		TLSServerName: c.TLSServerName,
 	}
 }

--- a/dubbo.go
+++ b/dubbo.go
@@ -76,9 +76,7 @@ func (ins *Instance) NewClient(opts ...client.ClientOption) (*client.Client, err
 	sdCfg := ins.insOpts.CloneShutdown()
 	metricsCfg := ins.insOpts.CloneMetrics()
 	otelCfg := ins.insOpts.CloneOtel()
-
-	// TODO: client tls config implement
-	// tlsCfg := ins.insOpts.CloneTLSConfig()
+	tlsCfg := ins.insOpts.CloneTLSConfig()
 
 	if conCfg != nil {
 		if !conCfg.Check {
@@ -108,6 +106,9 @@ func (ins *Instance) NewClient(opts ...client.ClientOption) (*client.Client, err
 	}
 	if otelCfg != nil {
 		cliOpts = append(cliOpts, client.SetClientOtel(otelCfg))
+	}
+	if tlsCfg != nil {
+		cliOpts = append(cliOpts, client.SetClientTLS(tlsCfg))
 	}
 
 	// options passed by users has higher priority

--- a/dubbo.go
+++ b/dubbo.go
@@ -77,6 +77,9 @@ func (ins *Instance) NewClient(opts ...client.ClientOption) (*client.Client, err
 	metricsCfg := ins.insOpts.CloneMetrics()
 	otelCfg := ins.insOpts.CloneOtel()
 
+	// TODO: client tls config implement
+	// tlsCfg := ins.insOpts.CloneTLSConfig()
+
 	if conCfg != nil {
 		if !conCfg.Check {
 			cliOpts = append(cliOpts, client.WithClientNoCheck())
@@ -131,6 +134,7 @@ func (ins *Instance) NewServer(opts ...server.ServerOption) (*server.Server, err
 	sdCfg := ins.insOpts.CloneShutdown()
 	metricsCfg := ins.insOpts.CloneMetrics()
 	otelCfg := ins.insOpts.CloneOtel()
+	tlsCfg := ins.insOpts.CloneTLSConfig()
 
 	if appCfg != nil {
 		srvOpts = append(srvOpts,
@@ -159,6 +163,9 @@ func (ins *Instance) NewServer(opts ...server.ServerOption) (*server.Server, err
 	}
 	if otelCfg != nil {
 		srvOpts = append(srvOpts, server.SetServerOtel(otelCfg))
+	}
+	if tlsCfg != nil {
+		srvOpts = append(srvOpts, server.SetServerTLS(tlsCfg))
 	}
 
 	// options passed by users have higher priority

--- a/global/tls_config.go
+++ b/global/tls_config.go
@@ -31,8 +31,7 @@ type TLSConfig struct {
 }
 
 func DefaultTLSConfig() *TLSConfig {
-	// please refer to /config/tls_config.go NewTLSConfigBuilder
-	return nil
+	return &TLSConfig{}
 }
 
 // Clone a new TLSConfig

--- a/global/tls_config.go
+++ b/global/tls_config.go
@@ -48,29 +48,3 @@ func (c *TLSConfig) Clone() *TLSConfig {
 		TLSServerName: c.TLSServerName,
 	}
 }
-
-type TLSOption func(*TLSConfig)
-
-func WithTLS_CACertFile(file string) TLSOption {
-	return func(cfg *TLSConfig) {
-		cfg.CACertFile = file
-	}
-}
-
-func WithTLS_TLSCertFile(file string) TLSOption {
-	return func(cfg *TLSConfig) {
-		cfg.TLSCertFile = file
-	}
-}
-
-func WithTLS_TLSKeyFile(file string) TLSOption {
-	return func(cfg *TLSConfig) {
-		cfg.TLSKeyFile = file
-	}
-}
-
-func WithTLS_TLSServerName(name string) TLSOption {
-	return func(cfg *TLSConfig) {
-		cfg.TLSServerName = name
-	}
-}

--- a/loader.go
+++ b/loader.go
@@ -47,7 +47,6 @@ var (
 )
 
 func Load(opts ...LoaderConfOption) error {
-	// conf
 	conf := NewLoaderConf(opts...)
 	if conf.opts == nil {
 		koan := GetConfigResolver(conf)
@@ -170,7 +169,6 @@ func WithBytes(bytes []byte) LoaderConfOption {
 
 // absolutePath get absolut path
 func absolutePath(inPath string) string {
-
 	if inPath == "$HOME" || strings.HasPrefix(inPath, "$HOME"+string(os.PathSeparator)) {
 		inPath = userHomeDir() + inPath[5:]
 	}

--- a/options.go
+++ b/options.go
@@ -485,6 +485,15 @@ func WithShutdown(opts ...graceful_shutdown.Option) InstanceOption {
 //	}
 //}
 
+// for example:
+//
+// WithTLS(
+// 	tls.WithCACertFile(xxx),
+// 	tls.WithTLSCertFile(xxx),
+// 	tls.WithTLSKeyFile(xxx),
+// 	tls.WithTLSServerName(xxx),
+// 	)
+
 func WithTLS(opts ...tls.TLSOption) InstanceOption {
 	tlsCfg := new(global.TLSConfig)
 	for _, opt := range opts {

--- a/options.go
+++ b/options.go
@@ -38,6 +38,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/otel/trace"
 	"dubbo.apache.org/dubbo-go/v3/protocol"
 	"dubbo.apache.org/dubbo-go/v3/registry"
+	"dubbo.apache.org/dubbo-go/v3/tls"
 )
 
 type InstanceOptions struct {
@@ -484,13 +485,13 @@ func WithShutdown(opts ...graceful_shutdown.Option) InstanceOption {
 //	}
 //}
 
-//func WithTLS(opts ...global.TLSOption) InstanceOption {
-//	tlsCfg := new(global.TLSConfig)
-//	for _, opt := range opts {
-//		opt(tlsCfg)
-//	}
-//
-//	return func(cfg *InstanceOptions) {
-//		cfg.TLSConfig = tlsCfg
-//	}
-//}
+func WithTLS(opts ...tls.TLSOption) InstanceOption {
+	tlsCfg := new(global.TLSConfig)
+	for _, opt := range opts {
+		opt(tlsCfg)
+	}
+
+	return func(cfg *InstanceOptions) {
+		cfg.TLSConfig = tlsCfg
+	}
+}

--- a/options.go
+++ b/options.go
@@ -485,15 +485,13 @@ func WithShutdown(opts ...graceful_shutdown.Option) InstanceOption {
 //	}
 //}
 
-func WithTLS(opts ...tls.TLSOption) InstanceOption {
-	// TODO: use newTLSOption is better
-	// just like WithProtocol
-	tlsCfg := new(global.TLSConfig)
-	for _, opt := range opts {
-		opt(tlsCfg)
-	}
+func WithTLS(opts ...tls.Option) InstanceOption {
+	tlsOpts := tls.NewOptions(opts...)
 
-	return func(cfg *InstanceOptions) {
-		cfg.TLSConfig = tlsCfg
+	return func(insOpts *InstanceOptions) {
+		if insOpts.TLSConfig == nil {
+			insOpts.TLSConfig = new(global.TLSConfig)
+		}
+		insOpts.TLSConfig = tlsOpts.TLSConf
 	}
 }

--- a/options.go
+++ b/options.go
@@ -485,16 +485,9 @@ func WithShutdown(opts ...graceful_shutdown.Option) InstanceOption {
 //	}
 //}
 
-// for example:
-//
-// WithTLS(
-// 	tls.WithCACertFile(xxx),
-// 	tls.WithTLSCertFile(xxx),
-// 	tls.WithTLSKeyFile(xxx),
-// 	tls.WithTLSServerName(xxx),
-// 	)
-
 func WithTLS(opts ...tls.TLSOption) InstanceOption {
+	// TODO: use newTLSOption is better
+	// just like WithProtocol
 	tlsCfg := new(global.TLSConfig)
 	for _, opt := range opts {
 		opt(tlsCfg)

--- a/protocol/dubbo3/dubbo3_invoker.go
+++ b/protocol/dubbo3/dubbo3_invoker.go
@@ -120,6 +120,8 @@ func NewDubboInvoker(url *common.URL) (*DubboInvoker, error) {
 
 	triOption := triConfig.NewTripleOption(opts...)
 
+	// TODO: remove config TLSConfig
+	// delete this branch
 	tlsConfig := config.GetRootConfig().TLSConfig
 	if tlsConfig != nil {
 		triOption.CACertFile = tlsConfig.CACertFile

--- a/protocol/dubbo3/dubbo3_invoker.go
+++ b/protocol/dubbo3/dubbo3_invoker.go
@@ -42,6 +42,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/config"
+	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/protocol"
 	invocation_impl "dubbo.apache.org/dubbo-go/v3/protocol/invocation"
 )
@@ -117,13 +118,22 @@ func NewDubboInvoker(url *common.URL) (*DubboInvoker, error) {
 	}
 
 	triOption := triConfig.NewTripleOption(opts...)
+
 	tlsConfig := config.GetRootConfig().TLSConfig
 	if tlsConfig != nil {
+		triOption.CACertFile = tlsConfig.CACertFile
 		triOption.TLSCertFile = tlsConfig.TLSCertFile
 		triOption.TLSKeyFile = tlsConfig.TLSKeyFile
-		triOption.CACertFile = tlsConfig.CACertFile
 		triOption.TLSServerName = tlsConfig.TLSServerName
-		logger.Infof("Triple Client initialized the TLSConfig configuration")
+		logger.Infof("DUBBO3 Client initialized the TLSConfig configuration")
+	} else if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
+		// use global TLSConfig handle tls
+		tlsConf := tlsConfRaw.(*global.TLSConfig)
+		triOption.CACertFile = tlsConf.CACertFile
+		triOption.TLSCertFile = tlsConf.TLSCertFile
+		triOption.TLSKeyFile = tlsConf.TLSKeyFile
+		triOption.TLSServerName = tlsConf.TLSServerName
+		logger.Infof("DUBBO3 Server initialized the TLSConfig configuration")
 	}
 	client, err := triple.NewTripleClient(consumerService, triOption)
 

--- a/protocol/dubbo3/dubbo3_invoker.go
+++ b/protocol/dubbo3/dubbo3_invoker.go
@@ -130,12 +130,7 @@ func NewDubboInvoker(url *common.URL) (*DubboInvoker, error) {
 	} else if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
 		// use global TLSConfig handle tls
 		tlsConf := tlsConfRaw.(*global.TLSConfig)
-		// TODO: find a better way to judge if tlsConfig valid
-		cfg, err := dubbotls.GetClientTlsConfig(tlsConf)
-		if err != nil {
-			return nil, err
-		}
-		if cfg != nil {
+		if dubbotls.IsClientTLSValid(tlsConf) {
 			triOption.CACertFile = tlsConf.CACertFile
 			triOption.TLSCertFile = tlsConf.TLSCertFile
 			triOption.TLSKeyFile = tlsConf.TLSKeyFile

--- a/protocol/dubbo3/dubbo3_invoker.go
+++ b/protocol/dubbo3/dubbo3_invoker.go
@@ -45,6 +45,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/protocol"
 	invocation_impl "dubbo.apache.org/dubbo-go/v3/protocol/invocation"
+	dubbotls "dubbo.apache.org/dubbo-go/v3/tls"
 )
 
 // same as dubbo_invoker.go attachmentKey
@@ -129,11 +130,18 @@ func NewDubboInvoker(url *common.URL) (*DubboInvoker, error) {
 	} else if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
 		// use global TLSConfig handle tls
 		tlsConf := tlsConfRaw.(*global.TLSConfig)
-		triOption.CACertFile = tlsConf.CACertFile
-		triOption.TLSCertFile = tlsConf.TLSCertFile
-		triOption.TLSKeyFile = tlsConf.TLSKeyFile
-		triOption.TLSServerName = tlsConf.TLSServerName
-		logger.Infof("DUBBO3 Server initialized the TLSConfig configuration")
+		// TODO: find a better way to judge if tlsConfig valid
+		cfg, err := dubbotls.GetClientTlsConfig(tlsConf)
+		if err != nil {
+			return nil, err
+		}
+		if cfg != nil {
+			triOption.CACertFile = tlsConf.CACertFile
+			triOption.TLSCertFile = tlsConf.TLSCertFile
+			triOption.TLSKeyFile = tlsConf.TLSKeyFile
+			triOption.TLSServerName = tlsConf.TLSServerName
+			logger.Infof("DUBBO3 Server initialized the TLSConfig configuration")
+		}
 	}
 	client, err := triple.NewTripleClient(consumerService, triOption)
 

--- a/protocol/dubbo3/dubbo3_protocol.go
+++ b/protocol/dubbo3/dubbo3_protocol.go
@@ -39,9 +39,9 @@ import (
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
-	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/config"
+	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/protocol"
 	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
 )
@@ -264,7 +264,7 @@ func (dp *DubboProtocol) openServer(url *common.URL, tripleCodecType tripleConst
 		triOption.CACertFile = tlsConfig.CACertFile
 		triOption.TLSServerName = tlsConfig.TLSServerName
 		logger.Infof("DUBBO3 Server initialized the TLSConfig configuration")
-	} else if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
+	} else if tlsConfRaw, tlsOk := url.GetAttribute(constant.TLSConfigKey); tlsOk {
 		// use global TLSConfig handle tls
 		tlsConf := tlsConfRaw.(*global.TLSConfig)
 		triOption.CACertFile = tlsConf.CACertFile

--- a/protocol/dubbo3/dubbo3_protocol.go
+++ b/protocol/dubbo3/dubbo3_protocol.go
@@ -268,13 +268,7 @@ func (dp *DubboProtocol) openServer(url *common.URL, tripleCodecType tripleConst
 	} else if tlsConfRaw, tlsOk := url.GetAttribute(constant.TLSConfigKey); tlsOk {
 		// use global TLSConfig handle tls
 		tlsConf := tlsConfRaw.(*global.TLSConfig)
-		// TODO: find a better way to judge if tlsConfig valid
-		cfg, err := dubbotls.GetServerTlsConfig(tlsConf)
-		if err != nil {
-			logger.Errorf("DUBBO3 Server inintialized the TLSConfig configuration failed. err: %v", err)
-			return
-		}
-		if cfg != nil {
+		if dubbotls.IsServerTLSValid(tlsConf) {
 			triOption.CACertFile = tlsConf.CACertFile
 			triOption.TLSCertFile = tlsConf.TLSCertFile
 			triOption.TLSKeyFile = tlsConf.TLSKeyFile

--- a/protocol/dubbo3/dubbo3_protocol.go
+++ b/protocol/dubbo3/dubbo3_protocol.go
@@ -258,11 +258,13 @@ func (dp *DubboProtocol) openServer(url *common.URL, tripleCodecType tripleConst
 
 	triOption := triConfig.NewTripleOption(opts...)
 
+	// TODO: remove config TLSConfig
+	// delete this branch
 	tlsConfig := config.GetRootConfig().TLSConfig
 	if tlsConfig != nil {
+		triOption.CACertFile = tlsConfig.CACertFile
 		triOption.TLSCertFile = tlsConfig.TLSCertFile
 		triOption.TLSKeyFile = tlsConfig.TLSKeyFile
-		triOption.CACertFile = tlsConfig.CACertFile
 		triOption.TLSServerName = tlsConfig.TLSServerName
 		logger.Infof("DUBBO3 Server initialized the TLSConfig configuration")
 	} else if tlsConfRaw, tlsOk := url.GetAttribute(constant.TLSConfigKey); tlsOk {

--- a/protocol/dubbo3/dubbo3_protocol.go
+++ b/protocol/dubbo3/dubbo3_protocol.go
@@ -39,6 +39,7 @@ import (
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/config"
 	"dubbo.apache.org/dubbo-go/v3/protocol"
@@ -262,7 +263,15 @@ func (dp *DubboProtocol) openServer(url *common.URL, tripleCodecType tripleConst
 		triOption.TLSKeyFile = tlsConfig.TLSKeyFile
 		triOption.CACertFile = tlsConfig.CACertFile
 		triOption.TLSServerName = tlsConfig.TLSServerName
-		logger.Infof("Triple Server initialized the TLSConfig configuration")
+		logger.Infof("DUBBO3 Server initialized the TLSConfig configuration")
+	} else if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
+		// use global TLSConfig handle tls
+		tlsConf := tlsConfRaw.(*global.TLSConfig)
+		triOption.CACertFile = tlsConf.CACertFile
+		triOption.TLSCertFile = tlsConf.TLSCertFile
+		triOption.TLSKeyFile = tlsConf.TLSKeyFile
+		triOption.TLSServerName = tlsConf.TLSServerName
+		logger.Infof("DUBBO3 Server initialized the TLSConfig configuration")
 	}
 
 	_, ok = dp.ExporterMap().Load(url.ServiceKey())

--- a/protocol/grpc/client.go
+++ b/protocol/grpc/client.go
@@ -92,7 +92,7 @@ func NewClient(url *common.URL) (*Client, error) {
 	)
 
 	// TODO: remove config TLSConfig
-	// delete this banch
+	// delete this branch
 	tlsConfig := config.GetRootConfig().TLSConfig
 	if tlsConfig != nil {
 		cfg, err := config.GetClientTlsConfig(&config.TLSConfig{

--- a/protocol/grpc/client.go
+++ b/protocol/grpc/client.go
@@ -109,17 +109,20 @@ func NewClient(url *common.URL) (*Client, error) {
 	} else if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
 		// use global TLSConfig handle tls
 		tlsConf := tlsConfRaw.(*global.TLSConfig)
-		cfg, err := dubbotls.GetServerTlsConfig(tlsConf)
-		if err != nil {
-			return nil, err
-		}
-		if cfg != nil {
-			logger.Infof("Grpc Client initialized the TLSConfig configuration")
-			dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(cfg)))
+		if dubbotls.IsClientTLSValid(tlsConf) {
+			cfg, err := dubbotls.GetServerTlsConfig(tlsConf)
+			if err != nil {
+				return nil, err
+			}
+			if cfg != nil {
+				logger.Infof("Grpc Client initialized the TLSConfig configuration")
+				dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(cfg)))
+			}
 		} else {
 			dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		}
 	} else {
+		// TODO: remove this else
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 

--- a/protocol/grpc/client.go
+++ b/protocol/grpc/client.go
@@ -113,8 +113,12 @@ func NewClient(url *common.URL) (*Client, error) {
 		if err != nil {
 			return nil, err
 		}
-		logger.Infof("Grpc Client initialized the TLSConfig configuration")
-		dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(cfg)))
+		if cfg != nil {
+			logger.Infof("Grpc Client initialized the TLSConfig configuration")
+			dialOpts = append(dialOpts, grpc.WithTransportCredentials(credentials.NewTLS(cfg)))
+		} else {
+			dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		}
 	} else {
 		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}

--- a/protocol/grpc/server.go
+++ b/protocol/grpc/server.go
@@ -129,8 +129,13 @@ func (s *Server) Start(url *common.URL) {
 		if tlsErr != nil {
 			return
 		}
-		logger.Infof("Grpc Server initialized the TLSConfig configuration")
-		serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(cfg)))
+		if cfg != nil {
+			logger.Infof("Grpc Server initialized the TLSConfig configuration")
+			serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(cfg)))
+		} else {
+
+			serverOpts = append(serverOpts, grpc.Creds(insecure.NewCredentials()))
+		}
 	} else {
 		serverOpts = append(serverOpts, grpc.Creds(insecure.NewCredentials()))
 	}

--- a/protocol/grpc/server.go
+++ b/protocol/grpc/server.go
@@ -107,7 +107,7 @@ func (s *Server) Start(url *common.URL) {
 	)
 
 	// TODO: remove config TLSConfig
-	// delete this banch
+	// delete this branch
 	tlsConfig := config.GetRootConfig().TLSConfig
 	if tlsConfig != nil {
 		var cfg *tls.Config

--- a/protocol/grpc/server.go
+++ b/protocol/grpc/server.go
@@ -125,18 +125,20 @@ func (s *Server) Start(url *common.URL) {
 	} else if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
 		// use global TLSConfig handle tls
 		tlsConf := tlsConfRaw.(*global.TLSConfig)
-		cfg, tlsErr := dubbotls.GetServerTlsConfig(tlsConf)
-		if tlsErr != nil {
-			return
-		}
-		if cfg != nil {
-			logger.Infof("Grpc Server initialized the TLSConfig configuration")
-			serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(cfg)))
+		if dubbotls.IsServerTLSValid(tlsConf) {
+			cfg, tlsErr := dubbotls.GetServerTlsConfig(tlsConf)
+			if tlsErr != nil {
+				return
+			}
+			if cfg != nil {
+				logger.Infof("Grpc Server initialized the TLSConfig configuration")
+				serverOpts = append(serverOpts, grpc.Creds(credentials.NewTLS(cfg)))
+			}
 		} else {
-
 			serverOpts = append(serverOpts, grpc.Creds(insecure.NewCredentials()))
 		}
 	} else {
+		// TODO: remove this else
 		serverOpts = append(serverOpts, grpc.Creds(insecure.NewCredentials()))
 	}
 

--- a/protocol/grpc/server.go
+++ b/protocol/grpc/server.go
@@ -125,8 +125,8 @@ func (s *Server) Start(url *common.URL) {
 	} else if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
 		// use global TLSConfig handle tls
 		tlsConf := tlsConfRaw.(*global.TLSConfig)
-		cfg, err := dubbotls.GetServerTlsConfig(tlsConf)
-		if err != nil {
+		cfg, tlsErr := dubbotls.GetServerTlsConfig(tlsConf)
+		if tlsErr != nil {
 			return
 		}
 		logger.Infof("Grpc Server initialized the TLSConfig configuration")

--- a/protocol/triple/client.go
+++ b/protocol/triple/client.go
@@ -183,13 +183,16 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 	// handle tls
 	var (
 		tlsFlag bool
+		tlsConf *global.TLSConfig
 		cfg     *tls.Config
 		err     error
 	)
 
 	tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey)
 	if ok {
-		tlsConf := tlsConfRaw.(*global.TLSConfig)
+		tlsConf = tlsConfRaw.(*global.TLSConfig)
+	}
+	if dubbotls.IsClientTLSValid(tlsConf) {
 		cfg, err = dubbotls.GetClientTlsConfig(tlsConf)
 		if err != nil {
 			return nil, err

--- a/protocol/triple/client.go
+++ b/protocol/triple/client.go
@@ -194,8 +194,10 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 		if err != nil {
 			return nil, err
 		}
-		logger.Infof("TRIPLE clientManager initialized the TLSConfig configuration")
-		tlsFlag = true
+		if cfg != nil {
+			logger.Infof("TRIPLE clientManager initialized the TLSConfig configuration")
+			tlsFlag = true
+		}
 	}
 
 	var transport http.RoundTripper

--- a/protocol/triple/dubbo3_invoker.go
+++ b/protocol/triple/dubbo3_invoker.go
@@ -137,12 +137,7 @@ func NewDubbo3Invoker(url *common.URL) (*DubboInvoker, error) {
 	} else if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
 		// use global TLSConfig handle tls
 		tlsConf := tlsConfRaw.(*global.TLSConfig)
-		// TODO: find a better way to judge if tlsConfig valid
-		cfg, err := dubbotls.GetClientTlsConfig(tlsConf)
-		if err != nil {
-			return nil, err
-		}
-		if cfg != nil {
+		if dubbotls.IsClientTLSValid(tlsConf) {
 			triOption.CACertFile = tlsConf.CACertFile
 			triOption.TLSCertFile = tlsConf.TLSCertFile
 			triOption.TLSKeyFile = tlsConf.TLSKeyFile

--- a/protocol/triple/dubbo3_invoker.go
+++ b/protocol/triple/dubbo3_invoker.go
@@ -45,6 +45,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/protocol"
 	invocation_impl "dubbo.apache.org/dubbo-go/v3/protocol/invocation"
+	dubbotls "dubbo.apache.org/dubbo-go/v3/tls"
 )
 
 // same as dubbo_invoker.go attachmentKey
@@ -136,11 +137,18 @@ func NewDubbo3Invoker(url *common.URL) (*DubboInvoker, error) {
 	} else if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
 		// use global TLSConfig handle tls
 		tlsConf := tlsConfRaw.(*global.TLSConfig)
-		triOption.CACertFile = tlsConf.CACertFile
-		triOption.TLSCertFile = tlsConf.TLSCertFile
-		triOption.TLSKeyFile = tlsConf.TLSKeyFile
-		triOption.TLSServerName = tlsConf.TLSServerName
-		logger.Infof("DUBBO3 Server initialized the TLSConfig configuration")
+		// TODO: find a better way to judge if tlsConfig valid
+		cfg, err := dubbotls.GetClientTlsConfig(tlsConf)
+		if err != nil {
+			return nil, err
+		}
+		if cfg != nil {
+			triOption.CACertFile = tlsConf.CACertFile
+			triOption.TLSCertFile = tlsConf.TLSCertFile
+			triOption.TLSKeyFile = tlsConf.TLSKeyFile
+			triOption.TLSServerName = tlsConf.TLSServerName
+			logger.Infof("DUBBO3 Server initialized the TLSConfig configuration")
+		}
 	}
 
 	client, err := triple.NewTripleClient(consumerService, triOption)

--- a/protocol/triple/dubbo3_invoker.go
+++ b/protocol/triple/dubbo3_invoker.go
@@ -126,7 +126,7 @@ func NewDubbo3Invoker(url *common.URL) (*DubboInvoker, error) {
 	triOption := triConfig.NewTripleOption(opts...)
 
 	// TODO: remove config TLSConfig
-	// delete this banch
+	// delete this branch
 	tlsConfig := config.GetRootConfig().TLSConfig
 	if tlsConfig != nil {
 		triOption.CACertFile = tlsConfig.CACertFile

--- a/protocol/triple/health/healthServer.go
+++ b/protocol/triple/health/healthServer.go
@@ -173,7 +173,7 @@ func (srv *HealthTripleServer) Resume() {
 func init() {
 	healthServer = NewServer()
 	internal.HealthSetServingStatusServing = SetServingStatusServing
-	server.SetProServices(&server.InternalService{
+	server.SetProviderServices(&server.InternalService{
 		Name: "healthCheck",
 		Init: func(options *server.ServiceOptions) (*server.ServiceDefinition, bool) {
 			return &server.ServiceDefinition{

--- a/protocol/triple/reflection/serverreflection.go
+++ b/protocol/triple/reflection/serverreflection.go
@@ -266,7 +266,7 @@ var reflectionServer *ReflectionServer
 func init() {
 	reflectionServer = NewServer()
 	internal.ReflectionRegister = Register
-	server.SetProServices(&server.InternalService{
+	server.SetProviderServices(&server.InternalService{
 		Name: "reflection",
 		Init: func(options *server.ServiceOptions) (*server.ServiceDefinition, bool) {
 			return &server.ServiceDefinition{

--- a/protocol/triple/server.go
+++ b/protocol/triple/server.go
@@ -97,8 +97,10 @@ func (s *Server) Start(invoker protocol.Invoker, info *common.ServiceInfo) {
 			logger.Errorf("TRIPLE Server inintialized the TLSConfig configuration failed. err: %v", err)
 			return
 		}
-		s.triServer.SetTLSConfig(cfg)
-		logger.Infof("TRIPLE Server initialized the TLSConfig configuration")
+		if cfg != nil {
+			s.triServer.SetTLSConfig(cfg)
+			logger.Infof("TRIPLE Server initialized the TLSConfig configuration")
+		}
 	}
 
 	hanOpts := getHanOpts(URL)

--- a/protocol/triple/server.go
+++ b/protocol/triple/server.go
@@ -88,19 +88,21 @@ func (s *Server) Start(invoker protocol.Invoker, info *common.ServiceInfo) {
 
 	// TODO: move tls config to handleService
 
+	var tlsConf *global.TLSConfig
+
 	// handle tls
 	tlsConfRaw, ok := URL.GetAttribute(constant.TLSConfigKey)
 	if ok {
-		tlsConf := tlsConfRaw.(*global.TLSConfig)
+		tlsConf = tlsConfRaw.(*global.TLSConfig)
+	}
+	if dubbotls.IsServerTLSValid(tlsConf) {
 		cfg, err := dubbotls.GetServerTlsConfig(tlsConf)
 		if err != nil {
 			logger.Errorf("TRIPLE Server inintialized the TLSConfig configuration failed. err: %v", err)
 			return
 		}
-		if cfg != nil {
-			s.triServer.SetTLSConfig(cfg)
-			logger.Infof("TRIPLE Server initialized the TLSConfig configuration")
-		}
+		s.triServer.SetTLSConfig(cfg)
+		logger.Infof("TRIPLE Server initialized the TLSConfig configuration")
 	}
 
 	hanOpts := getHanOpts(URL)

--- a/protocol/triple/server.go
+++ b/protocol/triple/server.go
@@ -37,7 +37,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/protocol"
 	"dubbo.apache.org/dubbo-go/v3/protocol/dubbo3"
 	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
-	"dubbo.apache.org/dubbo-go/v3/tls"
+	dubbotls "dubbo.apache.org/dubbo-go/v3/tls"
 	grpc_go "github.com/dubbogo/grpc-go"
 	"github.com/dustin/go-humanize"
 	"google.golang.org/grpc"
@@ -85,7 +85,7 @@ func (s *Server) Start(invoker protocol.Invoker, info *common.ServiceInfo) {
 	tlsConfRaw, ok := URL.GetAttribute(constant.TLSConfigKey)
 	if ok {
 		tlsConf := tlsConfRaw.(*global.TLSConfig)
-		cfg, err := tls.GetServerTlsConfig(tlsConf)
+		cfg, err := dubbotls.GetServerTlsConfig(tlsConf)
 		if err != nil {
 			return
 		}

--- a/protocol/triple/server.go
+++ b/protocol/triple/server.go
@@ -87,6 +87,7 @@ func (s *Server) Start(invoker protocol.Invoker, info *common.ServiceInfo) {
 		tlsConf := tlsConfRaw.(*global.TLSConfig)
 		cfg, err := dubbotls.GetServerTlsConfig(tlsConf)
 		if err != nil {
+			logger.Errorf("TRIPLE Server inintialized the TLSConfig configuration failed. err: %v", err)
 			return
 		}
 		s.triServer.SetTLSConfig(cfg)

--- a/protocol/triple/server.go
+++ b/protocol/triple/server.go
@@ -24,11 +24,21 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+)
 
+import (
 	"github.com/dubbogo/gost/log/logger"
 
 	hessian "github.com/apache/dubbo-go-hessian2"
 
+	grpc_go "github.com/dubbogo/grpc-go"
+
+	"github.com/dustin/go-humanize"
+
+	"google.golang.org/grpc"
+)
+
+import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/config"
@@ -38,9 +48,6 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/protocol/dubbo3"
 	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
 	dubbotls "dubbo.apache.org/dubbo-go/v3/tls"
-	grpc_go "github.com/dubbogo/grpc-go"
-	"github.com/dustin/go-humanize"
-	"google.golang.org/grpc"
 
 	tri "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol"
 )

--- a/remoting/getty/getty_client.go
+++ b/remoting/getty/getty_client.go
@@ -88,13 +88,7 @@ func initClient(url *common.URL) {
 		} else if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
 			// use global TLSConfig handle tls
 			tlsConf := tlsConfRaw.(*global.TLSConfig)
-			// TODO: find a better way to judge if tlsConfig valid
-			cfg, err := dubbotls.GetServerTlsConfig(tlsConf)
-			if err != nil {
-				logger.Errorf("Getty client inintialized the TLSConfig configuration failed. err: %v", err)
-				return
-			}
-			if cfg != nil {
+			if dubbotls.IsClientTLSValid(tlsConf) {
 				srvConf.SSLEnabled = true
 				srvConf.TLSBuilder = &getty.ClientTlsConfigBuilder{
 					ClientKeyCertChainPath:        tlsConf.TLSCertFile,

--- a/remoting/getty/getty_client_test.go
+++ b/remoting/getty/getty_client_test.go
@@ -490,7 +490,9 @@ func TestInitClient(t *testing.T) {
 		},
 	}
 	config.SetRootConfig(rootConf)
-	initServer("dubbo")
+	url, err := common.NewURL("dubbo://127.0.0.1:20003/test")
+	assert.Nil(t, err)
+	initServer(url)
 	config.SetRootConfig(*originRootConf)
 	assert.NotNil(t, srvConf)
 }

--- a/remoting/getty/getty_server.go
+++ b/remoting/getty/getty_server.go
@@ -81,13 +81,7 @@ func initServer(url *common.URL) {
 		} else if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
 			// use global TLSConfig handle tls
 			tlsConf := tlsConfRaw.(*global.TLSConfig)
-			// TODO: find a better way to judge if tlsConfig valid
-			cfg, err := dubbotls.GetServerTlsConfig(tlsConf)
-			if err != nil {
-				logger.Errorf("Getty Server inintialized the TLSConfig configuration failed. err: %v", err)
-				return
-			}
-			if cfg != nil {
+			if dubbotls.IsServerTLSValid(tlsConf) {
 				srvConf.SSLEnabled = true
 				srvConf.TLSBuilder = &getty.ServerTlsConfigBuilder{
 					ServerKeyCertChainPath:        tlsConf.TLSCertFile,

--- a/remoting/getty/getty_server_test.go
+++ b/remoting/getty/getty_server_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 import (
+	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/config"
 )
 
@@ -41,7 +42,9 @@ func TestInitServer(t *testing.T) {
 		},
 	}
 	config.SetRootConfig(rootConf)
-	initServer("dubbo")
+	url, err := common.NewURL("dubbo://127.0.0.1:20003/test")
+	assert.Nil(t, err)
+	initServer(url)
 	config.SetRootConfig(*originRootConf)
 	assert.NotNil(t, srvConf)
 }

--- a/server/action.go
+++ b/server/action.go
@@ -211,9 +211,8 @@ func (svcOpts *ServiceOptions) export(info *common.ServiceInfo) error {
 		}
 
 		// NOTE: tmp here for tls
-		if svcOpts.srvOpts.TLS != nil {
-			ivkURL.SetAttribute(constant.TLSConfigKey, svcOpts.srvOpts.TLS)
-		}
+		// TODO: put it in up case
+		ivkURL.SetAttribute(constant.TLSConfigKey, svcOpts.srvOpts.TLS)
 
 		// post process the URL to be exported
 		svcOpts.postProcessConfig(ivkURL)

--- a/server/action.go
+++ b/server/action.go
@@ -199,6 +199,8 @@ func (svcOpts *ServiceOptions) export(info *common.ServiceInfo) error {
 			common.WithMethods(strings.Split(methods, ",")),
 			// todo(DMwangnima): remove this
 			common.WithAttribute(constant.ServiceInfoKey, info),
+			// TLSConifg
+			common.WithAttribute(constant.TLSConfigKey, svcOpts.srvOpts.TLS),
 			common.WithToken(svcConf.Token),
 			common.WithParamsValue(constant.MetadataTypeKey, svcOpts.metadataType),
 			// fix https://github.com/apache/dubbo-go/issues/2176
@@ -209,10 +211,6 @@ func (svcOpts *ServiceOptions) export(info *common.ServiceInfo) error {
 		if len(svcConf.Tag) > 0 {
 			ivkURL.AddParam(constant.Tagkey, svcConf.Tag)
 		}
-
-		// NOTE: tmp here for tls
-		// TODO: put it in up case
-		ivkURL.SetAttribute(constant.TLSConfigKey, svcOpts.srvOpts.TLS)
 
 		// post process the URL to be exported
 		svcOpts.postProcessConfig(ivkURL)

--- a/server/action.go
+++ b/server/action.go
@@ -205,8 +205,14 @@ func (svcOpts *ServiceOptions) export(info *common.ServiceInfo) error {
 			common.WithParamsValue(constant.MaxServerSendMsgSize, proto.MaxServerSendMsgSize),
 			common.WithParamsValue(constant.MaxServerRecvMsgSize, proto.MaxServerRecvMsgSize),
 		)
+
 		if len(svcConf.Tag) > 0 {
 			ivkURL.AddParam(constant.Tagkey, svcConf.Tag)
+		}
+
+		// NOTE: tmp here for tls
+		if svcOpts.srvOpts.TLS != nil {
+			ivkURL.SetAttribute(constant.TLSConfigKey, svcOpts.srvOpts.TLS)
 		}
 
 		// post process the URL to be exported
@@ -254,11 +260,6 @@ func (svcOpts *ServiceOptions) generatorInvoker(url *common.URL, info *common.Se
 	if info != nil {
 		url.SetAttribute(constant.ServiceInfoKey, info)
 		url.SetAttribute(constant.RpcServiceKey, svcOpts.rpcService)
-	}
-
-	// NOTE: tmp here for tls
-	if svcOpts.srvOpts.TLS != nil {
-		url.SetAttribute(constant.TLSConfigKey, svcOpts.srvOpts.TLS)
 	}
 
 	return proxyFactory.GetInvoker(url)

--- a/server/options.go
+++ b/server/options.go
@@ -78,8 +78,7 @@ func (srvOpts *ServerOptions) init(opts ...ServerOption) error {
 		opt(srvOpts)
 	}
 
-	// TODO: test server TLSOption is good or bad?
-	// need to write a demo actually.
+	// NOTE: TLSOption is good, wonderful!!!
 
 	if err := defaults.Set(srvOpts); err != nil {
 		return err
@@ -477,6 +476,9 @@ func SetServerProvider(provider *global.ProviderConfig) ServerOption {
 	}
 }
 
+// FIXME: ServiceOptions contains ServerOptions?
+// Not ServerOptions contains ServiceOptions?
+// we need to find a way to fix it.
 type ServiceOptions struct {
 	Application *global.ApplicationConfig
 	Provider    *global.ProviderConfig

--- a/server/options.go
+++ b/server/options.go
@@ -410,18 +410,14 @@ func WithServerAdaptiveServiceVerbose() ServerOption {
 // WithServerTLSOption applies TLS options to the server configuration.
 // It iterates over the provided tls.
 // TLSOption and applies them to the ServerOptions.TLS field.
-func WithServerTLSOption(opts ...tls.TLSOption) ServerOption {
-	// TODO: tls.NewOptions(opts...) implement
-	// avoid to use loop to apply options
-	// ref: WithServerProtocol func
+func WithServerTLSOption(opts ...tls.Option) ServerOption {
+	tlsOpts := tls.NewOptions(opts...)
 
-	return func(serverOpts *ServerOptions) {
-		if serverOpts.TLS == nil {
-			serverOpts.TLS = &global.TLSConfig{}
+	return func(srvOpts *ServerOptions) {
+		if srvOpts.TLS == nil {
+			srvOpts.TLS = new(global.TLSConfig)
 		}
-		for _, opt := range opts {
-			opt(serverOpts.TLS)
-		}
+		srvOpts.TLS = tlsOpts.TLSConf
 	}
 }
 

--- a/server/options.go
+++ b/server/options.go
@@ -78,8 +78,6 @@ func (srvOpts *ServerOptions) init(opts ...ServerOption) error {
 		opt(srvOpts)
 	}
 
-	// NOTE: TLSOption is good, wonderful!!!
-
 	if err := defaults.Set(srvOpts); err != nil {
 		return err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -149,15 +149,16 @@ func (s *Server) Serve() error {
 	if err := metadata.InitRegistryMetadataReport(s.cfg.Registries); err != nil {
 		return err
 	}
-	opts := metadata.NewOptions(
+	metadataOpts := metadata.NewOptions(
 		metadata.WithAppName(s.cfg.Application.Name),
 		metadata.WithMetadataType(s.cfg.Application.MetadataType),
 		metadata.WithPort(getMetadataPort(s.cfg)),
 		metadata.WithMetadataProtocol(s.cfg.Application.MetadataServiceProtocol),
 	)
-	if err := opts.Init(); err != nil {
+	if err := metadataOpts.Init(); err != nil {
 		return err
 	}
+
 	if err := s.exportServices(); err != nil {
 		return err
 	}
@@ -275,7 +276,7 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 	return srv, nil
 }
 
-func SetProServices(sd *InternalService) {
+func SetProviderServices(sd *InternalService) {
 	if sd.Name == "" {
 		logger.Warnf("[internal service]internal name is empty, please set internal name")
 		return

--- a/tls/config.go
+++ b/tls/config.go
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"os"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/global"
+)
+
+// GetServerTlsConfig build server tls config from TLSConfig
+func GetServerTlsConfig(tlsConf *global.TLSConfig) (*tls.Config, error) {
+	//no TLS
+	if tlsConf.TLSCertFile == "" && tlsConf.TLSKeyFile == "" {
+		return nil, nil
+	}
+	var ca *x509.CertPool
+	cfg := &tls.Config{}
+	//need mTLS
+	if tlsConf.CACertFile != "" {
+		ca = x509.NewCertPool()
+		caBytes, err := os.ReadFile(tlsConf.CACertFile)
+		if err != nil {
+			return nil, err
+		}
+		if ok := ca.AppendCertsFromPEM(caBytes); !ok {
+			return nil, errors.New("failed to parse root certificate")
+		}
+		cfg.ClientAuth = tls.RequireAndVerifyClientCert
+		cfg.ClientCAs = ca
+	}
+	cert, err := tls.LoadX509KeyPair(tlsConf.TLSCertFile, tlsConf.TLSKeyFile)
+	if err != nil {
+		return nil, err
+	}
+	cfg.Certificates = []tls.Certificate{cert}
+	cfg.ServerName = tlsConf.TLSServerName
+
+	return cfg, nil
+}
+
+// GetClientTlsConfig build client tls config from TLSConfig
+func GetClientTlsConfig(tlsConf *global.TLSConfig) (*tls.Config, error) {
+	//no TLS
+	if tlsConf.CACertFile == "" {
+		return nil, nil
+	}
+	cfg := &tls.Config{
+		ServerName: tlsConf.TLSServerName,
+	}
+	ca := x509.NewCertPool()
+	caBytes, err := os.ReadFile(tlsConf.CACertFile)
+	if err != nil {
+		return nil, err
+	}
+	if ok := ca.AppendCertsFromPEM(caBytes); !ok {
+		return nil, errors.New("failed to parse root certificate")
+	}
+	cfg.RootCAs = ca
+	//need mTls
+	if tlsConf.TLSCertFile != "" {
+		var cert tls.Certificate
+		cert, err = tls.LoadX509KeyPair(tlsConf.TLSCertFile, tlsConf.TLSKeyFile)
+		if err != nil {
+			return nil, err
+		}
+		cfg.Certificates = []tls.Certificate{cert}
+	}
+	return cfg, err
+}

--- a/tls/helper.go
+++ b/tls/helper.go
@@ -28,12 +28,27 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/global"
 )
 
+func IsServerTLSValid(tlsConf *global.TLSConfig) bool {
+	if tlsConf == nil {
+		return false
+	}
+	return tlsConf.TLSCertFile != "" && tlsConf.TLSKeyFile != ""
+}
+
+func IsClientTLSValid(tlsConf *global.TLSConfig) bool {
+	if tlsConf == nil {
+		return false
+	}
+	return tlsConf.CACertFile != ""
+}
+
 // GetServerTlsConfig build server tls config from TLSConfig
 func GetServerTlsConfig(tlsConf *global.TLSConfig) (*tls.Config, error) {
 	//no TLS
-	if tlsConf.TLSCertFile == "" && tlsConf.TLSKeyFile == "" {
+	if tlsConf.TLSCertFile == "" || tlsConf.TLSKeyFile == "" {
 		return nil, nil
 	}
+
 	var ca *x509.CertPool
 	cfg := &tls.Config{}
 	//need mTLS
@@ -65,6 +80,7 @@ func GetClientTlsConfig(tlsConf *global.TLSConfig) (*tls.Config, error) {
 	if tlsConf.CACertFile == "" {
 		return nil, nil
 	}
+
 	cfg := &tls.Config{
 		ServerName: tlsConf.TLSServerName,
 	}

--- a/tls/helper_test.go
+++ b/tls/helper_test.go
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tls
+
+import (
+	"testing"
+
+	"dubbo.apache.org/dubbo-go/v3/global"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsServerTLSValid(t *testing.T) {
+	tests := []struct {
+		name     string
+		tlsConf  *global.TLSConfig
+		expected bool
+	}{
+		{
+			name: "Valid TLSConfig with cert and key",
+			tlsConf: &global.TLSConfig{
+				TLSCertFile: "cert.pem",
+				TLSKeyFile:  "key.pem",
+			},
+			expected: true,
+		},
+		{
+			name: "Invalid TLSConfig with empty cert and key",
+			tlsConf: &global.TLSConfig{
+				TLSCertFile: "",
+				TLSKeyFile:  "",
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid TLSConfig with only cert",
+			tlsConf: &global.TLSConfig{
+				TLSCertFile: "cert.pem",
+				TLSKeyFile:  "",
+			},
+			expected: false,
+		},
+		{
+			name: "Invalid TLSConfig with only key",
+			tlsConf: &global.TLSConfig{
+				TLSCertFile: "",
+				TLSKeyFile:  "key.pem",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsServerTLSValid(tt.tlsConf)
+			assert.Equal(t, tt.expected, result, "Test case %s failed", tt.name)
+		})
+	}
+}
+
+func TestIsClientTLSValid(t *testing.T) {
+	tests := []struct {
+		name     string
+		tlsConf  *global.TLSConfig
+		expected bool
+	}{
+		{
+			name: "Valid Client TLSConfig with CA cert",
+			tlsConf: &global.TLSConfig{
+				CACertFile: "ca.pem",
+			},
+			expected: true,
+		},
+		{
+			name: "Invalid Client TLSConfig with empty CA cert",
+			tlsConf: &global.TLSConfig{
+				CACertFile: "",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsClientTLSValid(tt.tlsConf)
+			assert.Equal(t, tt.expected, result, "Test case %s failed", tt.name)
+		})
+	}
+}

--- a/tls/options.go
+++ b/tls/options.go
@@ -33,19 +33,19 @@ func WithCACertFile(file string) TLSOption {
 	}
 }
 
-func WithTLSCertFile(file string) TLSOption {
+func WithCertFile(file string) TLSOption {
 	return func(cfg *global.TLSConfig) {
 		cfg.TLSCertFile = file
 	}
 }
 
-func WithTLSKeyFile(file string) TLSOption {
+func WithKeyFile(file string) TLSOption {
 	return func(cfg *global.TLSConfig) {
 		cfg.TLSKeyFile = file
 	}
 }
 
-func WithTLSServerName(name string) TLSOption {
+func WithServerName(name string) TLSOption {
 	return func(cfg *global.TLSConfig) {
 		cfg.TLSServerName = name
 	}

--- a/tls/options.go
+++ b/tls/options.go
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tls
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/global"
+)
+
+// The consideration of not placing TLSOption in the global package is
+// to prevent users from directly using the global package, so I created
+// a new tls directory to allow users to establish config through the tls package.
+
+type TLSOption func(*global.TLSConfig)
+
+func WithTLS_CACertFile(file string) TLSOption {
+	return func(cfg *global.TLSConfig) {
+		cfg.CACertFile = file
+	}
+}
+
+func WithTLS_TLSCertFile(file string) TLSOption {
+	return func(cfg *global.TLSConfig) {
+		cfg.TLSCertFile = file
+	}
+}
+
+func WithTLS_TLSKeyFile(file string) TLSOption {
+	return func(cfg *global.TLSConfig) {
+		cfg.TLSKeyFile = file
+	}
+}
+
+func WithTLS_TLSServerName(name string) TLSOption {
+	return func(cfg *global.TLSConfig) {
+		cfg.TLSServerName = name
+	}
+}

--- a/tls/options.go
+++ b/tls/options.go
@@ -27,25 +27,25 @@ import (
 
 type TLSOption func(*global.TLSConfig)
 
-func WithTLS_CACertFile(file string) TLSOption {
+func WithCACertFile(file string) TLSOption {
 	return func(cfg *global.TLSConfig) {
 		cfg.CACertFile = file
 	}
 }
 
-func WithTLS_TLSCertFile(file string) TLSOption {
+func WithTLSCertFile(file string) TLSOption {
 	return func(cfg *global.TLSConfig) {
 		cfg.TLSCertFile = file
 	}
 }
 
-func WithTLS_TLSKeyFile(file string) TLSOption {
+func WithTLSKeyFile(file string) TLSOption {
 	return func(cfg *global.TLSConfig) {
 		cfg.TLSKeyFile = file
 	}
 }
 
-func WithTLS_TLSServerName(name string) TLSOption {
+func WithTLSServerName(name string) TLSOption {
 	return func(cfg *global.TLSConfig) {
 		cfg.TLSServerName = name
 	}

--- a/tls/options.go
+++ b/tls/options.go
@@ -25,28 +25,44 @@ import (
 // to prevent users from directly using the global package, so I created
 // a new tls directory to allow users to establish config through the tls package.
 
-type TLSOption func(*global.TLSConfig)
+type Options struct {
+	TLSConf *global.TLSConfig
+}
 
-func WithCACertFile(file string) TLSOption {
-	return func(cfg *global.TLSConfig) {
-		cfg.CACertFile = file
+func defaultOptions() *Options {
+	return &Options{TLSConf: global.DefaultTLSConfig()}
+}
+
+func NewOptions(opts ...Option) *Options {
+	defOpts := defaultOptions()
+	for _, opt := range opts {
+		opt(defOpts)
+	}
+	return defOpts
+}
+
+type Option func(*Options)
+
+func WithCACertFile(file string) Option {
+	return func(opts *Options) {
+		opts.TLSConf.CACertFile = file
 	}
 }
 
-func WithCertFile(file string) TLSOption {
-	return func(cfg *global.TLSConfig) {
-		cfg.TLSCertFile = file
+func WithCertFile(file string) Option {
+	return func(opts *Options) {
+		opts.TLSConf.TLSCertFile = file
 	}
 }
 
-func WithKeyFile(file string) TLSOption {
-	return func(cfg *global.TLSConfig) {
-		cfg.TLSKeyFile = file
+func WithKeyFile(file string) Option {
+	return func(opts *Options) {
+		opts.TLSConf.TLSKeyFile = file
 	}
 }
 
-func WithServerName(name string) TLSOption {
-	return func(cfg *global.TLSConfig) {
-		cfg.TLSServerName = name
+func WithServerName(name string) Option {
+	return func(opts *Options) {
+		opts.TLSConf.TLSServerName = name
 	}
 }


### PR DESCRIPTION
We plan to move TLSConfig from the config package to the global package, for which we need TLSOptions. However, we cannot place TLSOptions in the global package, otherwise it will cause circular dependencies, making global a second config package. Therefore, it is necessary for us to create a tls directory.

How to pass TLSConfig is a question, and I handled it this way:
common.WithAttribute(constant.TLSConfigKey, svcOpts.srvOpts.TLS)
Using the Attribute field in the URL to pass parameters, TLSConfig will not appear in the URL string. The Attribute is designed to pass various configurations, but very few people use it, so I plan to use Attribute to pass TLSConfig.

The following samples have all been tested successfully.

Instance sample
```go
        ins, err := dubbo.NewInstance(
                dubbo.WithName("dubbo_instance_sample"),
                dubbo.WithProtocol(
                        protocol.WithTriple(),
                        protocol.WithPort(20000),
                ),
                dubbo.WithTLS(
                        tls.WithCACertFile("client_ca_cert.pem"),
                        tls.WithCertFile("server2_cert.pem"),
                        tls.WithKeyFile("server2_key.pem"),
                        tls.WithServerName("dubbogo.test.example.com"),
                ),
        )
```

Server sample
```go
        srv, err := server.NewServer(
                server.WithServerProtocol(
                        protocol.WithPort(20000),
                        protocol.WithTriple(),
                ),
                server.WithServerTLSOption(
                        tls.WithCACertFile("client_ca_cert.pem"),
                        tls.WithCertFile("server2_cert.pem"),
                        tls.WithKeyFile("server2_key.pem"),
                        tls.WithServerName("dubbogo.test.example.com"),
                ),
        )
```

Client sample
```go
        cli, err := client.NewClient(
                client.WithClientURL("127.0.0.1:20000"),
                client.WithClientTLSOption(
                        tls.WithCACertFile("server_ca_cert.pem"),
                        tls.WithCertFile("client2_cert.pem"),
                        tls.WithKeyFile("client2_key.pem"),
                        tls.WithServerName("dubbogo.test.example.com"),
                ),
        )
```

dubbo.load server yaml file
```go
func main() {
        greet.SetProviderGreetService(&GreetTripleServer{})
        if err := dubbo.Load(); err != nil {
                panic(err)
        }
        select {}
}
```
``` yaml
# dubbo server yaml configure file
dubbo:
  registries:
    demoZK:
      protocol: zookeeper
      timeout: 10s
      address: 127.0.0.1:2181
  protocols:
    tripleProtocol:
      name: tri
      port: 20000
  provider:
    services:
      GreetTripleServer:
        interface: com.apache.dubbo.sample.Greeter
  tls_config:
    ca-cert-file: client_ca_cert.pem
    tls-cert-file: server1_cert.pem
    tls-key-file: server1_key.pem
    tls-server-name: dubbogo.test.example.com
```

dubbo.load client yaml file
```go
func main() {
        greet.SetConsumerGreetService(svc)
        if err := dubbo.Load(); err != nil {
                panic(err)
        }
        req, err := svc.Greet(context.Background(), &greet.GreetRequest{Name: "name"})
        if err != nil {
                panic(err)
        }
        logger.Infof("Greeting: %v", req.Greeting)
}
```
```yaml
# dubbo client yaml configure file
dubbo:
  registries:
    demoZK:
      protocol: zookeeper
      timeout: 3s
      address: 127.0.0.1:2181
  consumer:
    references:
      GreetServiceImpl:
        protocol: tri
        interface: com.apache.dubbo.sample.Greeter
        registry: demoZK
        retries: 3
        timeout: 3000
  tls_config:
    ca-cert-file: server_ca_cert.pem
    tls-cert-file: client1_cert.pem
    tls-key-file: client1_key.pem
    tls-server-name: dubbogo.test.example.com
```

The benefits of this PR:
1.  It enables the new API to fully support TLS.
2.  It completely frees the TLS part of the remoting and protocol packages from the circular dependency on the config package, preparing for the future removal of the config package.