### PR TITLE
test: Add unit tests for graceful_shutdown package

### DIFF
--- a/graceful_shutdown/options_test.go
+++ b/graceful_shutdown/options_test.go
@@ -20,9 +20,14 @@ package graceful_shutdown
 import (
 	"testing"
 	"time"
+)
 
-	"dubbo.apache.org/dubbo-go/v3/global"
+import (
 	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/global"
 )
 
 func TestDefaultOptions(t *testing.T) {

--- a/graceful_shutdown/shutdown_test.go
+++ b/graceful_shutdown/shutdown_test.go
@@ -22,7 +22,9 @@ import (
 	"sync"
 	"testing"
 	"time"
+)
 
+import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )


### PR DESCRIPTION
# Graceful Shutdown 测试覆盖率报告

graceful_shutdown/
├── common.go                  # 核心逻辑完全覆盖 (parseDuration 函数) 覆盖率 100% 
├── options.go                 # 核心逻辑完全覆盖 (所有配置函数) 覆盖率 100% 
├── shutdown.go                # 核心逻辑部分覆盖 (Init 65.5%, waitAndAcceptNewRequests 100%, waitForSendingAndReceivingRequests 100%, waitingConsumerProcessedTimeout 85.7%, waitingProviderProcessedTimeout 60.0%) 
│   ├── beforeShutdown         # 未覆盖 
│   ├── destroyRegistries      # 未覆盖 
│   └── destroyProtocols       # 未覆盖 
├── options_test.go            # 新增测试文件 
└── shutdown_test.go           # 新增测试文件 
