### PR TITLE
feat:  improve URL generation logic

### DIFF
--- a/config/registry_config_test.go
+++ b/config/registry_config_test.go
@@ -109,7 +109,7 @@ func TestNewRegistryConfigBuilder(t *testing.T) {
 		SetWeight(100).
 		SetParams(map[string]string{"timeout": "3s"}).
 		AddParam("timeout", "15s").
-		SetRegistryType("local").
+		SetRegistryType("all").
 		Build()
 
 	config.DynamicUpdateProperties(config)
@@ -126,6 +126,11 @@ func TestNewRegistryConfigBuilder(t *testing.T) {
 	url, err = config.toURL(common.PROVIDER)
 	assert.NoError(t, err)
 	assert.Equal(t, url.GetParam("timeout", "3s"), "15s")
+
+	urls, err := config.toURLs(common.PROVIDER)
+	assert.NoError(t, err)
+	assert.Equal(t, urls[0].GetParam("timeout", "3s"), "15s")
+	assert.Equal(t, len(urls), 2)
 
 	address := config.translateRegistryAddress()
 	assert.Equal(t, address, "127.0.0.1:8848")


### PR DESCRIPTION
While addressing the  #2044 , I discovered that Dubbo-go already supports both interface-level and service-level service discovery for providers. The original problem described in the issue no longer exists as users can simply set `registry-type: all` in their configuration to enable both modes simultaneously,like this:

```
nacos:
  protocol: nacos
  address: 127.0.0.1:8848
  username: nacos
  password: nacos
  namespace: my-ns
  group: dubbo
  registry-type: all  # Enable both discovery modes
  params:
    nacos.logLevel: warn
```

So I just optimized the code related to this, improving its readability.
