### PR TITLE
fix(test): refactor variable names for clarity and consistency in tests

### DIFF
--- a/filter/README.md
+++ b/filter/README.md
@@ -29,7 +29,7 @@ import _ "dubbo.apache.org/dubbo-go/v3/filter/filter_impl"
 - execlmt: Execute Limit Filter(https://github.com/apache/dubbo-go/pull/246)
 - generic: Generic Filter(https://github.com/apache/dubbo-go/pull/291)
 - gshutdown: Graceful Shutdown Filter
-- hystrix: Hystric Filter(https://github.com/apache/dubbo-go/pull/133)
+- hystrix: Hystrix Filter(https://github.com/apache/dubbo-go/pull/133)
 - metrics: Metrics Filter(https://github.com/apache/dubbo-go/pull/342)
 - seata: Seata Filter
 - sentinel: Sentinel Filter

--- a/filter/accesslog/filter_test.go
+++ b/filter/accesslog/filter_test.go
@@ -51,8 +51,8 @@ func TestFilter_Invoke_Not_Config(t *testing.T) {
 	inv := invocation.NewRPCInvocation("MethodName", []any{"OK", "Hello"}, attach)
 
 	accessLogFilter := &Filter{}
-	result := accessLogFilter.Invoke(context.Background(), invoker, inv)
-	assert.Nil(t, result.Error())
+	invokeResult := accessLogFilter.Invoke(context.Background(), invoker, inv)
+	assert.Nil(t, invokeResult.Error())
 }
 
 func TestFilterInvokeDefaultConfig(t *testing.T) {
@@ -72,13 +72,13 @@ func TestFilterInvokeDefaultConfig(t *testing.T) {
 	inv := invocation.NewRPCInvocation("MethodName", []any{"OK", "Hello"}, attach)
 
 	accessLogFilter := &Filter{}
-	result := accessLogFilter.Invoke(context.Background(), invoker, inv)
-	assert.Nil(t, result.Error())
+	invokeResult := accessLogFilter.Invoke(context.Background(), invoker, inv)
+	assert.Nil(t, invokeResult.Error())
 }
 
 func TestFilterOnResponse(t *testing.T) {
-	result := &result.RPCResult{}
+	rpcResult := &result.RPCResult{}
 	accessLogFilter := &Filter{}
-	response := accessLogFilter.OnResponse(context.TODO(), result, nil, nil)
-	assert.Equal(t, result, response)
+	response := accessLogFilter.OnResponse(context.TODO(), rpcResult, nil, nil)
+	assert.Equal(t, rpcResult, response)
 }

--- a/filter/active/filter_test.go
+++ b/filter/active/filter_test.go
@@ -63,10 +63,10 @@ func TestFilterOnResponse(t *testing.T) {
 	defer ctrl.Finish()
 	invoker := mock.NewMockInvoker(ctrl)
 	invoker.EXPECT().GetURL().Return(url).Times(1)
-	result := &result.RPCResult{
+	rpcResult := &result.RPCResult{
 		Err: errors.New("test"),
 	}
-	filter.OnResponse(context.TODO(), result, invoker, invoc)
+	filter.OnResponse(context.TODO(), rpcResult, invoker, invoc)
 	methodStatus := base.GetMethodStatus(url, "test")
 	urlStatus := base.GetURLStatus(url)
 

--- a/filter/auth/accesskey_storage.go
+++ b/filter/auth/accesskey_storage.go
@@ -35,13 +35,13 @@ var (
 )
 
 func init() {
-	extension.SetAccessKeyStorages(constant.DefaultAccessKeyStorage, newDefaultAccesskeyStorage)
+	extension.SetAccessKeyStorages(constant.DefaultAccessKeyStorage, newDefaultAccessKeyStorage)
 }
 
 // defaultAccesskeyStorage is the default implementation of AccesskeyStorage
 type defaultAccesskeyStorage struct{}
 
-func newDefaultAccesskeyStorage() filter.AccessKeyStorage {
+func newDefaultAccessKeyStorage() filter.AccessKeyStorage {
 	if storage == nil {
 		storageOnce.Do(func() {
 			storage = &defaultAccesskeyStorage{}

--- a/filter/auth/accesskey_storage_test.go
+++ b/filter/auth/accesskey_storage_test.go
@@ -32,14 +32,14 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
 )
 
-func TestDefaultAccesskeyStorage_GetAccesskeyPair(t *testing.T) {
-	url := common.NewURLWithOptions(
+func TestDefaultAccessKeyStorage_GetAccessKeyPair(t *testing.T) {
+	baseUrl := common.NewURLWithOptions(
 		common.WithParams(url.Values{}),
 		common.WithParamsValue(constant.SecretAccessKeyKey, "skey"),
 		common.WithParamsValue(constant.AccessKeyIDKey, "akey"))
 	inv := &invocation.RPCInvocation{}
 	storage = &defaultAccesskeyStorage{}
-	accesskeyPair := storage.GetAccessKeyPair(inv, url)
-	assert.Equal(t, "skey", accesskeyPair.SecretKey)
-	assert.Equal(t, "akey", accesskeyPair.AccessKey)
+	accessKeyPair := storage.GetAccessKeyPair(inv, baseUrl)
+	assert.Equal(t, "skey", accessKeyPair.SecretKey)
+	assert.Equal(t, "akey", accessKeyPair.AccessKey)
 }

--- a/filter/auth/default_authenticator.go
+++ b/filter/auth/default_authenticator.go
@@ -62,7 +62,7 @@ func (authenticator *defaultAuthenticator) Sign(inv base.Invocation, url *common
 	consumer := url.GetParam(constant.ApplicationKey, "")
 	accessKeyPair, err := getAccessKeyPair(inv, url)
 	if err != nil {
-		return errors.New("get accesskey pair failed, cause: " + err.Error())
+		return errors.New("get accessKey pair failed, cause: " + err.Error())
 	}
 	rpcInv := inv.(*invocation.RPCInvocation)
 	signature, err := getSignature(url, inv, accessKeyPair.SecretKey, currentTimeMillis)
@@ -123,8 +123,8 @@ func (authenticator *defaultAuthenticator) Authenticate(inv base.Invocation, url
 }
 
 func getAccessKeyPair(inv base.Invocation, url *common.URL) (*filter.AccessKeyPair, error) {
-	accesskeyStorage := extension.GetAccessKeyStorages(url.GetParam(constant.AccessKeyStorageKey, constant.DefaultAccessKeyStorage))
-	accessKeyPair := accesskeyStorage.GetAccessKeyPair(inv, url)
+	accessKeyStorage := extension.GetAccessKeyStorages(url.GetParam(constant.AccessKeyStorageKey, constant.DefaultAccessKeyStorage))
+	accessKeyPair := accessKeyStorage.GetAccessKeyPair(inv, url)
 	if accessKeyPair == nil || IsEmpty(accessKeyPair.AccessKey, false) || IsEmpty(accessKeyPair.SecretKey, true) {
 		return nil, errors.New("accessKeyId or secretAccessKey not found")
 	} else {

--- a/filter/auth/default_authenticator_test.go
+++ b/filter/auth/default_authenticator_test.go
@@ -38,47 +38,47 @@ import (
 func TestDefaultAuthenticator_Authenticate(t *testing.T) {
 	secret := "dubbo-sk"
 	access := "dubbo-ak"
-	testurl, _ := common.NewURL("dubbo://127.0.0.1:20000/com.ikurento.user.UserProvider?interface=com.ikurento.user.UserProvider&group=gg&version=2.6.0")
-	testurl.SetParam(constant.ParameterSignatureEnableKey, "true")
-	testurl.SetParam(constant.AccessKeyIDKey, access)
-	testurl.SetParam(constant.SecretAccessKeyKey, secret)
-	parmas := []any{"OK", struct {
+	testUrl, _ := common.NewURL("dubbo://127.0.0.1:20000/com.ikurento.user.UserProvider?interface=com.ikurento.user.UserProvider&group=gg&version=2.6.0")
+	testUrl.SetParam(constant.ParameterSignatureEnableKey, "true")
+	testUrl.SetParam(constant.AccessKeyIDKey, access)
+	testUrl.SetParam(constant.SecretAccessKeyKey, secret)
+	params := []any{"OK", struct {
 		Name string
 		ID   int64
 	}{"YUYU", 1}}
-	inv := invocation.NewRPCInvocation("test", parmas, nil)
+	inv := invocation.NewRPCInvocation("test", params, nil)
 	requestTime := strconv.Itoa(int(time.Now().Unix() * 1000))
-	signature, _ := getSignature(testurl, inv, secret, requestTime)
+	signature, _ := getSignature(testUrl, inv, secret, requestTime)
 
 	authenticator = &defaultAuthenticator{}
 
-	invcation := invocation.NewRPCInvocation("test", parmas, map[string]any{
+	rpcInvocation := invocation.NewRPCInvocation("test", params, map[string]any{
 		constant.RequestSignatureKey: signature,
 		constant.Consumer:            "test",
 		constant.RequestTimestampKey: requestTime,
 		constant.AKKey:               access,
 	})
-	err := authenticator.Authenticate(invcation, testurl)
+	err := authenticator.Authenticate(rpcInvocation, testUrl)
 	assert.Nil(t, err)
 	// modify the params
-	invcation = invocation.NewRPCInvocation("test", parmas[:1], map[string]any{
+	rpcInvocation = invocation.NewRPCInvocation("test", params[:1], map[string]any{
 		constant.RequestSignatureKey: signature,
 		constant.Consumer:            "test",
 		constant.RequestTimestampKey: requestTime,
 		constant.AKKey:               access,
 	})
-	err = authenticator.Authenticate(invcation, testurl)
+	err = authenticator.Authenticate(rpcInvocation, testUrl)
 	assert.NotNil(t, err)
 }
 
 func TestDefaultAuthenticator_Sign(t *testing.T) {
 	authenticator = &defaultAuthenticator{}
-	testurl, _ := common.NewURL("dubbo://127.0.0.1:20000/com.ikurento.user.UserProvider?application=test&interface=com.ikurento.user.UserProvider&group=gg&version=2.6.0")
-	testurl.SetParam(constant.AccessKeyIDKey, "akey")
-	testurl.SetParam(constant.SecretAccessKeyKey, "skey")
-	testurl.SetParam(constant.ParameterSignatureEnableKey, "false")
+	testUrl, _ := common.NewURL("dubbo://127.0.0.1:20000/com.ikurento.user.UserProvider?application=test&interface=com.ikurento.user.UserProvider&group=gg&version=2.6.0")
+	testUrl.SetParam(constant.AccessKeyIDKey, "akey")
+	testUrl.SetParam(constant.SecretAccessKeyKey, "skey")
+	testUrl.SetParam(constant.ParameterSignatureEnableKey, "false")
 	inv := invocation.NewRPCInvocation("test", []any{"OK"}, nil)
-	_ = authenticator.Sign(inv, testurl)
+	_ = authenticator.Sign(inv, testUrl)
 	assert.NotEqual(t, inv.GetAttachmentWithDefaultValue(constant.RequestSignatureKey, ""), "")
 	assert.NotEqual(t, inv.GetAttachmentWithDefaultValue(constant.Consumer, ""), "")
 	assert.NotEqual(t, inv.GetAttachmentWithDefaultValue(constant.RequestTimestampKey, ""), "")
@@ -86,12 +86,12 @@ func TestDefaultAuthenticator_Sign(t *testing.T) {
 }
 
 func Test_getAccessKeyPairSuccess(t *testing.T) {
-	testurl := common.NewURLWithOptions(
+	testUrl := common.NewURLWithOptions(
 		common.WithParams(url.Values{}),
 		common.WithParamsValue(constant.SecretAccessKeyKey, "skey"),
 		common.WithParamsValue(constant.AccessKeyIDKey, "akey"))
-	invcation := invocation.NewRPCInvocation("MethodName", []any{"OK"}, nil)
-	_, e := getAccessKeyPair(invcation, testurl)
+	rpcInvocation := invocation.NewRPCInvocation("MethodName", []any{"OK"}, nil)
+	_, e := getAccessKeyPair(rpcInvocation, testUrl)
 	assert.Nil(t, e)
 }
 
@@ -100,45 +100,45 @@ func Test_getAccessKeyPairFailed(t *testing.T) {
 		e := recover()
 		assert.NotNil(t, e)
 	}()
-	testurl := common.NewURLWithOptions(
+	testUrl := common.NewURLWithOptions(
 		common.WithParams(url.Values{}),
 		common.WithParamsValue(constant.AccessKeyIDKey, "akey"))
-	invcation := invocation.NewRPCInvocation("MethodName", []any{"OK"}, nil)
-	_, e := getAccessKeyPair(invcation, testurl)
+	rpcInvocation := invocation.NewRPCInvocation("MethodName", []any{"OK"}, nil)
+	_, e := getAccessKeyPair(rpcInvocation, testUrl)
 	assert.NotNil(t, e)
-	testurl = common.NewURLWithOptions(
+	testUrl = common.NewURLWithOptions(
 		common.WithParams(url.Values{}),
 		common.WithParamsValue(constant.SecretAccessKeyKey, "skey"),
 		common.WithParamsValue(constant.AccessKeyIDKey, "akey"), common.WithParamsValue(constant.AccessKeyStorageKey, "dubbo"))
-	_, e = getAccessKeyPair(invcation, testurl)
+	_, e = getAccessKeyPair(rpcInvocation, testUrl)
 	assert.NoError(t, e)
 }
 
 func Test_getSignatureWithinParams(t *testing.T) {
-	testurl, _ := common.NewURL("dubbo://127.0.0.1:20000/com.ikurento.user.UserProvider?interface=com.ikurento.user.UserProvider&group=gg&version=2.6.0")
-	testurl.SetParam(constant.ParameterSignatureEnableKey, "true")
+	testUrl, _ := common.NewURL("dubbo://127.0.0.1:20000/com.ikurento.user.UserProvider?interface=com.ikurento.user.UserProvider&group=gg&version=2.6.0")
+	testUrl.SetParam(constant.ParameterSignatureEnableKey, "true")
 	inv := invocation.NewRPCInvocation("test", []any{"OK"}, map[string]any{
 		"": "",
 	})
 	secret := "dubbo"
 	current := strconv.Itoa(int(time.Now().Unix() * 1000))
-	signature, _ := getSignature(testurl, inv, secret, current)
+	signature, _ := getSignature(testUrl, inv, secret, current)
 	requestString := fmt.Sprintf(constant.SignatureStringFormat,
-		testurl.ColonSeparatedKey(), inv.MethodName(), secret, current)
+		testUrl.ColonSeparatedKey(), inv.MethodName(), secret, current)
 	s, _ := SignWithParams(inv.Arguments(), requestString, secret)
 	assert.False(t, IsEmpty(signature, false))
 	assert.Equal(t, s, signature)
 }
 
 func Test_getSignature(t *testing.T) {
-	testurl, _ := common.NewURL("dubbo://127.0.0.1:20000/com.ikurento.user.UserProvider?interface=com.ikurento.user.UserProvider&group=gg&version=2.6.0")
-	testurl.SetParam(constant.ParameterSignatureEnableKey, "false")
+	testUrl, _ := common.NewURL("dubbo://127.0.0.1:20000/com.ikurento.user.UserProvider?interface=com.ikurento.user.UserProvider&group=gg&version=2.6.0")
+	testUrl.SetParam(constant.ParameterSignatureEnableKey, "false")
 	inv := invocation.NewRPCInvocation("test", []any{"OK"}, nil)
 	secret := "dubbo"
 	current := strconv.Itoa(int(time.Now().Unix() * 1000))
-	signature, _ := getSignature(testurl, inv, secret, current)
+	signature, _ := getSignature(testUrl, inv, secret, current)
 	requestString := fmt.Sprintf(constant.SignatureStringFormat,
-		testurl.ColonSeparatedKey(), inv.MethodName(), secret, current)
+		testUrl.ColonSeparatedKey(), inv.MethodName(), secret, current)
 	s := Sign(requestString, secret)
 	assert.False(t, IsEmpty(signature, false))
 	assert.Equal(t, s, signature)

--- a/filter/auth/provider_auth_filter_test.go
+++ b/filter/auth/provider_auth_filter_test.go
@@ -65,10 +65,10 @@ func TestProviderAuthFilter_Invoke(t *testing.T) {
 	filter := &authFilter{}
 	defer ctrl.Finish()
 	invoker := mock.NewMockInvoker(ctrl)
-	result := &result.RPCResult{}
-	invoker.EXPECT().Invoke(context.Background(), inv).Return(result).Times(2)
+	rpcResult := &result.RPCResult{}
+	invoker.EXPECT().Invoke(context.Background(), inv).Return(rpcResult).Times(2)
 	invoker.EXPECT().GetURL().Return(url).Times(2)
-	assert.Equal(t, result, filter.Invoke(context.Background(), invoker, inv))
+	assert.Equal(t, rpcResult, filter.Invoke(context.Background(), invoker, inv))
 	url.SetParam(constant.ServiceAuthKey, "true")
-	assert.Equal(t, result, filter.Invoke(context.Background(), invoker, inv))
+	assert.Equal(t, rpcResult, filter.Invoke(context.Background(), invoker, inv))
 }

--- a/filter/auth/sign_util_test.go
+++ b/filter/auth/sign_util_test.go
@@ -35,7 +35,6 @@ func TestIsEmpty(t *testing.T) {
 		args args
 		want bool
 	}{
-		// TODO: Add test cases.
 		{"whitespace_false", args{s: "   ", allowSpace: false}, true},
 		{"whitespace_true", args{s: "   ", allowSpace: true}, false},
 		{"normal_false", args{s: "hello,dubbo", allowSpace: false}, false},
@@ -80,7 +79,8 @@ func TestSignWithParams(t *testing.T) {
 			ID   int64
 		}{"YuYu", 1},
 	}
-	signature, _ := SignWithParams(params, metadata, key)
+	signature, err := SignWithParams(params, metadata, key)
+	assert.NoError(t, err)
 	assert.False(t, IsEmpty(signature, false))
 }
 
@@ -106,8 +106,11 @@ func Test_toBytes(t *testing.T) {
 			ID   int64
 		}{"YuYu", 1},
 	}
-	jsonBytes, _ := toBytes(params)
-	jsonBytes2, _ := toBytes(params2)
+	jsonBytes, err := toBytes(params)
+	assert.NoError(t, err)
 	assert.NotNil(t, jsonBytes)
+	jsonBytes2, err2 := toBytes(params2)
+	assert.NoError(t, err2)
+	assert.NotNil(t, jsonBytes2)
 	assert.Equal(t, jsonBytes, jsonBytes2)
 }

--- a/filter/generic/filter_test.go
+++ b/filter/generic/filter_test.go
@@ -65,8 +65,8 @@ func TestFilter_Invoke(t *testing.T) {
 			return &result.RPCResult{}
 		})
 
-	result := filter.Invoke(context.Background(), mockInvoker, normalInvocation)
-	assert.NotNil(t, result)
+	r := filter.Invoke(context.Background(), mockInvoker, normalInvocation)
+	assert.NotNil(t, r)
 }
 
 // test isMakingAGenericCall branch
@@ -98,6 +98,6 @@ func TestFilter_InvokeWithGenericCall(t *testing.T) {
 			return &result.RPCResult{}
 		})
 
-	result := filter.Invoke(context.Background(), mockInvoker, genericInvocation)
-	assert.NotNil(t, result)
+	r := filter.Invoke(context.Background(), mockInvoker, genericInvocation)
+	assert.NotNil(t, r)
 }

--- a/filter/generic/generalizer/protobuf_json_test.go
+++ b/filter/generic/generalizer/protobuf_json_test.go
@@ -32,13 +32,13 @@ func TestProtobufJsonGeneralizer(t *testing.T) {
 	req := &RequestType{
 		Id: 1,
 	}
-	reqjson, err := g.Generalize(req)
+	reqJson, err := g.Generalize(req)
 	assert.Nil(t, err)
-	rreq, err := g.Realize(reqjson, reflect.TypeOf(req))
+	rReq, err := g.Realize(reqJson, reflect.TypeOf(req))
 	assert.Nil(t, err)
-	reqobj, ok := rreq.(*RequestType)
+	reqObj, ok := rReq.(*RequestType)
 	assert.True(t, ok)
-	assert.Equal(t, req.Id, reqobj.GetId())
+	assert.Equal(t, req.Id, reqObj.GetId())
 
 	resp := &ResponseType{
 		Code:    200,
@@ -46,14 +46,14 @@ func TestProtobufJsonGeneralizer(t *testing.T) {
 		Name:    "xavierniu",
 		Message: "Nice to meet you",
 	}
-	respjson, err := g.Generalize(resp)
+	respJson, err := g.Generalize(resp)
 	assert.Nil(t, err)
-	rresp, err := g.Realize(respjson, reflect.TypeOf(resp))
+	rResp, err := g.Realize(respJson, reflect.TypeOf(resp))
 	assert.Nil(t, err)
-	respobj, ok := rresp.(*ResponseType)
+	respObj, ok := rResp.(*ResponseType)
 	assert.True(t, ok)
-	assert.Equal(t, resp.Code, respobj.GetCode())
-	assert.Equal(t, resp.Id, respobj.GetId())
-	assert.Equal(t, resp.Name, respobj.GetName())
-	assert.Equal(t, resp.Message, respobj.GetMessage())
+	assert.Equal(t, resp.Code, respObj.GetCode())
+	assert.Equal(t, resp.Id, respObj.GetId())
+	assert.Equal(t, resp.Name, respObj.GetName())
+	assert.Equal(t, resp.Message, respObj.GetMessage())
 }

--- a/filter/generic/service_filter_test.go
+++ b/filter/generic/service_filter_test.go
@@ -171,19 +171,19 @@ func TestServiceFilter_Invoke(t *testing.T) {
 			}
 		}).AnyTimes()
 
-	result := filter.Invoke(context.Background(), mockInvoker, invocation4)
-	assert.Nil(t, result.Error())
-	assert.Equal(t, "hello, world", result.Result())
+	invokeResult := filter.Invoke(context.Background(), mockInvoker, invocation4)
+	assert.Nil(t, invokeResult.Error())
+	assert.Equal(t, "hello, world", invokeResult.Result())
 
-	result = filter.Invoke(context.Background(), mockInvoker, invocation5)
+	invokeResult = filter.Invoke(context.Background(), mockInvoker, invocation5)
 	assert.Equal(t,
 		fmt.Sprintf("\"hello11\" method is not found, service key: %s", ivkUrl.ServiceKey()),
-		fmt.Sprintf("%v", result.Error()))
+		fmt.Sprintf("%v", invokeResult.Error()))
 
-	result = filter.Invoke(context.Background(), mockInvoker, invocation6)
+	invokeResult = filter.Invoke(context.Background(), mockInvoker, invocation6)
 	assert.Equal(t,
 		"the number of args(=2) is not matched with \"Hello\" method",
-		fmt.Sprintf("%v", result.Error()))
+		fmt.Sprintf("%v", invokeResult.Error()))
 
 	//result = filter.Invoke(context.Background(), mockInvoker, invocation7)
 	//assert.Equal(t, int64(200), result.Result().(*generalizer.ResponseType).GetCode())
@@ -210,6 +210,6 @@ func TestServiceFilter_OnResponse(t *testing.T) {
 		Rest: "result",
 	}
 
-	result := filter.OnResponse(context.Background(), rpcResult, nil, invocation1)
-	assert.Equal(t, "result", result.Result())
+	response := filter.OnResponse(context.Background(), rpcResult, nil, invocation1)
+	assert.Equal(t, "result", response.Result())
 }

--- a/filter/graceful_shutdown/consumer_filter_test.go
+++ b/filter/graceful_shutdown/consumer_filter_test.go
@@ -39,8 +39,8 @@ import (
 
 func TestConsumerFilterInvokeWithGlobalPackage(t *testing.T) {
 	var (
-		url            = common.NewURLWithOptions(common.WithParams(url.Values{}))
-		invocation     = invocation.NewRPCInvocation("GetUser", []any{"OK"}, make(map[string]any))
+		baseUrl        = common.NewURLWithOptions(common.WithParams(url.Values{}))
+		rpcInvocation  = invocation.NewRPCInvocation("GetUser", []any{"OK"}, make(map[string]any))
 		opt            = graceful_shutdown.NewOptions()
 		filterValue, _ = extension.GetFilter(constant.GracefulShutdownConsumerFilterKey)
 	)
@@ -51,7 +51,7 @@ func TestConsumerFilterInvokeWithGlobalPackage(t *testing.T) {
 	filter.Set(constant.GracefulShutdownFilterShutdownConfig, opt.Shutdown)
 	assert.Equal(t, filter.shutdownConfig, opt.Shutdown)
 
-	result := filter.Invoke(context.Background(), base.NewBaseInvoker(url), invocation)
+	result := filter.Invoke(context.Background(), base.NewBaseInvoker(baseUrl), rpcInvocation)
 	assert.NotNil(t, result)
 	assert.Nil(t, result.Error())
 }
@@ -59,9 +59,9 @@ func TestConsumerFilterInvokeWithGlobalPackage(t *testing.T) {
 // only for compatibility with old config, able to directly remove after config is deleted
 func TestConsumerFilterInvokeWithConfigPackage(t *testing.T) {
 	var (
-		url        = common.NewURLWithOptions(common.WithParams(url.Values{}))
-		invocation = invocation.NewRPCInvocation("GetUser", []any{"OK"}, make(map[string]any))
-		rootConfig = config.NewRootConfigBuilder().
+		baseUrl       = common.NewURLWithOptions(common.WithParams(url.Values{}))
+		rpcInvocation = invocation.NewRPCInvocation("GetUser", []any{"OK"}, make(map[string]any))
+		rootConfig    = config.NewRootConfigBuilder().
 				SetShutDown(config.NewShutDownConfigBuilder().
 					SetTimeout("60s").
 					SetStepTimeout("3s").
@@ -75,7 +75,7 @@ func TestConsumerFilterInvokeWithConfigPackage(t *testing.T) {
 	filter.Set(constant.GracefulShutdownFilterShutdownConfig, config.GetShutDown())
 	assert.Equal(t, filter.shutdownConfig, compatGlobalShutdownConfig(config.GetShutDown()))
 
-	result := filter.Invoke(context.Background(), base.NewBaseInvoker(url), invocation)
+	result := filter.Invoke(context.Background(), base.NewBaseInvoker(baseUrl), rpcInvocation)
 	assert.NotNil(t, result)
 	assert.Nil(t, result.Error())
 }

--- a/filter/hystrix/filter_test.go
+++ b/filter/hystrix/filter_test.go
@@ -157,10 +157,10 @@ func TestHystrixFilterInvokeSuccess(t *testing.T) {
 		fmt.Sprintf("dubbo://%s:%d/com.ikurento.user.UserProvider", constant.LocalHostValue, constant.DefaultPort))
 	assert.NoError(t, err)
 	testInvoker := testMockSuccessInvoker{*base.NewBaseInvoker(testUrl)}
-	result := hf.Invoke(context.Background(), &testInvoker, &invocation.RPCInvocation{})
-	assert.NotNil(t, result)
-	assert.NoError(t, result.Error())
-	assert.NotNil(t, result.Result())
+	invokeResult := hf.Invoke(context.Background(), &testInvoker, &invocation.RPCInvocation{})
+	assert.NotNil(t, invokeResult)
+	assert.NoError(t, invokeResult.Error())
+	assert.NotNil(t, invokeResult.Result())
 }
 
 func TestHystrixFilterInvokeFail(t *testing.T) {
@@ -169,12 +169,12 @@ func TestHystrixFilterInvokeFail(t *testing.T) {
 		fmt.Sprintf("dubbo://%s:%d/com.ikurento.user.UserProvider", constant.LocalHostValue, constant.DefaultPort))
 	assert.NoError(t, err)
 	testInvoker := testMockFailInvoker{*base.NewBaseInvoker(testUrl)}
-	result := hf.Invoke(context.Background(), &testInvoker, &invocation.RPCInvocation{})
-	assert.NotNil(t, result)
-	assert.Error(t, result.Error())
+	invokeResult := hf.Invoke(context.Background(), &testInvoker, &invocation.RPCInvocation{})
+	assert.NotNil(t, invokeResult)
+	assert.Error(t, invokeResult.Error())
 }
 
-func TestHystricFilterInvokeCircuitBreak(t *testing.T) {
+func TestHystrixFilterInvokeCircuitBreak(t *testing.T) {
 	mockInitHystrixConfig()
 	hystrix.Flush()
 	hf := &Filter{COrP: true}
@@ -185,8 +185,8 @@ func TestHystricFilterInvokeCircuitBreak(t *testing.T) {
 				fmt.Sprintf("dubbo://%s:%d/com.ikurento.user.UserProvider", constant.LocalHostValue, constant.DefaultPort))
 			assert.NoError(t, err)
 			testInvoker := testMockSuccessInvoker{*base.NewBaseInvoker(testUrl)}
-			result := hf.Invoke(context.Background(), &testInvoker, &invocation.RPCInvocation{})
-			resChan <- result
+			invokeResult := hf.Invoke(context.Background(), &testInvoker, &invocation.RPCInvocation{})
+			resChan <- invokeResult
 		}()
 	}
 	// This can not always pass the test when on travis due to concurrency, you can uncomment the code below and test it locally
@@ -200,7 +200,7 @@ func TestHystricFilterInvokeCircuitBreak(t *testing.T) {
 	//assert.True(t, lastRest)
 }
 
-func TestHystricFilterInvokeCircuitBreakOmitException(t *testing.T) {
+func TestHystrixFilterInvokeCircuitBreakOmitException(t *testing.T) {
 	mockInitHystrixConfig()
 	hystrix.Flush()
 	reg, _ := regexp.Compile(".*exception.*")
@@ -213,8 +213,8 @@ func TestHystricFilterInvokeCircuitBreakOmitException(t *testing.T) {
 				fmt.Sprintf("dubbo://%s:%d/com.ikurento.user.UserProvider", constant.LocalHostValue, constant.DefaultPort))
 			assert.NoError(t, err)
 			testInvoker := testMockSuccessInvoker{*base.NewBaseInvoker(testUrl)}
-			result := hf.Invoke(context.Background(), &testInvoker, &invocation.RPCInvocation{})
-			resChan <- result
+			invokeResult := hf.Invoke(context.Background(), &testInvoker, &invocation.RPCInvocation{})
+			resChan <- invokeResult
 		}()
 	}
 	// This can not always pass the test when on travis due to concurrency, you can uncomment the code below and test it locally

--- a/filter/seata/filter_test.go
+++ b/filter/seata/filter_test.go
@@ -49,9 +49,9 @@ func (iv *testMockSeataInvoker) Invoke(ctx context.Context, _ base.Invocation) r
 
 func TestSeataFilter_Invoke(t *testing.T) {
 	filter := &seataFilter{}
-	result := filter.Invoke(context.Background(), &testMockSeataInvoker{}, invocation.NewRPCInvocation("$echo",
+	invokeResult := filter.Invoke(context.Background(), &testMockSeataInvoker{}, invocation.NewRPCInvocation("$echo",
 		[]any{"OK"}, map[string]any{
 			string(SEATA_XID): "10.30.21.227:8091:2000047792",
 		}))
-	assert.Equal(t, "10.30.21.227:8091:2000047792", result.Result())
+	assert.Equal(t, "10.30.21.227:8091:2000047792", invokeResult.Result())
 }

--- a/filter/sentinel/filter_test.go
+++ b/filter/sentinel/filter_test.go
@@ -147,8 +147,8 @@ func TestSentinelFilter_ErrorCount(t *testing.T) {
 
 	f := &sentinelProviderFilter{}
 	for i := 0; i < 50; i++ {
-		result := f.Invoke(context.TODO(), mockInvoker, mockInvocation)
-		assert.Error(t, result.Error())
+		invokeResult := f.Invoke(context.TODO(), mockInvoker, mockInvocation)
+		assert.Error(t, invokeResult.Error())
 	}
 	select {
 	case <-time.After(time.Second):
@@ -182,8 +182,8 @@ func TestProviderFilter_Invoke(t *testing.T) {
 	assert.NoError(t, err)
 	mockInvoker := base.NewBaseInvoker(url)
 	mockInvocation := invocation.NewRPCInvocation("hello", []any{"OK"}, make(map[string]any))
-	result := f.Invoke(context.TODO(), mockInvoker, mockInvocation)
-	assert.NoError(t, result.Error())
+	invokeResult := f.Invoke(context.TODO(), mockInvoker, mockInvocation)
+	assert.NoError(t, invokeResult.Error())
 }
 
 func TestGetResourceName(t *testing.T) {

--- a/filter/token/filter_test.go
+++ b/filter/token/filter_test.go
@@ -37,13 +37,13 @@ import (
 func TestTokenFilterInvoke(t *testing.T) {
 	filter := &tokenFilter{}
 
-	url := common.NewURLWithOptions(
+	baseUrl := common.NewURLWithOptions(
 		common.WithParams(url.Values{}),
 		common.WithParamsValue(constant.TokenKey, "ori_key"))
 	attch := make(map[string]any)
 	attch[constant.TokenKey] = "ori_key"
 	result := filter.Invoke(context.Background(),
-		base.NewBaseInvoker(url),
+		base.NewBaseInvoker(baseUrl),
 		invocation.NewRPCInvocation("MethodName",
 			[]any{"OK"}, attch))
 	assert.Nil(t, result.Error())

--- a/filter/tps/filter_test.go
+++ b/filter/tps/filter_test.go
@@ -48,12 +48,12 @@ func TestTpsLimitFilterInvokeWithNoTpsLimiter(t *testing.T) {
 		common.WithParamsValue(constant.TPSLimiterKey, ""))
 	attch := make(map[string]any)
 
-	result := tpsFilter.Invoke(context.Background(),
+	invokeResult := tpsFilter.Invoke(context.Background(),
 		base.NewBaseInvoker(invokeUrl),
 		invocation.NewRPCInvocation("MethodName",
 			[]any{"OK"}, attch))
-	assert.Nil(t, result.Error())
-	assert.Nil(t, result.Result())
+	assert.Nil(t, invokeResult.Error())
+	assert.Nil(t, invokeResult.Result())
 }
 
 func TestGenericFilterInvokeWithDefaultTpsLimiter(t *testing.T) {
@@ -71,12 +71,12 @@ func TestGenericFilterInvokeWithDefaultTpsLimiter(t *testing.T) {
 		common.WithParamsValue(constant.TPSLimiterKey, constant.DefaultKey))
 	attch := make(map[string]any)
 
-	result := tpsFilter.Invoke(context.Background(),
+	invokeResult := tpsFilter.Invoke(context.Background(),
 		base.NewBaseInvoker(invokeUrl),
 		invocation.NewRPCInvocation("MethodName",
 			[]any{"OK"}, attch))
-	assert.Nil(t, result.Error())
-	assert.Nil(t, result.Result())
+	assert.Nil(t, invokeResult.Error())
+	assert.Nil(t, invokeResult.Result())
 }
 
 func TestGenericFilterInvokeWithDefaultTpsLimiterNotAllow(t *testing.T) {
@@ -102,9 +102,9 @@ func TestGenericFilterInvokeWithDefaultTpsLimiterNotAllow(t *testing.T) {
 		common.WithParamsValue(constant.TPSLimiterKey, constant.DefaultKey))
 	attch := make(map[string]any)
 
-	result := tpsFilter.Invoke(context.Background(),
+	invokeResult := tpsFilter.Invoke(context.Background(),
 		base.NewBaseInvoker(invokeUrl),
 		invocation.NewRPCInvocation("MethodName", []any{"OK"}, attch))
-	assert.Nil(t, result.Error())
-	assert.Nil(t, result.Result())
+	assert.Nil(t, invokeResult.Error())
+	assert.Nil(t, invokeResult.Result())
 }


### PR DESCRIPTION
1、the variable 'result'/'url' conflicts with the name of the imported software package
2、correct word mistakes
3、optimize filter/auth/sign_util_test.go