### PR TITLE
fix(apollo): delete the generation of configuration files

### DIFF
--- a/config_center/apollo/impl_test.go
+++ b/config_center/apollo/impl_test.go
@@ -24,16 +24,22 @@ import (
 	"strings"
 	"sync"
 	"testing"
+)
 
-	"dubbo.apache.org/dubbo-go/v3/common"
-	"dubbo.apache.org/dubbo-go/v3/config"
-	"dubbo.apache.org/dubbo-go/v3/config_center"
-	"dubbo.apache.org/dubbo-go/v3/remoting"
+import (
 	"github.com/knadh/koanf"
 	"github.com/knadh/koanf/parsers/json"
 	"github.com/knadh/koanf/parsers/yaml"
 	"github.com/knadh/koanf/providers/rawbytes"
+
 	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/config"
+	"dubbo.apache.org/dubbo-go/v3/config_center"
+	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
 
 const (


### PR DESCRIPTION
fix the generation of configuration files when running unit tests in Apollo.