### PR TITLE
fix: Fix incorrect index usage in blacklist refresh logic

### DIFF
--- a/protocol/base/rpc_status.go
+++ b/protocol/base/rpc_status.go
@@ -266,7 +266,7 @@ func TryRefreshBlackList() {
 				defer wg.Done()
 				for j := range ivks {
 					if j%3-i == 0 && ivks[j].IsAvailable() {
-						RemoveInvokerUnhealthyStatus(ivks[i])
+						RemoveInvokerUnhealthyStatus(ivks[j])
 					}
 				}
 			}(ivks, i)


### PR DESCRIPTION
## Description
Fix critical bug in blacklist refresh logic where wrong invoker was being removed.

## Problem  
- Code checked `ivks[j].IsAvailable()` but removed `ivks[i]`
- Caused frequent incorrect blacklist operations and excessive logging

## Solution
Change `RemoveInvokerUnhealthyStatus(ivks[i])` to `RemoveInvokerUnhealthyStatus(ivks[j])`

## Impact
Eliminates incorrect blacklist operations and log spam.