### PR TITLE
feat(otel): add Insecure option to tracing configuration

### DIFF
--- a/compat.go
+++ b/compat.go
@@ -387,6 +387,7 @@ func compatOtelConfig(c *global.OtelConfig) *config.OtelConfig {
 			Propagator:  c.TracingConfig.Propagator,
 			SampleMode:  c.TracingConfig.SampleMode,
 			SampleRatio: c.TracingConfig.SampleRatio,
+			Insecure:    c.TracingConfig.Insecure,
 		},
 	}
 }
@@ -901,6 +902,7 @@ func compatGlobalOtelConfig(c *config.OtelConfig) *global.OtelConfig {
 			Propagator:  c.TraceConfig.Propagator,
 			SampleMode:  c.TraceConfig.SampleMode,
 			SampleRatio: c.TraceConfig.SampleRatio,
+			Insecure:    c.TraceConfig.Insecure,
 		},
 	}
 }

--- a/config/otel_config.go
+++ b/config/otel_config.go
@@ -43,6 +43,7 @@ type OtelTraceConfig struct {
 	Propagator  string  `default:"w3c" yaml:"propagator" json:"propagator,omitempty" property:"propagator"`       // one of w3c(standard), b3(for zipkin),
 	SampleMode  string  `default:"ratio" yaml:"sample-mode" json:"sample-mode,omitempty" property:"sample-mode"`  // one of always, never, ratio
 	SampleRatio float64 `default:"0.5" yaml:"sample-ratio" json:"sample-ratio,omitempty" property:"sample-ratio"` // [0.0, 1.0]
+	Insecure    bool    `default:"false" yaml:"insecure" json:"insecure,omitempty" property:"insecure"`
 }
 
 func (oc *OtelConfig) Init(appConfig *ApplicationConfig) error {
@@ -95,6 +96,7 @@ func (c *OtelTraceConfig) toTraceProviderConfig(a *ApplicationConfig) *trace.Exp
 		ServiceNamespace: a.Organization,
 		ServiceName:      a.Name,
 		ServiceVersion:   a.Version,
+		Insecure:         c.Insecure,
 	}
 	return tpc
 }

--- a/global/otel_config.go
+++ b/global/otel_config.go
@@ -29,6 +29,7 @@ type OtelTraceConfig struct {
 	Propagator  string  `default:"w3c" yaml:"propagator" json:"propagator,omitempty" property:"propagator"`       // one of w3c(standard), b3(for zipkin),
 	SampleMode  string  `default:"ratio" yaml:"sample-mode" json:"sample-mode,omitempty" property:"sample-mode"`  // one of always, never, ratio
 	SampleRatio float64 `default:"0.5" yaml:"sample-ratio" json:"sample-ratio,omitempty" property:"sample-ratio"` // [0.0, 1.0]
+	Insecure    bool    `default:"false" yaml:"insecure" json:"insecure,omitempty" property:"insecure"`
 }
 
 func DefaultOtelConfig() *OtelConfig {
@@ -67,5 +68,6 @@ func (c *OtelTraceConfig) Clone() *OtelTraceConfig {
 		Propagator:  c.Propagator,
 		SampleMode:  c.SampleMode,
 		SampleRatio: c.SampleRatio,
+		Insecure:    c.Insecure,
 	}
 }

--- a/otel/trace/exporter.go
+++ b/otel/trace/exporter.go
@@ -44,6 +44,7 @@ type ExporterConfig struct {
 	ServiceNamespace string
 	ServiceName      string
 	ServiceVersion   string
+	Insecure         bool
 }
 
 type Exporter interface {

--- a/otel/trace/options.go
+++ b/otel/trace/options.go
@@ -138,3 +138,9 @@ func WithEndpoint(endpoint string) Option {
 		opts.Otel.TracingConfig.Endpoint = endpoint
 	}
 }
+
+func WithInsecure() Option {
+	return func(opts *Options) {
+		opts.Otel.TracingConfig.Insecure = true
+	}
+}

--- a/otel/trace/otlp/exporter.go
+++ b/otel/trace/otlp/exporter.go
@@ -57,7 +57,18 @@ func newHttpExporter(config *trace.ExporterConfig) (trace.Exporter, error) {
 	if httpInstance == nil {
 		initHttpOnce.Do(func() {
 			customFunc := func() (sdktrace.SpanExporter, error) {
-				client := otlptracehttp.NewClient(otlptracehttp.WithEndpoint(config.Endpoint))
+				var client otlptrace.Client
+				if config.Insecure {
+					client = otlptracehttp.NewClient(
+						otlptracehttp.WithEndpoint(config.Endpoint),
+						otlptracehttp.WithInsecure(),
+					)
+				} else {
+					client = otlptracehttp.NewClient(
+						otlptracehttp.WithEndpoint(config.Endpoint),
+					)
+				}
+
 				return otlptrace.New(context.Background(), client)
 			}
 


### PR DESCRIPTION
Add Insecure option to tracing configuration, without this option, otlp http exporter only export tracing through https schema. If want to export tracing to a http endpoint, must use this option.