### PR TITLE
fix(router): fix tag router bypass in v3 API mode

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -79,6 +79,19 @@ func (conn *Connection) call(ctx context.Context, reqs []any, resp any, methodNa
 	if err != nil {
 		return nil, err
 	}
+
+	if attaRaw := ctx.Value(constant.AttachmentKey); attaRaw != nil {
+		if userAtta, ok := attaRaw.(map[string]string); ok {
+			for key, val := range userAtta {
+				inv.SetAttachment(key, val)
+			}
+		} else if userAtta, ok := attaRaw.(map[string]any); ok {
+			for key, val := range userAtta {
+				inv.SetAttachment(key, val)
+			}
+		}
+	}
+
 	return conn.refOpts.invoker.Invoke(ctx, inv), nil
 }
 

--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -405,6 +405,7 @@ const (
 	DefaultMetadataStorageType             = "local"
 	RemoteMetadataStorageType              = "remote"
 	ServiceInstanceEndpoints               = "dubbo.endpoints"
+	ServiceInstanceKey                     = "service_instance"
 	MetadataServicePrefix                  = "dubbo.metadata-service."
 	MetadataServiceURLParamsPropertyName   = MetadataServicePrefix + "url-params"
 	MetadataServiceURLsPropertyName        = MetadataServicePrefix + "urls"


### PR DESCRIPTION
### Description
In dubbo-go v3 `NewInstance` API, the TagRouter is bypassed even when `force.tag=true` is set. This is due to a data propagation gap in the Triple protocol and a metadata recognition gap in the TagRouter for v3 `ServiceInstance`.
This pr fixed it.

Fixes #3199 

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
