### PR TITLE
feat(client): add WithInterface option

### DIFF
--- a/client/action.go
+++ b/client/action.go
@@ -107,7 +107,9 @@ func (refOpts *ReferenceOptions) refer(srv common.RPCService, info *ClientInfo) 
 
 	var methods []string
 	if info != nil {
-		ref.InterfaceName = info.InterfaceName
+		if ref.InterfaceName == "" {
+			ref.InterfaceName = info.InterfaceName
+		}
 		methods = info.MethodNames
 		refOpts.id = info.InterfaceName
 		refOpts.info = info

--- a/client/options.go
+++ b/client/options.go
@@ -166,6 +166,26 @@ func WithFilter(filter string) ReferenceOption {
 	}
 }
 
+// WithInterface sets the interface name for the service reference.
+//
+// As a functional option, it is passed to a client constructor
+// (e.g., NewGreetService) to configure which remote service to connect to.
+//
+// The interfaceName is a crucial identifier for service discovery and routing,
+// and it must exactly match the name registered by the service provider.
+//
+// Usage:
+//
+//	svc, err := greet.NewGreetService(
+//	    cli,
+//	    client.WithInterface("com.your.company.GreetService"),
+//	)
+func WithInterface(interfaceName string) ReferenceOption {
+	return func(opts *ReferenceOptions) {
+		opts.Reference.InterfaceName = interfaceName
+	}
+}
+
 func WithRegistryIDs(registryIDs ...string) ReferenceOption {
 	return func(opts *ReferenceOptions) {
 		if len(registryIDs) > 0 {

--- a/server/options.go
+++ b/server/options.go
@@ -604,9 +604,24 @@ type ServiceOption func(*ServiceOptions)
 
 // ---------- For user ----------
 
-func WithInterface(intf string) ServiceOption {
+// WithInterface sets the interface name for the service being exposed.
+//
+// As a functional option, it is passed to a service registration function
+// (e.g., RegisterGreetServiceHandler) to configure the service's properties.
+//
+// The `interfaceName` acts as the unique identifier for this service in the registry.
+// Clients (consumers) must use this exact name to discover and invoke the service.
+//
+// Usage:
+//
+//	err := greet.RegisterGreetServiceHandler(
+//	    srv,
+//	    &GreetTripleServer{},
+//	    server.WithInterface("com.your.company.GreetService"),
+//	)
+func WithInterface(interfaceName string) ServiceOption {
 	return func(opts *ServiceOptions) {
-		opts.Service.Interface = intf
+		opts.Service.Interface = interfaceName
 	}
 }
 


### PR DESCRIPTION
## description

This pull request introduces a new functional option, `WithInterface`, for the client-side reference configuration.

### Motivation

To provide a clear and idiomatic way for users to configure the remote service they intend to call, this PR adds `WithInterface` following the common functional options pattern. This approach makes the client setup more readable and consistent with modern Go practices.

This configuration is essential for the service discovery mechanism to correctly locate and route requests to the appropriate provider.

### Changes

  - Adds a new exported function `WithInterface(interfaceName string) ReferenceOption`.
  - This function allows the target interface name to be passed directly into the client constructor.

### Usage Example

```go
  svc, err := greet.NewGreetService(
      cli,
      client.WithInterface("com.your.company.GreetService"),
  )
```