### PR TITLE
fix(router/affinity): prevent panic caused by nil return in initialization phase

### DIFF
--- a/cluster/router/affinity/router_test.go
+++ b/cluster/router/affinity/router_test.go
@@ -28,6 +28,7 @@ import (
 import (
 	"dubbo.apache.org/dubbo-go/v3/cluster/router/condition"
 	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/config_center"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
@@ -234,4 +235,15 @@ affinityAware:
 		})
 	}
 
+}
+
+func Test_newApplicationAffinityRouter(t *testing.T) {
+	u, _ := common.NewURL("condition://0.0.0.0/com.foo.BarService")
+	router := newApplicationAffinityRouter(u)
+	assert.Nil(t, router)
+
+	u.SetParam(constant.ApplicationKey, "test-app")
+	router = newApplicationAffinityRouter(u)
+	assert.NotNil(t, router)
+	assert.Equal(t, "test-app", router.currentApplication)
 }

--- a/cluster/router/chain/chain.go
+++ b/cluster/router/chain/chain.go
@@ -33,6 +33,7 @@ import (
 import (
 	"dubbo.apache.org/dubbo-go/v3/cluster/router"
 	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 )
@@ -108,6 +109,12 @@ func (c *RouterChain) copyRouters() []router.PriorityRouter {
 // NewRouterChain init router chain
 // Loop routerFactories and call NewRouter method
 func NewRouterChain(url *common.URL) (*RouterChain, error) {
+	if url.SubURL != nil {
+		if appName := url.SubURL.GetParam(constant.ApplicationKey, ""); appName != "" {
+			url.CompareAndSwapParam(constant.ApplicationKey, "", appName)
+		}
+	}
+
 	routerFactories := extension.GetRouterFactories()
 	if len(routerFactories) == 0 {
 		return nil, perrors.Errorf("No routerFactory exits , create one please")

--- a/common/url.go
+++ b/common/url.go
@@ -564,6 +564,22 @@ func (c *URL) SetParam(key string, value string) {
 	c.params.Set(key, value)
 }
 
+// CompareAndSwapParam will set the key-value pair into URL when the current value equals the expected value.
+// It returns true if the value was set successfully, false otherwise.
+// This is a thread-safe compare-and-swap operation.
+func (c *URL) CompareAndSwapParam(key string, expected string, newValue string) bool {
+	c.paramsLock.Lock()
+	defer c.paramsLock.Unlock()
+	if c.params == nil {
+		c.params = url.Values{}
+	}
+	if c.params.Get(key) == expected {
+		c.params.Set(key, newValue)
+		return true
+	}
+	return false
+}
+
 func (c *URL) SetAttribute(key string, value any) {
 	c.attributesLock.Lock()
 	defer c.attributesLock.Unlock()


### PR DESCRIPTION
### Description
在一些情况下，client 配置 affinity router 时，会因为 nil 而触发段错误
```
2026-02-17 21:27:55     ERROR   affinity/router.go:90       Application affinity router must set application name
2026/02/17 21:27:55 Authenticated: id=72061538416853150, timeout=4000
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe915e9]
```
该 bug 只会在配置了 application 模式的 affinity router 上出现，如果配置 service 模式的 affinity router 则不会触发该 bug

配置代码:
client:
```go
	conn, _, _ := zk.Connect([]string{"127.0.0.1:2181"}, time.Second*5)
	defer conn.Close()
	conn.Create("/dubbo/config/dubbo/router_affinity_consumer.affinity-router", []byte(`configVersion: v3.1
scope: application
key: router_affinity_consumer
enabled: true
runtime: true
affinityAware:
  key: region
  ratio: 1`), 0, zk.WorldACL(zk.PermAll))

	ins, _ := dubbo.NewInstance(
		dubbo.WithName("router_affinity_consumer"),
		dubbo.WithRegistry(registry.WithZookeeper(), registry.WithAddress("127.0.0.1:2181")),
		dubbo.WithConfigCenter(config_center.WithZookeeper(), config_center.WithAddress("127.0.0.1:2181"), config_center.WithGroup("dubbo")),
	)

	cli, _ := ins.NewClient(client.WithClientProtocolTriple())
	svc, _ := greet.NewGreetService(cli, client.WithParam("region", "shanghai"))

	ctx := context.WithValue(context.Background(),
		constant.DubboCtxKey("attachment"),
		map[string]interface{}{"region": "shanghai"},
	)
```

server:
```go
	ins, _ := dubbo.NewInstance(
		dubbo.WithName("router_affinity_provider_a"),
		dubbo.WithRegistry(registry.WithZookeeper(), registry.WithAddress("127.0.0.1:2181")),
	)

	srv, _ := ins.NewServer(server.WithServerProtocol(protocol.WithTriple(), protocol.WithPort(20000)))

	handler := &AffinityGreetServer{}
	greet.RegisterGreetServiceHandler(srv, handler, server.WithParam("region", "hangzhou"))

	srv.Serve()
```
bug 原因是当前版本的client应用名未能被正确传递至 router chain。这导致 router chain 在 初始化 affinity router 时，由于获取到空应用名而直接返回 nil。最终造成 nil 被访问而 panic

本 pr 添加了在 router chain 读取应用名的逻辑来修复此 bug

Fixes #3203

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
