### PR TITLE
refactor: switch to global protocol config

### DIFF
--- a/common/constant/default.go
+++ b/common/constant/default.go
@@ -47,6 +47,7 @@ const (
 	DefaultRestClient       = "resty"
 	DefaultRestServer       = "go-restful"
 	DefaultPort             = 20000
+	DefaultPortString       = "20000"
 )
 
 const (

--- a/common/extension/protocol.go
+++ b/common/extension/protocol.go
@@ -31,7 +31,7 @@ func SetProtocol(name string, v func() protocol.Protocol) {
 // GetProtocol finds the protocol extension with @name
 func GetProtocol(name string) protocol.Protocol {
 	if protocols[name] == nil {
-		panic("protocol for " + name + " is not existing, make sure you have import the package.")
+		panic("protocol for [" + name + "] is not existing, make sure you have import the package.")
 	}
 	return protocols[name]()
 }

--- a/global/protocol_config.go
+++ b/global/protocol_config.go
@@ -17,11 +17,15 @@
 
 package global
 
+import (
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+)
+
 // ProtocolConfig is protocol configuration
 type ProtocolConfig struct {
-	Name   string `default:"dubbo" validate:"required" yaml:"name" json:"name,omitempty" property:"name"`
+	Name   string `yaml:"name" json:"name,omitempty" property:"name"`
 	Ip     string `yaml:"ip"  json:"ip,omitempty" property:"ip"`
-	Port   string `default:"20000" yaml:"port" json:"port,omitempty" property:"port"`
+	Port   string `yaml:"port" json:"port,omitempty" property:"port"`
 	Params any    `yaml:"params" json:"params,omitempty" property:"params"`
 
 	// MaxServerSendMsgSize max size of server send message, 1mb=1000kb=1000000b 1mib=1024kb=1048576b.
@@ -32,7 +36,10 @@ type ProtocolConfig struct {
 }
 
 func DefaultProtocolConfig() *ProtocolConfig {
-	return &ProtocolConfig{}
+	return &ProtocolConfig{
+		Name: constant.TriProtocol,
+		Port: constant.DefaultPortString,
+	}
 }
 
 // Clone a new ProtocolConfig

--- a/protocol/options.go
+++ b/protocol/options.go
@@ -22,6 +22,7 @@ import (
 )
 
 import (
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/global"
 )
 
@@ -44,7 +45,7 @@ func NewOptions(opts ...Option) *Options {
 	if defOpts.ID == "" {
 		if defOpts.Protocol.Name == "" {
 			// should be the same as default value of config.ProtocolConfig.Protocol
-			defOpts.ID = "tri"
+			defOpts.ID = constant.TriProtocol
 		} else {
 			defOpts.ID = defOpts.Protocol.Name
 		}

--- a/server/action.go
+++ b/server/action.go
@@ -107,7 +107,7 @@ func (svcOpts *ServiceOptions) IsExport() bool {
 }
 
 // Get Random Port
-func getRandomPort(protocolConfigs []*config.ProtocolConfig) *list.List {
+func getRandomPort(protocolConfigs []*global.ProtocolConfig) *list.List {
 	ports := list.New()
 	for _, proto := range protocolConfigs {
 		if len(proto.Port) > 0 {
@@ -161,7 +161,7 @@ func (svcOpts *ServiceOptions) export(info *common.ServiceInfo) error {
 	}
 
 	urlMap := svcOpts.getUrlMap()
-	protocolConfigs := loadProtocol(svc.ProtocolIDs, svcOpts.protocolsCompat)
+	protocolConfigs := loadProtocol(svc.ProtocolIDs, svcOpts.Protocols)
 	if len(protocolConfigs) == 0 {
 		logger.Warnf("The service %v'svcOpts '%v' protocols don't has right protocolConfigs, Please check your configuration center and transfer protocol ", svc.Interface, svc.ProtocolIDs)
 		return nil
@@ -281,8 +281,8 @@ func setRegistrySubURL(ivkURL *common.URL, regUrl *common.URL) {
 }
 
 // loadProtocol filter protocols by ids
-func loadProtocol(protocolIds []string, protocols map[string]*config.ProtocolConfig) []*config.ProtocolConfig {
-	returnProtocols := make([]*config.ProtocolConfig, 0, len(protocols))
+func loadProtocol(protocolIds []string, protocols map[string]*global.ProtocolConfig) []*global.ProtocolConfig {
+	returnProtocols := make([]*global.ProtocolConfig, 0, len(protocols))
 	for _, v := range protocolIds {
 		for k, config := range protocols {
 			if v == k {

--- a/server/compat.go
+++ b/server/compat.go
@@ -61,32 +61,3 @@ func compatRegistryConfig(c *global.RegistryConfig) *config.RegistryConfig {
 		UseAsConfigCenter: c.UseAsConfigCenter,
 	}
 }
-
-func compatMethodConfig(c *global.MethodConfig) *config.MethodConfig {
-	return &config.MethodConfig{
-		InterfaceId:                 c.InterfaceId,
-		InterfaceName:               c.InterfaceName,
-		Name:                        c.Name,
-		Retries:                     c.Retries,
-		LoadBalance:                 c.LoadBalance,
-		Weight:                      c.Weight,
-		TpsLimitInterval:            c.TpsLimitInterval,
-		TpsLimitRate:                c.TpsLimitRate,
-		TpsLimitStrategy:            c.TpsLimitStrategy,
-		ExecuteLimit:                c.ExecuteLimit,
-		ExecuteLimitRejectedHandler: c.ExecuteLimitRejectedHandler,
-		Sticky:                      c.Sticky,
-		RequestTimeout:              c.RequestTimeout,
-	}
-}
-
-func compatProtocolConfig(c *global.ProtocolConfig) *config.ProtocolConfig {
-	return &config.ProtocolConfig{
-		Name:                 c.Name,
-		Ip:                   c.Ip,
-		Port:                 c.Port,
-		Params:               c.Params,
-		MaxServerSendMsgSize: c.MaxServerSendMsgSize,
-		MaxServerRecvMsgSize: c.MaxServerRecvMsgSize,
-	}
-}

--- a/server/options.go
+++ b/server/options.go
@@ -475,10 +475,8 @@ type ServiceOptions struct {
 	// TODO: remove this when config package is remove
 	IDLMode string
 
-	methodsCompat     []*config.MethodConfig
 	applicationCompat *config.ApplicationConfig
 	registriesCompat  map[string]*config.RegistryConfig
-	protocolsCompat   map[string]*config.ProtocolConfig
 }
 
 func defaultServiceOptions() *ServiceOptions {
@@ -542,15 +540,6 @@ func (svcOpts *ServiceOptions) init(srv *Server, opts ...ServiceOption) error {
 	// initialize Protocols
 	if len(svc.RCProtocolsMap) == 0 {
 		svc.RCProtocolsMap = svcOpts.Protocols
-	}
-	if len(svc.RCProtocolsMap) > 0 {
-		svcOpts.protocolsCompat = make(map[string]*config.ProtocolConfig)
-		for key, pro := range svc.RCProtocolsMap {
-			svcOpts.protocolsCompat[key] = compatProtocolConfig(pro)
-			if err := svcOpts.protocolsCompat[key].Init(); err != nil {
-				return err
-			}
-		}
 	}
 
 	svc.RegistryIDs = commonCfg.TranslateIds(svc.RegistryIDs)


### PR DESCRIPTION
I submitted this PR because it affected my normal development. I was adding triple config to the protocol config and found that it was not effective. After debugging, I discovered that the protocol config being used was actually from the config package, so I decided to switch to using the global package's primary protocol config.

Actually, it's also possible to add the same fields in the config package, but I hate wasting time on things that are outdated and will soon be deprecated. Moreover, using the global protocol config is only a matter of time.

The changes in this PR are compatible with old dubbo-go.