### PR TITLE
test: enhance triple stream validation in unit tests

### DIFF
--- a/protocol/triple/triple_protocol/triple_ext_test.go
+++ b/protocol/triple/triple_protocol/triple_ext_test.go
@@ -1658,6 +1658,9 @@ func TestStreamForServer(t *testing.T) {
 		t.Parallel()
 		client, server := newPingServer(&pluggablePingServer{
 			sum: func(ctx context.Context, stream *triple.ClientStream) (*triple.Response, error) {
+				// First receive the client's message to ensure the stream is established
+				assert.True(t, stream.Receive(&pingv1.SumRequest{}))
+				// Now try to send non-proto message, which should fail
 				assert.NotNil(t, stream.Conn().Send("not-proto"))
 				return triple.NewResponse(&pingv1.SumResponse{}), nil
 			},


### PR DESCRIPTION
### Description
Fixes #3149 

This pull request makes a minor improvement to the `TestStreamForServer` test by ensuring that the client stream is properly established before attempting to send a non-protobuf message. This helps verify the correct behavior of the stream handling logic.

- **Test robustness improvement:**
  * In `triple_ext_test.go`, the test now explicitly receives the client's message before sending a non-proto message, ensuring the stream is established and making the test more reliable.

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
