### PR TITLE
refactor: remove config package dependency from health and reflectionservices

### DIFF
--- a/protocol/triple/health/healthServer.go
+++ b/protocol/triple/health/healthServer.go
@@ -31,7 +31,6 @@ import (
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
-	"dubbo.apache.org/dubbo-go/v3/config"
 	"dubbo.apache.org/dubbo-go/v3/internal"
 	"dubbo.apache.org/dubbo-go/v3/protocol/triple/health/triple_health"
 	"dubbo.apache.org/dubbo-go/v3/server"
@@ -186,9 +185,6 @@ func init() {
 		Priority: constant.DefaultPriority,
 	})
 
-	// In order to adapt config.Load
-	// Plans for future removal
-	config.SetProviderServiceWithInfo(healthServer, &triple_health.Health_ServiceInfo)
 }
 
 func SetServingStatusServing(service string) {

--- a/protocol/triple/reflection/serverreflection.go
+++ b/protocol/triple/reflection/serverreflection.go
@@ -38,7 +38,6 @@ import (
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
-	"dubbo.apache.org/dubbo-go/v3/config"
 	"dubbo.apache.org/dubbo-go/v3/internal"
 	"dubbo.apache.org/dubbo-go/v3/internal/reflection"
 	rpb "dubbo.apache.org/dubbo-go/v3/protocol/triple/reflection/triple_reflection"
@@ -278,9 +277,6 @@ func init() {
 		},
 		Priority: constant.DefaultPriority,
 	})
-	// In order to adapt config.Load
-	// Plans for future removal
-	config.SetProviderServiceWithInfo(reflectionServer, &rpb.ServerReflection_ServiceInfo)
 }
 
 func Register(s reflection.ServiceInfoProvider) {


### PR DESCRIPTION
Remove dependencies on config package from:
- protocol/triple/health/healthServer.go
- protocol/triple/reflection/serverreflection.go

Both services already register via server.SetProviderServices() in init(), so config.SetProviderServiceWithInfo() calls are no longer needed.

config.SetProviderServiceWithInfo()：
- 这个函数只是将服务和元数据存储在 config 包的 map 中
- 这些 map (proServices, proServicesInfo) 实际上在新的架构中已经不再使用
- 而新架构中服务已通过 server.SetProviderServices() 注册

### Description
Related to #2741 

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
