### PR TITLE
fix: dubbo.metadata.storage-type ==remote, metadata param is empty

### DIFF
--- a/registry/servicediscovery/customizer/metadata_service_version_customizer.go
+++ b/registry/servicediscovery/customizer/metadata_service_version_customizer.go
@@ -46,6 +46,10 @@ func (p *MetadtaServiceVersionCustomizer) GetPriority() int {
 
 // Customize put the the string like [{"protocol": "dubbo", "port": 123}] into instance's metadata
 func (p *MetadtaServiceVersionCustomizer) Customize(instance registry.ServiceInstance) {
+	if instance.GetMetadata()[constant.MetadataStorageTypePropertyName] != constant.DefaultMetadataStorageType {
+		return
+	}
+	// only run when storage-type == local
 	metadata := instance.GetMetadata()[constant.MetadataServiceURLParamsPropertyName]
 	params := make(map[string]string)
 	err := json.Unmarshal([]byte(metadata), &params)


### PR DESCRIPTION
ref #2950 