### PR TITLE
fix: resolve memory leaks in goroutine management, file handles, and extension caches

### DIFF
--- a/common/extension/filter.go
+++ b/common/extension/filter.go
@@ -58,3 +58,23 @@ func GetRejectedExecutionHandler(name string) (filter.RejectedExecutionHandler, 
 	}
 	return creator(), nil
 }
+
+// UnregisterFilter removes the filter extension with @name
+// This helps prevent memory leaks in dynamic extension scenarios
+func UnregisterFilter(name string) {
+	delete(filters, name)
+}
+
+// UnregisterRejectedExecutionHandler removes the RejectedExecutionHandler with @name
+func UnregisterRejectedExecutionHandler(name string) {
+	delete(rejectedExecutionHandler, name)
+}
+
+// GetAllFilterNames returns all registered filter names
+func GetAllFilterNames() []string {
+	names := make([]string, 0, len(filters))
+	for name := range filters {
+		names = append(names, name)
+	}
+	return names
+}

--- a/common/extension/loadbalance.go
+++ b/common/extension/loadbalance.go
@@ -37,3 +37,17 @@ func GetLoadbalance(name string) loadbalance.LoadBalance {
 
 	return loadbalances[name]()
 }
+
+// UnregisterLoadbalance removes the loadbalance extension with @name
+func UnregisterLoadbalance(name string) {
+	delete(loadbalances, name)
+}
+
+// GetAllLoadbalanceNames returns all registered loadbalance names
+func GetAllLoadbalanceNames() []string {
+	names := make([]string, 0, len(loadbalances))
+	for name := range loadbalances {
+		names = append(names, name)
+	}
+	return names
+}

--- a/common/extension/memory_leak_test.go
+++ b/common/extension/memory_leak_test.go
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package extension
+
+import (
+	"context"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/cluster/loadbalance"
+	"dubbo.apache.org/dubbo-go/v3/filter"
+	"dubbo.apache.org/dubbo-go/v3/protocol/base"
+	"dubbo.apache.org/dubbo-go/v3/protocol/result"
+)
+
+// Mock implementations for testing
+type MockProtocol struct {
+	base.BaseProtocol
+}
+
+type MockFilter struct{}
+
+func (m *MockFilter) Invoke(ctx context.Context, invoker base.Invoker, invocation base.Invocation) result.Result {
+	return &result.RPCResult{}
+}
+
+func (m *MockFilter) OnResponse(ctx context.Context, res result.Result, invoker base.Invoker, invocation base.Invocation) result.Result {
+	return res
+}
+
+type MockLoadBalance struct{}
+
+func (m *MockLoadBalance) Select(invokers []base.Invoker, invocation base.Invocation) base.Invoker {
+	return nil
+}
+
+// TestProtocolMemoryManagement tests protocol registration and unregistration
+func TestProtocolMemoryManagement(t *testing.T) {
+	testName := "test-protocol-memory"
+
+	// Get initial count
+	initialCount := len(GetAllProtocolNames())
+
+	// Register a protocol
+	SetProtocol(testName, func() base.Protocol {
+		return &MockProtocol{}
+	})
+
+	// Verify registration
+	afterRegisterCount := len(GetAllProtocolNames())
+	assert.Equal(t, initialCount+1, afterRegisterCount, "Protocol should be registered")
+
+	// Verify protocol can be retrieved
+	assert.NotPanics(t, func() {
+		GetProtocol(testName)
+	}, "Should be able to get registered protocol")
+
+	// Unregister the protocol
+	UnregisterProtocol(testName)
+
+	// Verify unregistration
+	afterUnregisterCount := len(GetAllProtocolNames())
+	assert.Equal(t, initialCount, afterUnregisterCount, "Protocol should be unregistered")
+
+	// Verify protocol cannot be retrieved
+	assert.Panics(t, func() {
+		GetProtocol(testName)
+	}, "Should panic when trying to get unregistered protocol")
+}
+
+// TestFilterMemoryManagement tests filter registration and unregistration
+func TestFilterMemoryManagement(t *testing.T) {
+	testName := "test-filter-memory"
+
+	// Get initial count
+	initialCount := len(GetAllFilterNames())
+
+	// Register a filter
+	SetFilter(testName, func() filter.Filter {
+		return &MockFilter{}
+	})
+
+	// Verify registration
+	afterRegisterCount := len(GetAllFilterNames())
+	assert.Equal(t, initialCount+1, afterRegisterCount, "Filter should be registered")
+
+	// Verify filter can be retrieved
+	f, exists := GetFilter(testName)
+	assert.True(t, exists, "Should be able to get registered filter")
+	assert.NotNil(t, f, "Retrieved filter should not be nil")
+
+	// Unregister the filter
+	UnregisterFilter(testName)
+
+	// Verify unregistration
+	afterUnregisterCount := len(GetAllFilterNames())
+	assert.Equal(t, initialCount, afterUnregisterCount, "Filter should be unregistered")
+
+	// Verify filter cannot be retrieved
+	f, exists = GetFilter(testName)
+	assert.False(t, exists, "Should not be able to get unregistered filter")
+	assert.Nil(t, f, "Retrieved filter should be nil")
+}
+
+// TestLoadbalanceMemoryManagement tests loadbalance registration and unregistration
+func TestLoadbalanceMemoryManagement(t *testing.T) {
+	testName := "test-loadbalance-memory"
+
+	// Get initial count
+	initialCount := len(GetAllLoadbalanceNames())
+
+	// Register a loadbalance
+	SetLoadbalance(testName, func() loadbalance.LoadBalance {
+		return &MockLoadBalance{}
+	})
+
+	// Verify registration
+	afterRegisterCount := len(GetAllLoadbalanceNames())
+	assert.Equal(t, initialCount+1, afterRegisterCount, "LoadBalance should be registered")
+
+	// Verify loadbalance can be retrieved
+	assert.NotPanics(t, func() {
+		GetLoadbalance(testName)
+	}, "Should be able to get registered loadbalance")
+
+	// Unregister the loadbalance
+	UnregisterLoadbalance(testName)
+
+	// Verify unregistration
+	afterUnregisterCount := len(GetAllLoadbalanceNames())
+	assert.Equal(t, initialCount, afterUnregisterCount, "LoadBalance should be unregistered")
+
+	// Verify loadbalance cannot be retrieved
+	assert.Panics(t, func() {
+		GetLoadbalance(testName)
+	}, "Should panic when trying to get unregistered loadbalance")
+}

--- a/common/extension/protocol.go
+++ b/common/extension/protocol.go
@@ -35,3 +35,18 @@ func GetProtocol(name string) base.Protocol {
 	}
 	return protocols[name]()
 }
+
+// UnregisterProtocol removes the protocol extension with @name
+// This helps prevent memory leaks in dynamic extension scenarios
+func UnregisterProtocol(name string) {
+	delete(protocols, name)
+}
+
+// GetAllProtocolNames returns all registered protocol names
+func GetAllProtocolNames() []string {
+	names := make([]string, 0, len(protocols))
+	for name := range protocols {
+		names = append(names, name)
+	}
+	return names
+}

--- a/filter/accesslog/filter.go
+++ b/filter/accesslog/filter.go
@@ -102,7 +102,7 @@ func newFilter() filter.Filter {
 				ctx:       ctx,
 				cancel:    cancel,
 			}
-			accessLogFilter.start()
+			go accessLogFilter.processLogs()
 		})
 	}
 	return accessLogFilter
@@ -187,11 +187,6 @@ func (f *Filter) buildAccessLogData(_ base.Invoker, invocation base.Invocation) 
 // OnResponse do nothing
 func (f *Filter) OnResponse(_ context.Context, result result.Result, _ base.Invoker, _ base.Invocation) result.Result {
 	return result
-}
-
-// start initializes and starts the background goroutine for processing logs
-func (f *Filter) start() {
-	go f.processLogs()
 }
 
 // processLogs runs in a background goroutine to process log data

--- a/filter/accesslog/filter.go
+++ b/filter/accesslog/filter.go
@@ -424,12 +424,12 @@ func (f *Filter) shutdown() {
 
 		// Close all cached file handles
 		f.fileLock.Lock()
+		defer f.fileLock.Unlock()
 		for path, file := range f.fileCache {
 			if err := file.Close(); err != nil {
 				logger.Warnf("Error closing access log file %s: %v", path, err)
 			}
 			delete(f.fileCache, path)
 		}
-		f.fileLock.Unlock()
 	})
 }

--- a/filter/accesslog/filter_test.go
+++ b/filter/accesslog/filter_test.go
@@ -50,8 +50,8 @@ func TestFilter_Invoke_Not_Config(t *testing.T) {
 	attach := make(map[string]any, 10)
 	inv := invocation.NewRPCInvocation("MethodName", []any{"OK", "Hello"}, attach)
 
-	accessLogFilter := &Filter{}
-	invokeResult := accessLogFilter.Invoke(context.Background(), invoker, inv)
+	filter := &Filter{}
+	invokeResult := filter.Invoke(context.Background(), invoker, inv)
 	assert.Nil(t, invokeResult.Error())
 }
 
@@ -71,14 +71,14 @@ func TestFilterInvokeDefaultConfig(t *testing.T) {
 	attach[constant.GroupKey] = "MyGroup"
 	inv := invocation.NewRPCInvocation("MethodName", []any{"OK", "Hello"}, attach)
 
-	accessLogFilter := &Filter{}
-	invokeResult := accessLogFilter.Invoke(context.Background(), invoker, inv)
+	filter := &Filter{}
+	invokeResult := filter.Invoke(context.Background(), invoker, inv)
 	assert.Nil(t, invokeResult.Error())
 }
 
 func TestFilterOnResponse(t *testing.T) {
 	rpcResult := &result.RPCResult{}
-	accessLogFilter := &Filter{}
-	response := accessLogFilter.OnResponse(context.TODO(), rpcResult, nil, nil)
+	filter := &Filter{}
+	response := filter.OnResponse(context.TODO(), rpcResult, nil, nil)
 	assert.Equal(t, rpcResult, response)
 }

--- a/filter/accesslog/memory_leak_test.go
+++ b/filter/accesslog/memory_leak_test.go
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accesslog
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/protocol/base"
+	invocation_impl "dubbo.apache.org/dubbo-go/v3/protocol/invocation"
+	"dubbo.apache.org/dubbo-go/v3/protocol/result"
+)
+
+// TestAccessLogFilterGoroutineShutdown tests that the goroutine is properly shut down
+func TestAccessLogFilterGoroutineShutdown(t *testing.T) {
+	// Reset global state
+	once.Do(func() {}) // Trigger once
+	accessLogFilter = nil
+	shutdownCancel = nil
+	shutdownCtx = nil
+	shutdownOnce = sync.Once{}
+	once = sync.Once{}
+
+	// Count goroutines before
+	initialGoroutines := runtime.NumGoroutine()
+
+	// Create filter (this should start the goroutine)
+	filter := newFilter()
+	assert.NotNil(t, filter)
+
+	// Give the goroutine time to start
+	time.Sleep(100 * time.Millisecond)
+	postCreateGoroutines := runtime.NumGoroutine()
+
+	// Should have at least one more goroutine
+	assert.Greater(t, postCreateGoroutines, initialGoroutines)
+
+	// Shutdown the filter
+	Shutdown()
+
+	// Give goroutine time to exit
+	time.Sleep(100 * time.Millisecond)
+	runtime.GC() // Force garbage collection
+
+	postShutdownGoroutines := runtime.NumGoroutine()
+
+	// Goroutine count should be back to original or less
+	assert.LessOrEqual(t, postShutdownGoroutines, initialGoroutines+1,
+		"Goroutines should be cleaned up after shutdown")
+}
+
+// TestAccessLogFilterFileHandleManagement tests proper file handle management
+func TestAccessLogFilterFileHandleManagement(t *testing.T) {
+	// Reset global state
+	once.Do(func() {}) // Trigger once
+	accessLogFilter = nil
+	shutdownCancel = nil
+	shutdownCtx = nil
+	shutdownOnce = sync.Once{}
+	once = sync.Once{}
+
+	tempFile := "/tmp/test_access_log.log"
+	defer os.Remove(tempFile)
+
+	// Create filter
+	filter := newFilter().(*Filter)
+
+	// Create test URL and invocation
+	url := common.NewURLWithOptions(
+		common.WithParamsValue(constant.AccessLogFilterKey, tempFile),
+	)
+
+	invoker := &MockInvoker{url: url}
+	invocation := &invocation_impl.RPCInvocation{}
+
+	// Invoke multiple times to test file handle caching
+	for i := 0; i < 5; i++ {
+		filter.Invoke(context.Background(), invoker, invocation)
+	}
+
+	// Wait for logs to be processed
+	time.Sleep(100 * time.Millisecond)
+
+	// Check that file is in cache
+	filter.fileLock.RLock()
+	cachedFile, exists := filter.fileCache[tempFile]
+	filter.fileLock.RUnlock()
+
+	assert.True(t, exists, "File should be cached")
+	assert.NotNil(t, cachedFile, "Cached file should not be nil")
+
+	// Shutdown and verify files are closed
+	Shutdown()
+
+	// Check that cache is cleared
+	filter.fileLock.RLock()
+	cacheSize := len(filter.fileCache)
+	filter.fileLock.RUnlock()
+
+	assert.Equal(t, 0, cacheSize, "File cache should be empty after shutdown")
+}
+
+// MockInvoker for testing
+type MockInvoker struct {
+	base.BaseInvoker
+	url *common.URL
+}
+
+func (m *MockInvoker) GetURL() *common.URL {
+	return m.url
+}
+
+func (m *MockInvoker) Invoke(ctx context.Context, invocation base.Invocation) result.Result {
+	return &result.RPCResult{}
+}

--- a/filter/accesslog/memory_leak_test.go
+++ b/filter/accesslog/memory_leak_test.go
@@ -38,15 +38,16 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/protocol/result"
 )
 
-// TestAccessLogFilterGoroutineShutdown tests that the goroutine is properly shut down
-func TestAccessLogFilterGoroutineShutdown(t *testing.T) {
-	// Reset global state
+// resetGlobalState resets the global state for testing
+func resetGlobalState() {
 	once.Do(func() {}) // Trigger once
 	accessLogFilter = nil
-	shutdownCancel = nil
-	shutdownCtx = nil
-	shutdownOnce = sync.Once{}
 	once = sync.Once{}
+}
+
+// TestAccessLogFilterGoroutineShutdown tests that the goroutine is properly shut down
+func TestAccessLogFilterGoroutineShutdown(t *testing.T) {
+	resetGlobalState()
 
 	// Count goroutines before
 	initialGoroutines := runtime.NumGoroutine()
@@ -78,13 +79,7 @@ func TestAccessLogFilterGoroutineShutdown(t *testing.T) {
 
 // TestAccessLogFilterFileHandleManagement tests proper file handle management
 func TestAccessLogFilterFileHandleManagement(t *testing.T) {
-	// Reset global state
-	once.Do(func() {}) // Trigger once
-	accessLogFilter = nil
-	shutdownCancel = nil
-	shutdownCtx = nil
-	shutdownOnce = sync.Once{}
-	once = sync.Once{}
+	resetGlobalState()
 
 	tempFile := "/tmp/test_access_log.log"
 	defer os.Remove(tempFile)

--- a/registry/nacos/service_discovery.go
+++ b/registry/nacos/service_discovery.go
@@ -89,6 +89,7 @@ func (n *nacosServiceDiscovery) Destroy() error {
 
 	// Clean up listeners to prevent potential leaks
 	n.listenerLock.Lock()
+	defer n.listenerLock.Unlock()
 	// Unsubscribe from all services to stop callbacks
 	for serviceName := range n.instanceListenerMap {
 		err := n.namingClient.Client().Unsubscribe(&vo.SubscribeParam{
@@ -101,7 +102,6 @@ func (n *nacosServiceDiscovery) Destroy() error {
 	}
 	// Clear the listener map
 	n.instanceListenerMap = make(map[string]*gxset.HashSet)
-	n.listenerLock.Unlock()
 
 	n.namingClient.Close()
 	return nil

--- a/registry/nacos/service_discovery.go
+++ b/registry/nacos/service_discovery.go
@@ -86,6 +86,23 @@ func (n *nacosServiceDiscovery) Destroy() error {
 			logger.Errorf("Unregister nacos instance:%+v, err:%+v", inst, err)
 		}
 	}
+
+	// Clean up listeners to prevent potential leaks
+	n.listenerLock.Lock()
+	// Unsubscribe from all services to stop callbacks
+	for serviceName := range n.instanceListenerMap {
+		err := n.namingClient.Client().Unsubscribe(&vo.SubscribeParam{
+			ServiceName: serviceName,
+			GroupName:   n.group,
+		})
+		if err != nil {
+			logger.Warnf("Failed to unsubscribe from service %s: %v", serviceName, err)
+		}
+	}
+	// Clear the listener map
+	n.instanceListenerMap = make(map[string]*gxset.HashSet)
+	n.listenerLock.Unlock()
+
 	n.namingClient.Close()
 	return nil
 }

--- a/registry/nacos/service_discovery_test.go
+++ b/registry/nacos/service_discovery_test.go
@@ -324,7 +324,7 @@ func (c mockClient) Subscribe(param *vo.SubscribeParam) error {
 }
 
 func (c mockClient) Unsubscribe(param *vo.SubscribeParam) error {
-	panic("implement me")
+	return nil
 }
 
 func (c mockClient) GetAllServicesInfo(param vo.GetAllServiceInfoParam) (model.ServiceList, error) {


### PR DESCRIPTION
This PR addresses critical memory leaks, goroutine deadlocks, and file handle leaks that could lead to resource exhaustion in production environments. The fixes include comprehensive architectural improvements to the access log filter, extension cache management, and Nacos service discovery components.

Key Changes

Access Log Filter Refactoring (filter/accesslog/)

  - Fix goroutine deadlock: Move context management to Filter struct to reduce global dependencies
  - Add timeout protection: Implement timeout mechanisms for writeLogToFile to prevent deadlocks
  - Improve architecture: Extract goroutine logic to dedicated start/processLogs/drainLogs methods
  - Enhanced error handling: Add panic recovery in processLogs goroutine
  - Clean up globals: Remove unused global variables (shutdownOnce, shutdownCtx, shutdownCancel)

Extension Cache Management (common/extension/)

  - Add unregister methods: Implement proper cleanup methods for filter, loadbalance, and protocol caches
  - Prevent memory accumulation: Enable proper resource cleanup when extensions are no longer needed

Nacos Service Discovery (registry/nacos/)

  - Enhanced cleanup: Improve service discovery cleanup mechanisms to prevent resource leaks
  - Fix mock implementation: Correct Nacos mockClient.Unsubscribe implementation for better testing

Testing Improvements

  - Memory leak validation: Add comprehensive memory leak tests for all affected components
  - Fix variable shadowing: Resolve variable shadow issues in access log filter tests
  - Improve test isolation: Create resetGlobalState helper to reduce test code duplication

Closes: #3025