### PR TITLE
fix(router): resolve polaris application lookup from URL attributes

### DIFF
--- a/cluster/router/polaris/router.go
+++ b/cluster/router/polaris/router.go
@@ -87,17 +87,19 @@ func newPolarisRouter(url *common.URL) (*polarisRouter, error) {
 		return nil, fmt.Errorf("polaris router must set application name")
 	}
 
-	// get from url attr
-	registries, ok := url.GetAttribute(constant.RegistriesConfigKey)
-	if !ok {
-		registries = make(map[string]*global.RegistryConfig)
+	// get from url attr with safe type assertion
+	registriesMap := make(map[string]*global.RegistryConfig)
+	if registriesRaw, ok := url.GetAttribute(constant.RegistriesConfigKey); ok {
+		if typedRegistries, ok := registriesRaw.(map[string]*global.RegistryConfig); ok && typedRegistries != nil {
+			registriesMap = typedRegistries
+		}
 	}
 
 	if err := remotingpolaris.Check(); errors.Is(err, remotingpolaris.ErrorNoOpenPolarisAbility) {
 		return &polarisRouter{
 			openRoute:          false,
 			currentApplication: applicationName,
-			Registries:         registries.(map[string]*global.RegistryConfig),
+			Registries:         registriesMap,
 		}, nil
 	}
 
@@ -115,7 +117,7 @@ func newPolarisRouter(url *common.URL) (*polarisRouter, error) {
 		routerAPI:          routerAPI,
 		consumerAPI:        consumerAPI,
 		currentApplication: applicationName,
-		Registries:         registries.(map[string]*global.RegistryConfig),
+		Registries:         registriesMap,
 	}, nil
 }
 

--- a/cluster/router/polaris/router_test.go
+++ b/cluster/router/polaris/router_test.go
@@ -91,3 +91,22 @@ func TestNewPolarisRouterApplicationNameFromSubURLParam(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "param-app", r.currentApplication)
 }
+
+func TestNewPolarisRouterInvalidRegistriesTypeShouldFallback(t *testing.T) {
+	url := mustNewURL(t, serviceURLWithApp)
+	url.SetAttribute(constant.RegistriesConfigKey, map[string]global.RegistryConfig{
+		"test": {},
+	})
+
+	var (
+		r   *polarisRouter
+		err error
+	)
+	require.NotPanics(t, func() {
+		r, err = newPolarisRouter(url)
+	})
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	require.NotNil(t, r.Registries)
+	require.Empty(t, r.Registries)
+}


### PR DESCRIPTION
### Description

Fixes #3151

Root cause is storage-vs-retrieval mismatch for `application` in Polaris router:
- `ApplicationKey` is often stored in URL attributes as `*global.ApplicationConfig`
- old Polaris router logic only checked URL params, so it could not read application name correctly

### What changed

1. `cluster/router/polaris/router.go`
   - update `newPolarisRouter` lookup order for application name:
     - main URL param (backward compatibility)
     - main URL attribute (`*global.ApplicationConfig` / `global.ApplicationConfig`)
     - SubURL param
     - SubURL attribute (`*global.ApplicationConfig` / `global.ApplicationConfig`)
   - keep `switch` inline in `newPolarisRouter` (no helper wrapper)
   - remove `config` package dependency from this lookup
   - when Polaris ability is not enabled, still return router with resolved `currentApplication` so tests can verify the actual resolution path

2. `cluster/router/polaris/router_test.go`
   - add/maintain focused tests for:
     - application from main URL param
     - application from main URL attribute
     - application from SubURL param
     - application from SubURL attribute
     - missing application error
   - all happy-path tests now assert `currentApplication`, avoiding vacuous pass on `require.NoError` only

### Verification

- Unit tests:
  - `go test ./cluster/router/polaris ./cluster/router/chain`
- Polaris integration sample:
  - `docker compose -f samples/docker-compose.yml up -d --wait`
  - `bash samples/integrate_test.sh registry/polaris`
  - `docker compose -f samples/docker-compose.yml down`
  - observed success with:
    - `Greet response: greeting:"hello world"`
    - `Sample flow completed for: registry/polaris`

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
