### PR TITLE
refactor: replace `filter/polaris/limit` use of config package

### DIFF
--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -200,6 +200,7 @@ const (
 	RegistrySimplifiedKey   = "simplified"
 	RegistryNamespaceKey    = "registry.namespace"
 	RegistryGroupKey        = "registry.group"
+	RegistryTypeKey         = "registry.type"
 	RegistryTypeInterface   = "interface"
 	RegistryTypeService     = "service"
 	RegistryTypeAll         = "all"

--- a/config/metadata_config.go
+++ b/config/metadata_config.go
@@ -112,6 +112,7 @@ func (mc *MetadataReportConfig) toReportOptions() (*metadata.ReportOptions, erro
 func registryToReportOptions(id string, rc *RegistryConfig) (*metadata.ReportOptions, error) {
 	opts := metadata.NewReportOptions(
 		metadata.WithRegistryId(id),
+		metadata.WithRegistryType(rc.RegistryType),
 		metadata.WithProtocol(rc.Protocol),
 		metadata.WithAddress(rc.Address),
 		metadata.WithUsername(rc.Username),

--- a/config/registry_config.go
+++ b/config/registry_config.go
@@ -83,6 +83,7 @@ func (c *RegistryConfig) getUrlMap(roleType common.RoleType) url.Values {
 	urlMap.Set(constant.RegistryKey+"."+constant.WeightKey, strconv.FormatInt(c.Weight, 10))
 	urlMap.Set(constant.RegistryTTLKey, c.TTL)
 	urlMap.Set(constant.ClientNameKey, clientNameID(c, c.Protocol, c.Address))
+	urlMap.Set(constant.RegistryTypeKey, c.RegistryType)
 
 	for k, v := range c.Params {
 		urlMap.Set(k, v)

--- a/metadata/options.go
+++ b/metadata/options.go
@@ -107,7 +107,8 @@ func WithMetadataProtocol(protocol string) Option {
 }
 
 type ReportOptions struct {
-	registryId string
+	registryId   string
+	registryType string
 	*global.MetadataReportConfig
 }
 
@@ -132,6 +133,7 @@ func InitRegistryMetadataReport(registries map[string]*global.RegistryConfig) er
 func fromRegistry(id string, rc *global.RegistryConfig) *ReportOptions {
 	opts := NewReportOptions(
 		WithRegistryId(id),
+		WithRegistryType(rc.RegistryType),
 		WithProtocol(rc.Protocol),
 		WithAddress(rc.Address),
 		WithUsername(rc.Username),
@@ -269,5 +271,11 @@ func WithParams(params map[string]string) ReportOption {
 func WithRegistryId(id string) ReportOption {
 	return func(opts *ReportOptions) {
 		opts.registryId = id
+	}
+}
+
+func WithRegistryType(t string) ReportOption {
+	return func(opts *ReportOptions) {
+		opts.registryType = t
 	}
 }

--- a/registry/options.go
+++ b/registry/options.go
@@ -189,6 +189,12 @@ func WithRegisterInterface() Option {
 	}
 }
 
+func WithRegisterService() Option {
+	return func(opts *Options) {
+		opts.Registry.RegistryType = constant.RegistryTypeService
+	}
+}
+
 func WithoutUseAsMetaReport() Option {
 	return func(opts *Options) {
 		opts.Registry.UseAsMetaReport = "false"

--- a/server/action.go
+++ b/server/action.go
@@ -285,6 +285,7 @@ func (svcOpts *ServiceOptions) generatorInvoker(url *common.URL, info *common.Se
 // setRegistrySubURL set registry sub url is ivkURl
 func setRegistrySubURL(ivkURL *common.URL, regUrl *common.URL) {
 	ivkURL.AddParam(constant.RegistryKey, regUrl.GetParam(constant.RegistryKey, ""))
+	ivkURL.AddParam(constant.RegistryTypeKey, regUrl.GetParam(constant.RegistryTypeKey, ""))
 	regUrl.SubURL = ivkURL
 }
 


### PR DESCRIPTION
#2741 

- `filter/polaris/limit`  previous depends on config package, this pr replace it with `url.GetParam`.
- minor improvements to comments and code clarity are included.