### PR TITLE
fix: release the lock in advance in case causing deadlock

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -105,9 +105,6 @@ func (s *Server) genSvcOpts(handler any, info *common.ServiceInfo, opts ...Servi
 	}
 	var svcOpts []ServiceOption
 
-	// add read lock for value copy and svcOpts to initialize.
-	s.mu.RLock()
-	defer s.mu.RUnlock()
 	appCfg := s.cfg.Application
 	proCfg := s.cfg.Provider
 	prosCfg := s.cfg.Protocols
@@ -349,12 +346,10 @@ func (s *Server) Serve() error {
 func (s *Server) exportInternalServices() error {
 	cfg := &ServiceOptions{}
 
-	s.mu.RLock()
 	cfg.Application = s.cfg.Application
 	cfg.Provider = s.cfg.Provider
 	cfg.Protocols = s.cfg.Protocols
 	cfg.Registries = s.cfg.Registries
-	s.mu.RUnlock()
 
 	services := make([]*InternalService, 0, len(internalProServices))
 


### PR DESCRIPTION
### Description
Fixes #3237 

The Serve() method uses `select{}` to block the thread, which makes `s.mu.Unlock` unable to release the lock.
This PR calls Unlock method in advance to avoid deadlock problem.

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
