### PR TITLE
 docs: fix broken documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,14 +165,14 @@ For usage details, see the [imports-formatter README](https://github.com/dubbogo
 ## Ecosystem
 - [dubbo-go-samples](https://github.com/apache/dubbo-go-samples)
 - [dubbo-go-pixiu which acting as a proxy to solve Dubbo multi-language interoperability](https://github.com/apache/dubbo-go-pixiu)
-- [Interoperability with Dubbo Java](https://dubbo-next.staged.apache.org/zh-cn/overview/mannual/golang-sdk/tutorial/interop-dubbo/)
+- [Interoperability with Dubbo Java](https://cn.dubbo.apache.org/zh-cn/overview/mannual/golang-sdk/tutorial/interop-dubbo/)
 - [Protoc-gen-go-triple](https://github.com/dubbogo/protoc-gen-go-triple/)
 - [Console](https://github.com/apache/dubbo-kubernetes), under development
 
 ## Documentation
 
 - Official Website: https://dubbo.apache.org/
-- Dubbo-go Documentation: https://dubbo.apache.org/docs/dubbo-go/
+- Dubbo-go Documentation: https://cn.dubbo.apache.org/zh-cn/overview/mannual/golang-sdk/
 - CHANGELOG: https://github.com/apache/dubbo-go/blob/main/CHANGELOG.md
 
 ## Community

--- a/README_CN.md
+++ b/README_CN.md
@@ -155,14 +155,14 @@ func main() {
 
 - [dubbo-go-samples](https://github.com/apache/dubbo-go-samples)
 - [dubbo-go-pixiu: 作为代理解决 Dubbo 多语言互通问题](https://github.com/apache/dubbo-go-pixiu)
-- [与 Dubbo Java 互通](https://dubbo-next.staged.apache.org/zh-cn/overview/mannual/golang-sdk/tutorial/interop-dubbo/)
+- [与 Dubbo Java 互通](https://cn.dubbo.apache.org/zh-cn/overview/mannual/golang-sdk/tutorial/interop-dubbo/)
 - [Protoc-gen-go-triple](https://github.com/dubbogo/protoc-gen-go-triple/)
 - [控制台 (Console)](https://github.com/apache/dubbo-kubernetes)，开发中
 
 ## 社区与文档
 
 * **官方网站**: https://dubbo.apache.org/
-* **官方文档**: https://dubbo.apache.org/docs/dubbo-go/
+* **官方文档**: https://cn.dubbo.apache.org/zh-cn/overview/mannual/golang-sdk/
 * **问题反馈**: [GitHub Issues](https://github.com/apache/dubbo-go/issues)
 
 关于提交补丁和贡献流程的详细信息，请访问 [CONTRIBUTING](./CONTRIBUTING.md)。


### PR DESCRIPTION
### Description

Fix broken and outdated documentation links in README.md and README_CN.md:

- Replace `dubbo.apache.org/docs/dubbo-go/` (404) with correct documentation URL
- Replace staging site links (`dubbo-next.staged.apache.org`) with production site (`cn.dubbo.apache.org`)

### Checklist
- [x] I confirm the target branch is `main`
- [x] Code has passed local testing
- [ ] I have added tests that prove my fix is effective or that my feature works
