### PR TITLE
refactor: rename ExpectedCodecName to FallbackCodecName internally

### DIFF
--- a/protocol/triple/triple_protocol/envelope.go
+++ b/protocol/triple/triple_protocol/envelope.go
@@ -76,7 +76,7 @@ func (w *envelopeWriter) Marshal(message any) *Error {
 	raw, err := w.codec.Marshal(message)
 	if err != nil {
 		if w.backupCodec != nil && w.codec.Name() != w.backupCodec.Name() {
-			logger.Debugf("failed to marshal message with codec %s, trying alternative codec %s", w.codec.Name(), w.backupCodec.Name())
+			logger.Debugf("failed to marshal message with primary codec %s, trying fallback codec %s", w.codec.Name(), w.backupCodec.Name())
 			raw, err = w.backupCodec.Marshal(message)
 		}
 		if err != nil {
@@ -138,7 +138,7 @@ func (w *envelopeWriter) write(env *envelope) *Error {
 type envelopeReader struct {
 	reader          io.Reader
 	codec           Codec
-	backupCodec     Codec //backupCodec is for mismatch between expected codec and content-type
+	backupCodec     Codec // backupCodec is the fallback codec when primary codec fails
 	last            envelope
 	compressionPool *compressionPool
 	bufferPool      *bufferPool
@@ -202,7 +202,7 @@ func (r *envelopeReader) Unmarshal(message any) *Error {
 
 	if err := r.codec.Unmarshal(data.Bytes(), message); err != nil {
 		if r.backupCodec != nil && r.backupCodec.Name() != r.codec.Name() {
-			logger.Debugf("failed to unmarshal message with codec %s, trying alternative codec %s", r.codec.Name(), r.backupCodec.Name())
+			logger.Debugf("failed to unmarshal message with primary codec %s, trying fallback codec %s", r.codec.Name(), r.backupCodec.Name())
 			err = r.backupCodec.Unmarshal(data.Bytes(), message)
 		}
 		if err != nil {

--- a/protocol/triple/triple_protocol/handler.go
+++ b/protocol/triple/triple_protocol/handler.go
@@ -381,7 +381,7 @@ type handlerConfig struct {
 	CompressionPools            map[string]*compressionPool
 	CompressionNames            []string
 	Codecs                      map[string]Codec
-	ExpectedCodecName           string
+	FallbackCodecName           string
 	CompressMinBytes            int
 	Interceptor                 Interceptor
 	Procedure                   string
@@ -446,7 +446,7 @@ func (c *handlerConfig) newProtocolHandlers(streamType StreamType) []protocolHan
 			Spec:              c.newSpec(streamType),
 			Codecs:            codecs,
 			CompressionPools:  compressors,
-			ExpectedCodecName: c.ExpectedCodecName,
+			FallbackCodecName: c.FallbackCodecName,
 			// config content
 			CompressMinBytes:            c.CompressMinBytes,
 			BufferPool:                  c.BufferPool,

--- a/protocol/triple/triple_protocol/option.go
+++ b/protocol/triple/triple_protocol/option.go
@@ -186,8 +186,12 @@ func WithVersion(version string) Option {
 	return &versionOption{version}
 }
 
+// WithExpectedCodecName sets a fallback codec for the server handler.
+// When the primary codec (from client's Content-Type) fails to unmarshal
+// the request, the server will attempt to use this fallback codec.
+// This enhances interoperability, especially with Java clients.
 func WithExpectedCodecName(ExpectedCodecName string) Option {
-	return &ExpectedCodecNameOption{ExpectedCodecName: ExpectedCodecName}
+	return &FallbackCodecNameOption{FallbackCodecName: ExpectedCodecName}
 }
 
 // Option implements both [ClientOption] and [HandlerOption], so it can be
@@ -475,16 +479,29 @@ func (o *idempotencyOption) applyToHandler(config *handlerConfig) {
 	config.IdempotencyLevel = o.idempotencyLevel
 }
 
+type FallbackCodecNameOption struct {
+	FallbackCodecName string
+}
+
+func (o *FallbackCodecNameOption) applyToClient(config *clientConfig) {
+	// Do nothing as client doesn't have codec fallback issues
+}
+
+func (o *FallbackCodecNameOption) applyToHandler(config *handlerConfig) {
+	config.FallbackCodecName = o.FallbackCodecName
+}
+
+// Deprecated: Use FallbackCodecNameOption instead.
 type ExpectedCodecNameOption struct {
 	ExpectedCodecName string
 }
 
 func (o *ExpectedCodecNameOption) applyToClient(config *clientConfig) {
-	//Do nothing as client doesn't have codec issues
+	// Do nothing as client doesn't have codec fallback issues
 }
 
 func (o *ExpectedCodecNameOption) applyToHandler(config *handlerConfig) {
-	config.ExpectedCodecName = o.ExpectedCodecName
+	config.FallbackCodecName = o.ExpectedCodecName
 }
 
 type tripleOption struct{}

--- a/protocol/triple/triple_protocol/option.go
+++ b/protocol/triple/triple_protocol/option.go
@@ -491,19 +491,6 @@ func (o *FallbackCodecNameOption) applyToHandler(config *handlerConfig) {
 	config.FallbackCodecName = o.FallbackCodecName
 }
 
-// Deprecated: Use FallbackCodecNameOption instead.
-type ExpectedCodecNameOption struct {
-	ExpectedCodecName string
-}
-
-func (o *ExpectedCodecNameOption) applyToClient(config *clientConfig) {
-	// Do nothing as client doesn't have codec fallback issues
-}
-
-func (o *ExpectedCodecNameOption) applyToHandler(config *handlerConfig) {
-	config.FallbackCodecName = o.ExpectedCodecName
-}
-
 type tripleOption struct{}
 
 func (o *tripleOption) applyToClient(config *clientConfig) {

--- a/protocol/triple/triple_protocol/protocol.go
+++ b/protocol/triple/triple_protocol/protocol.go
@@ -72,7 +72,7 @@ type protocol interface {
 type protocolHandlerParams struct {
 	Spec                        Spec
 	Codecs                      readOnlyCodecs
-	ExpectedCodecName           string
+	FallbackCodecName           string
 	CompressionPools            readOnlyCompressionPools
 	CompressMinBytes            int
 	BufferPool                  *bufferPool

--- a/protocol/triple/triple_protocol/protocol_grpc.go
+++ b/protocol/triple/triple_protocol/protocol_grpc.go
@@ -189,7 +189,7 @@ func (g *grpcHandler) NewConn(
 	// content-type -> codecName -> codec
 	codecName := grpcCodecFromContentType(getHeaderCanonical(request.Header, headerContentType))
 	codec := g.Codecs.Get(codecName) // handler.go guarantees this is not nil
-	backupCodec := g.Codecs.Get(g.ExpectedCodecName)
+	backupCodec := g.Codecs.Get(g.FallbackCodecName)
 	protocolName := ProtocolGRPC
 	conn := wrapHandlerConnWithCodedErrors(&grpcHandlerConn{
 		spec: g.Spec,

--- a/protocol/triple/triple_protocol/protocol_triple.go
+++ b/protocol/triple/triple_protocol/protocol_triple.go
@@ -159,7 +159,7 @@ func (h *tripleHandler) NewConn(
 		contentType,
 	)
 	codec := h.Codecs.Get(codecName)
-	backupCodec := h.Codecs.Get(h.ExpectedCodecName)
+	backupCodec := h.Codecs.Get(h.FallbackCodecName)
 	// todo:// need to figure it out
 	// The codec can be nil in the GET request case; that's okay: when failed
 	// is non-nil, codec is never used.
@@ -481,7 +481,7 @@ func (hc *tripleUnaryHandlerConn) writeResponseHeader(err error) {
 type tripleUnaryMarshaler struct {
 	writer           io.Writer
 	codec            Codec
-	backupCodec      Codec
+	backupCodec      Codec // backupCodec is the fallback codec when primary codec fails
 	compressMinBytes int
 	compressionName  string
 	compressionPool  *compressionPool
@@ -497,7 +497,7 @@ func (m *tripleUnaryMarshaler) Marshal(message any) *Error {
 	data, err := m.codec.Marshal(message)
 	if err != nil {
 		if m.backupCodec != nil && m.codec.Name() != m.backupCodec.Name() {
-			logger.Warnf("failed to marshal message with codec %s, trying alternative codec %s", m.codec.Name(), m.backupCodec.Name())
+			logger.Warnf("failed to marshal message with primary codec %s, trying fallback codec %s", m.codec.Name(), m.backupCodec.Name())
 			data, err = m.backupCodec.Marshal(message)
 		}
 		if err != nil {
@@ -546,7 +546,7 @@ func (m *tripleUnaryRequestMarshaler) Marshal(message any) *Error {
 type tripleUnaryUnmarshaler struct {
 	reader          io.Reader
 	codec           Codec
-	backupCodec     Codec //backupCodec is for the situation when content-type mismatches with the expected codec
+	backupCodec     Codec // backupCodec is the fallback codec when primary codec fails
 	compressionPool *compressionPool
 	bufferPool      *bufferPool
 	alreadyRead     bool
@@ -557,7 +557,7 @@ func (u *tripleUnaryUnmarshaler) Unmarshal(message any) *Error {
 	err := u.UnmarshalFunc(message, u.codec.Unmarshal)
 	if err != nil {
 		if u.backupCodec != nil && u.codec.Name() != u.backupCodec.Name() {
-			logger.Warnf("failed to unmarshal message with codec %s, trying alternative codec %s", u.codec.Name(), u.backupCodec.Name())
+			logger.Warnf("failed to unmarshal message with primary codec %s, trying fallback codec %s", u.codec.Name(), u.backupCodec.Name())
 			err = u.UnmarshalFunc(message, u.backupCodec.Unmarshal)
 		}
 	}


### PR DESCRIPTION
### Description
Fixes #2875 

The field ExpectedCodecName was confusing as it actually serves as a 
fallback codec when the primary codec fails, not the expected/preferred 
codec. This change:
- Renames internal field ExpectedCodecName to FallbackCodecName
- Updates all internal usages across protocol handlers
- Improves log messages to clearly distinguish primary vs fallback codecs

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
