### PR TITLE
fix: read prefix  EOF error

### DIFF
--- a/protocol/triple/triple_protocol/envelope.go
+++ b/protocol/triple/triple_protocol/envelope.go
@@ -215,7 +215,11 @@ func (r *envelopeReader) Unmarshal(message any) *Error {
 func (r *envelopeReader) Read(env *envelope) *Error {
 	// Read prefix firstly, then read the packet with length specified by length field
 	prefixes := [5]byte{}
-	prefixBytesRead, err := r.reader.Read(prefixes[:])
+	// NOTE: We need to go to ReadFull prefixes and then handle the following steps,
+	// because when receiving data using the HTTP/3 protocol, due to the underlying
+	// UDP protocol, it often leads to processing the next steps without Read Full,
+	// which will cause EOF error.
+	prefixBytesRead, err := io.ReadFull(r.reader, prefixes[:])
 
 	switch {
 	case (err == nil || errors.Is(err, io.EOF)) &&
@@ -229,7 +233,7 @@ func (r *envelopeReader) Read(env *envelope) *Error {
 		// to the user so that they know that the stream has ended. We shouldn't
 		// add any alarming text about protocol errors, though.
 		return NewError(CodeUnknown, err)
-	case err != nil || prefixBytesRead < 5:
+	case err != nil:
 		// Something else has gone wrong - the stream didn't end cleanly.
 		if tripleErr, ok := asError(err); ok {
 			return tripleErr

--- a/protocol/triple/triple_protocol/envelope_test.go
+++ b/protocol/triple/triple_protocol/envelope_test.go
@@ -1,0 +1,76 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package triple_protocol
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/assert"
+)
+
+func TestEnvelopeRead(t *testing.T) {
+	t.Parallel()
+
+	prefixes := [5]byte{}
+	payload := []byte(`{"number": 42}`)
+	binary.BigEndian.PutUint32(prefixes[1:5], uint32(len(payload)))
+
+	buf := &bytes.Buffer{}
+	buf.Write(prefixes[:])
+	buf.Write(payload)
+
+	t.Run("full", func(t *testing.T) {
+		t.Parallel()
+		env := &envelope{Data: &bytes.Buffer{}}
+		rdr := envelopeReader{
+			reader: bytes.NewReader(buf.Bytes()),
+		}
+		assert.Nil(t, rdr.Read(env))
+		assert.Equal(t, payload, env.Data.Bytes())
+	})
+	t.Run("byteByByte", func(t *testing.T) {
+		t.Parallel()
+		env := &envelope{Data: &bytes.Buffer{}}
+		rdr := envelopeReader{
+			reader: byteByByteReader{
+				reader: bytes.NewReader(buf.Bytes()),
+			},
+		}
+		assert.Nil(t, rdr.Read(env))
+		assert.Equal(t, payload, env.Data.Bytes())
+	})
+}
+
+// byteByByteReader is test reader that reads a single byte at a time.
+type byteByByteReader struct {
+	reader io.ByteReader
+}
+
+func (b byteByByteReader) Read(data []byte) (int, error) {
+	if len(data) == 0 {
+		return 0, nil
+	}
+	next, err := b.reader.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	data[0] = next
+	return 1, nil
+}


### PR DESCRIPTION
We need to go to ReadFull prefixes and then handle the following steps, because when receiving data using the HTTP/3 protocol, due to the underlying UDP protocol, it often leads to processing the next steps without Read Full, which will cause some errrors like EOF.