### PR TITLE
fix(jsonrpc): prevent nil pointer panic on unregistered service path

### DIFF
--- a/protocol/jsonrpc/server.go
+++ b/protocol/jsonrpc/server.go
@@ -350,7 +350,10 @@ func serveRequest(ctx context.Context, header map[string]string, body []byte, co
 	logger.Debugf("args: %v", args)
 
 	// exporter invoke
-	exporter, _ := jsonrpcProtocol.ExporterMap().Load(path)
+	exporter, ok := jsonrpcProtocol.ExporterMap().Load(path)
+	if !ok {
+		return perrors.Errorf("service not found: %s", path)
+	}
 	invoker := exporter.(*JsonrpcExporter).GetInvoker()
 	if invoker != nil {
 		result := invoker.Invoke(ctx, invocation.NewRPCInvocation(methodName, args, map[string]any{

--- a/protocol/jsonrpc/server_test.go
+++ b/protocol/jsonrpc/server_test.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -49,6 +50,53 @@ func sendHTTPRequest(t *testing.T, conn net.Conn, contentType string) (*http.Res
 
 	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
 	return resp, err
+}
+
+// TestHandlePkg_UnregisteredPath verifies that a valid JSON-RPC request sent
+// to a path with no registered exporter returns an error response instead of
+// panicking with a nil pointer dereference (issue #3310).
+func TestHandlePkg_UnregisteredPath(t *testing.T) {
+	// Ensure the package-level jsonrpcProtocol is initialized, as it would be
+	// in production when the protocol is loaded via extension.
+	GetProtocol()
+
+	serverConn, clientConn := net.Pipe()
+	defer func() {
+		_ = clientConn.Close()
+	}()
+	defer func() {
+		_ = serverConn.Close()
+	}()
+
+	s := NewServer()
+	go s.handlePkg(serverConn)
+
+	jsonBody := `{"jsonrpc":"2.0","method":"SayHello","params":["hello"],"id":1}`
+
+	err := clientConn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	require.NoError(t, err)
+
+	req := "POST /UnregisteredService HTTP/1.1\r\n" +
+		"Host: localhost\r\n" +
+		"Content-Type: application/json\r\n" +
+		"Content-Length: " + strconv.Itoa(len(jsonBody)) + "\r\n" +
+		"\r\n" +
+		jsonBody
+	_, err = clientConn.Write([]byte(req))
+	require.NoError(t, err)
+
+	resp, err := http.ReadResponse(bufio.NewReader(clientConn), nil)
+	require.NoError(t, err, "server should respond without panicking")
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	require.Equal(t, 500, resp.StatusCode)
+	require.Contains(t, string(body), "service not found",
+		"response body should indicate the service was not found")
 }
 
 func TestHandlePkg_ContentType(t *testing.T) {


### PR DESCRIPTION
## Bug
- **Symptom**: JSON-RPC server panics with nil pointer dereference when a request targets an unregistered service path
- **Root cause**: `ExporterMap().Load(path)` in `serveRequest()` discards the `ok` return value. When path is not registered, `exporter` is nil, and the type assertion `exporter.(*JsonrpcExporter)` panics.
- **Issue**: #3310

## Fix
- Check the `ok` return value from `ExporterMap().Load(path)`
- When `!ok`, return `perrors.Errorf("service not found: %s", path)` instead of proceeding to type-assert a nil value

## Verification
- **New test**: `TestHandlePkg_UnregisteredPath` — sends valid JSON-RPC request to unregistered path, asserts HTTP 500 with "service not found" (no panic)
- **Existing tests**: All 6 `TestHandlePkg_ContentType` sub-tests pass
- **Full package**: All 9 tests in `protocol/jsonrpc` pass
- **Static analysis**: `go vet ./protocol/jsonrpc/` passes

Closes #3310