### PR TITLE
refactor: replace deprecated CAS with CompareAndSwap

### DIFF
--- a/cluster/cluster/base/cluster_invoker.go
+++ b/cluster/cluster/base/cluster_invoker.go
@@ -56,7 +56,7 @@ func (invoker *BaseClusterInvoker) GetURL() *common.URL {
 
 func (invoker *BaseClusterInvoker) Destroy() {
 	// this is must atom operation
-	if invoker.Destroyed.CAS(false, true) {
+	if invoker.Destroyed.CompareAndSwap(false, true) {
 		invoker.Directory.Destroy()
 	}
 }

--- a/cluster/directory/base/directory.go
+++ b/cluster/directory/base/directory.go
@@ -93,7 +93,7 @@ func (dir *Directory) isProperRouter(url *common.URL) bool {
 
 // DoDestroy stop directory
 func (dir *Directory) DoDestroy(doDestroy func()) {
-	if dir.destroyed.CAS(false, true) {
+	if dir.destroyed.CompareAndSwap(false, true) {
 		dir.mutex.Lock()
 		doDestroy()
 		dir.mutex.Unlock()

--- a/registry/mock_registry.go
+++ b/registry/mock_registry.go
@@ -62,7 +62,7 @@ func (r *MockRegistry) UnRegister(conf *common.URL) error {
 
 // nolint
 func (r *MockRegistry) Destroy() {
-	if r.destroyed.CAS(false, true) {
+	if r.destroyed.CompareAndSwap(false, true) {
 	}
 }
 


### PR DESCRIPTION
refactor: replace deprecated CAS with CompareAndSwap

The referenced atomic package is marked：
```
// CAS is an atomic compare-and-swap for bool values.
//
// Deprecated: Use CompareAndSwap.
func (x *Bool) CAS(old, new bool) (swapped bool) {
	return x.CompareAndSwap(old, new)
}

// CompareAndSwap is an atomic compare-and-swap for bool values.
func (x *Bool) CompareAndSwap(old, new bool) (swapped bool) {
	return x.v.CompareAndSwap(boolToInt(old), boolToInt(new))
}
```

Make a safe substitution