### PR TITLE
fix(triple): harden openServer against config errors

### DIFF
--- a/protocol/triple/triple.go
+++ b/protocol/triple/triple.go
@@ -85,10 +85,17 @@ func (tp *TripleProtocol) openServer(invoker base.Invoker, info *common.ServiceI
 		panic("[TRIPLE Protocol]" + url.Key() + "is not existing")
 	}
 
-	// TODO: handle errors
-	tripleConfRaw, _ := url.GetAttribute(constant.TripleConfigKey)
-	// TODO: verificate the tripleConf
-	tripleConf, _ := tripleConfRaw.(*global.TripleConfig)
+	tripleConfRaw, ok := url.GetAttribute(constant.TripleConfigKey)
+	if !ok {
+		logger.Errorf("Triple config is not found for url: %s", url.Key())
+		return
+	}
+
+	tripleConf, ok := tripleConfRaw.(*global.TripleConfig)
+	if !ok || tripleConf == nil {
+		logger.Errorf("Triple config obtained from url: %s is not of type *global.TripleConfig or is nil", url.Key())
+		return
+	}
 
 	srv := NewServer(tripleConf)
 	srv.Start(invoker, info)


### PR DESCRIPTION
## Description

The previous implementation of the `openServer` function was not robust against configuration errors. It did not properly handle cases where the Triple protocol configuration was missing from the URL's attributes or was of an incorrect type. This could lead to a panic from a nil pointer dereference or a failed type assertion, impacting service stability.

This PR addresses this issue by introducing proper error handling and validation to the `openServer` function.

### Key Changes

- **Handle Missing Configuration**: The code now checks if `TripleConfigKey` exists in the URL's attributes. If it's missing, it logs an error and returns gracefully instead of proceeding.
- **Validate Configuration Type**: It now verifies that the configuration value is not `nil` and can be correctly asserted to the `*global.TripleConfig` type. If the check fails, it logs an error and returns.

These changes prevent the server from panicking due to invalid or missing configuration, making the service startup process more resilient.