### PR TITLE
Refactor/cluster logger format

### DIFF
--- a/cluster/cluster/adaptivesvc/cluster_invoker.go
+++ b/cluster/cluster/adaptivesvc/cluster_invoker.go
@@ -86,21 +86,21 @@ func (ivk *adaptiveServiceClusterInvoker) Invoke(ctx context.Context, invocation
 		}
 	}
 	if remainingStr == "" {
-		logger.Errorf("[adasvc cluster] The %s field type of value %v should be string.",
-			constant.AdaptiveServiceRemainingKey, remainingIface)
+		logger.Errorf("[AdaptiveSvc] %s field type invalid, key=%s value=%v",
+			constant.AdaptiveServiceRemainingKey, constant.AdaptiveServiceRemainingKey, remainingIface)
 		return res
 	}
 	remaining, err := strconv.Atoi(remainingStr)
 	if err != nil {
-		logger.Warnf("the remaining is unexpected, we need a int type, but we got %s, err: %v.", remainingStr, err)
+		logger.Warnf("[AdaptiveSvc] parse remaining failed, remaining=%s err=%v", remainingStr, err)
 		return res
 	}
-	logger.Debugf("[adasvc cluster] The server status was received successfully, %s: %#v",
+	logger.Debugf("[AdaptiveSvc] received server status, %s=%s",
 		constant.AdaptiveServiceRemainingKey, remainingStr)
 	err = metrics.LocalMetrics.SetMethodMetrics(invoker.GetURL(),
 		invocation.MethodName(), metrics.HillClimbing, uint64(remaining))
 	if err != nil {
-		logger.Warnf("adaptive service metrics update is failed, err: %v", err)
+		logger.Warnf("[AdaptiveSvc] update metrics failed, err=%v", err)
 		return &result.RPCResult{Err: err}
 	}
 

--- a/cluster/cluster/adaptivesvc/cluster_invoker.go
+++ b/cluster/cluster/adaptivesvc/cluster_invoker.go
@@ -86,13 +86,13 @@ func (ivk *adaptiveServiceClusterInvoker) Invoke(ctx context.Context, invocation
 		}
 	}
 	if remainingStr == "" {
-		logger.Errorf("[AdaptiveSvc] %s field type invalid, key=%s value=%v, expected string" ,
+		logger.Errorf("[AdaptiveSvc] %s field type invalid, key=%s value=%v, expected string",
 			constant.AdaptiveServiceRemainingKey, constant.AdaptiveServiceRemainingKey, remainingIface)
 		return res
 	}
 	remaining, err := strconv.Atoi(remainingStr)
 	if err != nil {
-		logger.Warnf("[AdaptiveSvc] parse remaining failed, remaining=%s err=%v, expected int" , remainingStr, err)
+		logger.Warnf("[AdaptiveSvc] parse remaining failed, remaining=%s err=%v, expected int", remainingStr, err)
 		return res
 	}
 	logger.Debugf("[AdaptiveSvc] received server status, %s=%s",

--- a/cluster/cluster/adaptivesvc/cluster_invoker.go
+++ b/cluster/cluster/adaptivesvc/cluster_invoker.go
@@ -86,21 +86,21 @@ func (ivk *adaptiveServiceClusterInvoker) Invoke(ctx context.Context, invocation
 		}
 	}
 	if remainingStr == "" {
-		logger.Errorf("[AdaptiveSvc] %s field type invalid, key=%s value=%v, expected string",
+		logger.Errorf("[Cluster][AdaptiveSvc] %s field type invalid, key=%s value=%v, expected string",
 			constant.AdaptiveServiceRemainingKey, constant.AdaptiveServiceRemainingKey, remainingIface)
 		return res
 	}
 	remaining, err := strconv.Atoi(remainingStr)
 	if err != nil {
-		logger.Warnf("[AdaptiveSvc] parse remaining failed, remaining=%s err=%v, expected int", remainingStr, err)
+		logger.Warnf("[Cluster][AdaptiveSvc] parse remaining failed, remaining=%s err=%v, expected int", remainingStr, err)
 		return res
 	}
-	logger.Debugf("[AdaptiveSvc] received server status, %s=%s",
+	logger.Debugf("[Cluster][AdaptiveSvc] received server status, %s=%s",
 		constant.AdaptiveServiceRemainingKey, remainingStr)
 	err = metrics.LocalMetrics.SetMethodMetrics(invoker.GetURL(),
 		invocation.MethodName(), metrics.HillClimbing, uint64(remaining))
 	if err != nil {
-		logger.Warnf("[AdaptiveSvc] update metrics failed, err=%v", err)
+		logger.Warnf("[Cluster][AdaptiveSvc] update metrics failed, err=%v", err)
 		return &result.RPCResult{Err: err}
 	}
 

--- a/cluster/cluster/adaptivesvc/cluster_invoker.go
+++ b/cluster/cluster/adaptivesvc/cluster_invoker.go
@@ -86,13 +86,13 @@ func (ivk *adaptiveServiceClusterInvoker) Invoke(ctx context.Context, invocation
 		}
 	}
 	if remainingStr == "" {
-		logger.Errorf("[AdaptiveSvc] %s field type invalid, key=%s value=%v",
+		logger.Errorf("[AdaptiveSvc] %s field type invalid, key=%s value=%v, expected string" ,
 			constant.AdaptiveServiceRemainingKey, constant.AdaptiveServiceRemainingKey, remainingIface)
 		return res
 	}
 	remaining, err := strconv.Atoi(remainingStr)
 	if err != nil {
-		logger.Warnf("[AdaptiveSvc] parse remaining failed, remaining=%s err=%v", remainingStr, err)
+		logger.Warnf("[AdaptiveSvc] parse remaining failed, remaining=%s err=%v, expected int" , remainingStr, err)
 		return res
 	}
 	logger.Debugf("[AdaptiveSvc] received server status, %s=%s",

--- a/cluster/cluster/base/cluster_invoker.go
+++ b/cluster/cluster/base/cluster_invoker.go
@@ -127,7 +127,7 @@ func (invoker *BaseClusterInvoker) doSelectInvoker(lb loadbalance.LoadBalance, i
 			return invokers[0]
 		}
 		base.SetInvokerUnhealthyStatus(invokers[0])
-		logger.Errorf("the invokers of %s is nil. ", invokers[0].GetURL().ServiceKey())
+		logger.Errorf("[Cluster] invoker unavailable, serviceKey=%s", invokers[0].GetURL().ServiceKey())
 		return nil
 	}
 
@@ -149,8 +149,7 @@ func (invoker *BaseClusterInvoker) doSelectInvoker(lb loadbalance.LoadBalance, i
 				continue
 			}
 			if !reselectedInvoker.IsAvailable() {
-				logger.Infof("the invoker of %s is not available, maybe some network error happened or the server is shutdown.",
-					invoker.GetURL().Ip)
+				logger.Infof("[Cluster] invoker unavailable, ip=%s", invoker.GetURL().Ip)
 				base.SetInvokerUnhealthyStatus(reselectedInvoker)
 				otherInvokers = getOtherInvokers(otherInvokers, reselectedInvoker)
 				continue

--- a/cluster/cluster/base/cluster_invoker.go
+++ b/cluster/cluster/base/cluster_invoker.go
@@ -127,7 +127,7 @@ func (invoker *BaseClusterInvoker) doSelectInvoker(lb loadbalance.LoadBalance, i
 			return invokers[0]
 		}
 		base.SetInvokerUnhealthyStatus(invokers[0])
-		logger.Errorf("[Cluster] invoker unavailable, serviceKey=%s", invokers[0].GetURL().ServiceKey())
+		logger.Errorf("[Cluster] invoker unavailable, serviceKey=%s, reason=nil", invokers[0].GetURL().ServiceKey())
 		return nil
 	}
 

--- a/cluster/cluster/broadcast/cluster_invoker.go
+++ b/cluster/cluster/broadcast/cluster_invoker.go
@@ -58,7 +58,7 @@ func (invoker *broadcastClusterInvoker) Invoke(ctx context.Context, invocation p
 	for _, ivk := range invokers {
 		res = ivk.Invoke(ctx, invocation)
 		if res.Error() != nil {
-			logger.Warnf("broadcast invoker invoke err: %v when use invoker: %v\n", res.Error(), ivk)
+			logger.Warnf("[Broadcast] invoke failed, err=%v invoker=%v", res.Error(), ivk)
 			err = res.Error()
 		}
 	}

--- a/cluster/cluster/broadcast/cluster_invoker.go
+++ b/cluster/cluster/broadcast/cluster_invoker.go
@@ -58,7 +58,7 @@ func (invoker *broadcastClusterInvoker) Invoke(ctx context.Context, invocation p
 	for _, ivk := range invokers {
 		res = ivk.Invoke(ctx, invocation)
 		if res.Error() != nil {
-			logger.Warnf("[Broadcast] invoke failed, err=%v invoker=%v", res.Error(), ivk)
+			logger.Warnf("[Cluster][Broadcast] invoke failed, err=%v invoker=%v", res.Error(), ivk)
 			err = res.Error()
 		}
 	}

--- a/cluster/cluster/failback/cluster_invoker.go
+++ b/cluster/cluster/failback/cluster_invoker.go
@@ -65,7 +65,7 @@ func newFailbackClusterInvoker(directory directory.Directory) protocolbase.Invok
 	retriesConfig := invoker.GetURL().GetParam(constant.RetriesKey, constant.DefaultFailbackTimes)
 	retries, err := strconv.Atoi(retriesConfig)
 	if err != nil || retries < 0 {
-		logger.Error("Your retries config is invalid,pls do a check. And will use the default fail back times configuration instead.")
+		logger.Error("[Failback] retries config invalid, using default")
 		retries = constant.DefaultFailbackTimesInt
 	}
 
@@ -112,7 +112,7 @@ func (invoker *failbackClusterInvoker) process(ctx context.Context) {
 
 			// ignore return. the get must success.
 			if _, err = invoker.taskList.Get(1); err != nil {
-				logger.Warnf("get task found err: %v\n", err)
+				logger.Warnf("[Failback] get task failed, err=%v", err)
 				break
 			}
 			go invoker.tryTimerTaskProc(ctx, retryTask)
@@ -124,7 +124,7 @@ func (invoker *failbackClusterInvoker) process(ctx context.Context) {
 func (invoker *failbackClusterInvoker) Invoke(ctx context.Context, invocation protocolbase.Invocation) result.Result {
 	invokers := invoker.Directory.List(invocation)
 	if err := invoker.CheckInvokers(invokers, invocation); err != nil {
-		logger.Errorf("Failed to invoke the method %v in the service %v, wait for retry in background. Ignored exception: %v.\n",
+		logger.Errorf("[Failback] check invokers failed, method=%s service=%s err=%v",
 			invocation.MethodName(), invoker.GetURL().Service(), err)
 		return &result.RPCResult{}
 	}
@@ -151,14 +151,14 @@ func (invoker *failbackClusterInvoker) Invoke(ctx context.Context, invocation pr
 
 		taskLen := invoker.taskList.Len()
 		if taskLen >= invoker.failbackTasks {
-			logger.Warnf("tasklist is too full > %d.\n", taskLen)
+			logger.Warnf("[Failback] task list full, len=%d", taskLen)
 			return &result.RPCResult{}
 		}
 
 		timerTask := newRetryTimerTask(loadBalance, invocation, invokers, ivk, invoker)
 		invoker.taskList.Put(timerTask)
 
-		logger.Errorf("Failback to invoke the method %v in the service %v, wait for retry in background. Ignored exception: %v.\n",
+		logger.Errorf("[Failback] invoke failed, method=%s service=%s err=%v",
 			methodName, url.Service(), res.Error().Error())
 		// ignore
 		return &result.RPCResult{}
@@ -192,21 +192,21 @@ type retryTimerTask struct {
 }
 
 func (t *retryTimerTask) checkRetry() {
-	logger.Errorf("Failed retry to invoke the method %v in the service %v, wait again. The exception: %v",
+	logger.Errorf("[Failback] retry failed, method=%s service=%s err=%v",
 		t.invocation.MethodName(), t.clusterInvoker.GetURL().Service(), t.lastErr)
 	t.retries++
 	t.nextBackoff = t.backoff.NextBackOff() // calculate next exponential backoff wait time
 
 	if t.retries > t.maxRetries || t.nextBackoff == backoff.Stop {
-		logger.Errorf("Retry times exceed threshold (%v), invocation-> %v",
+		logger.Errorf("[Failback] retry exceeded, retries=%d invocation=%v",
 			t.retries, t.invocation)
 		return
 	}
 
-	logger.Infof("Failback retry scheduled after %v for method %v", t.nextBackoff, t.invocation.MethodName())
+	logger.Infof("[Failback] retry scheduled, backoff=%v method=%s", t.nextBackoff, t.invocation.MethodName())
 
 	if err := t.clusterInvoker.taskList.Put(t); err != nil {
-		logger.Errorf("invoker.taskList.Put(retryTask:%#v) = error:%v", t, err)
+		logger.Errorf("[Failback] put task failed, task=%v err=%v", t, err)
 		return
 	}
 	t.lastT = time.Now() // update lastT after successful Put

--- a/cluster/cluster/failback/cluster_invoker.go
+++ b/cluster/cluster/failback/cluster_invoker.go
@@ -65,7 +65,7 @@ func newFailbackClusterInvoker(directory directory.Directory) protocolbase.Invok
 	retriesConfig := invoker.GetURL().GetParam(constant.RetriesKey, constant.DefaultFailbackTimes)
 	retries, err := strconv.Atoi(retriesConfig)
 	if err != nil || retries < 0 {
-		logger.Error("[Failback] retries config invalid, using default")
+		logger.Error("[Cluster][Failback] retries config invalid, using default")
 		retries = constant.DefaultFailbackTimesInt
 	}
 
@@ -112,7 +112,7 @@ func (invoker *failbackClusterInvoker) process(ctx context.Context) {
 
 			// ignore return. the get must success.
 			if _, err = invoker.taskList.Get(1); err != nil {
-				logger.Warnf("[Failback] get task failed, err=%v", err)
+				logger.Warnf("[Cluster][Failback] get task failed, err=%v", err)
 				break
 			}
 			go invoker.tryTimerTaskProc(ctx, retryTask)
@@ -124,7 +124,7 @@ func (invoker *failbackClusterInvoker) process(ctx context.Context) {
 func (invoker *failbackClusterInvoker) Invoke(ctx context.Context, invocation protocolbase.Invocation) result.Result {
 	invokers := invoker.Directory.List(invocation)
 	if err := invoker.CheckInvokers(invokers, invocation); err != nil {
-		logger.Errorf("[Failback] check invokers failed, method=%s service=%s err=%v",
+		logger.Errorf("[Cluster][Failback] check invokers failed, method=%s service=%s err=%v",
 			invocation.MethodName(), invoker.GetURL().Service(), err)
 		return &result.RPCResult{}
 	}
@@ -151,14 +151,14 @@ func (invoker *failbackClusterInvoker) Invoke(ctx context.Context, invocation pr
 
 		taskLen := invoker.taskList.Len()
 		if taskLen >= invoker.failbackTasks {
-			logger.Warnf("[Failback] task list full, len=%d", taskLen)
+			logger.Warnf("[Cluster][Failback] task list full, len=%d", taskLen)
 			return &result.RPCResult{}
 		}
 
 		timerTask := newRetryTimerTask(loadBalance, invocation, invokers, ivk, invoker)
 		invoker.taskList.Put(timerTask)
 
-		logger.Errorf("[Failback] invoke failed, method=%s service=%s err=%v",
+		logger.Errorf("[Cluster][Failback] invoke failed, method=%s service=%s err=%v",
 			methodName, url.Service(), res.Error().Error())
 		// ignore
 		return &result.RPCResult{}
@@ -192,21 +192,21 @@ type retryTimerTask struct {
 }
 
 func (t *retryTimerTask) checkRetry() {
-	logger.Errorf("[Failback] retry failed, method=%s service=%s err=%v",
+	logger.Errorf("[Cluster][Failback] retry failed, method=%s service=%s err=%v",
 		t.invocation.MethodName(), t.clusterInvoker.GetURL().Service(), t.lastErr)
 	t.retries++
 	t.nextBackoff = t.backoff.NextBackOff() // calculate next exponential backoff wait time
 
 	if t.retries > t.maxRetries || t.nextBackoff == backoff.Stop {
-		logger.Errorf("[Failback] retry exceeded, retries=%d invocation=%v",
+		logger.Errorf("[Cluster][Failback] retry exceeded, retries=%d invocation=%v",
 			t.retries, t.invocation)
 		return
 	}
 
-	logger.Infof("[Failback] retry scheduled, backoff=%v method=%s", t.nextBackoff, t.invocation.MethodName())
+	logger.Infof("[Cluster][Failback] retry scheduled, backoff=%v method=%s", t.nextBackoff, t.invocation.MethodName())
 
 	if err := t.clusterInvoker.taskList.Put(t); err != nil {
-		logger.Errorf("[Failback] put task failed, task=%v err=%v", t, err)
+		logger.Errorf("[Cluster][Failback] put task failed, task=%v err=%v", t, err)
 		return
 	}
 	t.lastT = time.Now() // update lastT after successful Put

--- a/cluster/cluster/failover/cluster_invoker.go
+++ b/cluster/cluster/failover/cluster_invoker.go
@@ -19,7 +19,6 @@ package failover
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 )
 
@@ -97,17 +96,15 @@ func (invoker *failoverClusterInvoker) Invoke(ctx context.Context, invocation pr
 	invokerSvc := invoker.GetURL().Service()
 	invokerUrl := invoker.Directory.GetURL()
 	if ivk == nil {
-		logger.Errorf("Failed to invoke the method %s of the service %s .No provider is available.", methodName, invokerSvc)
+		logger.Errorf("[Failover] no provider available, method=%s service=%s", methodName, invokerSvc)
 		return &result.RPCResult{
 			Err: perrors.Errorf("Failed to invoke the method %s of the service %s .No provider is available because can't connect server.",
 				methodName, invokerSvc),
 		}
 	}
 
-	logger.Errorf(fmt.Sprintf("Failed to invoke the method %v in the service %v. "+
-		"Tried %v times of the providers %v (%v/%v) from the registry %v on the consumer %v using the dubbo version %v. "+
-		"Last error is %+v.", methodName, invokerSvc, retries, providers, len(providers), len(invokers),
-		invokerUrl, ip, constant.Version, res.Error().Error()))
+	logger.Errorf("[Failover] invoke failed after retries, method=%s service=%s retries=%d providers=%d/%d registry=%s consumer=%s version=%s lastErr=%v",
+		methodName, invokerSvc, retries, len(providers), len(invokers), invokerUrl, ip, constant.Version, res.Error().Error())
 
 	return res
 }

--- a/cluster/cluster/failover/cluster_invoker.go
+++ b/cluster/cluster/failover/cluster_invoker.go
@@ -96,14 +96,14 @@ func (invoker *failoverClusterInvoker) Invoke(ctx context.Context, invocation pr
 	invokerSvc := invoker.GetURL().Service()
 	invokerUrl := invoker.Directory.GetURL()
 	if ivk == nil {
-		logger.Errorf("[Failover] no provider available, method=%s service=%s", methodName, invokerSvc)
+		logger.Errorf("[Cluster][Failover] no provider available, method=%s service=%s", methodName, invokerSvc)
 		return &result.RPCResult{
 			Err: perrors.Errorf("Failed to invoke the method %s of the service %s .No provider is available because can't connect server.",
 				methodName, invokerSvc),
 		}
 	}
 
-	logger.Errorf("[Failover] invoke failed after retries, method=%s service=%s retries=%d providers=%d/%d registry=%s consumer=%s version=%s lastErr=%v",
+	logger.Errorf("[Cluster][Failover] invoke failed after retries, method=%s service=%s retries=%d providers=%d/%d registry=%s consumer=%s version=%s lastErr=%v",
 		methodName, invokerSvc, retries, len(providers), len(invokers), invokerUrl, ip, constant.Version, res.Error().Error())
 
 	return res

--- a/cluster/cluster/failsafe/cluster_invoker.go
+++ b/cluster/cluster/failsafe/cluster_invoker.go
@@ -77,7 +77,7 @@ func (invoker *failsafeClusterInvoker) Invoke(ctx context.Context, invocation pr
 	res = ivk.Invoke(ctx, invocation)
 	if res.Error() != nil {
 		// ignore
-		logger.Errorf("Failsafe ignore exception: %v.\n", res.Error().Error())
+		logger.Errorf("[Failsafe] Ignore exception, err=%v", res.Error().Error())
 		return &result.RPCResult{}
 	}
 	return res

--- a/cluster/cluster/failsafe/cluster_invoker.go
+++ b/cluster/cluster/failsafe/cluster_invoker.go
@@ -77,7 +77,7 @@ func (invoker *failsafeClusterInvoker) Invoke(ctx context.Context, invocation pr
 	res = ivk.Invoke(ctx, invocation)
 	if res.Error() != nil {
 		// ignore
-		logger.Errorf("[Failsafe] Ignore exception, err=%v", res.Error().Error())
+		logger.Errorf("[Cluster][Failsafe] ignore exception, err=%v", res.Error().Error())
 		return &result.RPCResult{}
 	}
 	return res

--- a/cluster/cluster/forking/cluster_invoker.go
+++ b/cluster/cluster/forking/cluster_invoker.go
@@ -76,7 +76,7 @@ func (invoker *forkingClusterInvoker) Invoke(ctx context.Context, invocation pro
 		go func(k protocolbase.Invoker) {
 			result := k.Invoke(ctx, invocation)
 			if err := resultQ.Put(result); err != nil {
-				logger.Errorf("resultQ put failed with exception: %v.\n", err)
+				logger.Errorf("[Forking] resultQ put failed with exception err=%v", err)
 			}
 		}(ivk)
 	}

--- a/cluster/cluster/forking/cluster_invoker.go
+++ b/cluster/cluster/forking/cluster_invoker.go
@@ -76,7 +76,7 @@ func (invoker *forkingClusterInvoker) Invoke(ctx context.Context, invocation pro
 		go func(k protocolbase.Invoker) {
 			result := k.Invoke(ctx, invocation)
 			if err := resultQ.Put(result); err != nil {
-				logger.Errorf("[Forking] resultQ put failed with exception err=%v", err)
+				logger.Errorf("[Cluster][Forking] resultQ put failed with exception err=%v", err)
 			}
 		}(ivk)
 	}

--- a/cluster/cluster/mock.go
+++ b/cluster/cluster/mock.go
@@ -102,7 +102,7 @@ func (bi *MockInvoker) Invoke(c context.Context, invocation base.Invocation) res
 }
 
 func (bi *MockInvoker) Destroy() {
-	logger.Infof("Destroy invoker: %v", bi.GetURL().String())
+	logger.Infof("[Mock] Destroy invoker url=%s", bi.GetURL().String())
 	bi.destroyed = true
 	bi.available = false
 }

--- a/cluster/directory/static/directory.go
+++ b/cluster/directory/static/directory.go
@@ -49,7 +49,7 @@ func NewDirectory(invokers []protocolbase.Invoker) *directory {
 
 	err := dir.BuildRouterChain(invokers, url)
 	if err != nil {
-		logger.Error(err)
+		logger.Error("[Directory] build router chain failed, err=%v", err)
 		dir.RouterChain().SetInvokers(invokers)
 	}
 

--- a/cluster/loadbalance/p2c/loadbalance.go
+++ b/cluster/loadbalance/p2c/loadbalance.go
@@ -113,8 +113,7 @@ func (l *p2cLoadBalance) Select(invokers []base.Invoker, invocation base.Invocat
 	m := metrics.LocalMetrics
 	// picks two nodes randomly
 	i, j := l.randomPicker(len(invokers))
-	logger.Debugf("[P2C select] Two invokers were selected, invoker[%d]: %s, invoker[%d]: %s.",
-		i, invokers[i], j, invokers[j])
+	logger.Debugf("[P2C] select two invokers i=%d j=%d", i, j)
 
 	methodName := invocation.ActualMethodName()
 	// remainingIIface, remainingJIface means remaining capacity of node i and node j.
@@ -122,10 +121,10 @@ func (l *p2cLoadBalance) Select(invokers []base.Invoker, invocation base.Invocat
 	remainingIIface, err := m.GetMethodMetrics(invokers[i].GetURL(), methodName, metrics.HillClimbing)
 	if err != nil {
 		if errors.Is(err, metrics.ErrMetricsNotFound) {
-			logger.Debugf("[P2C select] The invoker[%d] was selected, because it hasn't been selected before.", i)
+			logger.Debugf("[P2C] select invoker i=%d (no prior metrics)", i)
 			return invokers[i]
 		}
-		logger.Warnf("get method metrics err: %v", err)
+		logger.Warnf("[P2C] get method metrics err=%v", err)
 		return nil
 	}
 
@@ -133,33 +132,34 @@ func (l *p2cLoadBalance) Select(invokers []base.Invoker, invocation base.Invocat
 	remainingJIface, err := m.GetMethodMetrics(invokers[j].GetURL(), methodName, metrics.HillClimbing)
 	if err != nil {
 		if errors.Is(err, metrics.ErrMetricsNotFound) {
-			logger.Debugf("[P2C select] The invoker[%d] was selected, because it hasn't been selected before.", j)
+			logger.Debugf("[P2C] select invoker j=%d (no prior metrics)", j)
 			return invokers[j]
 		}
-		logger.Warnf("get method metrics err: %v", err)
+		logger.Warnf("[P2C] get method metrics err=%v", err)
 		return nil
 	}
 
 	// Convert interface to int, if the type is unexpected, panic immediately
 	remainingI, ok := remainingIIface.(uint64)
 	if !ok {
-		panic(fmt.Sprintf("[P2C select] the type of %s expects to be uint64, but gets %T",
+		panic(fmt.Sprintf("[P2C] type check failed: key=%s expected=uint64 actual=%T",
 			metrics.HillClimbing, remainingIIface))
 	}
 
 	remainingJ, ok := remainingJIface.(uint64)
 	if !ok {
-		panic(fmt.Sprintf("the type of %s expects to be uint64, but gets %T", metrics.HillClimbing, remainingJIface))
+		panic(fmt.Sprintf("[P2C] type check failed: key=%s expected=uint64 actual=%T",
+			metrics.HillClimbing, remainingJIface))
 	}
 
-	logger.Debugf("[P2C select] The invoker[%d] remaining is %d, and the invoker[%d] is %d.", i, remainingI, j, remainingJ)
+	logger.Debugf("[P2C] compare remaining capacity i=%d val=%d j=%d val=%d", i, remainingI, j, remainingJ)
 
 	// For the remaining capacity, the bigger, the better.
 	if remainingI > remainingJ {
-		logger.Debugf("[P2C select] The invoker[%d] was selected.", i)
+		logger.Debugf("[P2C] select invoker i=%d", i)
 		return invokers[i]
 	}
 
-	logger.Debugf("[P2C select] The invoker[%d] was selected.", j)
+	logger.Debugf("[P2C] select invoker j=%d", j)
 	return invokers[j]
 }

--- a/cluster/loadbalance/p2c/loadbalance.go
+++ b/cluster/loadbalance/p2c/loadbalance.go
@@ -113,7 +113,7 @@ func (l *p2cLoadBalance) Select(invokers []base.Invoker, invocation base.Invocat
 	m := metrics.LocalMetrics
 	// picks two nodes randomly
 	i, j := l.randomPicker(len(invokers))
-	logger.Debugf("[P2C] select two invokers i=%d j=%d", i, j)
+	logger.Debugf("[Loadbalance][P2C] select two invokers i=%d j=%d", i, j)
 
 	methodName := invocation.ActualMethodName()
 	// remainingIIface, remainingJIface means remaining capacity of node i and node j.
@@ -121,10 +121,10 @@ func (l *p2cLoadBalance) Select(invokers []base.Invoker, invocation base.Invocat
 	remainingIIface, err := m.GetMethodMetrics(invokers[i].GetURL(), methodName, metrics.HillClimbing)
 	if err != nil {
 		if errors.Is(err, metrics.ErrMetricsNotFound) {
-			logger.Debugf("[P2C] select invoker i=%d (no prior metrics)", i)
+			logger.Debugf("[Loadbalance][P2C] select invoker i=%d (no prior metrics)", i)
 			return invokers[i]
 		}
-		logger.Warnf("[P2C] get method metrics err=%v", err)
+		logger.Warnf("[Loadbalance][P2C] get method metrics err=%v", err)
 		return nil
 	}
 
@@ -132,34 +132,34 @@ func (l *p2cLoadBalance) Select(invokers []base.Invoker, invocation base.Invocat
 	remainingJIface, err := m.GetMethodMetrics(invokers[j].GetURL(), methodName, metrics.HillClimbing)
 	if err != nil {
 		if errors.Is(err, metrics.ErrMetricsNotFound) {
-			logger.Debugf("[P2C] select invoker j=%d (no prior metrics)", j)
+			logger.Debugf("[Loadbalance][P2C] select invoker j=%d (no prior metrics)", j)
 			return invokers[j]
 		}
-		logger.Warnf("[P2C] get method metrics err=%v", err)
+		logger.Warnf("[Loadbalance][P2C] get method metrics err=%v", err)
 		return nil
 	}
 
 	// Convert interface to int, if the type is unexpected, panic immediately
 	remainingI, ok := remainingIIface.(uint64)
 	if !ok {
-		panic(fmt.Sprintf("[P2C] type check failed: key=%s expected=uint64 actual=%T",
+		panic(fmt.Sprintf("[Loadbalance][P2C] type check failed: key=%s expected=uint64 actual=%T",
 			metrics.HillClimbing, remainingIIface))
 	}
 
 	remainingJ, ok := remainingJIface.(uint64)
 	if !ok {
-		panic(fmt.Sprintf("[P2C] type check failed: key=%s expected=uint64 actual=%T",
+		panic(fmt.Sprintf("[Loadbalance][P2C] type check failed: key=%s expected=uint64 actual=%T",
 			metrics.HillClimbing, remainingJIface))
 	}
 
-	logger.Debugf("[P2C] compare remaining capacity i=%d val=%d j=%d val=%d", i, remainingI, j, remainingJ)
+	logger.Debugf("[Loadbalance][P2C] compare remaining capacity i=%d val=%d j=%d val=%d", i, remainingI, j, remainingJ)
 
 	// For the remaining capacity, the bigger, the better.
 	if remainingI > remainingJ {
-		logger.Debugf("[P2C] select invoker i=%d", i)
+		logger.Debugf("[Loadbalance][P2C] select invoker i=%d", i)
 		return invokers[i]
 	}
 
-	logger.Debugf("[P2C] select invoker j=%d", j)
+	logger.Debugf("[Loadbalance][P2C] select invoker j=%d", j)
 	return invokers[j]
 }

--- a/cluster/router/affinity/router.go
+++ b/cluster/router/affinity/router.go
@@ -55,13 +55,13 @@ func (s *ServiceAffinityRoute) Notify(invokers []base.Invoker) {
 
 	url := invokers[0].GetURL()
 	if url == nil {
-		logger.Error("Failed to notify a Service Affinity rule, because url is empty")
+		logger.Error("[Affinity] failed to notify service affinity rule: url is empty")
 		return
 	}
 
 	dynamicConfiguration := conf.GetEnvInstance().GetDynamicConfiguration()
 	if dynamicConfiguration == nil {
-		logger.Infof("Config center does not start, Affinity router will not be enabled")
+		logger.Infof("[Affinity] config center not started, affinity router disabled")
 		return
 	}
 
@@ -69,7 +69,7 @@ func (s *ServiceAffinityRoute) Notify(invokers []base.Invoker) {
 	dynamicConfiguration.AddListener(key, s)
 	value, err := dynamicConfiguration.GetRule(key)
 	if err != nil {
-		logger.Errorf("Failed to query affinity rule, key=%s, err=%v", key, err)
+		logger.Errorf("[Affinity] query affinity rule failed: key=%s, err=%v", key, err)
 		return
 	}
 
@@ -87,7 +87,7 @@ func newApplicationAffinityRouter(url *common.URL) *ApplicationAffinityRoute {
 	applicationName := url.GetParam(constant.ApplicationKey, "")
 
 	if applicationName == "" {
-		logger.Errorf("Application affinity router must set application name")
+		logger.Errorf("[Affinity] application name is required")
 		return nil
 	}
 
@@ -108,19 +108,19 @@ func (s *ApplicationAffinityRoute) Notify(invokers []base.Invoker) {
 	}
 	url := invokers[0].GetURL()
 	if url == nil {
-		logger.Error("Failed to notify a dynamically affinity rule, because url is empty")
+		logger.Error("[Affinity] failed to notify dynamic affinity rule: url is empty")
 		return
 	}
 
 	dynamicConfiguration := conf.GetEnvInstance().GetDynamicConfiguration()
 	if dynamicConfiguration == nil {
-		logger.Infof("Config center does not start, Affinity router will not be enabled")
+		logger.Infof("[Affinity] config center not started, affinity router disabled")
 		return
 	}
 
 	providerApplication := url.GetParam("application", "")
 	if providerApplication == "" || providerApplication == s.currentApplication {
-		logger.Warn("Affinity router get providerApplication is empty, will not subscribe to provider app rules.")
+		logger.Warnf("[Affinity] provider application is empty or equals to current, will not subscribe")
 		return
 	}
 
@@ -134,7 +134,7 @@ func (s *ApplicationAffinityRoute) Notify(invokers []base.Invoker) {
 		dynamicConfiguration.AddListener(key, s)
 		value, err := dynamicConfiguration.GetRule(key)
 		if err != nil {
-			logger.Errorf("Failed to query affinity rule, key=%s, err=%v", key, err)
+			logger.Errorf("[Affinity] query affinity rule failed: key=%s, err=%v", key, err)
 			return
 		}
 
@@ -160,12 +160,12 @@ func (a *affinityRoute) Process(event *config_center.ConfigChangeEvent) {
 	case remoting.EventTypeAdd, remoting.EventTypeUpdate:
 		cfg, err := parseConfig(event.Value.(string))
 		if err != nil {
-			logger.Errorf("Failed to parse affinity config, key=%s, err=%v", a.key, err)
+			logger.Errorf("[Affinity] parse affinity config failed: key=%s, err=%v", a.key, err)
 			return
 		}
 
 		if cfg.AffinityAware.Ratio < 0 || cfg.AffinityAware.Ratio > 100 {
-			logger.Errorf("Failed to parse affinity config, affinity.ratio=%d, expect 0-100", a.ratio)
+			logger.Errorf("[Affinity] invalid affinity ratio: ratio=%d, expected=0-100", cfg.AffinityAware.Ratio)
 			return
 		}
 
@@ -176,7 +176,7 @@ func (a *affinityRoute) Process(event *config_center.ConfigChangeEvent) {
 		rule := strings.Join([]string{key, key}, "=$")
 		f, err := condition.NewFieldMatcher(rule)
 		if err != nil {
-			logger.Errorf("Failed to parse affinity config, key=%s, rule=%s ,err=%v", a.key, rule, err)
+			logger.Errorf("[Affinity] parse affinity rule failed: key=%s, rule=%s, err=%v", a.key, rule, err)
 			return
 		}
 

--- a/cluster/router/affinity/router.go
+++ b/cluster/router/affinity/router.go
@@ -55,13 +55,13 @@ func (s *ServiceAffinityRoute) Notify(invokers []base.Invoker) {
 
 	url := invokers[0].GetURL()
 	if url == nil {
-		logger.Error("[Affinity] failed to notify service affinity rule: url is empty")
+		logger.Error("[Router][Affinity] failed to notify service affinity rule: url is empty")
 		return
 	}
 
 	dynamicConfiguration := conf.GetEnvInstance().GetDynamicConfiguration()
 	if dynamicConfiguration == nil {
-		logger.Infof("[Affinity] config center not started, affinity router disabled")
+		logger.Infof("[Router][Affinity] config center not started, affinity router disabled")
 		return
 	}
 
@@ -69,7 +69,7 @@ func (s *ServiceAffinityRoute) Notify(invokers []base.Invoker) {
 	dynamicConfiguration.AddListener(key, s)
 	value, err := dynamicConfiguration.GetRule(key)
 	if err != nil {
-		logger.Errorf("[Affinity] query affinity rule failed: key=%s, err=%v", key, err)
+		logger.Errorf("[Router][Affinity] query affinity rule failed: key=%s, err=%v", key, err)
 		return
 	}
 
@@ -87,7 +87,7 @@ func newApplicationAffinityRouter(url *common.URL) *ApplicationAffinityRoute {
 	applicationName := url.GetParam(constant.ApplicationKey, "")
 
 	if applicationName == "" {
-		logger.Errorf("[Affinity] application name is required")
+		logger.Errorf("[Router][Affinity] application name is required")
 		return nil
 	}
 
@@ -108,19 +108,19 @@ func (s *ApplicationAffinityRoute) Notify(invokers []base.Invoker) {
 	}
 	url := invokers[0].GetURL()
 	if url == nil {
-		logger.Error("[Affinity] failed to notify dynamic affinity rule: url is empty")
+		logger.Error("[Router][Affinity] failed to notify dynamic affinity rule: url is empty")
 		return
 	}
 
 	dynamicConfiguration := conf.GetEnvInstance().GetDynamicConfiguration()
 	if dynamicConfiguration == nil {
-		logger.Infof("[Affinity] config center not started, affinity router disabled")
+		logger.Infof("[Router][Affinity] config center not started, affinity router disabled")
 		return
 	}
 
 	providerApplication := url.GetParam("application", "")
 	if providerApplication == "" || providerApplication == s.currentApplication {
-		logger.Warnf("[Affinity] provider application is empty or equals to current, will not subscribe")
+		logger.Warnf("[Router][Affinity] provider application is empty or equals to current, will not subscribe")
 		return
 	}
 
@@ -134,7 +134,7 @@ func (s *ApplicationAffinityRoute) Notify(invokers []base.Invoker) {
 		dynamicConfiguration.AddListener(key, s)
 		value, err := dynamicConfiguration.GetRule(key)
 		if err != nil {
-			logger.Errorf("[Affinity] query affinity rule failed: key=%s, err=%v", key, err)
+			logger.Errorf("[Router][Affinity] query affinity rule failed: key=%s, err=%v", key, err)
 			return
 		}
 
@@ -160,12 +160,12 @@ func (a *affinityRoute) Process(event *config_center.ConfigChangeEvent) {
 	case remoting.EventTypeAdd, remoting.EventTypeUpdate:
 		cfg, err := parseConfig(event.Value.(string))
 		if err != nil {
-			logger.Errorf("[Affinity] parse affinity config failed: key=%s, err=%v", a.key, err)
+			logger.Errorf("[Router][Affinity] parse affinity config failed: key=%s, err=%v", a.key, err)
 			return
 		}
 
 		if cfg.AffinityAware.Ratio < 0 || cfg.AffinityAware.Ratio > 100 {
-			logger.Errorf("[Affinity] invalid affinity ratio: ratio=%d, expected=0-100", cfg.AffinityAware.Ratio)
+			logger.Errorf("[Router][Affinity] invalid affinity ratio: ratio=%d, expected=0-100", cfg.AffinityAware.Ratio)
 			return
 		}
 
@@ -176,7 +176,7 @@ func (a *affinityRoute) Process(event *config_center.ConfigChangeEvent) {
 		rule := strings.Join([]string{key, key}, "=$")
 		f, err := condition.NewFieldMatcher(rule)
 		if err != nil {
-			logger.Errorf("[Affinity] parse affinity rule failed: key=%s, rule=%s, err=%v", a.key, rule, err)
+			logger.Errorf("[Router][Affinity] parse affinity rule failed: key=%s, rule=%s, err=%v", a.key, rule, err)
 			return
 		}
 

--- a/cluster/router/chain/chain.go
+++ b/cluster/router/chain/chain.go
@@ -131,7 +131,7 @@ func (c *RouterChain) injectStaticRouters(url *common.URL) {
 	}
 	staticRoutersAttr, ok := staticRoutersAttrAny.([]*global.RouterConfig)
 	if !ok {
-		logger.Errorf("failed to type assert routers config: expected []*global.RouterConfig, got %T", staticRoutersAttrAny)
+		logger.Errorf("[Chain] failed to type assert routers config: expected type=%T", staticRoutersAttrAny)
 		return
 	}
 	if len(staticRoutersAttr) == 0 {
@@ -183,7 +183,7 @@ func NewRouterChain(url *common.URL) (*RouterChain, error) {
 	for key, routerFactory := range routerFactories {
 		r, err := routerFactory().NewPriorityRouter(url)
 		if err != nil {
-			logger.Errorf("Build router chain failed with routerFactories key:%s and error:%v", key, err)
+			logger.Errorf("[Chain] build router chain failed: key=%s, error=%v", key, err)
 			continue
 		} else if r == nil {
 			continue

--- a/cluster/router/chain/chain.go
+++ b/cluster/router/chain/chain.go
@@ -131,7 +131,7 @@ func (c *RouterChain) injectStaticRouters(url *common.URL) {
 	}
 	staticRoutersAttr, ok := staticRoutersAttrAny.([]*global.RouterConfig)
 	if !ok {
-		logger.Errorf("[Chain] failed to type assert routers config: expected type=%T", staticRoutersAttrAny)
+		logger.Errorf("[Router][Chain] failed to type assert routers config: expected type=%T", staticRoutersAttrAny)
 		return
 	}
 	if len(staticRoutersAttr) == 0 {
@@ -183,7 +183,7 @@ func NewRouterChain(url *common.URL) (*RouterChain, error) {
 	for key, routerFactory := range routerFactories {
 		r, err := routerFactory().NewPriorityRouter(url)
 		if err != nil {
-			logger.Errorf("[Chain] build router chain failed: key=%s, error=%v", key, err)
+			logger.Errorf("[Router][Chain] build router chain failed: key=%s, error=%v", key, err)
 			continue
 		} else if r == nil {
 			continue

--- a/cluster/router/condition/dynamic_router.go
+++ b/cluster/router/condition/dynamic_router.go
@@ -66,7 +66,7 @@ func (m *multiplyConditionRoute) route(invokers []base.Invoker, url *common.URL,
 	if len(m.trafficDisabled) != 0 {
 		for _, cond := range m.trafficDisabled {
 			if cond.MatchRequest(url, invocation) {
-				logger.Warnf("Request has been disabled %s by Condition.trafficDisable.match=\"%s\"", url.String(), cond.rule)
+				logger.Warnf("[Condition] request traffic disabled: url=%s, rule=%s", url.String(), cond.rule)
 				invocation.SetAttachment(constant.TrafficDisableKey, struct{}{})
 				return []base.Invoker{}
 			}
@@ -83,7 +83,7 @@ func (m *multiplyConditionRoute) route(invokers []base.Invoker, url *common.URL,
 			if len(invokers) == 0 {
 				routeChains, ok := invocation.Attributes()["condition-chain"].([]string)
 				if ok {
-					logger.Errorf("request[%s] route an empty set in condition-route:: %s", url.String(), strings.Join(routeChains, "-->"))
+						logger.Errorf("[Condition] route returned empty set: chain=%s", strings.Join(routeChains, "-->"))
 				}
 				return []base.Invoker{}
 			}
@@ -158,14 +158,14 @@ func (d *DynamicRouter) SetStaticConfig(cfg *global.RouterConfig) {
 	for _, conditionRule := range cfg.Conditions {
 		url, err := common.NewURL("condition://")
 		if err != nil {
-			logger.Warnf("[condition router] failed to create condition URL: %v", err)
+			logger.Warnf("[Condition] failed to create condition URL: err=%v", err)
 			continue
 		}
 		url.AddParam(constant.RuleKey, conditionRule)
 		url.AddParam(constant.ForceKey, strconv.FormatBool(force))
 		conditionRoute, err := NewConditionStateRouter(url)
 		if err != nil {
-			logger.Warnf("[condition router] failed to parse condition rule %q: %v", conditionRule, err)
+			logger.Warnf("[Condition] failed to parse condition rule: rule=%s, err=%v", conditionRule, err)
 			continue
 		}
 		conditionRouters = append(conditionRouters, conditionRoute)
@@ -185,7 +185,7 @@ func (d *DynamicRouter) Process(event *config_center.ConfigChangeEvent) {
 	} else {
 		rc, force, enable, err := generateCondition(event.Value.(string))
 		if err != nil {
-			logger.Errorf("generate condition error: %v", err)
+			logger.Errorf("[Condition] failed to generate condition: err=%v", err)
 			d.conditionRouter = nil
 		} else {
 			d.force, d.enable, d.conditionRouter = force, enable, rc
@@ -239,7 +239,7 @@ func generateCondition(rawConfig string) (condRouter, bool, bool, error) {
 func generateMultiConditionRoute(rawConfig string) (*multiplyConditionRoute, bool, bool, error) {
 	routerConfig, err := parseMultiConditionRoute(rawConfig)
 	if err != nil {
-		logger.Warnf("[condition router]Build a new condition route config error, %s and we will use the original condition rule configuration.", err.Error())
+		logger.Warnf("[Condition] failed to build condition route config: err=%s", err.Error())
 		return nil, false, false, err
 	}
 
@@ -289,7 +289,7 @@ func generateMultiConditionRoute(rawConfig string) (*multiplyConditionRoute, boo
 func generateConditionsRoute(rawConfig string) (stateRouters, bool, bool, error) {
 	routerConfig, err := parseConditionRoute(rawConfig)
 	if err != nil {
-		logger.Warnf("[condition router]Build a new condition route config error, %s and we will use the original condition rule configuration.", err.Error())
+		logger.Warnf("[Condition] failed to build condition route config: err=%s", err.Error())
 		return nil, false, false, err
 	}
 
@@ -342,7 +342,7 @@ func (s *ServiceRouter) Notify(invokers []base.Invoker) {
 	}
 	url := invokers[0].GetURL()
 	if url == nil {
-		logger.Error("Failed to notify a dynamically condition rule, because url is empty")
+		logger.Error("[Condition] failed to notify condition router: url is empty")
 		return
 	}
 
@@ -408,7 +408,7 @@ func (a *ApplicationRouter) Notify(invokers []base.Invoker) {
 	}
 	url := invokers[0].GetURL()
 	if url == nil {
-		logger.Error("Failed to notify a dynamically condition rule, because url is empty")
+		logger.Error("[Condition] failed to notify condition router: url is empty")
 		return
 	}
 
@@ -420,7 +420,7 @@ func (a *ApplicationRouter) Notify(invokers []base.Invoker) {
 
 	providerApplication := url.GetParam("application", "")
 	if providerApplication == "" || providerApplication == a.currentApplication {
-		logger.Warn("condition router get providerApplication is empty, will not subscribe to provider app rules.")
+		logger.Warnf("[Condition] provider application is empty, will not subscribe to provider app rules")
 		return
 	}
 
@@ -434,7 +434,7 @@ func (a *ApplicationRouter) Notify(invokers []base.Invoker) {
 		a.application = providerApplication
 		value, err := dynamicConfiguration.GetRule(key)
 		if err != nil {
-			logger.Errorf("Failed to query condition rule, key=%s, err=%v", key, err)
+			logger.Errorf("[Condition] failed to query condition rule: key=%s, err=%v", key, err)
 			return
 		}
 		if value == "" {

--- a/cluster/router/condition/dynamic_router.go
+++ b/cluster/router/condition/dynamic_router.go
@@ -83,7 +83,7 @@ func (m *multiplyConditionRoute) route(invokers []base.Invoker, url *common.URL,
 			if len(invokers) == 0 {
 				routeChains, ok := invocation.Attributes()["condition-chain"].([]string)
 				if ok {
-						logger.Errorf("[Condition] route returned empty set: chain=%s", strings.Join(routeChains, "-->"))
+					logger.Errorf("[Condition] route returned empty set: chain=%s", strings.Join(routeChains, "-->"))
 				}
 				return []base.Invoker{}
 			}

--- a/cluster/router/condition/dynamic_router.go
+++ b/cluster/router/condition/dynamic_router.go
@@ -66,7 +66,7 @@ func (m *multiplyConditionRoute) route(invokers []base.Invoker, url *common.URL,
 	if len(m.trafficDisabled) != 0 {
 		for _, cond := range m.trafficDisabled {
 			if cond.MatchRequest(url, invocation) {
-				logger.Warnf("[Condition] request traffic disabled: url=%s, rule=%s", url.String(), cond.rule)
+				logger.Warnf("[Router][Condition] request traffic disabled: url=%s, rule=%s", url.String(), cond.rule)
 				invocation.SetAttachment(constant.TrafficDisableKey, struct{}{})
 				return []base.Invoker{}
 			}
@@ -83,7 +83,7 @@ func (m *multiplyConditionRoute) route(invokers []base.Invoker, url *common.URL,
 			if len(invokers) == 0 {
 				routeChains, ok := invocation.Attributes()["condition-chain"].([]string)
 				if ok {
-					logger.Errorf("[Condition] route returned empty set: chain=%s", strings.Join(routeChains, "-->"))
+					logger.Errorf("[Router][Condition] route returned empty set: chain=%s", strings.Join(routeChains, "-->"))
 				}
 				return []base.Invoker{}
 			}
@@ -158,14 +158,14 @@ func (d *DynamicRouter) SetStaticConfig(cfg *global.RouterConfig) {
 	for _, conditionRule := range cfg.Conditions {
 		url, err := common.NewURL("condition://")
 		if err != nil {
-			logger.Warnf("[Condition] failed to create condition URL: err=%v", err)
+			logger.Warnf("[Router][Condition] failed to create condition URL: err=%v", err)
 			continue
 		}
 		url.AddParam(constant.RuleKey, conditionRule)
 		url.AddParam(constant.ForceKey, strconv.FormatBool(force))
 		conditionRoute, err := NewConditionStateRouter(url)
 		if err != nil {
-			logger.Warnf("[Condition] failed to parse condition rule: rule=%s, err=%v", conditionRule, err)
+			logger.Warnf("[Router][Condition] failed to parse condition rule: rule=%s, err=%v", conditionRule, err)
 			continue
 		}
 		conditionRouters = append(conditionRouters, conditionRoute)
@@ -185,7 +185,7 @@ func (d *DynamicRouter) Process(event *config_center.ConfigChangeEvent) {
 	} else {
 		rc, force, enable, err := generateCondition(event.Value.(string))
 		if err != nil {
-			logger.Errorf("[Condition] failed to generate condition: err=%v", err)
+			logger.Errorf("[Router][Condition] failed to generate condition: err=%v", err)
 			d.conditionRouter = nil
 		} else {
 			d.force, d.enable, d.conditionRouter = force, enable, rc
@@ -239,7 +239,7 @@ func generateCondition(rawConfig string) (condRouter, bool, bool, error) {
 func generateMultiConditionRoute(rawConfig string) (*multiplyConditionRoute, bool, bool, error) {
 	routerConfig, err := parseMultiConditionRoute(rawConfig)
 	if err != nil {
-		logger.Warnf("[Condition] failed to build condition route config: err=%s", err.Error())
+		logger.Warnf("[Router][Condition] failed to build condition route config: err=%s", err.Error())
 		return nil, false, false, err
 	}
 
@@ -289,7 +289,7 @@ func generateMultiConditionRoute(rawConfig string) (*multiplyConditionRoute, boo
 func generateConditionsRoute(rawConfig string) (stateRouters, bool, bool, error) {
 	routerConfig, err := parseConditionRoute(rawConfig)
 	if err != nil {
-		logger.Warnf("[Condition] failed to build condition route config: err=%s", err.Error())
+		logger.Warnf("[Router][Condition] failed to build condition route config: err=%s", err.Error())
 		return nil, false, false, err
 	}
 
@@ -342,24 +342,24 @@ func (s *ServiceRouter) Notify(invokers []base.Invoker) {
 	}
 	url := invokers[0].GetURL()
 	if url == nil {
-		logger.Error("[Condition] failed to notify condition router: url is empty")
+		logger.Error("[Router][Condition] failed to notify condition router: url is empty")
 		return
 	}
 
 	dynamicConfiguration := conf.GetEnvInstance().GetDynamicConfiguration()
 	if dynamicConfiguration == nil {
-		logger.Infof("Config center does not start, Condition router will not be enabled")
+		logger.Infof("[Router][Condition] Config center does not start, Condition router will not be enabled")
 		return
 	}
 	key := strings.Join([]string{url.ColonSeparatedKey(), constant.ConditionRouterRuleSuffix}, "")
 	dynamicConfiguration.AddListener(key, s)
 	value, err := dynamicConfiguration.GetRule(key)
 	if err != nil {
-		logger.Errorf("Failed to query condition rule, key=%s, err=%v", key, err)
+		logger.Errorf("[Router][Condition] Failed to query condition rule, key=%s, err=%v", key, err)
 		return
 	}
 	if value == "" {
-		logger.Infof("Condition rule is empty, key=%s", key)
+		logger.Infof("[Router][Condition] Condition rule is empty, key=%s", key)
 		return
 	}
 	s.Process(&config_center.ConfigChangeEvent{Key: key, Value: value, ConfigType: remoting.EventTypeAdd})
@@ -408,19 +408,19 @@ func (a *ApplicationRouter) Notify(invokers []base.Invoker) {
 	}
 	url := invokers[0].GetURL()
 	if url == nil {
-		logger.Error("[Condition] failed to notify condition router: url is empty")
+		logger.Error("[Router][Condition] failed to notify condition router: url is empty")
 		return
 	}
 
 	dynamicConfiguration := conf.GetEnvInstance().GetDynamicConfiguration()
 	if dynamicConfiguration == nil {
-		logger.Infof("Config center does not start, Condition router will not be enabled")
+		logger.Infof("[Router][Condition] Config center does not start, Condition router will not be enabled")
 		return
 	}
 
 	providerApplication := url.GetParam("application", "")
 	if providerApplication == "" || providerApplication == a.currentApplication {
-		logger.Warnf("[Condition] provider application is empty, will not subscribe to provider app rules")
+		logger.Warnf("[Router][Condition] provider application is empty, will not subscribe to provider app rules")
 		return
 	}
 
@@ -434,11 +434,11 @@ func (a *ApplicationRouter) Notify(invokers []base.Invoker) {
 		a.application = providerApplication
 		value, err := dynamicConfiguration.GetRule(key)
 		if err != nil {
-			logger.Errorf("[Condition] failed to query condition rule: key=%s, err=%v", key, err)
+			logger.Errorf("[Router][Condition] failed to query condition rule: key=%s, err=%v", key, err)
 			return
 		}
 		if value == "" {
-			logger.Infof("Condition rule is empty, key=%s", key)
+			logger.Infof("[Router][Condition] Condition rule is empty, key=%s", key)
 			return
 		}
 		a.Process(&config_center.ConfigChangeEvent{Key: key, Value: value, ConfigType: remoting.EventTypeUpdate})

--- a/cluster/router/condition/matcher/argument.go
+++ b/cluster/router/condition/matcher/argument.go
@@ -34,8 +34,7 @@ import (
 )
 
 var (
-	argumentsPattern      = regexp.MustCompile(`arguments\[([0-9]+)\]`)
-	notFoundArgumentValue = "dubbo internal not found argument condition value"
+	argumentsPattern = regexp.MustCompile(`arguments\[([0-9]+)\]`)
 )
 
 // ArgumentConditionMatcher analysis the arguments in the rule.
@@ -58,19 +57,19 @@ func (a *ArgumentConditionMatcher) GetValue(sample map[string]string, url *commo
 	argumentExpress := expressArray[0]
 	matcher := argumentsPattern.FindStringSubmatch(argumentExpress)
 	if len(matcher) == 0 {
-		logger.Warn(notFoundArgumentValue)
+		logger.Warn("[Argument] argument not found")
 		return ""
 	}
 
 	// extract the argument index
 	index, err := strconv.Atoi(matcher[1])
 	if err != nil {
-		logger.Warn(notFoundArgumentValue)
+		logger.Warnf("[Argument] argument not found: index=%d", index)
 		return ""
 	}
 
 	if index < 0 || index > len(invocation.Arguments()) {
-		logger.Warn(notFoundArgumentValue)
+		logger.Warnf("[Argument] argument not found: index=%d", index)
 		return ""
 	}
 	return fmt.Sprint(invocation.Arguments()[index])

--- a/cluster/router/condition/matcher/argument.go
+++ b/cluster/router/condition/matcher/argument.go
@@ -57,19 +57,19 @@ func (a *ArgumentConditionMatcher) GetValue(sample map[string]string, url *commo
 	argumentExpress := expressArray[0]
 	matcher := argumentsPattern.FindStringSubmatch(argumentExpress)
 	if len(matcher) == 0 {
-		logger.Warn("[Argument] argument not found")
+		logger.Warn("[Router][Condition] argument not found")
 		return ""
 	}
 
 	// extract the argument index
 	index, err := strconv.Atoi(matcher[1])
 	if err != nil {
-		logger.Warnf("[Argument] argument not found: index=%d", index)
+		logger.Warnf("[Router][Condition] argument not found: index=%d", index)
 		return ""
 	}
 
 	if index < 0 || index > len(invocation.Arguments()) {
-		logger.Warnf("[Argument] argument not found: index=%d", index)
+		logger.Warnf("[Router][Condition] argument not found: index=%d", index)
 		return ""
 	}
 	return fmt.Sprint(invocation.Arguments()[index])

--- a/cluster/router/condition/matcher/attachment.go
+++ b/cluster/router/condition/matcher/attachment.go
@@ -32,8 +32,7 @@ import (
 )
 
 var (
-	attachmentPattern       = regexp.MustCompile(`attachments\[([a-zA-Z0-9_]+)\]`)
-	notFoundAttachmentValue = "dubbo internal not found attachment condition value"
+	attachmentPattern = regexp.MustCompile(`attachments\[([a-zA-Z0-9_]+)\]`)
 )
 
 // AttachmentConditionMatcher analysis the attachments in the rule.
@@ -55,13 +54,13 @@ func (a *AttachmentConditionMatcher) GetValue(sample map[string]string, url *com
 	attachmentExpress := expressArray[0]
 	matcher := attachmentPattern.FindStringSubmatch(attachmentExpress)
 	if len(matcher) == 0 {
-		logger.Warn(notFoundAttachmentValue)
+		logger.Warn("[Attachment] attachment key not found")
 		return ""
 	}
 	// extract the attachment key
 	attachmentKey := matcher[1]
 	if attachmentKey == "" {
-		logger.Warn(notFoundAttachmentValue)
+		logger.Warn("[Attachment] attachment key is empty")
 		return ""
 	}
 	// extract the attachment value

--- a/cluster/router/condition/matcher/attachment.go
+++ b/cluster/router/condition/matcher/attachment.go
@@ -54,13 +54,13 @@ func (a *AttachmentConditionMatcher) GetValue(sample map[string]string, url *com
 	attachmentExpress := expressArray[0]
 	matcher := attachmentPattern.FindStringSubmatch(attachmentExpress)
 	if len(matcher) == 0 {
-		logger.Warn("[Attachment] attachment key not found")
+		logger.Warn("[Router][Condition] attachment key not found")
 		return ""
 	}
 	// extract the attachment key
 	attachmentKey := matcher[1]
 	if attachmentKey == "" {
-		logger.Warn("[Attachment] attachment key is empty")
+		logger.Warn("[Router][Condition] attachment key is empty")
 		return ""
 	}
 	// extract the attachment value

--- a/cluster/router/condition/matcher/base.go
+++ b/cluster/router/condition/matcher/base.go
@@ -118,7 +118,7 @@ func doPatternMatch(pattern string, value string, url *common.URL, invocation ba
 		}
 	}
 	// If no value matcher is available, will force to use wildcard value matcher
-	logger.Error("Executing condition rule value match expression error, will force to use wildcard value matcher")
+	logger.Errorf("[Matcher] no matching value pattern found, using wildcard: pattern=%s", pattern)
 
 	valuePattern := pattern_value.GetValuePattern(constant.Wildcard)
 	return valuePattern.Match(pattern, value, url, invocation, isWhenCondition)

--- a/cluster/router/condition/matcher/base.go
+++ b/cluster/router/condition/matcher/base.go
@@ -118,7 +118,7 @@ func doPatternMatch(pattern string, value string, url *common.URL, invocation ba
 		}
 	}
 	// If no value matcher is available, will force to use wildcard value matcher
-	logger.Errorf("[Matcher] no matching value pattern found, using wildcard: pattern=%s", pattern)
+	logger.Errorf("[Router][Condition] no matching value pattern found, using wildcard: pattern=%s", pattern)
 
 	valuePattern := pattern_value.GetValuePattern(constant.Wildcard)
 	return valuePattern.Match(pattern, value, url, invocation, isWhenCondition)

--- a/cluster/router/condition/matcher/pattern_value/scope.go
+++ b/cluster/router/condition/matcher/pattern_value/scope.go
@@ -122,5 +122,5 @@ func convertToIntRange(rawStart, rawEnd string) (int, int, error) {
 }
 
 func logError(pattern, value string) {
-	logger.Errorf("Parse integer error, Invalid condition rule '%s' or value '%s', will ignore.", pattern, value)
+	logger.Errorf("[Scope] parse integer failed: pattern=%s, value=%s", pattern, value)
 }

--- a/cluster/router/condition/matcher/pattern_value/scope.go
+++ b/cluster/router/condition/matcher/pattern_value/scope.go
@@ -122,5 +122,5 @@ func convertToIntRange(rawStart, rawEnd string) (int, int, error) {
 }
 
 func logError(pattern, value string) {
-	logger.Errorf("[Scope] parse integer failed: pattern=%s, value=%s", pattern, value)
+	logger.Errorf("[Router][Condition] parse integer failed: pattern=%s, value=%s", pattern, value)
 }

--- a/cluster/router/condition/route.go
+++ b/cluster/router/condition/route.go
@@ -85,7 +85,7 @@ func (s *StateRouter) Route(invokers []base.Invoker, url *common.URL, invocation
 	}
 
 	if len(s.thenCondition) == 0 {
-		logger.Warn("condition state router thenCondition is empty")
+		logger.Warn("[Router] [Condition] thenCondition is empty")
 		return []base.Invoker{}
 	}
 
@@ -392,7 +392,7 @@ func (m MultiDestRouter) Route(invokers []base.Invoker, url *common.URL, invocat
 	}
 
 	if len(m.thenCondition) == 0 {
-		logger.Warn("condition state router thenCondition is empty")
+		logger.Warn("[Router] [Condition] thenCondition is empty")
 		return []base.Invoker{}, true
 	}
 

--- a/cluster/router/condition/route.go
+++ b/cluster/router/condition/route.go
@@ -85,7 +85,7 @@ func (s *StateRouter) Route(invokers []base.Invoker, url *common.URL, invocation
 	}
 
 	if len(s.thenCondition) == 0 {
-		logger.Warn("[Router] [Condition] thenCondition is empty")
+		logger.Warn("[Router][Condition] thenCondition is empty")
 		return []base.Invoker{}
 	}
 
@@ -392,7 +392,7 @@ func (m MultiDestRouter) Route(invokers []base.Invoker, url *common.URL, invocat
 	}
 
 	if len(m.thenCondition) == 0 {
-		logger.Warn("[Router] [Condition] thenCondition is empty")
+		logger.Warn("[Router][Condition] thenCondition is empty")
 		return []base.Invoker{}, true
 	}
 

--- a/cluster/router/polaris/router.go
+++ b/cluster/router/polaris/router.go
@@ -138,12 +138,12 @@ func (p *polarisRouter) Route(invokers []base.Invoker, url *common.URL,
 	invocation base.Invocation) []base.Invoker {
 
 	if !p.openRoute {
-		logger.Debug("[Router][Polaris] not open polaris route ability")
+		logger.Debug("[Router] [Polaris] not open polaris route ability")
 		return invokers
 	}
 
 	if len(invokers) == 0 {
-		logger.Warn("[Router][Polaris] invokers from previous router is empty")
+		logger.Warn("[Router] [Polaris] invokers from previous router is empty")
 		return invokers
 	}
 
@@ -259,12 +259,12 @@ func (p *polarisRouter) buildTrafficLabels(svc string) ([]string, error) {
 	engine := p.routerAPI.SDKContext().GetEngine()
 	resp, err := engine.SyncGetServiceRule(model.EventRouting, req)
 	if err != nil {
-		logger.Errorf("[Router][Polaris] ns:%s svc:%s get route rule fail : %+v", req.GetNamespace(), req.GetService(), err)
+		logger.Errorf("[Router] [Polaris] get route rule failed, namespace=%s service=%s error=%+v", req.GetNamespace(), req.GetService(), err)
 		return nil, err
 	}
 
 	if resp == nil || resp.GetValue() == nil {
-		logger.Errorf("[Router][Polaris] ns:%s svc:%s get route rule empty", req.GetNamespace(), req.GetService())
+		logger.Errorf("[Router] [Polaris] get route rule empty, namespace=%s service=%s", req.GetNamespace(), req.GetService())
 		return nil, ErrorPolarisServiceRouteRuleEmpty
 	}
 
@@ -320,7 +320,7 @@ func (p *polarisRouter) buildInstanceMap(svc string) map[string]model.Instance {
 		},
 	})
 	if err != nil {
-		logger.Errorf("[Router][Polaris] ns:%s svc:%s get all instances fail : %+v", remotingpolaris.GetNamespace(), svc, err)
+		logger.Errorf("[Router] [Polaris] get all instances failed, namespace=%s service=%s error=%+v", remotingpolaris.GetNamespace(), svc, err)
 		return nil
 	}
 
@@ -354,7 +354,7 @@ func (p *polarisRouter) Notify(invokers []base.Invoker) {
 	}
 	service := p.getService(invokers[0].GetURL())
 	if service == "" {
-		logger.Error("url service is empty")
+		logger.Error("[Router] [Polaris] url service is empty")
 		return
 	}
 
@@ -366,7 +366,7 @@ func (p *polarisRouter) Notify(invokers []base.Invoker) {
 	engine := p.routerAPI.SDKContext().GetEngine()
 	_, err := engine.SyncGetServiceRule(model.EventRouting, req)
 	if err != nil {
-		logger.Errorf("[Router][Polaris] ns:%s svc:%s get route rule fail : %+v", req.GetNamespace(), req.GetService(), err)
+		logger.Errorf("[Router] [Polaris] get route rule failed, namespace=%s service=%s error=%+v", req.GetNamespace(), req.GetService(), err)
 		return
 	}
 
@@ -377,7 +377,7 @@ func (p *polarisRouter) Notify(invokers []base.Invoker) {
 		},
 	})
 	if err != nil {
-		logger.Errorf("[Router][Polaris] ns:%s svc:%s get all instances fail : %+v", req.GetNamespace(), req.GetService(), err)
+		logger.Errorf("[Router] [Polaris] get all instances failed, namespace=%s service=%s error=%+v", req.GetNamespace(), req.GetService(), err)
 		return
 	}
 }

--- a/cluster/router/polaris/router.go
+++ b/cluster/router/polaris/router.go
@@ -138,12 +138,12 @@ func (p *polarisRouter) Route(invokers []base.Invoker, url *common.URL,
 	invocation base.Invocation) []base.Invoker {
 
 	if !p.openRoute {
-		logger.Debug("[Router] [Polaris] not open polaris route ability")
+		logger.Debug("[Router][Polaris] not open polaris route ability")
 		return invokers
 	}
 
 	if len(invokers) == 0 {
-		logger.Warn("[Router] [Polaris] invokers from previous router is empty")
+		logger.Warn("[Router][Polaris] invokers from previous router is empty")
 		return invokers
 	}
 
@@ -259,12 +259,12 @@ func (p *polarisRouter) buildTrafficLabels(svc string) ([]string, error) {
 	engine := p.routerAPI.SDKContext().GetEngine()
 	resp, err := engine.SyncGetServiceRule(model.EventRouting, req)
 	if err != nil {
-		logger.Errorf("[Router] [Polaris] get route rule failed, namespace=%s service=%s error=%+v", req.GetNamespace(), req.GetService(), err)
+		logger.Errorf("[Router][Polaris] get route rule failed, namespace=%s service=%s error=%+v", req.GetNamespace(), req.GetService(), err)
 		return nil, err
 	}
 
 	if resp == nil || resp.GetValue() == nil {
-		logger.Errorf("[Router] [Polaris] get route rule empty, namespace=%s service=%s", req.GetNamespace(), req.GetService())
+		logger.Errorf("[Router][Polaris] get route rule empty, namespace=%s service=%s", req.GetNamespace(), req.GetService())
 		return nil, ErrorPolarisServiceRouteRuleEmpty
 	}
 
@@ -320,7 +320,7 @@ func (p *polarisRouter) buildInstanceMap(svc string) map[string]model.Instance {
 		},
 	})
 	if err != nil {
-		logger.Errorf("[Router] [Polaris] get all instances failed, namespace=%s service=%s error=%+v", remotingpolaris.GetNamespace(), svc, err)
+		logger.Errorf("[Router][Polaris] get all instances failed, namespace=%s service=%s error=%+v", remotingpolaris.GetNamespace(), svc, err)
 		return nil
 	}
 
@@ -354,7 +354,7 @@ func (p *polarisRouter) Notify(invokers []base.Invoker) {
 	}
 	service := p.getService(invokers[0].GetURL())
 	if service == "" {
-		logger.Error("[Router] [Polaris] url service is empty")
+		logger.Error("[Router][Polaris] url service is empty")
 		return
 	}
 
@@ -366,7 +366,7 @@ func (p *polarisRouter) Notify(invokers []base.Invoker) {
 	engine := p.routerAPI.SDKContext().GetEngine()
 	_, err := engine.SyncGetServiceRule(model.EventRouting, req)
 	if err != nil {
-		logger.Errorf("[Router] [Polaris] get route rule failed, namespace=%s service=%s error=%+v", req.GetNamespace(), req.GetService(), err)
+		logger.Errorf("[Router][Polaris] get route rule failed, namespace=%s service=%s error=%+v", req.GetNamespace(), req.GetService(), err)
 		return
 	}
 
@@ -377,7 +377,7 @@ func (p *polarisRouter) Notify(invokers []base.Invoker) {
 		},
 	})
 	if err != nil {
-		logger.Errorf("[Router] [Polaris] get all instances failed, namespace=%s service=%s error=%+v", req.GetNamespace(), req.GetService(), err)
+		logger.Errorf("[Router][Polaris] get all instances failed, namespace=%s service=%s error=%+v", req.GetNamespace(), req.GetService(), err)
 		return
 	}
 }

--- a/cluster/router/script/router.go
+++ b/cluster/router/script/router.go
@@ -76,7 +76,7 @@ func (s *ScriptRouter) Process(event *config_center.ConfigChangeEvent) {
 	}
 	cfg, err := parseRoute(rawConf)
 	if err != nil {
-		logger.Errorf("Parse route cfg failed: %v", err)
+		logger.Errorf("[Router] [Script] parse route config failed, error=%v", err)
 		return
 	}
 
@@ -86,26 +86,26 @@ func (s *ScriptRouter) Process(event *config_center.ConfigChangeEvent) {
 		if s.enabled && s.scriptType != "" {
 			in, err := ins.GetInstances(s.scriptType)
 			if err != nil {
-				logger.Errorf("GetInstances failed to Destroy: %v", err)
+				logger.Errorf("[Router] [Script] GetInstances failed to destroy, error=%v", err)
 			} else {
 				in.Destroy(s.rawScript)
 			}
 		}
 		// check new config
 		if cfg.ScriptType == "" {
-			logger.Errorf("`type` field must be set in config")
+			logger.Errorf("[Router] [Script] type field must be set in config")
 			return
 		}
 		if cfg.Script == "" {
-			logger.Errorf("`script` field must be set in config")
+			logger.Errorf("[Router] [Script] script field must be set in config")
 			return
 		}
 		if cfg.Key == "" {
-			logger.Errorf("`applicationName` field must be set in config")
+			logger.Errorf("[Router] [Script] applicationName field must be set in config")
 			return
 		}
 		if !*cfg.Enabled {
-			logger.Infof("`enabled` field equiles false, this rule will be ignored :%s", cfg.Script)
+			logger.Infof("enabled field equals false, this rule will be ignored, script=%s", cfg.Script)
 		}
 		// rewrite to ScriptRouter
 		s.enabled = *cfg.Enabled
@@ -115,7 +115,7 @@ func (s *ScriptRouter) Process(event *config_center.ConfigChangeEvent) {
 		// compile script
 		in, err := ins.GetInstances(s.scriptType)
 		if err != nil {
-			logger.Errorf("GetInstances failed: %v", err)
+			logger.Errorf("[Router] [Script] GetInstances failed, error=%v", err)
 			s.enabled = false
 			return
 		}
@@ -124,7 +124,7 @@ func (s *ScriptRouter) Process(event *config_center.ConfigChangeEvent) {
 			// fail, disable rule
 			if err != nil {
 				s.enabled = false
-				logger.Errorf("Compile Script failed: %v", err)
+				logger.Errorf("[Router] [Script] compile script failed, error=%v", err)
 			}
 		}
 
@@ -163,7 +163,7 @@ func (s *ScriptRouter) Route(invokers []base.Invoker, _ *common.URL, invocation 
 
 	res, err := s.runScript(scriptType, rawScript, invokers, invocation)
 	if err != nil {
-		logger.Warnf("ScriptRouter.Route error: %v", err)
+		logger.Warnf("[Router] [Script] route failed, error=%v", err)
 	}
 
 	return res
@@ -183,19 +183,19 @@ func (s *ScriptRouter) Notify(invokers []base.Invoker) {
 	}
 	url := invokers[0].GetURL()
 	if url == nil {
-		logger.Error("Failed to notify a dynamically Script rule, because url is empty")
+		logger.Error("[Router] [Script] url is empty")
 		return
 	}
 
 	dynamicConfiguration := conf.GetEnvInstance().GetDynamicConfiguration()
 	if dynamicConfiguration == nil {
-		logger.Infof("Config center does not start, Script router will not be enabled")
+		logger.Info("Config center does not start, Script router will not be enabled")
 		return
 	}
 
 	providerApplication := url.GetParam("application", "")
 	if providerApplication == "" {
-		logger.Warn("Script router get providerApplication is empty, will not subscribe to provider app rules.")
+		logger.Warn("[Router] [Script] providerApplication is empty, will not subscribe to provider app rules")
 		return
 	}
 
@@ -213,7 +213,7 @@ func (s *ScriptRouter) Notify(invokers []base.Invoker) {
 		s.applicationName = providerApplication
 		value, err = dynamicConfiguration.GetRule(listenTarget)
 		if err != nil {
-			logger.Errorf("Failed to query Script rule, applicationName=%s, listening=%s, err=%v", s.applicationName, listenTarget, err)
+			logger.Errorf("[Router] [Script] query script rule failed, applicationName=%s listenTarget=%s error=%v", s.applicationName, listenTarget, err)
 		}
 		s.Process(&config_center.ConfigChangeEvent{Key: listenTarget, Value: value, ConfigType: remoting.EventTypeUpdate})
 	}

--- a/cluster/router/script/router.go
+++ b/cluster/router/script/router.go
@@ -76,7 +76,7 @@ func (s *ScriptRouter) Process(event *config_center.ConfigChangeEvent) {
 	}
 	cfg, err := parseRoute(rawConf)
 	if err != nil {
-		logger.Errorf("[Router] [Script] parse route config failed, error=%v", err)
+		logger.Errorf("[Router][Script] parse route config failed, error=%v", err)
 		return
 	}
 
@@ -86,26 +86,26 @@ func (s *ScriptRouter) Process(event *config_center.ConfigChangeEvent) {
 		if s.enabled && s.scriptType != "" {
 			in, err := ins.GetInstances(s.scriptType)
 			if err != nil {
-				logger.Errorf("[Router] [Script] GetInstances failed to destroy, error=%v", err)
+				logger.Errorf("[Router][Script] GetInstances failed to destroy, error=%v", err)
 			} else {
 				in.Destroy(s.rawScript)
 			}
 		}
 		// check new config
 		if cfg.ScriptType == "" {
-			logger.Errorf("[Router] [Script] type field must be set in config")
+			logger.Errorf("[Router][Script] type field must be set in config")
 			return
 		}
 		if cfg.Script == "" {
-			logger.Errorf("[Router] [Script] script field must be set in config")
+			logger.Errorf("[Router][Script] script field must be set in config")
 			return
 		}
 		if cfg.Key == "" {
-			logger.Errorf("[Router] [Script] applicationName field must be set in config")
+			logger.Errorf("[Router][Script] applicationName field must be set in config")
 			return
 		}
 		if !*cfg.Enabled {
-			logger.Infof("enabled field equals false, this rule will be ignored, script=%s", cfg.Script)
+			logger.Infof("[Router][Script] enabled field equals false, this rule will be ignored, script=%s", cfg.Script)
 		}
 		// rewrite to ScriptRouter
 		s.enabled = *cfg.Enabled
@@ -115,7 +115,7 @@ func (s *ScriptRouter) Process(event *config_center.ConfigChangeEvent) {
 		// compile script
 		in, err := ins.GetInstances(s.scriptType)
 		if err != nil {
-			logger.Errorf("[Router] [Script] GetInstances failed, error=%v", err)
+			logger.Errorf("[Router][Script] GetInstances failed, error=%v", err)
 			s.enabled = false
 			return
 		}
@@ -124,7 +124,7 @@ func (s *ScriptRouter) Process(event *config_center.ConfigChangeEvent) {
 			// fail, disable rule
 			if err != nil {
 				s.enabled = false
-				logger.Errorf("[Router] [Script] compile script failed, error=%v", err)
+				logger.Errorf("[Router][Script] compile script failed, error=%v", err)
 			}
 		}
 
@@ -163,7 +163,7 @@ func (s *ScriptRouter) Route(invokers []base.Invoker, _ *common.URL, invocation 
 
 	res, err := s.runScript(scriptType, rawScript, invokers, invocation)
 	if err != nil {
-		logger.Warnf("[Router] [Script] route failed, error=%v", err)
+		logger.Warnf("[Router][Script] route failed, error=%v", err)
 	}
 
 	return res
@@ -183,19 +183,19 @@ func (s *ScriptRouter) Notify(invokers []base.Invoker) {
 	}
 	url := invokers[0].GetURL()
 	if url == nil {
-		logger.Error("[Router] [Script] url is empty")
+		logger.Error("[Router][Script] url is empty")
 		return
 	}
 
 	dynamicConfiguration := conf.GetEnvInstance().GetDynamicConfiguration()
 	if dynamicConfiguration == nil {
-		logger.Info("Config center does not start, Script router will not be enabled")
+		logger.Info("[Router][Script] Config center does not start, Script router will not be enabled")
 		return
 	}
 
 	providerApplication := url.GetParam("application", "")
 	if providerApplication == "" {
-		logger.Warn("[Router] [Script] providerApplication is empty, will not subscribe to provider app rules")
+		logger.Warn("[Router][Script] providerApplication is empty, will not subscribe to provider app rules")
 		return
 	}
 
@@ -213,7 +213,7 @@ func (s *ScriptRouter) Notify(invokers []base.Invoker) {
 		s.applicationName = providerApplication
 		value, err = dynamicConfiguration.GetRule(listenTarget)
 		if err != nil {
-			logger.Errorf("[Router] [Script] query script rule failed, applicationName=%s listenTarget=%s error=%v", s.applicationName, listenTarget, err)
+			logger.Errorf("[Router][Script] query script rule failed, applicationName=%s listenTarget=%s error=%v", s.applicationName, listenTarget, err)
 		}
 		s.Process(&config_center.ConfigChangeEvent{Key: listenTarget, Value: value, ConfigType: remoting.EventTypeUpdate})
 	}

--- a/cluster/router/tag/match.go
+++ b/cluster/router/tag/match.go
@@ -57,7 +57,7 @@ func staticTag(invokers []base.Invoker, url *common.URL, invocation base.Invocat
 			return invoker.GetURL().GetParam(constant.Tagkey, "") != ""
 		})
 	}
-	logger.Debugf("[tag router] filter static tag, invokers=%+v", result)
+	logger.Debugf("[Router] [Tag] filter static tag, invokers=%+v", result)
 	return result
 }
 
@@ -85,9 +85,9 @@ func requestEmptyTag(invokers []base.Invoker, cfg global.RouterConfig) []base.In
 			continue
 		}
 		result = filterInvokers(result, tagCfg.Addresses, getAddressPredicate(true))
-		logger.Debugf("[tag router]filter empty tag address, invokers=%+v", result)
+		logger.Debugf("[Router] [Tag] filter empty tag address, invokers=%+v", result)
 	}
-	logger.Debugf("[tag router]filter empty tag, invokers=%+v", result)
+	logger.Debugf("[Router] [Tag] filter empty tag, invokers=%+v", result)
 	return result
 }
 
@@ -125,11 +125,11 @@ func requestTag(invokers []base.Invoker, url *common.URL, invocation base.Invoca
 			result = filterInvokers(invokers, tag, func(invoker base.Invoker, tag any) bool {
 				return invoker.GetURL().GetParam(constant.Tagkey, "") != tag
 			})
-			logger.Debugf("[tag router] filter dynamic tag, tag=%s, invokers=%+v", tag, result)
+			logger.Debugf("[Router] [Tag] filter dynamic tag, tag=%s invokers=%+v", tag, result)
 		} else {
 			// filter address does not match
 			result = filterInvokers(invokers, addresses, getAddressPredicate(false))
-			logger.Debugf("[tag router] filter dynamic tag address, invokers=%+v", result)
+			logger.Debugf("[Router] [Tag] filter dynamic tag address, invokers=%+v", result)
 		}
 	}
 	// returns the result directly
@@ -147,7 +147,7 @@ func requestTag(invokers []base.Invoker, url *common.URL, invocation base.Invoca
 		return result
 	}
 	result = filterInvokers(invokers, addresses, getAddressPredicate(true))
-	logger.Debugf("[tag router] failover match all providers without any tags, invokers=%+v", result)
+	logger.Debugf("[Router] [Tag] failover match all providers without any tags, invokers=%+v", result)
 	return result
 }
 
@@ -168,7 +168,7 @@ func requestIsForce(url *common.URL, invocation base.Invocation) bool {
 	force := invocation.GetAttachmentWithDefaultValue(constant.ForceUseTag, url.GetParam(constant.ForceUseTag, "false"))
 	ok, err := strconv.ParseBool(force)
 	if err != nil {
-		logger.Errorf("parse force param fail,force=%s,err=%v", force, err)
+		logger.Errorf("[Router] [Tag] parse force param failed, force=%s error=%v", force, err)
 	}
 	return ok
 }

--- a/cluster/router/tag/match.go
+++ b/cluster/router/tag/match.go
@@ -57,7 +57,7 @@ func staticTag(invokers []base.Invoker, url *common.URL, invocation base.Invocat
 			return invoker.GetURL().GetParam(constant.Tagkey, "") != ""
 		})
 	}
-	logger.Debugf("[Router] [Tag] filter static tag, invokers=%+v", result)
+	logger.Debugf("[Router][Tag] filter static tag, invokers=%+v", result)
 	return result
 }
 
@@ -85,9 +85,9 @@ func requestEmptyTag(invokers []base.Invoker, cfg global.RouterConfig) []base.In
 			continue
 		}
 		result = filterInvokers(result, tagCfg.Addresses, getAddressPredicate(true))
-		logger.Debugf("[Router] [Tag] filter empty tag address, invokers=%+v", result)
+		logger.Debugf("[Router][Tag] filter empty tag address, invokers=%+v", result)
 	}
-	logger.Debugf("[Router] [Tag] filter empty tag, invokers=%+v", result)
+	logger.Debugf("[Router][Tag] filter empty tag, invokers=%+v", result)
 	return result
 }
 
@@ -125,11 +125,11 @@ func requestTag(invokers []base.Invoker, url *common.URL, invocation base.Invoca
 			result = filterInvokers(invokers, tag, func(invoker base.Invoker, tag any) bool {
 				return invoker.GetURL().GetParam(constant.Tagkey, "") != tag
 			})
-			logger.Debugf("[Router] [Tag] filter dynamic tag, tag=%s invokers=%+v", tag, result)
+			logger.Debugf("[Router][Tag] filter dynamic tag, tag=%s invokers=%+v", tag, result)
 		} else {
 			// filter address does not match
 			result = filterInvokers(invokers, addresses, getAddressPredicate(false))
-			logger.Debugf("[Router] [Tag] filter dynamic tag address, invokers=%+v", result)
+			logger.Debugf("[Router][Tag] filter dynamic tag address, invokers=%+v", result)
 		}
 	}
 	// returns the result directly
@@ -147,7 +147,7 @@ func requestTag(invokers []base.Invoker, url *common.URL, invocation base.Invoca
 		return result
 	}
 	result = filterInvokers(invokers, addresses, getAddressPredicate(true))
-	logger.Debugf("[Router] [Tag] failover match all providers without any tags, invokers=%+v", result)
+	logger.Debugf("[Router][Tag] failover match all providers without any tags, invokers=%+v", result)
 	return result
 }
 
@@ -168,7 +168,7 @@ func requestIsForce(url *common.URL, invocation base.Invocation) bool {
 	force := invocation.GetAttachmentWithDefaultValue(constant.ForceUseTag, url.GetParam(constant.ForceUseTag, "false"))
 	ok, err := strconv.ParseBool(force)
 	if err != nil {
-		logger.Errorf("[Router] [Tag] parse force param failed, force=%s error=%v", force, err)
+		logger.Errorf("[Router][Tag] parse force param failed, force=%s error=%v", force, err)
 	}
 	return ok
 }

--- a/cluster/router/tag/router.go
+++ b/cluster/router/tag/router.go
@@ -49,7 +49,7 @@ func NewTagPriorityRouter() (*PriorityRouter, error) {
 // Route Determine the target invokers list.
 func (p *PriorityRouter) Route(invokers []base.Invoker, url *common.URL, invocation base.Invocation) []base.Invoker {
 	if len(invokers) == 0 {
-		logger.Warnf("[tag router] invokers from previous router is empty")
+		logger.Warn("[Router] [Tag] invokers from previous router is empty")
 		return invokers
 	}
 	// get application name from invoker to look up tag routing config
@@ -82,23 +82,23 @@ func (p *PriorityRouter) Notify(invokers []base.Invoker) {
 	}
 	application := invokers[0].GetURL().GetParam(constant.ApplicationKey, "")
 	if application == "" {
-		logger.Warn("url application is empty, tag router will not be enabled")
+		logger.Warn("[Router] [Tag] url application is empty, tag router will not be enabled")
 		return
 	}
 	dynamicConfiguration := conf.GetEnvInstance().GetDynamicConfiguration()
 	if dynamicConfiguration == nil {
-		logger.Infof("Config center does not start, Tag router will not be enabled")
+		logger.Info("Config center does not start, Tag router will not be enabled")
 		return
 	}
 	key := strings.Join([]string{application, constant.TagRouterRuleSuffix}, "")
 	dynamicConfiguration.AddListener(key, p)
 	value, err := dynamicConfiguration.GetRule(key)
 	if err != nil {
-		logger.Errorf("query router rule fail,key=%s,err=%v", key, err)
+		logger.Errorf("[Router] [Tag] query router rule failed, key=%s error=%v", key, err)
 		return
 	}
 	if value == "" {
-		logger.Infof("router rule is empty,key=%s", key)
+		logger.Info("router rule is empty")
 		return
 	}
 	p.Process(&config_center.ConfigChangeEvent{Key: key, Value: value, ConfigType: remoting.EventTypeAdd})
@@ -122,7 +122,7 @@ func (p *PriorityRouter) SetStaticConfig(cfg *global.RouterConfig) {
 	// Derive storage key the same way Notify() does: application + suffix
 	key := strings.Join([]string{cfg.Key, constant.TagRouterRuleSuffix}, "")
 	p.routerConfigs.Store(key, *cfgCopy)
-	logger.Infof("[tag router] Applied static tag router config: key=%s", key)
+	logger.Infof("applied static tag router config, key=%s", key)
 }
 
 // Process applies config-center updates as the authoritative rule source at runtime.
@@ -135,12 +135,11 @@ func (p *PriorityRouter) Process(event *config_center.ConfigChangeEvent) {
 	}
 	routerConfig, err := parseRoute(event.Value.(string))
 	if err != nil {
-		logger.Warnf("[tag router]Parse new tag route config error, %+v "+
-			"and we will use the original tag rule configuration.", err)
+		logger.Warnf("[Router] [Tag] parse new tag route config failed, error=%+v", err)
 		return
 	}
 	p.routerConfigs.Store(event.Key, *routerConfig)
-	logger.Infof("[tag router]Parse tag router config success,routerConfig=%+v", routerConfig)
+	logger.Infof("parse tag router config success, routerConfig=%+v", routerConfig)
 }
 
 func parseRoute(routeContent string) (*global.RouterConfig, error) {

--- a/cluster/router/tag/router.go
+++ b/cluster/router/tag/router.go
@@ -49,7 +49,7 @@ func NewTagPriorityRouter() (*PriorityRouter, error) {
 // Route Determine the target invokers list.
 func (p *PriorityRouter) Route(invokers []base.Invoker, url *common.URL, invocation base.Invocation) []base.Invoker {
 	if len(invokers) == 0 {
-		logger.Warn("[Router] [Tag] invokers from previous router is empty")
+		logger.Warn("[Router][Tag] invokers from previous router is empty")
 		return invokers
 	}
 	// get application name from invoker to look up tag routing config
@@ -82,23 +82,23 @@ func (p *PriorityRouter) Notify(invokers []base.Invoker) {
 	}
 	application := invokers[0].GetURL().GetParam(constant.ApplicationKey, "")
 	if application == "" {
-		logger.Warn("[Router] [Tag] url application is empty, tag router will not be enabled")
+		logger.Warn("[Router][Tag] url application is empty, tag router will not be enabled")
 		return
 	}
 	dynamicConfiguration := conf.GetEnvInstance().GetDynamicConfiguration()
 	if dynamicConfiguration == nil {
-		logger.Info("Config center does not start, Tag router will not be enabled")
+		logger.Info("[Router][Tag] Config center does not start, Tag router will not be enabled")
 		return
 	}
 	key := strings.Join([]string{application, constant.TagRouterRuleSuffix}, "")
 	dynamicConfiguration.AddListener(key, p)
 	value, err := dynamicConfiguration.GetRule(key)
 	if err != nil {
-		logger.Errorf("[Router] [Tag] query router rule failed, key=%s error=%v", key, err)
+		logger.Errorf("[Router][Tag] query router rule failed, key=%s error=%v", key, err)
 		return
 	}
 	if value == "" {
-		logger.Info("router rule is empty")
+		logger.Info("[Router][Tag] router rule is empty")
 		return
 	}
 	p.Process(&config_center.ConfigChangeEvent{Key: key, Value: value, ConfigType: remoting.EventTypeAdd})
@@ -122,7 +122,7 @@ func (p *PriorityRouter) SetStaticConfig(cfg *global.RouterConfig) {
 	// Derive storage key the same way Notify() does: application + suffix
 	key := strings.Join([]string{cfg.Key, constant.TagRouterRuleSuffix}, "")
 	p.routerConfigs.Store(key, *cfgCopy)
-	logger.Infof("applied static tag router config, key=%s", key)
+	logger.Infof("[Router][Tag] applied static tag router config, key=%s", key)
 }
 
 // Process applies config-center updates as the authoritative rule source at runtime.
@@ -135,11 +135,11 @@ func (p *PriorityRouter) Process(event *config_center.ConfigChangeEvent) {
 	}
 	routerConfig, err := parseRoute(event.Value.(string))
 	if err != nil {
-		logger.Warnf("[Router] [Tag] parse new tag route config failed, error=%+v", err)
+		logger.Warnf("[Router][Tag] parse new tag route config failed, error=%+v", err)
 		return
 	}
 	p.routerConfigs.Store(event.Key, *routerConfig)
-	logger.Infof("parse tag router config success, routerConfig=%+v", routerConfig)
+	logger.Infof("[Router][Tag] parse tag router config success, routerConfig=%+v", routerConfig)
 }
 
 func parseRoute(routeContent string) (*global.RouterConfig, error) {


### PR DESCRIPTION
### Description
refactor(cluster): standardize logger format across cluster modules
This PR standardizes logger format for all cluster modules to improve log consistency and readability. The changes include:
Adding component-specific prefixes to all log messages for better identification:
[Broadcast], [Failback], [Failover], [Failsafe], [Forking], [Mock], [P2C], [Directory],
[Router] with sub-prefixes, [Cluster], [AdaptiveSvc]
Changing parameter format from colon-separated to structured key=value pairs
Removing decorative characters (colons, commas, dots, newlines) for cleaner output
Simplifying log messages and removing redundant parameters
Using appropriate log methods (Info/Warn/Error for fixed strings, *f variants only when formatting needed)
The refactoring covers all cluster sub-packages including cluster implementations, load balancing, directory management, routing modules, and base components. This standardization makes it easier to filter and analyze logs in production environments.

Fixes #3295

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
