### PR TITLE
fix(remoting): Refine Getty server TLS configuration

### DIFF
--- a/remoting/getty/getty_server.go
+++ b/remoting/getty/getty_server.go
@@ -96,14 +96,14 @@ func initServer(url *common.URL) {
 			if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
 				tlsConf, ok := tlsConfRaw.(*global.TLSConfig)
 				if !ok {
-					logger.Errorf("Getty client initialized the TLSConfig configuration failed")
+					logger.Errorf("Getty Server initialized the TLSConfig configuration failed")
 					return
 				}
 				tlsConfig = tlsConf
 			}
 		}
 
-		if tlsConfig != nil {
+		if tlsConfig != nil && dubbotls.IsServerTLSValid(tlsConfig) {
 			srvConf.SSLEnabled = true
 			srvConf.TLSBuilder = &getty.ServerTlsConfigBuilder{
 				ServerKeyCertChainPath:        tlsConfig.TLSCertFile,
@@ -111,22 +111,6 @@ func initServer(url *common.URL) {
 				ServerTrustCertCollectionPath: tlsConfig.CACertFile,
 			}
 			logger.Infof("Getty Server initialized the TLSConfig configuration")
-		} else if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
-			// use global TLSConfig handle tls
-			tlsConf, ok := tlsConfRaw.(*global.TLSConfig)
-			if !ok {
-				logger.Errorf("Getty Server initialized the TLSConfig configuration failed")
-				return
-			}
-			if dubbotls.IsServerTLSValid(tlsConf) {
-				srvConf.SSLEnabled = true
-				srvConf.TLSBuilder = &getty.ServerTlsConfigBuilder{
-					ServerKeyCertChainPath:        tlsConf.TLSCertFile,
-					ServerPrivateKeyPath:          tlsConf.TLSKeyFile,
-					ServerTrustCertCollectionPath: tlsConf.CACertFile,
-				}
-				logger.Infof("Getty Server initialized the TLSConfig configuration")
-			}
 		}
 		//getty params
 		gettyServerConfig := protocolConf.Params


### PR DESCRIPTION
Corrected a log message from 'client' to 'server' in Getty's TLS initialization. 
Enhanced server TLS setup by adding a validation check (`dubbotls.IsServerTLSValid`) before enabling SSL.
Removed redundant TLS configuration logic to simplify the code path.

### Description
Fixes #3155

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
