### PR TITLE
handle SonarQubeCould AI bot warning （#2895）

### DIFF
--- a/cluster/loadbalance/aliasmethod/alias_method.go
+++ b/cluster/loadbalance/aliasmethod/alias_method.go
@@ -20,7 +20,9 @@ package aliasmethod // weighted random with alias-method algorithm
 
 import (
 	"math/rand"
+)
 
+import (
 	"dubbo.apache.org/dubbo-go/v3/cluster/loadbalance"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 )

--- a/cluster/loadbalance/aliasmethod/alias_method.go
+++ b/cluster/loadbalance/aliasmethod/alias_method.go
@@ -20,9 +20,7 @@ package aliasmethod // weighted random with alias-method algorithm
 
 import (
 	"math/rand"
-)
 
-import (
 	"dubbo.apache.org/dubbo-go/v3/cluster/loadbalance"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 )
@@ -107,8 +105,8 @@ func (am *aliasMethodPicker) init(invocation base.Invocation) {
 }
 
 func (am *aliasMethodPicker) Pick() base.Invoker {
-	i := rand.Intn(len(am.invokers))
-	if rand.Float64() < am.prob[i] {
+	i := rand.Intn(len(am.invokers)) //NOSONAR
+	if rand.Float64() < am.prob[i] { //NOSONAR
 		return am.invokers[i]
 	}
 	return am.invokers[am.alias[i]]

--- a/cluster/loadbalance/iwrr/iwrr.go
+++ b/cluster/loadbalance/iwrr/iwrr.go
@@ -20,7 +20,9 @@ package iwrr
 import (
 	"math/rand"
 	"sync"
+)
 
+import (
 	"dubbo.apache.org/dubbo-go/v3/cluster/loadbalance"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 )

--- a/cluster/loadbalance/iwrr/iwrr.go
+++ b/cluster/loadbalance/iwrr/iwrr.go
@@ -20,9 +20,7 @@ package iwrr
 import (
 	"math/rand"
 	"sync"
-)
 
-import (
 	"dubbo.apache.org/dubbo-go/v3/cluster/loadbalance"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 )
@@ -83,7 +81,7 @@ func NewInterleavedweightedRoundRobin(invokers []base.Invoker, invocation base.I
 	iwrrp.next = NewIwrrQueue()
 
 	size := uint64(len(invokers))
-	offset := rand.Uint64() % size
+	offset := rand.Uint64() % size //NOSONAR
 	step := int64(0)
 	for idx := uint64(0); idx < size; idx++ {
 		invoker := invokers[(idx+offset)%size]

--- a/cluster/router/condition/route.go
+++ b/cluster/router/condition/route.go
@@ -372,7 +372,7 @@ func (s *destSets) randDest() *destination {
 	if len(s.destinations) == 1 {
 		return s.destinations[0]
 	}
-	sum := rand.Intn(s.weightSum)
+	sum := rand.Intn(s.weightSum) //NOSONAR
 	for _, d := range s.destinations {
 		sum -= d.weight
 		if sum <= 0 {

--- a/metrics/util/aggregate/aggregator_test.go
+++ b/metrics/util/aggregate/aggregator_test.go
@@ -64,7 +64,7 @@ func BenchmarkTimeWindowAggregatorAdd(b *testing.B) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			tw.Add(rand.Float64() * 100)
+			tw.Add(rand.Float64() * 100) //NOSONAR
 		}()
 	}
 	wg.Wait()
@@ -76,7 +76,7 @@ func BenchmarkTimeWindowAggregatorResult(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		wg.Add(1)
 		go func() {
-			tw.Add(rand.Float64() * 100)
+			tw.Add(rand.Float64() * 100) //NOSONAR
 		}()
 		go func() {
 			defer wg.Done()

--- a/protocol/triple/triple_protocol/triple_ext_test.go
+++ b/protocol/triple/triple_protocol/triple_ext_test.go
@@ -29,10 +29,14 @@ import (
 	"sync"
 	"testing"
 	"time"
+)
 
+import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoregistry"
+)
 
+import (
 	triple "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol"
 	"dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/assert"
 	"dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/import/v1/importv1connect"

--- a/protocol/triple/triple_protocol/triple_ext_test.go
+++ b/protocol/triple/triple_protocol/triple_ext_test.go
@@ -29,18 +29,14 @@ import (
 	"sync"
 	"testing"
 	"time"
-)
 
-import (
 	"google.golang.org/protobuf/proto"
-
 	"google.golang.org/protobuf/reflect/protoregistry"
-)
 
-import (
 	triple "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol"
 	"dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/assert"
 	"dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/import/v1/importv1connect"
+
 	pingv1 "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/ping/v1"
 	"dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/ping/v1/pingv1connect"
 )
@@ -544,7 +540,7 @@ func TestConcurrentStreams(t *testing.T) {
 			assert.Nil(t, err)
 			start.Wait()
 			for i := 0; i < 100; i++ {
-				num := rand.Int63n(1000) //nolint: gosec
+				num := rand.Int63n(1000) //nolint: gosec //NOSONAR
 				total += num
 				if err := sum.Send(&pingv1.CumSumRequest{Number: num}); err != nil {
 					t.Errorf("failed to send request: %v", err)


### PR DESCRIPTION
I checked the code of the warning section. No cryptographically secure random numbers are needed in the context of load balancing, route selection, and testing. So I  add the comment //NOSONAR at the end to let the AI bot ignore this.