### PR TITLE
chore(CI): add pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,7 @@
 ### Description
-Briefly describe the changes you've made...
+Fixes # (issue)
 
 ### Checklist
 - [ ] I confirm the target branch is `develop`
 - [ ] Code has passed local testing
+- [ ] I have added tests that prove my fix is effective or that my feature works


### PR DESCRIPTION
### Description
This PR adds a pull request template to explicitly remind contributors to target the `develop` branch instead of `main`. This helps prevent accidental submissions to the wrong branch.

### Brief changelog
- Add `.github/pull_request_template.md`