### PR TITLE
feat(generic): support protobuf-json serialization in generic filter

### DIFF
--- a/filter/generic/util.go
+++ b/filter/generic/util.go
@@ -49,19 +49,18 @@ func isMakingAGenericCall(invoker base.Invoker, invocation base.Invocation) bool
 
 // isGeneric receives a generic field from url of invoker to determine whether the service is generic or not
 func isGeneric(generic string) bool {
-	lowerGeneric := strings.ToLower(generic)
-	return lowerGeneric == constant.GenericSerializationDefault ||
-		lowerGeneric == constant.GenericSerializationGson ||
-		lowerGeneric == constant.GenericSerializationProtobufJson
+	return strings.EqualFold(generic, constant.GenericSerializationDefault) ||
+		strings.EqualFold(generic, constant.GenericSerializationGson) ||
+		strings.EqualFold(generic, constant.GenericSerializationProtobufJson)
 }
 
 func getGeneralizer(generic string) (g generalizer.Generalizer) {
-	switch strings.ToLower(generic) {
-	case constant.GenericSerializationDefault:
+	switch {
+	case strings.EqualFold(generic, constant.GenericSerializationDefault):
 		g = generalizer.GetMapGeneralizer()
-	case constant.GenericSerializationGson:
+	case strings.EqualFold(generic, constant.GenericSerializationGson):
 		g = generalizer.GetGsonGeneralizer()
-	case constant.GenericSerializationProtobufJson:
+	case strings.EqualFold(generic, constant.GenericSerializationProtobufJson):
 		g = generalizer.GetProtobufJsonGeneralizer()
 	default:
 		logger.Debugf("\"%s\" is not supported, use the default generalizer(MapGeneralizer)", generic)

--- a/filter/generic/util.go
+++ b/filter/generic/util.go
@@ -50,7 +50,9 @@ func isMakingAGenericCall(invoker base.Invoker, invocation base.Invocation) bool
 // isGeneric receives a generic field from url of invoker to determine whether the service is generic or not
 func isGeneric(generic string) bool {
 	lowerGeneric := strings.ToLower(generic)
-	return lowerGeneric == constant.GenericSerializationDefault
+	return lowerGeneric == constant.GenericSerializationDefault ||
+		lowerGeneric == constant.GenericSerializationGson ||
+		lowerGeneric == constant.GenericSerializationProtobufJson
 }
 
 func getGeneralizer(generic string) (g generalizer.Generalizer) {
@@ -59,7 +61,8 @@ func getGeneralizer(generic string) (g generalizer.Generalizer) {
 		g = generalizer.GetMapGeneralizer()
 	case constant.GenericSerializationGson:
 		g = generalizer.GetGsonGeneralizer()
-
+	case constant.GenericSerializationProtobufJson:
+		g = generalizer.GetProtobufJsonGeneralizer()
 	default:
 		logger.Debugf("\"%s\" is not supported, use the default generalizer(MapGeneralizer)", generic)
 		g = generalizer.GetMapGeneralizer()

--- a/filter/generic/util_test.go
+++ b/filter/generic/util_test.go
@@ -75,9 +75,13 @@ func TestIsMakingAGenericCall(t *testing.T) {
 func TestIsGeneric(t *testing.T) {
 	assert.True(t, isGeneric("true"))
 	assert.True(t, isGeneric("True"))
+	assert.True(t, isGeneric("gson"))
+	assert.True(t, isGeneric("Gson"))
+	assert.True(t, isGeneric("protobuf-json"))
+	assert.True(t, isGeneric("Protobuf-Json"))
 	assert.False(t, isGeneric("false"))
 	assert.False(t, isGeneric(""))
-	assert.False(t, isGeneric("bean")) // 目前代码逻辑仅匹配 "true"
+	assert.False(t, isGeneric("bean"))
 }
 
 func TestGetGeneralizer(t *testing.T) {
@@ -87,6 +91,13 @@ func TestGetGeneralizer(t *testing.T) {
 	g2 := getGeneralizer(constant.GenericSerializationGson)
 	assert.IsType(t, generalizer.GetGsonGeneralizer(), g2)
 
-	g3 := getGeneralizer("unsupported_type")
-	assert.IsType(t, generalizer.GetMapGeneralizer(), g3)
+	g3 := getGeneralizer(constant.GenericSerializationProtobufJson)
+	assert.IsType(t, generalizer.GetProtobufJsonGeneralizer(), g3)
+
+	// test case insensitive
+	g4 := getGeneralizer("Protobuf-Json")
+	assert.IsType(t, generalizer.GetProtobufJsonGeneralizer(), g4)
+
+	g5 := getGeneralizer("unsupported_type")
+	assert.IsType(t, generalizer.GetMapGeneralizer(), g5)
 }


### PR DESCRIPTION
Add protobuf-json generalizer support to the Filter layer, enabling generic calls with protobuf-json serialization for Triple protocol.

- Update isGeneric() to recognize 'protobuf-json' and 'gson' types
- Add protobuf-json case in getGeneralizer() to return ProtobufJsonGeneralizer
- Add corresponding unit tests for the new functionality

### Description
Related to #3167 

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
