### PR TITLE
feat: simplify server shutdown lifecycle #3042

### DIFF
--- a/graceful_shutdown/shutdown.go
+++ b/graceful_shutdown/shutdown.go
@@ -133,6 +133,15 @@ func Done() <-chan struct{} {
 	return shutdownDone
 }
 
+func IsDone() bool {
+	select {
+	case <-shutdownDone:
+		return true
+	default:
+		return false
+	}
+}
+
 func Shutdown(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()

--- a/graceful_shutdown/shutdown.go
+++ b/graceful_shutdown/shutdown.go
@@ -88,18 +88,23 @@ func Init(opts ...Option) {
 			opt(newOpts)
 		}
 
+		// retrieve ShutdownConfig for gracefulShutdownFilter
+		gracefulShutdownConsumerFilter, exist := extension.GetFilter(constant.GracefulShutdownConsumerFilterKey)
+		if !exist {
+			return
+		}
+		gracefulShutdownProviderFilter, exist := extension.GetFilter(constant.GracefulShutdownProviderFilterKey)
+		if !exist {
+			return
+		}
+
 		storeShutdownConfig(newOpts.Shutdown)
 
-		// retrieve ShutdownConfig for gracefulShutdownFilter
-		if gracefulShutdownConsumerFilter, exist := extension.GetFilter(constant.GracefulShutdownConsumerFilterKey); exist {
-			if filter, ok := gracefulShutdownConsumerFilter.(config.Setter); ok {
-				filter.Set(constant.GracefulShutdownFilterShutdownConfig, newOpts.Shutdown)
-			}
+		if filter, ok := gracefulShutdownConsumerFilter.(config.Setter); ok {
+			filter.Set(constant.GracefulShutdownFilterShutdownConfig, newOpts.Shutdown)
 		}
-		if gracefulShutdownProviderFilter, exist := extension.GetFilter(constant.GracefulShutdownProviderFilterKey); exist {
-			if filter, ok := gracefulShutdownProviderFilter.(config.Setter); ok {
-				filter.Set(constant.GracefulShutdownFilterShutdownConfig, newOpts.Shutdown)
-			}
+		if filter, ok := gracefulShutdownProviderFilter.(config.Setter); ok {
+			filter.Set(constant.GracefulShutdownFilterShutdownConfig, newOpts.Shutdown)
 		}
 
 		if newOpts.Shutdown.InternalSignal != nil && *newOpts.Shutdown.InternalSignal {

--- a/graceful_shutdown/shutdown.go
+++ b/graceful_shutdown/shutdown.go
@@ -24,6 +24,7 @@ import (
 	"os/signal"
 	"runtime/debug"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -66,6 +67,16 @@ var (
 
 	proMu     sync.Mutex
 	protocols map[string]struct{}
+
+	shutdownConfigMu sync.RWMutex
+	shutdownConfig   *global.ShutdownConfig
+
+	shutdownOnce    sync.Once
+	shutdownStarted atomic.Bool
+	shutdownDone    = make(chan struct{})
+	shutdownResult  error
+
+	signalNotify = signal.Notify
 )
 
 func Init(opts ...Option) {
@@ -76,26 +87,23 @@ func Init(opts ...Option) {
 			opt(newOpts)
 		}
 
-		// retrieve ShutdownConfig for gracefulShutdownFilter
-		gracefulShutdownConsumerFilter, exist := extension.GetFilter(constant.GracefulShutdownConsumerFilterKey)
-		if !exist {
-			return
-		}
-		gracefulShutdownProviderFilter, exist := extension.GetFilter(constant.GracefulShutdownProviderFilterKey)
-		if !exist {
-			return
-		}
-		if filter, ok := gracefulShutdownConsumerFilter.(config.Setter); ok {
-			filter.Set(constant.GracefulShutdownFilterShutdownConfig, newOpts.Shutdown)
-		}
+		storeShutdownConfig(newOpts.Shutdown)
 
-		if filter, ok := gracefulShutdownProviderFilter.(config.Setter); ok {
-			filter.Set(constant.GracefulShutdownFilterShutdownConfig, newOpts.Shutdown)
+		// retrieve ShutdownConfig for gracefulShutdownFilter
+		if gracefulShutdownConsumerFilter, exist := extension.GetFilter(constant.GracefulShutdownConsumerFilterKey); exist {
+			if filter, ok := gracefulShutdownConsumerFilter.(config.Setter); ok {
+				filter.Set(constant.GracefulShutdownFilterShutdownConfig, newOpts.Shutdown)
+			}
+		}
+		if gracefulShutdownProviderFilter, exist := extension.GetFilter(constant.GracefulShutdownProviderFilterKey); exist {
+			if filter, ok := gracefulShutdownProviderFilter.(config.Setter); ok {
+				filter.Set(constant.GracefulShutdownFilterShutdownConfig, newOpts.Shutdown)
+			}
 		}
 
 		if newOpts.Shutdown.InternalSignal != nil && *newOpts.Shutdown.InternalSignal {
 			signals := make(chan os.Signal, 1)
-			signal.Notify(signals, ShutdownSignals...)
+			signalNotify(signals, ShutdownSignals...)
 
 			go func() {
 				sig := <-signals
@@ -105,7 +113,9 @@ func Init(opts ...Option) {
 					logger.Warn("Shutdown gracefully timeout, applicationConfig will shutdown immediately. ")
 					os.Exit(0)
 				})
-				beforeShutdown(newOpts.Shutdown)
+				if err := Shutdown(context.Background()); err != nil {
+					logger.Warnf("Graceful shutdown --- shutdown completed with error: %v", err)
+				}
 				// those signals' original behavior is exit with dump ths stack, so we try to keep the behavior
 				for _, dumpSignal := range DumpHeapShutdownSignals {
 					if sig == dumpSignal {
@@ -116,6 +126,25 @@ func Init(opts ...Option) {
 			}()
 		}
 	})
+}
+
+func Done() <-chan struct{} {
+	return shutdownDone
+}
+
+func Shutdown(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	startShutdownOnce()
+
+	select {
+	case <-shutdownDone:
+		return shutdownResult
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // RegisterProtocol registers protocol which would be destroyed before shutdown.
@@ -164,6 +193,25 @@ func beforeShutdown(shutdown *global.ShutdownConfig) {
 
 	// 7. execute custom callbacks
 	executeCustomShutdownCallbacks(shutdown)
+}
+
+func startShutdownOnce() {
+	shutdownOnce.Do(func() {
+		shutdownStarted.Store(true)
+		go func() {
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					logger.Warnf("Graceful shutdown --- shutdown panicked --- %v", recovered)
+					shutdownResult = fmt.Errorf("graceful shutdown panic: %v", recovered)
+				}
+				close(shutdownDone)
+			}()
+
+			cfg := loadShutdownConfig()
+			beforeShutdown(cfg)
+			shutdownResult = nil
+		}()
+	})
 }
 
 // unregisterRegistries unregisters exported services from registries during graceful shutdown.
@@ -373,4 +421,21 @@ func getProtocolSafely(name string) (protocol protocolbase.Protocol, ok bool) {
 	protocol = extension.GetProtocol(name)
 	ok = protocol != nil
 	return protocol, ok
+}
+
+func storeShutdownConfig(cfg *global.ShutdownConfig) {
+	shutdownConfigMu.Lock()
+	defer shutdownConfigMu.Unlock()
+	shutdownConfig = cfg
+}
+
+func loadShutdownConfig() *global.ShutdownConfig {
+	shutdownConfigMu.RLock()
+	cfg := shutdownConfig
+	shutdownConfigMu.RUnlock()
+
+	if cfg != nil {
+		return cfg
+	}
+	return global.DefaultShutdownConfig()
 }

--- a/graceful_shutdown/shutdown.go
+++ b/graceful_shutdown/shutdown.go
@@ -39,6 +39,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/config"
 	"dubbo.apache.org/dubbo-go/v3/global"
+	"dubbo.apache.org/dubbo-go/v3/metrics/probe"
 	protocolbase "dubbo.apache.org/dubbo-go/v3/protocol/base"
 )
 
@@ -172,6 +173,7 @@ func beforeShutdown(shutdown *global.ShutdownConfig) {
 	// 1. mark closing state
 	logger.Info("Graceful shutdown --- Mark closing state.")
 	shutdown.Closing.Store(true)
+	probe.SetReady(false)
 
 	// 2. unregister services from registries
 	unregisterRegistries()

--- a/graceful_shutdown/shutdown_test.go
+++ b/graceful_shutdown/shutdown_test.go
@@ -20,6 +20,7 @@ package graceful_shutdown
 import (
 	"context"
 	"errors"
+	"os/signal"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -29,6 +30,7 @@ import (
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 import (
@@ -99,11 +101,23 @@ func (m *MockFilter) OnResponse(ctx context.Context, result result.Result, invok
 	return nil
 }
 
-func TestInit(t *testing.T) {
-	// Reset initOnce and protocols for testing
+func resetShutdownTestState() {
 	initOnce = sync.Once{}
 	protocols = nil
 	proMu = sync.Mutex{}
+
+	shutdownConfigMu = sync.RWMutex{}
+	shutdownConfig = nil
+	shutdownOnce = sync.Once{}
+	shutdownStarted = atomic.Bool{}
+	shutdownDone = make(chan struct{})
+	shutdownResult = nil
+	signalNotify = signal.Notify
+}
+
+func TestInit(t *testing.T) {
+	// Reset initOnce and protocols for testing
+	resetShutdownTestState()
 
 	// Register mock filters
 	mockConsumerFilter := &MockFilter{}
@@ -131,6 +145,54 @@ func TestInit(t *testing.T) {
 	// Remove mock filters
 	extension.UnregisterFilter(constant.GracefulShutdownConsumerFilterKey)
 	extension.UnregisterFilter(constant.GracefulShutdownProviderFilterKey)
+}
+
+func TestShutdownClosesDoneAndRunsOnce(t *testing.T) {
+	resetShutdownTestState()
+
+	callbackName := "shutdown-run-once-test"
+	originalCallback, callbackExists := extension.LookupGracefulShutdownCallback(callbackName)
+	t.Cleanup(func() {
+		extension.UnregisterGracefulShutdownCallback(callbackName)
+		if callbackExists {
+			extension.RegisterGracefulShutdownCallback(callbackName, originalCallback)
+		}
+	})
+
+	var callbackCalls atomic.Int32
+	extension.RegisterGracefulShutdownCallback(callbackName, func(ctx context.Context) error {
+		callbackCalls.Add(1)
+		return nil
+	})
+
+	cfg := global.DefaultShutdownConfig()
+	internalSignal := false
+	cfg.InternalSignal = &internalSignal
+	cfg.ConsumerUpdateWaitTime = "0s"
+	cfg.StepTimeout = "0s"
+	cfg.NotifyTimeout = "10ms"
+	cfg.OfflineRequestWindowTimeout = "0s"
+
+	Init(SetShutdownConfig(cfg))
+
+	firstDone := make(chan error, 1)
+	secondDone := make(chan error, 1)
+	go func() {
+		firstDone <- Shutdown(context.Background())
+	}()
+	go func() {
+		secondDone <- Shutdown(context.Background())
+	}()
+
+	require.NoError(t, <-firstDone)
+	require.NoError(t, <-secondDone)
+	assert.Equal(t, int32(1), callbackCalls.Load())
+
+	select {
+	case <-Done():
+	default:
+		t.Fatal("Done channel was not closed after Shutdown completed")
+	}
 }
 
 func TestRegisterProtocol(t *testing.T) {

--- a/graceful_shutdown/shutdown_test.go
+++ b/graceful_shutdown/shutdown_test.go
@@ -20,6 +20,7 @@ package graceful_shutdown
 import (
 	"context"
 	"errors"
+	"os"
 	"os/signal"
 	"sync"
 	"sync/atomic"
@@ -146,6 +147,32 @@ func TestInit(t *testing.T) {
 	// Remove mock filters
 	extension.UnregisterFilter(constant.GracefulShutdownConsumerFilterKey)
 	extension.UnregisterFilter(constant.GracefulShutdownProviderFilterKey)
+}
+
+func TestInitReturnsWhenGracefulShutdownFilterMissing(t *testing.T) {
+	resetShutdownTestState()
+
+	mockConsumerFilter := &MockFilter{}
+	mockConsumerFilter.On("Set", mock.Anything, mock.Anything).Return()
+
+	extension.SetFilter(constant.GracefulShutdownConsumerFilterKey, func() filter.Filter {
+		return mockConsumerFilter
+	})
+	extension.UnregisterFilter(constant.GracefulShutdownProviderFilterKey)
+	t.Cleanup(func() {
+		extension.UnregisterFilter(constant.GracefulShutdownConsumerFilterKey)
+	})
+
+	notifyCalled := atomic.Bool{}
+	signalNotify = func(chan<- os.Signal, ...os.Signal) {
+		notifyCalled.Store(true)
+	}
+
+	Init()
+
+	mockConsumerFilter.AssertNotCalled(t, "Set", mock.Anything, mock.Anything)
+	assert.False(t, notifyCalled.Load())
+	assert.Nil(t, shutdownConfig)
 }
 
 func TestShutdownClosesDoneAndRunsOnce(t *testing.T) {

--- a/graceful_shutdown/shutdown_test.go
+++ b/graceful_shutdown/shutdown_test.go
@@ -39,6 +39,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/filter"
 	"dubbo.apache.org/dubbo-go/v3/global"
+	"dubbo.apache.org/dubbo-go/v3/metrics/probe"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 	"dubbo.apache.org/dubbo-go/v3/protocol/result"
 )
@@ -193,6 +194,27 @@ func TestShutdownClosesDoneAndRunsOnce(t *testing.T) {
 	default:
 		t.Fatal("Done channel was not closed after Shutdown completed")
 	}
+}
+
+func TestBeforeShutdownMarksNotReady(t *testing.T) {
+	probe.Init(&probe.Config{
+		Enabled:          true,
+		Port:             "0",
+		UseInternalState: true,
+	})
+	probe.SetReady(true)
+	t.Cleanup(func() {
+		probe.SetReady(false)
+		probe.SetStartupComplete(false)
+		probe.EnableInternalState(false)
+	})
+
+	require.NoError(t, probe.CheckReadiness(context.Background()))
+
+	cfg := global.DefaultShutdownConfig()
+	beforeShutdown(cfg)
+
+	require.Error(t, probe.CheckReadiness(context.Background()))
 }
 
 func TestRegisterProtocol(t *testing.T) {

--- a/registry/exposed_tmp/exposed.go
+++ b/registry/exposed_tmp/exposed.go
@@ -18,6 +18,8 @@
 package exposed_tmp
 
 import (
+	"context"
+
 	"github.com/dubbogo/gost/log/logger"
 )
 
@@ -29,6 +31,11 @@ import (
 
 // RegisterServiceInstance register service instance
 func RegisterServiceInstance() error {
+	return RegisterServiceInstanceContext(context.Background())
+}
+
+// RegisterServiceInstanceContext registers service instances and checks cancellation between registries.
+func RegisterServiceInstanceContext(ctx context.Context) error {
 	defer func() {
 		// TODO: remove this recover func, this just to avoid some unit test failed, this will not happen in user side mostly
 		// config test -> metadata exporter -> dubbo protocol/remoting -> config, cycle import will occur
@@ -40,8 +47,31 @@ func RegisterServiceInstance() error {
 	protocol := extension.GetProtocol(constant.RegistryKey)
 	if rf, ok := protocol.(registry.RegistryFactory); ok {
 		for _, r := range rf.GetRegistries() {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
 			if sdr, ok := r.(registry.ServiceDiscoveryRegistry); ok {
 				if err := sdr.RegisterService(); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// UnregisterServiceInstance unregisters the current service instance from all service discovery registries.
+func UnregisterServiceInstance() error {
+	defer func() {
+		if err := recover(); err != nil {
+			logger.Errorf("unregister service instance failed,please check if registry protocol is imported, error: %v", err)
+		}
+	}()
+	protocol := extension.GetProtocol(constant.RegistryKey)
+	if rf, ok := protocol.(registry.RegistryFactory); ok {
+		for _, r := range rf.GetRegistries() {
+			if sdr, ok := r.(registry.ServiceDiscoveryRegistry); ok {
+				if err := sdr.UnRegisterService(); err != nil {
 					return err
 				}
 			}

--- a/registry/exposed_tmp/exposed.go
+++ b/registry/exposed_tmp/exposed.go
@@ -19,7 +19,9 @@ package exposed_tmp
 
 import (
 	"context"
+)
 
+import (
 	"github.com/dubbogo/gost/log/logger"
 )
 

--- a/server/server.go
+++ b/server/server.go
@@ -20,6 +20,7 @@ package server
 
 import (
 	"context"
+	stderrors "errors"
 	"reflect"
 	"sort"
 	"strconv"
@@ -36,6 +37,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/dubboutil"
+	"dubbo.apache.org/dubbo-go/v3/graceful_shutdown"
 	"dubbo.apache.org/dubbo-go/v3/metadata"
 	"dubbo.apache.org/dubbo-go/v3/metrics/probe"
 	"dubbo.apache.org/dubbo-go/v3/registry/exposed_tmp"
@@ -301,11 +303,13 @@ func enhanceServiceInfo(info *common.ServiceInfo) *common.ServiceInfo {
 	return info
 }
 
-func (s *Server) exportServices() error {
-	// add read lock to protect svcOptsMap data
+func (s *Server) exportServices(ctx context.Context) error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	for _, svcOpts := range s.svcOptsMap {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		if err := svcOpts.Export(); err != nil {
 			logger.Errorf("export %s service failed, err: %s", svcOpts.Service.Interface, err)
 			return errors.Wrapf(err, "failed to export service %s", svcOpts.Service.Interface)
@@ -315,6 +319,17 @@ func (s *Server) exportServices() error {
 }
 
 func (s *Server) Serve() error {
+	return s.ServeContext(context.Background())
+}
+
+func (s *Server) ServeContext(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	s.mu.Lock()
 	if s.serve {
 		// release lock in case causing deadlock
@@ -326,6 +341,13 @@ func (s *Server) Serve() error {
 
 	// release lock in case causing deadlock
 	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		s.serve = false
+		s.mu.Unlock()
+	}()
+
+	serviceInstanceRegistered := false
 
 	// the registryConfig in ServiceOptions and ServerOptions all need to init a metadataReporter,
 	// when ServiceOptions.init() is called we don't know if a new registry config is set in the future use serviceOption
@@ -341,26 +363,85 @@ func (s *Server) Serve() error {
 	if err := metadataOpts.Init(); err != nil {
 		return err
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 
-	if err := s.exportServices(); err != nil {
-		return err
+	if err := s.exportServices(ctx); err != nil {
+		return s.rollbackServeStartWithCause(err, serviceInstanceRegistered)
 	}
-	if err := s.exportInternalServices(); err != nil {
-		return err
+	if err := s.exportInternalServices(ctx); err != nil {
+		return s.rollbackServeStartWithCause(err, serviceInstanceRegistered)
 	}
-	if err := exposed_tmp.RegisterServiceInstance(); err != nil {
-		return err
+	if err := exposed_tmp.RegisterServiceInstanceContext(ctx); err != nil {
+		return s.rollbackServeStartWithCause(err, serviceInstanceRegistered)
 	}
+	serviceInstanceRegistered = true
 
 	// k8s probe ready
 	probe.SetStartupComplete(true)
 	probe.SetReady(true)
+	if err := ctx.Err(); err != nil {
+		return s.rollbackServeStartWithCause(err, serviceInstanceRegistered)
+	}
 
-	select {}
+	if done := ctx.Done(); done != nil {
+		select {
+		case <-graceful_shutdown.Done():
+			return graceful_shutdown.Shutdown(context.Background())
+		case <-done:
+			return graceful_shutdown.Shutdown(ctx)
+		}
+	}
+
+	<-graceful_shutdown.Done()
+	return graceful_shutdown.Shutdown(context.Background())
+}
+
+func (s *Server) rollbackServeStartWithCause(cause error, serviceInstanceRegistered bool) error {
+	if rollbackErr := s.rollbackServeStart(serviceInstanceRegistered); rollbackErr != nil {
+		return stderrors.Join(cause, errors.Wrap(rollbackErr, "startup rollback failed"))
+	}
+	return cause
+}
+
+func (s *Server) rollbackServeStart(serviceInstanceRegistered bool) error {
+	probe.SetReady(false)
+	probe.SetStartupComplete(false)
+
+	s.unexportInternalServices()
+	s.unexportServices()
+
+	if serviceInstanceRegistered {
+		if err := exposed_tmp.UnregisterServiceInstance(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Server) unexportServices() {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, svcOpts := range s.svcOptsMap {
+		if svcOpts != nil {
+			svcOpts.Unexport()
+		}
+	}
+}
+
+func (s *Server) unexportInternalServices() {
+	internalProLock.Lock()
+	defer internalProLock.Unlock()
+	for _, service := range internalProServices {
+		if service != nil && service.svcOpts != nil {
+			service.svcOpts.Unexport()
+		}
+	}
 }
 
 // In order to expose internal services
-func (s *Server) exportInternalServices() error {
+func (s *Server) exportInternalServices(ctx context.Context) error {
 	cfg := &ServiceOptions{}
 
 	cfg.Application = s.cfg.Application
@@ -373,6 +454,9 @@ func (s *Server) exportInternalServices() error {
 	internalProLock.Lock()
 	defer internalProLock.Unlock()
 	for _, service := range internalProServices {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if service.Init == nil {
 			return errors.New("[internal service]internal service init func is empty, please set the init func correctly")
 		}
@@ -395,6 +479,9 @@ func (s *Server) exportInternalServices() error {
 	})
 
 	for _, service := range services {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		if service.BeforeExport != nil {
 			service.BeforeExport(service.svcOpts)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -339,6 +339,9 @@ func (s *Server) ServeContext(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}
+	if graceful_shutdown.IsDone() {
+		return errors.New("server cannot be started after graceful shutdown completed")
+	}
 
 	s.mu.Lock()
 	if s.serve {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -477,8 +477,8 @@ func TestServeContextDoesNotRestartAfterGracefulShutdownCompletes(t *testing.T) 
 
 	cancel()
 	select {
-	case err := <-serveDone:
-		require.ErrorIs(t, err, context.Canceled)
+	case serveErr := <-serveDone:
+		require.ErrorIs(t, serveErr, context.Canceled)
 	case <-time.After(time.Second):
 		t.Fatal("ServeContext did not return after context cancellation")
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -19,10 +19,14 @@ package server
 
 import (
 	"context"
+	"os"
+	"os/signal"
 	"reflect"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 	"unsafe"
 )
 
@@ -34,8 +38,407 @@ import (
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/global"
+	"dubbo.apache.org/dubbo-go/v3/graceful_shutdown"
+	"dubbo.apache.org/dubbo-go/v3/protocol/base"
+	"dubbo.apache.org/dubbo-go/v3/registry"
 )
+
+//go:linkname extensionProtocols dubbo.apache.org/dubbo-go/v3/common/extension.protocols
+var extensionProtocols *extension.Registry[func() base.Protocol]
+
+//go:linkname gracefulShutdownInitOnce dubbo.apache.org/dubbo-go/v3/graceful_shutdown.initOnce
+var gracefulShutdownInitOnce sync.Once
+
+//go:linkname gracefulShutdownProtocols dubbo.apache.org/dubbo-go/v3/graceful_shutdown.protocols
+var gracefulShutdownProtocols map[string]struct{}
+
+//go:linkname gracefulShutdownProMu dubbo.apache.org/dubbo-go/v3/graceful_shutdown.proMu
+var gracefulShutdownProMu sync.Mutex
+
+//go:linkname gracefulShutdownConfigMu dubbo.apache.org/dubbo-go/v3/graceful_shutdown.shutdownConfigMu
+var gracefulShutdownConfigMu sync.RWMutex
+
+//go:linkname gracefulShutdownConfig dubbo.apache.org/dubbo-go/v3/graceful_shutdown.shutdownConfig
+var gracefulShutdownConfig *global.ShutdownConfig
+
+//go:linkname gracefulShutdownOnce dubbo.apache.org/dubbo-go/v3/graceful_shutdown.shutdownOnce
+var gracefulShutdownOnce sync.Once
+
+//go:linkname gracefulShutdownStarted dubbo.apache.org/dubbo-go/v3/graceful_shutdown.shutdownStarted
+var gracefulShutdownStarted atomic.Bool
+
+//go:linkname gracefulShutdownDone dubbo.apache.org/dubbo-go/v3/graceful_shutdown.shutdownDone
+var gracefulShutdownDone chan struct{}
+
+//go:linkname gracefulShutdownResult dubbo.apache.org/dubbo-go/v3/graceful_shutdown.shutdownResult
+var gracefulShutdownResult error
+
+//go:linkname gracefulShutdownSignalNotify dubbo.apache.org/dubbo-go/v3/graceful_shutdown.signalNotify
+var gracefulShutdownSignalNotify func(chan<- os.Signal, ...os.Signal)
+
+func resetInternalProviderServicesForTest(t *testing.T) {
+	t.Helper()
+
+	internalProLock.Lock()
+	originalServices := internalProServices
+	internalProServices = nil
+	internalProLock.Unlock()
+
+	t.Cleanup(func() {
+		internalProLock.Lock()
+		defer internalProLock.Unlock()
+		internalProServices = originalServices
+	})
+}
+
+type mockServeProtocol struct {
+	base.BaseProtocol
+}
+
+type mockServeRegistryFactoryProtocol struct {
+	base.BaseProtocol
+}
+
+type mockServeRegistry struct{}
+
+func (p *mockServeRegistryFactoryProtocol) GetRegistries() []registry.Registry {
+	return []registry.Registry{&mockServeRegistry{}}
+}
+
+func (r *mockServeRegistry) GetURL() *common.URL {
+	return &common.URL{}
+}
+
+func (r *mockServeRegistry) IsAvailable() bool {
+	return true
+}
+
+func (r *mockServeRegistry) Destroy() {}
+
+func (r *mockServeRegistry) Register(*common.URL) error {
+	return nil
+}
+
+func (r *mockServeRegistry) UnRegister(*common.URL) error {
+	return nil
+}
+
+func (r *mockServeRegistry) Subscribe(*common.URL, registry.NotifyListener) error {
+	return nil
+}
+
+func (r *mockServeRegistry) UnSubscribe(*common.URL, registry.NotifyListener) error {
+	return nil
+}
+
+func (r *mockServeRegistry) LoadSubscribeInstances(*common.URL, registry.NotifyListener) error {
+	return nil
+}
+
+func (r *mockServeRegistry) RegisterService() error {
+	return nil
+}
+
+func (r *mockServeRegistry) UnRegisterService() error {
+	return nil
+}
+
+type countingServeExporter struct {
+	invoker       base.Invoker
+	unexportCount *atomic.Int32
+}
+
+func (e *countingServeExporter) GetInvoker() base.Invoker {
+	return e.invoker
+}
+
+func (e *countingServeExporter) UnExport() {
+	if e.unexportCount != nil {
+		e.unexportCount.Add(1)
+	}
+	if e.invoker != nil {
+		e.invoker.Destroy()
+	}
+}
+
+type countingServeProtocol struct {
+	base.BaseProtocol
+	exportCount   *atomic.Int32
+	unexportCount *atomic.Int32
+}
+
+func (p *countingServeProtocol) Export(invoker base.Invoker) base.Exporter {
+	if p.exportCount != nil {
+		p.exportCount.Add(1)
+	}
+	return &countingServeExporter{
+		invoker:       invoker,
+		unexportCount: p.unexportCount,
+	}
+}
+
+type countingServeRegistry struct {
+	registerCount   *atomic.Int32
+	unregisterCount *atomic.Int32
+	registerBlock   <-chan struct{}
+}
+
+func (r *countingServeRegistry) GetURL() *common.URL {
+	return &common.URL{}
+}
+
+func (r *countingServeRegistry) IsAvailable() bool {
+	return true
+}
+
+func (r *countingServeRegistry) Destroy() {}
+
+func (r *countingServeRegistry) Register(*common.URL) error {
+	return nil
+}
+
+func (r *countingServeRegistry) UnRegister(*common.URL) error {
+	return nil
+}
+
+func (r *countingServeRegistry) Subscribe(*common.URL, registry.NotifyListener) error {
+	return nil
+}
+
+func (r *countingServeRegistry) UnSubscribe(*common.URL, registry.NotifyListener) error {
+	return nil
+}
+
+func (r *countingServeRegistry) LoadSubscribeInstances(*common.URL, registry.NotifyListener) error {
+	return nil
+}
+
+func (r *countingServeRegistry) RegisterService() error {
+	if r.registerCount != nil {
+		r.registerCount.Add(1)
+	}
+	if r.registerBlock != nil {
+		<-r.registerBlock
+	}
+	return nil
+}
+
+func (r *countingServeRegistry) UnRegisterService() error {
+	if r.unregisterCount != nil {
+		r.unregisterCount.Add(1)
+	}
+	return nil
+}
+
+type countingServeRegistryFactoryProtocol struct {
+	base.BaseProtocol
+	registry registry.Registry
+}
+
+func (p *countingServeRegistryFactoryProtocol) GetRegistries() []registry.Registry {
+	return []registry.Registry{p.registry}
+}
+
+func registerServeTestProtocols(t *testing.T) {
+	t.Helper()
+
+	originalProtocols := extensionProtocols.Snapshot()
+	extension.SetProtocol("dubbo", func() base.Protocol {
+		return &mockServeProtocol{BaseProtocol: base.NewBaseProtocol()}
+	})
+	extension.SetProtocol(constant.RegistryKey, func() base.Protocol {
+		return &mockServeRegistryFactoryProtocol{BaseProtocol: base.NewBaseProtocol()}
+	})
+	t.Cleanup(func() {
+		for name, factory := range originalProtocols {
+			extension.SetProtocol(name, factory)
+		}
+		if _, ok := originalProtocols["dubbo"]; !ok {
+			extension.UnregisterProtocol("dubbo")
+		}
+		if _, ok := originalProtocols[constant.RegistryKey]; !ok {
+			extension.UnregisterProtocol(constant.RegistryKey)
+		}
+	})
+}
+
+func registerCountingServeTestProtocols(
+	t *testing.T,
+	exportCount, unexportCount, registerCount, unregisterCount *atomic.Int32,
+	registerBlock <-chan struct{},
+) {
+	t.Helper()
+
+	originalProtocols := extensionProtocols.Snapshot()
+	extension.SetProtocol(constant.TriProtocol, func() base.Protocol {
+		return &countingServeProtocol{
+			BaseProtocol:  base.NewBaseProtocol(),
+			exportCount:   exportCount,
+			unexportCount: unexportCount,
+		}
+	})
+	extension.SetProtocol(constant.RegistryKey, func() base.Protocol {
+		return &countingServeRegistryFactoryProtocol{
+			BaseProtocol: base.NewBaseProtocol(),
+			registry: &countingServeRegistry{
+				registerCount:   registerCount,
+				unregisterCount: unregisterCount,
+				registerBlock:   registerBlock,
+			},
+		}
+	})
+	t.Cleanup(func() {
+		for name, factory := range originalProtocols {
+			extension.SetProtocol(name, factory)
+		}
+		if _, ok := originalProtocols[constant.TriProtocol]; !ok {
+			extension.UnregisterProtocol(constant.TriProtocol)
+		}
+		if _, ok := originalProtocols[constant.RegistryKey]; !ok {
+			extension.UnregisterProtocol(constant.RegistryKey)
+		}
+	})
+}
+
+func resetGracefulShutdownStateForTest(t *testing.T) {
+	t.Helper()
+
+	gracefulShutdownInitOnce = sync.Once{}
+	gracefulShutdownProtocols = nil
+	gracefulShutdownProMu = sync.Mutex{}
+	gracefulShutdownConfigMu = sync.RWMutex{}
+	gracefulShutdownConfig = nil
+	gracefulShutdownOnce = sync.Once{}
+	gracefulShutdownStarted = atomic.Bool{}
+	gracefulShutdownDone = make(chan struct{})
+	gracefulShutdownResult = nil
+	gracefulShutdownSignalNotify = signal.Notify
+}
+
+func TestServeContextReturnsAfterContextCancellation(t *testing.T) {
+	resetGracefulShutdownStateForTest(t)
+	t.Cleanup(func() {
+		resetGracefulShutdownStateForTest(t)
+	})
+	resetInternalProviderServicesForTest(t)
+	registerServeTestProtocols(t)
+
+	internalSignal := false
+	shutdownCfg := global.DefaultShutdownConfig()
+	shutdownCfg.InternalSignal = &internalSignal
+	shutdownCfg.ConsumerUpdateWaitTime = "0s"
+	shutdownCfg.StepTimeout = "0s"
+	shutdownCfg.NotifyTimeout = "10ms"
+	shutdownCfg.OfflineRequestWindowTimeout = "0s"
+
+	srv, err := NewServer(SetServerShutdown(shutdownCfg))
+	require.NoError(t, err)
+	require.NoError(t, srv.Register(&MockServerRPCService{}, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- srv.ServeContext(ctx)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-serveDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("ServeContext did not return after context cancellation")
+	}
+
+	select {
+	case <-graceful_shutdown.Done():
+	case <-time.After(time.Second):
+		t.Fatal("process-level graceful shutdown did not finish after context cancellation")
+	}
+}
+
+func TestServeContextDoesNotStartWhenContextAlreadyCanceled(t *testing.T) {
+	resetGracefulShutdownStateForTest(t)
+	t.Cleanup(func() {
+		resetGracefulShutdownStateForTest(t)
+	})
+	resetInternalProviderServicesForTest(t)
+
+	var exportCount, unexportCount, registerCount, unregisterCount atomic.Int32
+	registerCountingServeTestProtocols(t, &exportCount, &unexportCount, &registerCount, &unregisterCount, nil)
+
+	internalSignal := false
+	shutdownCfg := global.DefaultShutdownConfig()
+	shutdownCfg.InternalSignal = &internalSignal
+	protocols := map[string]*global.ProtocolConfig{
+		constant.TriProtocol: global.DefaultProtocolConfig(),
+	}
+
+	srv, err := NewServer(SetServerShutdown(shutdownCfg), SetServerProtocols(protocols))
+	require.NoError(t, err)
+	require.NoError(t, srv.Register(&MockServerRPCService{}, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = srv.ServeContext(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, int32(0), exportCount.Load())
+	assert.Equal(t, int32(0), unexportCount.Load())
+	assert.Equal(t, int32(0), registerCount.Load())
+	assert.Equal(t, int32(0), unregisterCount.Load())
+}
+
+func TestServeContextRollsBackWhenCanceledDuringStartup(t *testing.T) {
+	resetGracefulShutdownStateForTest(t)
+	t.Cleanup(func() {
+		resetGracefulShutdownStateForTest(t)
+	})
+	resetInternalProviderServicesForTest(t)
+
+	var exportCount, unexportCount, registerCount, unregisterCount atomic.Int32
+	registerBlock := make(chan struct{})
+	registerCountingServeTestProtocols(t, &exportCount, &unexportCount, &registerCount, &unregisterCount, registerBlock)
+
+	internalSignal := false
+	shutdownCfg := global.DefaultShutdownConfig()
+	shutdownCfg.InternalSignal = &internalSignal
+	protocols := map[string]*global.ProtocolConfig{
+		constant.TriProtocol: global.DefaultProtocolConfig(),
+	}
+
+	srv, err := NewServer(SetServerShutdown(shutdownCfg), SetServerProtocols(protocols))
+	require.NoError(t, err)
+	require.NoError(t, srv.Register(&MockServerRPCService{}, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- srv.ServeContext(ctx)
+	}()
+
+	require.Eventually(t, func() bool {
+		return registerCount.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+	close(registerBlock)
+
+	select {
+	case err := <-serveDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("ServeContext did not return after startup cancellation")
+	}
+
+	assert.Equal(t, int32(1), exportCount.Load())
+	assert.Equal(t, int32(1), unexportCount.Load())
+	assert.Equal(t, int32(1), registerCount.Load())
+	assert.Equal(t, int32(1), unregisterCount.Load())
+}
 
 // Test NewServer creates a server successfully
 func TestNewServer(t *testing.T) {
@@ -432,6 +835,17 @@ func (m *mockServerRPCService) Reference() string {
 	return "com.example.MockService"
 }
 
+// MockServerRPCService is an exported version used by protocol paths that reflect on handler types.
+type MockServerRPCService struct{}
+
+func (m *MockServerRPCService) Invoke(methodName string, params []any, results []any) error {
+	return nil
+}
+
+func (m *MockServerRPCService) Reference() string {
+	return "com.example.MockService"
+}
+
 // Test concurrency: multiple goroutines registering services
 func TestConcurrentServiceRegistration(t *testing.T) {
 	srv, err := NewServer()
@@ -536,7 +950,8 @@ func TestExportServicesEmpty(t *testing.T) {
 	srv, err := NewServer()
 	require.NoError(t, err)
 
-	err = srv.exportServices()
+	ctx := context.Background()
+	err = srv.exportServices(ctx)
 	assert.NoError(t, err)
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -443,6 +443,65 @@ func TestServeContextRollsBackWhenCanceledDuringStartup(t *testing.T) {
 	assert.Equal(t, int32(1), unregisterCount.Load())
 }
 
+func TestServeContextDoesNotRestartAfterGracefulShutdownCompletes(t *testing.T) {
+	resetGracefulShutdownStateForTest(t)
+	t.Cleanup(func() {
+		resetGracefulShutdownStateForTest(t)
+	})
+	resetInternalProviderServicesForTest(t)
+
+	var exportCount, unexportCount, registerCount, unregisterCount atomic.Int32
+	registerCountingServeTestProtocols(t, &exportCount, &unexportCount, &registerCount, &unregisterCount, nil)
+
+	internalSignal := false
+	shutdownCfg := global.DefaultShutdownConfig()
+	shutdownCfg.InternalSignal = &internalSignal
+	shutdownCfg.ConsumerUpdateWaitTime = "0s"
+	shutdownCfg.StepTimeout = "0s"
+	shutdownCfg.NotifyTimeout = "0s"
+	shutdownCfg.OfflineRequestWindowTimeout = "0s"
+
+	srv, err := NewServer(SetServerShutdown(shutdownCfg))
+	require.NoError(t, err)
+	require.NoError(t, srv.Register(&MockServerRPCService{}, nil))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- srv.ServeContext(ctx)
+	}()
+
+	require.Eventually(t, func() bool {
+		return registerCount.Load() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+	select {
+	case err := <-serveDone:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("ServeContext did not return after context cancellation")
+	}
+	select {
+	case <-graceful_shutdown.Done():
+	case <-time.After(time.Second):
+		t.Fatal("process-level graceful shutdown did not finish after context cancellation")
+	}
+
+	exportCountAfterShutdown := exportCount.Load()
+	unexportCountAfterShutdown := unexportCount.Load()
+	registerCountAfterShutdown := registerCount.Load()
+	unregisterCountAfterShutdown := unregisterCount.Load()
+
+	err = srv.ServeContext(context.Background())
+	require.Error(t, err)
+	assert.Equal(t, int32(1), registerCountAfterShutdown)
+	assert.Equal(t, exportCountAfterShutdown, exportCount.Load())
+	assert.Equal(t, unexportCountAfterShutdown, unexportCount.Load())
+	assert.Equal(t, registerCountAfterShutdown, registerCount.Load())
+	assert.Equal(t, unregisterCountAfterShutdown, unregisterCount.Load())
+}
+
 // Test NewServer creates a server successfully
 func TestNewServer(t *testing.T) {
 	srv, err := NewServer()

--- a/server/triple_case_route_integration_test.go
+++ b/server/triple_case_route_integration_test.go
@@ -180,7 +180,8 @@ func runTripleCaseRouteIntegration(
 
 	err = srv.Register(service, info, WithInterface(info.InterfaceName), WithNotRegister())
 	require.NoError(t, err)
-	err = srv.exportServices()
+	ctx := context.Background()
+	err = srv.exportServices(ctx)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {


### PR DESCRIPTION
## Summary

Fix `server.Server.Serve()` so it no longer blocks forever on `select {}`  #3042 

This change keeps the shutdown model split by responsibility:

## Changes

- add instance-level stop flow for `server.Server`
- replace the terminal `select {}` in `Serve()` with channel-based waiting
- make `Stop(ctx)` close the serve stop channel and wait for `Serve()` to exit
- register live servers as process-level shutdown stoppers
- add `graceful_shutdown.Done()` as a fallback release path for extreme shutdown races

