### PR TITLE
fix(filter):solve side effects caused by 3184 refactor

### DIFF
--- a/filter/active/filter.go
+++ b/filter/active/filter.go
@@ -73,8 +73,7 @@ func (f *activeFilter) Invoke(ctx context.Context, invoker base.Invoker, inv bas
 	// Cache the URL object to ensure BeginCount and EndCount use the same URL instance
 	// This prevents statistics inconsistency when the invoker is destroyed concurrently
 	url := invoker.GetURL()
-	rpcInv.SetAttachment(dubboInvokeURL, url)
-
+	rpcInv.SetAttribute(dubboInvokeURL, url)
 	base.BeginCount(url, inv.MethodName())
 	return invoker.Invoke(ctx, inv)
 }
@@ -83,19 +82,29 @@ func (f *activeFilter) Invoke(ctx context.Context, invoker base.Invoker, inv bas
 func (f *activeFilter) OnResponse(ctx context.Context, result result.Result, invoker base.Invoker, inv base.Invocation) result.Result {
 	rpcInv := inv.(*invocation.RPCInvocation)
 
-	// Retrieve the cached URL from Invoke phase to ensure statistics consistency
-	url := rpcInv.GetAttachmentInterface(dubboInvokeURL)
+	/// Retrieve the cached URL from Invoke phase with a nil default value
+	rawUrl := rpcInv.GetAttributeWithDefaultValue(dubboInvokeURL, nil)
+
+	// Safely assert the type. If rawUrl is nil, ok will be false and panic is avoided.
+	url, ok := rawUrl.(*common.URL)
+
+	// If the URL is missing or invalid, it means the Invoke phase was likely interrupted.
+	// Skip EndCount to prevent statistic inconsistency or panics.
+	if !ok || url == nil {
+		logger.Warnf("activeFilter cannot get cached URL from attribute, skip EndCount. Invoker may not have passed Invoke phase.")
+		return result
+	}
 
 	startTime, err := strconv.ParseInt(rpcInv.GetAttachmentWithDefaultValue(dubboInvokeStartTime, "0"), 10, 64)
 	if err != nil {
 		result.SetError(err)
 		logger.Errorf("parse dubbo_invoke_start_time to int64 failed")
 		// When err is not nil, use default elapsed value of 1
-		base.EndCount(url.(*common.URL), inv.MethodName(), 1, false)
+		base.EndCount(url, inv.MethodName(), 1, false)
 		return result
 	}
 
 	elapsed := base.CurrentTimeMillis() - startTime
-	base.EndCount(url.(*common.URL), inv.MethodName(), elapsed, result.Error() == nil)
+	base.EndCount(url, inv.MethodName(), elapsed, result.Error() == nil)
 	return result
 }

--- a/filter/active/filter_test.go
+++ b/filter/active/filter_test.go
@@ -52,9 +52,9 @@ func TestFilterInvoke(t *testing.T) {
 	invoker.EXPECT().GetURL().Return(url).Times(1)
 	filter.Invoke(context.Background(), invoker, invoc)
 	assert.NotEmpty(t, invoc.GetAttachmentWithDefaultValue(dubboInvokeStartTime, ""))
-	urlFromAttachment, ok := invoc.GetAttachmentInterface(dubboInvokeURL).(*common.URL)
-	assert.True(t, ok, "dubboInvokeURL should be cached in attachment")
-	assert.Equal(t, url.Key(), urlFromAttachment.Key(), "Cached URL should match original URL")
+	urlFromAttribute, ok := invoc.GetAttribute(dubboInvokeURL)
+	assert.True(t, ok, "dubboInvokeURL should be cached in attribute")
+	assert.Equal(t, url.Key(), urlFromAttribute.(*common.URL).Key(), "Cached URL should match original URL")
 
 }
 
@@ -64,8 +64,8 @@ func TestFilterOnResponse(t *testing.T) {
 	url, _ := common.NewURL(fmt.Sprintf("dubbo://%s:%d/com.alibaba.user.UserProvider", constant.LocalHostValue, constant.DefaultPort))
 	invoc := invocation.NewRPCInvocation("test", []any{"OK"}, map[string]any{
 		dubboInvokeStartTime: strconv.FormatInt(c-int64(elapsed), 10),
-		dubboInvokeURL:       url,
 	})
+	invoc.SetAttribute(dubboInvokeURL, url)
 	filter := activeFilter{}
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
@@ -100,8 +100,8 @@ func TestFilterOnResponseWithDefer(t *testing.T) {
 		url, _ := common.NewURL(fmt.Sprintf("dubbo://%s:%d/com.alibaba.user.UserProvider", constant.LocalHostValue, constant.DefaultPort))
 		invoc := invocation.NewRPCInvocation("test1", []any{"OK"}, map[string]any{
 			dubboInvokeStartTime: strconv.FormatInt(c, 10),
-			dubboInvokeURL:       url,
 		})
+		invoc.SetAttribute(dubboInvokeURL, url)
 		filter := activeFilter{}
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -131,8 +131,8 @@ func TestFilterOnResponseWithDefer(t *testing.T) {
 		url, _ := common.NewURL(fmt.Sprintf("dubbo://%s:%d/com.ikurento.user.UserProvider", constant.LocalHostValue, constant.DefaultPort))
 		invoc := invocation.NewRPCInvocation("test2", []any{"OK"}, map[string]any{
 			dubboInvokeStartTime: strconv.FormatInt(c, 10),
-			dubboInvokeURL:       url,
 		})
+		invoc.SetAttribute(dubboInvokeURL, url)
 		filter := activeFilter{}
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -165,8 +165,8 @@ func TestFilterOnResponseWithDefer(t *testing.T) {
 		url, _ := common.NewURL(fmt.Sprintf("dubbo://%s:%d/com.ikurento.user.UserProvider", constant.LocalHostValue, constant.DefaultPort))
 		invoc := invocation.NewRPCInvocation("test3", []any{"OK"}, map[string]any{
 			dubboInvokeStartTime: "invalid-time",
-			dubboInvokeURL:       url,
 		})
+		invoc.SetAttribute(dubboInvokeURL, url)
 		filter := activeFilter{}
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()
@@ -195,9 +195,8 @@ func TestFilterOnResponseWithDefer(t *testing.T) {
 		defer base.CleanAllStatus()
 
 		url, _ := common.NewURL(fmt.Sprintf("dubbo://%s:%d/com.ikurento.user.UserProvider", constant.LocalHostValue, constant.DefaultPort))
-		invoc := invocation.NewRPCInvocation("test4", []any{"OK"}, map[string]any{
-			dubboInvokeURL: url,
-		})
+		invoc := invocation.NewRPCInvocation("test4", []any{"OK"}, map[string]any{})
+		invoc.SetAttribute(dubboInvokeURL, url)
 		filter := activeFilter{}
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()


### PR DESCRIPTION
### Description
This PR fixes a side effect (active count leak) introduced by the `BaseInvoker` refactor in #3184.

**Background & Issue:**
In #3184, `BaseInvoker.GetURL()` was modified to return an `emptyURL` instead of `nil` when the invoker is concurrently destroyed. However, in `filter/active/filter.go`, if the destruction happens during an ongoing invocation, `BeginCount` and `EndCount` will operate on different URL objects (the original URL vs. the `emptyURL`). This mismatch causes the active count to leak, as the original URL's count is never decremented.

**Solution:**
To ensure consistency, this PR caches the original URL pointer in the `Invocation` attachments during the `Invoke` phase, so `OnResponse` can retrieve and use the exact same URL object for `EndCount`.

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works