### PR TITLE
fix: url equal with interface any value

### DIFF
--- a/common/url.go
+++ b/common/url.go
@@ -358,13 +358,23 @@ func (c *URL) URLEqual(url *URL) bool {
 
 	cGroup := tmpC.GetParam(constant.GroupKey, "")
 	urlGroup := tmpURL.GetParam(constant.GroupKey, "")
+
 	cKey := tmpC.Key()
 	urlKey := tmpURL.Key()
+
+	cInterface := tmpC.Service()
+	urlInterface := tmpURL.Service()
 
 	if cGroup == constant.AnyValue {
 		cKey = strings.Replace(cKey, "group=*", "group="+urlGroup, 1)
 	} else if urlGroup == constant.AnyValue {
 		urlKey = strings.Replace(urlKey, "group=*", "group="+cGroup, 1)
+	}
+
+	if cInterface == constant.AnyValue {
+		cKey = strings.Replace(cKey, "interface=*", "interface="+urlInterface, 1)
+	} else if urlInterface == constant.AnyValue {
+		urlKey = strings.Replace(urlKey, "interface=*", "interface="+cInterface, 1)
 	}
 
 	// 1. protocol, username, password, ip, port, service name, group, version should be equal
@@ -377,7 +387,6 @@ func (c *URL) URLEqual(url *URL) bool {
 		return false
 	}
 
-	// TODO :may need add interface key any value condition
 	return isMatchCategory(tmpURL.GetParam(constant.CategoryKey, constant.DefaultCategory), tmpC.GetParam(constant.CategoryKey, constant.DefaultCategory))
 }
 

--- a/common/url_test.go
+++ b/common/url_test.go
@@ -160,6 +160,21 @@ func TestURLEqual(t *testing.T) {
 	categoryAny, err := NewURL("dubbo://127.0.0.1:20000/com.ikurento.user.UserProvider?interface=com.ikurento.user.UserProvider&group=*&version=2.6.0&enabled=*&category=*")
 	assert.NoError(t, err)
 	assert.True(t, categoryAny.URLEqual(u3))
+
+	// test for interface with AnyValue (*)
+	u4, err := NewURL("dubbo://127.0.0.1:20000/com.ikurento.user.UserProvider?interface=com.ikurento.user.Service1&group=gg&version=2.6.0")
+	assert.NoError(t, err)
+	urlInterfaceAnyValue, err := NewURL("dubbo://127.0.0.1:20000/com.ikurento.user.UserProvider?interface=*&group=gg&version=2.6.0")
+	assert.NoError(t, err)
+	assert.True(t, u4.URLEqual(urlInterfaceAnyValue), "interface=* should match any interface")
+
+	// test for interface with AnyValue (*) in reverse order
+	assert.True(t, urlInterfaceAnyValue.URLEqual(u4), "interface=* should match any interface (reverse)")
+
+	// test for interface with different values (should fail)
+	u5, err := NewURL("dubbo://127.0.0.1:20000/com.ikurento.user.UserProvider?interface=com.ikurento.user.Service2&group=gg&version=2.6.0")
+	assert.NoError(t, err)
+	assert.False(t, u4.URLEqual(u5), "different interfaces should not match")
 }
 
 func TestURLGetParam(t *testing.T) {


### PR DESCRIPTION
- Fix URL equality to support interface=* (AnyValue) matching, consistent with group=*.
-  Update URLEqual() to replace wildcard with the concrete interface when comparing keys.
-  Add unit tests for forward, reverse, and negative cases.