### PR TITLE
fix(jsonrpc): prevent nil pointer panic when exporter not found in ExporterMap

### DIFF
--- a/protocol/jsonrpc/server.go
+++ b/protocol/jsonrpc/server.go
@@ -350,7 +350,10 @@ func serveRequest(ctx context.Context, header map[string]string, body []byte, co
 	logger.Debugf("args: %v", args)
 
 	// exporter invoke
-	exporter, _ := jsonrpcProtocol.ExporterMap().Load(path)
+	exporter, ok := jsonrpcProtocol.ExporterMap().Load(path)
+	if !ok {
+		return perrors.Errorf("service not found: %s", path)
+	}
 	invoker := exporter.(*JsonrpcExporter).GetInvoker()
 	if invoker != nil {
 		result := invoker.Invoke(ctx, invocation.NewRPCInvocation(methodName, args, map[string]any{

--- a/protocol/jsonrpc/server_test.go
+++ b/protocol/jsonrpc/server_test.go
@@ -19,6 +19,7 @@ package jsonrpc
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"net"
 	"net/http"
@@ -49,6 +50,25 @@ func sendHTTPRequest(t *testing.T, conn net.Conn, contentType string) (*http.Res
 
 	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
 	return resp, err
+}
+
+func TestServeRequest_ServiceNotFound(t *testing.T) {
+	GetProtocol()
+
+	serverConn, clientConn := net.Pipe()
+	defer require.NoError(t, clientConn.Close())
+	defer require.NoError(t, serverConn.Close())
+
+	header := map[string]string{
+		"Path":         "com.example.UnregisteredService",
+		"HttpMethod":   "POST",
+		"Content-Type": "application/json",
+	}
+	body := []byte(`{"jsonrpc":"2.0","method":"com.example.UnregisteredService.SayHello","id":1}`)
+
+	err := serveRequest(context.Background(), header, body, serverConn)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "service not found")
 }
 
 func TestHandlePkg_ContentType(t *testing.T) {


### PR DESCRIPTION
### Description
Fixes #3310

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
