### PR TITLE
refactor: replace hardcoded 'etcdv3' with constant.EtcdV3Key

### DIFF
--- a/registry/options.go
+++ b/registry/options.go
@@ -59,8 +59,7 @@ type Option func(*Options)
 
 func WithEtcdV3() Option {
 	return func(opts *Options) {
-		// todo(DMwangnima): move etcdv3 to constant
-		opts.Registry.Protocol = "etcdv3"
+		opts.Registry.Protocol = constant.EtcdV3Key
 	}
 }
 


### PR DESCRIPTION
 Maintain consistency with other registry options and resolve TODO comment.