### PR TITLE
chore(sonar): ignore sonar cloud ai bot useless warning

### DIFF
--- a/protocol/triple/triple_protocol/triple_ext_test.go
+++ b/protocol/triple/triple_protocol/triple_ext_test.go
@@ -544,7 +544,7 @@ func TestConcurrentStreams(t *testing.T) {
 			assert.Nil(t, err)
 			start.Wait()
 			for i := 0; i < 100; i++ {
-				num := rand.Int63n(1000) //nolint: gosec //NOSONAR
+				num := rand.Int63n(1000) //NOSONAR
 				total += num
 				if err := sum.Send(&pingv1.CumSumRequest{Number: num}); err != nil {
 					t.Errorf("failed to send request: %v", err)


### PR DESCRIPTION
## Description

SonarCloud is reporting a false-positive security warning on the use of `rand.Int63n` within the `TestConcurrentStreams` function. Using a non-cryptographically secure random number generator is acceptable and intended in this test context.

The previous attempt to suppress the warning using a combined comment (`//nolint: gosec //NOSONAR`) was not effective for SonarCloud. It appears that the Sonar scanner fails to parse its `//NOSONAR` directive when it's placed after another linter's suppression comment on the same line.

This PR resolves the issue by removing the `//nolint: gosec` part, leaving only the `//NOSONAR` directive. This allows SonarCloud to correctly recognize the suppression instruction and helps to clean up the CI analysis report.