### PR TITLE
fix: Fix incorrect index usage in blacklist refresh logic

### DIFF
--- a/protocol/rpc_status.go
+++ b/protocol/rpc_status.go
@@ -21,17 +21,12 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-)
 
-import (
 	"github.com/dubbogo/gost/log/logger"
 
-	uberAtomic "go.uber.org/atomic"
-)
-
-import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	uberAtomic "go.uber.org/atomic"
 )
 
 var (
@@ -266,7 +261,7 @@ func TryRefreshBlackList() {
 				defer wg.Done()
 				for j := range ivks {
 					if j%3-i == 0 && ivks[j].IsAvailable() {
-						RemoveInvokerUnhealthyStatus(ivks[i])
+						RemoveInvokerUnhealthyStatus(ivks[j])
 					}
 				}
 			}(ivks, i)


### PR DESCRIPTION
The TryRefreshBlackList function had a critical bug where it would check the availability of invoker at index j but incorrectly remove the invoker at index i, leading to wrong invokers being removed from the blacklist. This caused frequent and incorrect blacklist operations, resulting in excessive INFO logging and unstable service behavior.

Changes:
- Fix incorrect index usage: RemoveInvokerUnhealthyStatus(ivks[i]) -> RemoveInvokerUnhealthyStatus(ivks[j])
- Optimize import structure for better readability

This ensures the blacklist refresh mechanism works correctly by removing the actual invoker that was checked and found to be available.

Fixes: #XXXX