### PR TITLE
fix: polaris router support application name

### DIFF
--- a/cluster/router/polaris/router.go
+++ b/cluster/router/polaris/router.go
@@ -55,14 +55,11 @@ func newPolarisRouter(url *common.URL) (*polarisRouter, error) {
 
 	// get application name from url param
 	applicationName := url.GetParam(constant.ApplicationKey, "")
-
-	// if not found, try to get from SubURL (registry directory scenario)
 	if applicationName == "" {
 		applicationName = url.SubURL.GetParam(constant.ApplicationKey, "")
-	}
-
-	if applicationName == "" {
-		return nil, fmt.Errorf("polaris router must set application name")
+		if applicationName == "" {
+			return nil, fmt.Errorf("polaris router must set application name")
+		}
 	}
 
 	// get from url attr


### PR DESCRIPTION
### Description
Fixes #3163 

#### Root Cause

In the new API workflow, the application name is stored in the attributes of the service URL. However, the Polaris router is initialized using the registry URL during the construction of the router chain. Since the registry URL does not carry the application name information, it fails the validation check in the Polaris router.

#### Solution

Retrieve the application name directly from serviceUrl (the sub-URL of registryUrl)

#### Changes

File: cluster/router/polaris/router.go

 add the following logic to pass the application name:
```go 
	// if not found, try to get from SubURL (registry directory scenario)
	if applicationName == "" {
		applicationName = url.SubURL.GetParam(constant.ApplicationKey, "")
	}
```
### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works