### PR TITLE
fix(registry): preserve Nacos providers and environment metadata

### DIFF
--- a/metadata/info/metadata_info.go
+++ b/metadata/info/metadata_info.go
@@ -52,6 +52,7 @@ var IncludeKeys = gxset.NewSet(
 	constant.VersionKey,
 	constant.WarmupKey,
 	constant.WeightKey,
+	constant.EnvironmentKey,
 	constant.ReleaseKey)
 
 // MetadataInfo the metadata information of instance

--- a/metadata/info/metadata_info_test.go
+++ b/metadata/info/metadata_info_test.go
@@ -33,6 +33,7 @@ import (
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
 )
 
 var (
@@ -126,6 +127,19 @@ func TestServiceInfoGetMethods(t *testing.T) {
 func TestServiceInfoGetParams(t *testing.T) {
 	service := NewServiceInfoWithURL(serviceUrl)
 	assert.Equal(t, []string{"random"}, service.GetParams()["loadbalance"])
+}
+
+func TestServiceInfoGetParamsIncludesEnvironment(t *testing.T) {
+	serviceURL, err := common.NewURL("tri://127.0.0.1:20000/org.apache.dubbo.samples.proto.GreetService",
+		common.WithInterface("org.apache.dubbo.samples.proto.GreetService"),
+		common.WithParamsValue(constant.EnvironmentKey, "pre"),
+		common.WithMethods([]string{"Greet"}),
+	)
+	require.NoError(t, err)
+
+	service := NewServiceInfoWithURL(serviceURL)
+
+	assert.Equal(t, []string{"pre"}, service.GetParams()[constant.EnvironmentKey])
 }
 
 func TestServiceInfoGetMatchKey(t *testing.T) {

--- a/registry/servicediscovery/service_discovery_registry.go
+++ b/registry/servicediscovery/service_discovery_registry.go
@@ -115,6 +115,10 @@ func (s *serviceDiscoveryRegistry) RegisterService() error {
 func createInstance(meta *info.MetadataInfo, url *common.URL) registry.ServiceInstance {
 	params := make(map[string]string, 8)
 	params[constant.MetadataStorageTypePropertyName] = metadata.GetMetadataType()
+	// Keep routing attributes visible on the registered instance as well as in service metadata.
+	if environment := url.GetParam(constant.EnvironmentKey, ""); len(environment) > 0 {
+		params[constant.EnvironmentKey] = environment
+	}
 	port, err := strconv.Atoi(url.Port)
 	if err != nil {
 		logger.Warnf("Parse port %s failed, err: %v", url.Port, err)

--- a/registry/servicediscovery/service_instances_changed_listener_impl.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl.go
@@ -80,7 +80,7 @@ func NewServiceInstancesChangedListener(app string, services *gxset.HashSet) reg
 	}
 }
 
-// OnEvent on ServiceInstancesChangedEvent the service instances change event
+// OnEvent handles service instance change events by refreshing metadata, rebuilding service URLs, and notifying listeners.
 func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error {
 	ce, ok := e.(*registry.ServiceInstancesChangedEvent)
 	if !ok {
@@ -93,8 +93,9 @@ func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error
 	lstn.allInstances[ce.ServiceName] = ce.Instances
 	revisionToInstances := make(map[string][]registry.ServiceInstance)
 	newRevisionToMetadata := make(map[string]*info.MetadataInfo)
-	localServiceToRevisions := make(map[*info.ServiceInfo]*gxset.HashSet)
-	protocolRevisionsToUrls := make(map[string]map[*gxset.HashSet][]*common.URL)
+	// The same service match key can be exported by several revisions.
+	// Keep each revision's ServiceInfo so provider-specific params are not collapsed.
+	serviceToRevisionServices := make(map[string]map[string]*info.ServiceInfo)
 	newServiceURLs := make(map[string][]*common.URL)
 
 	logger.Infof("Received instance notification event of service %s, instance list size %d", ce.ServiceName, len(ce.Instances))
@@ -127,44 +128,38 @@ func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error
 				}
 				metadataInfo = meta
 			}
+			if metadataInfo == nil {
+				logger.Warnf("Metadata info is nil for instance %s (revision %s), skipping this instance",
+					instance.GetHost(), revision)
+				continue
+			}
 			instance.SetServiceMetadata(metadataInfo)
 			for _, service := range metadataInfo.Services {
-				if localServiceToRevisions[service] == nil {
-					localServiceToRevisions[service] = gxset.NewSet()
+				matchKey := service.GetMatchKey()
+				if serviceToRevisionServices[matchKey] == nil {
+					serviceToRevisionServices[matchKey] = make(map[string]*info.ServiceInfo)
 				}
-				localServiceToRevisions[service].Add(revision)
+				serviceToRevisionServices[matchKey][revision] = service
 			}
 
 			newRevisionToMetadata[revision] = metadataInfo
 		}
-		lstn.revisionToMetadata = newRevisionToMetadata
-		for revision, metadataInfo := range newRevisionToMetadata {
-			metaCache.Set(revision, metadataInfo)
-		}
+	}
+	lstn.revisionToMetadata = newRevisionToMetadata
+	for revision, metadataInfo := range newRevisionToMetadata {
+		metaCache.Set(revision, metadataInfo)
+	}
 
-		for serviceInfo, revisions := range localServiceToRevisions {
-			revisionsToUrls := protocolRevisionsToUrls[serviceInfo.Protocol]
-			if revisionsToUrls == nil {
-				protocolRevisionsToUrls[serviceInfo.Protocol] = make(map[*gxset.HashSet][]*common.URL)
-				revisionsToUrls = protocolRevisionsToUrls[serviceInfo.Protocol]
-			}
-			urls := revisionsToUrls[revisions]
-			if urls != nil {
-				newServiceURLs[serviceInfo.GetMatchKey()] = urls
-			} else {
-				urls = make([]*common.URL, 0, 8)
-				for _, v := range revisions.Values() {
-					r := v.(string)
-					for _, i := range revisionToInstances[r] {
-						if i != nil {
-							urls = append(urls, i.ToURLs(serviceInfo)...)
-						}
-					}
+	for serviceKey, revisionServices := range serviceToRevisionServices {
+		urls := make([]*common.URL, 0, 8)
+		for revision, serviceInfo := range revisionServices {
+			for _, i := range revisionToInstances[revision] {
+				if i != nil {
+					urls = append(urls, toInstanceServiceURLs(i, serviceInfo)...)
 				}
-				revisionsToUrls[revisions] = urls
-				newServiceURLs[serviceInfo.GetMatchKey()] = urls
 			}
 		}
+		newServiceURLs[serviceKey] = urls
 	}
 
 	lstn.serviceUrls = newServiceURLs
@@ -181,6 +176,29 @@ func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error
 	}
 
 	return nil
+}
+
+func toInstanceServiceURLs(instance registry.ServiceInstance, serviceInfo *info.ServiceInfo) []*common.URL {
+	urls := instance.ToURLs(serviceInfo)
+	// Environment is instance-level routing metadata and is not part of the revision hash.
+	// Treat the fresh instance value as authoritative so same-revision restarts
+	// can update or clear stale metadata cached by revision.
+	metadata := instance.GetMetadata()
+	if metadata == nil {
+		for _, url := range urls {
+			url.DelParam(constant.EnvironmentKey)
+		}
+		return urls
+	}
+	environment, ok := metadata[constant.EnvironmentKey]
+	for _, url := range urls {
+		if ok && len(environment) > 0 {
+			url.SetParam(constant.EnvironmentKey, environment)
+		} else {
+			url.DelParam(constant.EnvironmentKey)
+		}
+	}
+	return urls
 }
 
 // AddListenerAndNotify add notify listener and notify to listen service event

--- a/registry/servicediscovery/service_instances_changed_listener_impl_test.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl_test.go
@@ -1,0 +1,263 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package servicediscovery
+
+import (
+	"fmt"
+	"testing"
+)
+
+import (
+	gxset "github.com/dubbogo/gost/container/set"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/metadata/info"
+	"dubbo.apache.org/dubbo-go/v3/registry"
+)
+
+func TestServiceInstancesChangedListenerAggregatesSameServiceAcrossRevisions(t *testing.T) {
+	listener := NewServiceInstancesChangedListener(testApp, gxset.NewSet(testApp))
+	notify := &capturingNotifyListener{}
+	listener.AddListenerAndNotify(common.MatchKey(testInterface, constant.TriProtocol), notify)
+
+	instances := []registry.ServiceInstance{
+		newTestServiceInstance(t, 20000, "dev"),
+		newTestServiceInstance(t, 20001, "pre"),
+		newTestServiceInstance(t, 20002, "prod"),
+	}
+	require.NoError(t, listener.OnEvent(registry.NewServiceInstancesChangedEvent(testApp, instances)))
+
+	assertServiceEvents(t, notify.events, []string{"20000", "20001", "20002"}, []string{"dev", "pre", "prod"})
+}
+
+func TestServiceInstancesChangedListenerRefreshesURLsOnProviderRemoveAndRestart(t *testing.T) {
+	listener := NewServiceInstancesChangedListener(testApp, gxset.NewSet(testApp))
+	notify := &capturingNotifyListener{}
+	listener.AddListenerAndNotify(common.MatchKey(testInterface, constant.TriProtocol), notify)
+
+	dev := newTestServiceInstance(t, 20000, "dev")
+	pre := newTestServiceInstance(t, 20001, "pre")
+	prod := newTestServiceInstance(t, 20002, "prod")
+
+	require.NoError(t, listener.OnEvent(registry.NewServiceInstancesChangedEvent(testApp, []registry.ServiceInstance{
+		dev,
+		pre,
+		prod,
+	})))
+	assertServiceEvents(t, notify.events, []string{"20000", "20001", "20002"}, []string{"dev", "pre", "prod"})
+
+	require.NoError(t, listener.OnEvent(registry.NewServiceInstancesChangedEvent(testApp, []registry.ServiceInstance{
+		dev,
+		prod,
+	})))
+	assertServiceEvents(t, notify.events, []string{"20000", "20002"}, []string{"dev", "prod"})
+
+	restartedPre := newTestServiceInstanceWithRevision(t, 20001, "pre-restarted", "rev-20001-restarted")
+	require.NoError(t, listener.OnEvent(registry.NewServiceInstancesChangedEvent(testApp, []registry.ServiceInstance{
+		dev,
+		restartedPre,
+		prod,
+	})))
+	assertServiceEvents(t, notify.events, []string{"20000", "20001", "20002"}, []string{"dev", "pre-restarted", "prod"})
+}
+
+func TestServiceInstancesChangedListenerRefreshesAndClearsEnvironmentWhenRevisionIsUnchanged(t *testing.T) {
+	listener := NewServiceInstancesChangedListener(testApp, gxset.NewSet(testApp))
+	notify := &capturingNotifyListener{}
+	listener.AddListenerAndNotify(common.MatchKey(testInterface, constant.TriProtocol), notify)
+
+	revision := "rev-20001-same-environment-change"
+	metaCache.Set(revision, newTestMetadataInfo(t, revision, 20001, "pre"))
+
+	pre := newTestServiceInstanceOnly(20001, "pre", revision)
+	require.NoError(t, listener.OnEvent(registry.NewServiceInstancesChangedEvent(testApp, []registry.ServiceInstance{
+		pre,
+	})))
+	assertServiceEvents(t, notify.events, []string{"20001"}, []string{"pre"})
+
+	restartedPre := newTestServiceInstanceOnly(20001, "pre-restarted", revision)
+	require.NoError(t, listener.OnEvent(registry.NewServiceInstancesChangedEvent(testApp, []registry.ServiceInstance{
+		restartedPre,
+	})))
+	assertServiceEvents(t, notify.events, []string{"20001"}, []string{"pre-restarted"})
+
+	clearedPre := newTestServiceInstanceOnly(20001, "", revision)
+	require.NoError(t, listener.OnEvent(registry.NewServiceInstancesChangedEvent(testApp, []registry.ServiceInstance{
+		clearedPre,
+	})))
+	assertServiceEvents(t, notify.events, []string{"20001"}, []string{""})
+	assertServiceEventEnvironmentsAbsent(t, notify.events)
+
+	removedPre := newTestServiceInstanceOnly(20001, "ignored", revision)
+	delete(removedPre.GetMetadata(), constant.EnvironmentKey)
+	require.NoError(t, listener.OnEvent(registry.NewServiceInstancesChangedEvent(testApp, []registry.ServiceInstance{
+		removedPre,
+	})))
+	assertServiceEvents(t, notify.events, []string{"20001"}, []string{""})
+	assertServiceEventEnvironmentsAbsent(t, notify.events)
+}
+
+func TestServiceInstancesChangedListenerSkipsNilMetadataWithoutPanic(t *testing.T) {
+	listener := NewServiceInstancesChangedListener(testApp, gxset.NewSet(testApp))
+	notify := &capturingNotifyListener{}
+	listener.AddListenerAndNotify(common.MatchKey(testInterface, constant.TriProtocol), notify)
+
+	revision := "rev-20003-nil-metadata"
+	var metadataInfo *info.MetadataInfo
+	metaCache.Set(revision, metadataInfo)
+	t.Cleanup(func() {
+		metaCache.Delete(revision)
+	})
+
+	instance := newTestServiceInstanceOnly(20003, "pre", revision)
+	var err error
+	require.NotPanics(t, func() {
+		err = listener.OnEvent(registry.NewServiceInstancesChangedEvent(testApp, []registry.ServiceInstance{
+			instance,
+		}))
+	})
+	require.NoError(t, err)
+	assert.Empty(t, notify.events)
+}
+
+func TestCreateInstanceCarriesEnvironmentMetadata(t *testing.T) {
+	meta := info.NewMetadataInfo(testApp, "")
+	providerURL := newTestProviderURL(t, 20001, "pre")
+
+	instance := createInstance(meta, providerURL)
+
+	assert.Equal(t, "pre", instance.GetMetadata()[constant.EnvironmentKey])
+}
+
+func newTestServiceInstance(t *testing.T, port int, environment string) registry.ServiceInstance {
+	t.Helper()
+
+	return newTestServiceInstanceWithRevision(t, port, environment, fmt.Sprintf("rev-%d", port))
+}
+
+func newTestServiceInstanceWithRevision(t *testing.T, port int, environment string, revision string) registry.ServiceInstance {
+	t.Helper()
+
+	metaCache.Set(revision, newTestMetadataInfo(t, revision, port, environment))
+	return newTestServiceInstanceOnly(port, environment, revision)
+}
+
+func newTestServiceInstanceOnly(port int, environment string, revision string) registry.ServiceInstance {
+	return &registry.DefaultServiceInstance{
+		ID:          fmt.Sprintf("127.0.0.1:%d", port),
+		ServiceName: testApp,
+		Host:        "127.0.0.1",
+		Port:        port,
+		Enable:      true,
+		Healthy:     true,
+		Metadata: map[string]string{
+			constant.ExportedServicesRevisionPropertyName: revision,
+			constant.ServiceInstanceEndpoints:             fmt.Sprintf(`[{"port":%d,"protocol":"tri"}]`, port),
+			constant.EnvironmentKey:                       environment,
+		},
+	}
+}
+
+func newTestMetadataInfo(t *testing.T, revision string, port int, environment string) *info.MetadataInfo {
+	t.Helper()
+
+	serviceURL := newTestProviderURL(t, port, environment)
+	service := info.NewServiceInfoWithURL(serviceURL)
+	return info.NewMetadataInfoWithParams(testApp, revision, map[string]*info.ServiceInfo{
+		service.GetMatchKey(): service,
+	})
+}
+
+func newTestProviderURL(t *testing.T, port int, environment string) *common.URL {
+	t.Helper()
+
+	serviceURL, err := common.NewURL(
+		fmt.Sprintf("tri://127.0.0.1:%d/%s", port, testInterface),
+		common.WithInterface(testInterface),
+		common.WithMethods([]string{"Greet"}),
+		common.WithParamsValue(constant.ApplicationKey, testApp),
+		common.WithParamsValue(constant.EnvironmentKey, environment),
+		common.WithParamsValue(constant.SideKey, constant.SideProvider),
+	)
+	require.NoError(t, err)
+	return serviceURL
+}
+
+func assertServiceEvents(t *testing.T, events []*registry.ServiceEvent, ports, environments []string) {
+	t.Helper()
+
+	require.Len(t, events, len(ports))
+	require.Len(t, environments, len(ports))
+	assert.ElementsMatch(t, expectedServiceEvents(ports, environments), actualServiceEvents(events))
+}
+
+func assertServiceEventEnvironmentsAbsent(t *testing.T, events []*registry.ServiceEvent) {
+	t.Helper()
+
+	for _, event := range events {
+		assert.NotContains(t, event.Service.GetParams(), constant.EnvironmentKey)
+	}
+}
+
+type serviceEventAssertion struct {
+	port        string
+	environment string
+}
+
+func expectedServiceEvents(ports, environments []string) []serviceEventAssertion {
+	events := make([]serviceEventAssertion, 0, len(ports))
+	for i, port := range ports {
+		events = append(events, serviceEventAssertion{
+			port:        port,
+			environment: environments[i],
+		})
+	}
+	return events
+}
+
+func actualServiceEvents(events []*registry.ServiceEvent) []serviceEventAssertion {
+	actual := make([]serviceEventAssertion, 0, len(events))
+	for _, event := range events {
+		actual = append(actual, serviceEventAssertion{
+			port:        event.Service.Port,
+			environment: event.Service.GetParam(constant.EnvironmentKey, ""),
+		})
+	}
+	return actual
+}
+
+type capturingNotifyListener struct {
+	events []*registry.ServiceEvent
+}
+
+func (c *capturingNotifyListener) Notify(event *registry.ServiceEvent) {
+	c.events = append(c.events, event)
+}
+
+func (c *capturingNotifyListener) NotifyAll(events []*registry.ServiceEvent, callback func()) {
+	c.events = append([]*registry.ServiceEvent(nil), events...)
+	if callback != nil {
+		callback()
+	}
+}


### PR DESCRIPTION
### Description
Fixes #3302
### Why

When registering multiple providers under the same Nacos service, if these providers correspond to different metadata revisions, the consumer-side listener may only retain one provider when aggregating the URL, causing a `No provider available` error when dynamically switching to another provider.

Additionally, the `environment` set by the provider via `dubbo.WithEnvironment(...)` is not included in the service metadata/instance metadata. The consumer-side URL lacks this attribute, and the condition/script/tag router cannot correctly match by `environment`.

### Root Cause:

Multiple providers are registered, but the listener reuses/overwrites URLs with incorrect granularity.

The environment is not included in the routable metadata.

### PR Goal:

Fix the issue where the consumer directory only exposes one invoker in Nacos service discovery scenarios with multiple providers.

Enable the environment to be included in service metadata/instance metadata/consumer URLs, supporting dynamic routing.

### Success Criteria:

Consumer URLs can be generated across multiple revisions/providers for the same service.

The directory is refreshed according to the current instance after provider remove/restart.

The environment is visible in condition/script/tag router.

### Paths this PR should affect:

metadata/info

registry/servicediscovery

Entry URL metadata in the registry directory/router

### Revise
Adding environment to IncludeKeys: resolves missing routable attributes in consumer URLs.

Writing instance metadata to createInstance: resolves missing raw instance metadata in Nacos.

Changing listener aggregation from pointer/set to serviceKey -> revision -> ServiceInfo: resolves issues of multiple revisions overwriting/reusing the same service.

Provider remove/restart testing:  proves that old URLs are not left in the directory and are not lost upon provider restart.

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
