### PR TITLE
fix: change ERROR to WARN log level when application parameter is empty in Tag Router

### DIFF
--- a/cluster/router/tag/router.go
+++ b/cluster/router/tag/router.go
@@ -79,7 +79,7 @@ func (p *PriorityRouter) Notify(invokers []base.Invoker) {
 	}
 	application := invokers[0].GetURL().GetParam(constant.ApplicationKey, "")
 	if application == "" {
-		logger.Error("url application is empty")
+		logger.Warn("url application is empty, tag router will not be enabled")
 		return
 	}
 	dynamicConfiguration := conf.GetEnvInstance().GetDynamicConfiguration()


### PR DESCRIPTION
Change the log level from `ERROR` to `WARN` and improve the log message to be more descriptive.

Missing `application` parameter is not a system error - it's a configuration issue that gracefully degrades functionality

Related to #3024 