### PR TITLE
refactor(protocol/triple): remove config package dependency

### DIFF
--- a/protocol/triple/dubbo3_invoker.go
+++ b/protocol/triple/dubbo3_invoker.go
@@ -40,7 +40,6 @@ import (
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
-	"dubbo.apache.org/dubbo-go/v3/config"
 	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 	"dubbo.apache.org/dubbo-go/v3/protocol/result"
@@ -68,8 +67,7 @@ type DubboInvoker struct {
 
 // NewDubbo3Invoker constructor
 func NewDubbo3Invoker(url *common.URL) (*DubboInvoker, error) {
-	// TODO: Temporary compatibility with old APIs, can be removed later
-	rt := config.GetConsumerConfig().RequestTimeout
+	var rt string
 	if consumerConfRaw, ok := url.GetAttribute(constant.ConsumerConfigKey); ok {
 		if consumerConf, ok := consumerConfRaw.(*global.ConsumerConfig); ok {
 			rt = consumerConf.RequestTimeout
@@ -77,15 +75,9 @@ func NewDubbo3Invoker(url *common.URL) (*DubboInvoker, error) {
 	}
 
 	timeout := url.GetParamDuration(constant.TimeoutKey, rt)
-	// for triple pb serialization. The bean name from provider is the provider reference key,
-	// which can't locate the target consumer stub, so we use interface key..
-	interfaceKey := url.GetParam(constant.InterfaceKey, "")
-	//TODO: Temporary compatibility with old APIs, can be removed later
-	consumerService := config.GetConsumerServiceByInterfaceName(interfaceKey)
-	if consumerService == nil {
-		if rpcService, ok := url.GetAttribute(constant.RpcServiceKey); ok {
-			consumerService = rpcService
-		}
+	var consumerService any
+	if rpcService, ok := url.GetAttribute(constant.RpcServiceKey); ok {
+		consumerService = rpcService
 	}
 
 	dubboSerializerType := url.GetParam(constant.SerializationKey, constant.ProtobufSerialization)
@@ -127,14 +119,9 @@ func NewDubbo3Invoker(url *common.URL) (*DubboInvoker, error) {
 	opts = append(opts, triConfig.WithGRPCKeepAliveTimeInterval(keepAliveInterval))
 	opts = append(opts, triConfig.WithGRPCKeepAliveTimeout(keepAliveTimeout))
 
-	tracingKey := url.GetParam(constant.TracingConfigKey, "")
-	if tracingKey != "" {
-		tracingConfig := config.GetTracingConfig(tracingKey)
-		if tracingConfig != nil {
+	if tracingConfRaw, ok := url.GetAttribute(constant.TracingConfigKey); ok {
+		if tracingConfig, ok := tracingConfRaw.(*global.TracingConfig); ok && tracingConfig != nil {
 			if tracingConfig.Name == "jaeger" {
-				if tracingConfig.ServiceName == "" {
-					tracingConfig.ServiceName = config.GetApplicationConfig().Name
-				}
 				opts = append(opts, triConfig.WithJaegerConfig(
 					tracingConfig.Address,
 					tracingConfig.ServiceName,
@@ -148,16 +135,7 @@ func NewDubbo3Invoker(url *common.URL) (*DubboInvoker, error) {
 
 	triOption := triConfig.NewTripleOption(opts...)
 
-	// TODO: remove config TLSConfig
-	// delete this branch
-	tlsConfig := config.GetRootConfig().TLSConfig
-	if tlsConfig != nil {
-		triOption.CACertFile = tlsConfig.CACertFile
-		triOption.TLSCertFile = tlsConfig.TLSCertFile
-		triOption.TLSKeyFile = tlsConfig.TLSKeyFile
-		triOption.TLSServerName = tlsConfig.TLSServerName
-		logger.Infof("DUBBO3 Client initialized the TLSConfig configuration")
-	} else if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
+	if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
 		// use global TLSConfig handle tls
 		tlsConf, ok := tlsConfRaw.(*global.TLSConfig)
 		if !ok {

--- a/protocol/triple/server.go
+++ b/protocol/triple/server.go
@@ -42,7 +42,6 @@ import (
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
-	"dubbo.apache.org/dubbo-go/v3/config"
 	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/internal"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
@@ -153,8 +152,7 @@ func (s *Server) Start(invoker base.Invoker, info *common.ServiceInfo) {
 		s.handleServiceWithInfo(intfName, invoker, reflectInfo, hanOpts...)
 		s.saveServiceInfo(intfName, reflectInfo)
 	} else {
-		// old triple idl mode and old triple non-idl mode
-		s.compatHandleService(intfName, url.Group(), url.Version(), hanOpts...)
+		s.compatHandleService(url, intfName, url.Group(), url.Version(), hanOpts...)
 	}
 	internal.ReflectionRegister(s)
 
@@ -186,7 +184,7 @@ func (s *Server) RefreshService(invoker base.Invoker, info *common.ServiceInfo) 
 		s.handleServiceWithInfo(intfName, invoker, info, hanOpts...)
 		s.saveServiceInfo(intfName, info)
 	} else {
-		s.compatHandleService(intfName, URL.Group(), URL.Version(), hanOpts...)
+		s.compatHandleService(URL, intfName, URL.Group(), URL.Version(), hanOpts...)
 	}
 }
 
@@ -250,8 +248,13 @@ func getHanOpts(url *common.URL, tripleConf *global.TripleConfig) (hanOpts []tri
 
 // *Important*, this function is responsible for being compatible with old triple-gen code and non-idl code
 // compatHandleService registers handler based on ServiceConfig and provider service.
-func (s *Server) compatHandleService(interfaceName string, group, version string, opts ...tri.HandlerOption) {
-	providerServices := config.GetProviderConfig().Services
+func (s *Server) compatHandleService(url *common.URL, interfaceName string, group, version string, opts ...tri.HandlerOption) {
+	var providerServices map[string]*global.ServiceConfig
+	if providerConfRaw, ok := url.GetAttribute(constant.ProviderConfigKey); ok {
+		if providerConf, ok := providerConfRaw.(*global.ProviderConfig); ok && providerConf != nil {
+			providerServices = providerConf.Services
+		}
+	}
 	if len(providerServices) == 0 {
 		logger.Info("Provider service map is null, please register ProviderServices")
 		return
@@ -260,8 +263,11 @@ func (s *Server) compatHandleService(interfaceName string, group, version string
 		if providerService.Interface != interfaceName || providerService.Group != group || providerService.Version != version {
 			continue
 		}
-		// todo(DMwangnima): judge protocol type
-		service := config.GetProviderService(key)
+		service, _ := url.GetAttribute(constant.RpcServiceKey)
+		if service == nil {
+			logger.Warnf("no rpc service found for key: %v", key)
+			continue
+		}
 		serviceKey := common.ServiceKey(providerService.Interface, providerService.Group, providerService.Version)
 		exporter, _ := tripleProtocol.ExporterMap().Load(serviceKey)
 		if exporter == nil {


### PR DESCRIPTION
Remove `config` package dependency from `protocol/triple/server.go` and `protocol/triple/dubbo3_invoker.go`

### Changes
- **dubbo3_invoker.go**: 
  - Get `RequestTimeout` from URL attribute `ConsumerConfigKey` instead of `config.GetConsumerConfig()`
  - Get consumer service from URL attribute `RpcServiceKey` instead of `config.GetConsumerServiceByInterfaceName()`
  - Get tracing config from URL attribute `TracingConfigKey` instead of `config.GetTracingConfig()`
  - Get TLS config from URL attribute `TLSConfigKey` only, remove `config.GetRootConfig().TLSConfig` fallback
- **server.go**:
  - Get provider services from URL attribute `ProviderConfigKey` instead of `config.GetProviderConfig().Services`
  - Get RPC service from URL attribute `RpcServiceKey` instead of `config.GetProviderService()`
### Description
Related #3204  

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
