### PR TITLE
fix(auth): handle error in GetAccessKeyStorages and return it

### DIFF
--- a/common/extension/auth.go
+++ b/common/extension/auth.go
@@ -18,6 +18,10 @@
 package extension
 
 import (
+	"errors"
+)
+
+import (
 	"dubbo.apache.org/dubbo-go/v3/filter"
 )
 
@@ -47,9 +51,10 @@ func SetAccessKeyStorages(name string, fcn func() filter.AccessKeyStorage) {
 
 // GetAccessKeyStorages finds the storage with the @name.
 // Panic if not found
-func GetAccessKeyStorages(name string) filter.AccessKeyStorage {
-	if accessKeyStorages[name] == nil {
-		panic("accessKeyStorages for " + name + " is not existing, make sure you have import the package.")
+func GetAccessKeyStorages(name string) (filter.AccessKeyStorage, error) {
+	f := accessKeyStorages[name]
+	if f == nil {
+		return nil, errors.New("accessKeyStorages for " + name + " is not existing, make sure you have import the package.")
 	}
-	return accessKeyStorages[name]()
+	return f(), nil
 }

--- a/filter/auth/default_authenticator.go
+++ b/filter/auth/default_authenticator.go
@@ -123,7 +123,10 @@ func (authenticator *defaultAuthenticator) Authenticate(inv base.Invocation, url
 }
 
 func getAccessKeyPair(inv base.Invocation, url *common.URL) (*filter.AccessKeyPair, error) {
-	accessKeyStorage := extension.GetAccessKeyStorages(url.GetParam(constant.AccessKeyStorageKey, constant.DefaultAccessKeyStorage))
+	accessKeyStorage, err := extension.GetAccessKeyStorages(url.GetParam(constant.AccessKeyStorageKey, constant.DefaultAccessKeyStorage))
+	if err != nil {
+		return nil, err
+	}
 	accessKeyPair := accessKeyStorage.GetAccessKeyPair(inv, url)
 	if accessKeyPair == nil || IsEmpty(accessKeyPair.AccessKey, false) || IsEmpty(accessKeyPair.SecretKey, true) {
 		return nil, errors.New("accessKeyId or secretAccessKey not found")


### PR DESCRIPTION
This PR revisits the fix for issue [#3008](https://github.com/apache/dubbo-go/issues/3008) and supersedes the previously closed PR [#3015.](https://github.com/apache/dubbo-go/pull/3015).