### PR TITLE
fix(triple): prevent traceparent corruption in triple_invoker

### DIFF
--- a/protocol/triple/triple_invoker.go
+++ b/protocol/triple/triple_invoker.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"sync"
 )
 
@@ -161,6 +162,11 @@ func mergeAttachmentToOutgoing(ctx context.Context, inv base.Invocation) (contex
 	if timeout, ok := inv.GetAttachment(constant.TimeoutKey); ok {
 		ctx = context.WithValue(ctx, tri.TimeoutKey{}, timeout)
 	}
+	// Reset outgoing headers with a fresh empty header before appending.
+	// Without this, AppendToOutgoingContext mutates a shared http.Header pointer
+	// from the parent context, causing traceparent accumulation when the same
+	// parent ctx is reused across serial RPCs (e.g. Service A → B then A → C).
+	ctx = tri.NewOutgoingContext(ctx, http.Header{})
 	for key, valRaw := range inv.Attachments() {
 		if str, ok := valRaw.(string); ok {
 			ctx = tri.AppendToOutgoingContext(ctx, key, str)
@@ -202,6 +208,15 @@ func parseInvocation(ctx context.Context, url *common.URL, invocation base.Invoc
 	return callType, inRaw, method, nil
 }
 
+// tracePropagationKeys lists header keys managed by trace propagators (e.g. W3C TraceContext).
+// These must not be copied from user-supplied ctx attachments into the invocation because the
+// OTEL filter has already injected the correct values for the current span.  Allowing the copy
+// would silently overwrite them with stale upstream values.
+var tracePropagationKeys = map[string]struct{}{
+	"traceparent": {},
+	"tracestate":  {},
+}
+
 // parseAttachments retrieves attachments from users passed-in and URL, then injects them into ctx
 func parseAttachments(ctx context.Context, url *common.URL, invocation base.Invocation) {
 	// retrieve users passed-in attachment
@@ -209,6 +224,10 @@ func parseAttachments(ctx context.Context, url *common.URL, invocation base.Invo
 	if attaRaw != nil {
 		if userAtta, ok := attaRaw.(map[string]any); ok {
 			for key, val := range userAtta {
+				// Skip trace-propagation keys to preserve values injected by the OTEL filter.
+				if _, skip := tracePropagationKeys[key]; skip {
+					continue
+				}
 				invocation.SetAttachment(key, val)
 			}
 		}

--- a/protocol/triple/triple_invoker_test.go
+++ b/protocol/triple/triple_invoker_test.go
@@ -503,3 +503,84 @@ func Test_mergeAttachmentToOutgoing(t *testing.T) {
 		})
 	}
 }
+
+// TestParseAttachments_TraceparentNotOverwritten verifies that parseAttachments does NOT
+// copy traceparent/tracestate from ctx attachments into the invocation, preserving the
+// values injected by the OTEL filter. (Regression test for issue #3240, Root Cause 1)
+func TestParseAttachments_TraceparentNotOverwritten(t *testing.T) {
+	// Simulate: OTEL filter has already injected the correct traceparent into invocation
+	otelTraceparent := "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01"
+	otelTracestate := "vendor=opaque"
+
+	inv := invocation.NewRPCInvocationWithOptions(
+		invocation.WithAttachment("traceparent", otelTraceparent),
+		invocation.WithAttachment("tracestate", otelTracestate),
+	)
+
+	// Simulate: upstream request ctx carries a DIFFERENT (stale) traceparent
+	upstreamTraceparent := "00-cccccccccccccccccccccccccccccccc-dddddddddddddddd-01"
+	upstreamTracestate := "vendor=stale"
+	userAtta := map[string]any{
+		"traceparent": upstreamTraceparent,
+		"tracestate":  upstreamTracestate,
+		"user-key":    "user-val", // normal user key should still be copied
+	}
+	ctx := context.WithValue(context.Background(), constant.AttachmentKey, userAtta)
+
+	url := common.NewURLWithOptions()
+	parseAttachments(ctx, url, inv)
+
+	// traceparent and tracestate must remain as the OTEL filter set them
+	tp, _ := inv.GetAttachment("traceparent")
+	assert.Equal(t, otelTraceparent, tp, "traceparent must not be overwritten by ctx attachment")
+
+	ts, _ := inv.GetAttachment("tracestate")
+	assert.Equal(t, otelTracestate, ts, "tracestate must not be overwritten by ctx attachment")
+
+	// normal user key must still be copied
+	uk, _ := inv.GetAttachment("user-key")
+	assert.Equal(t, "user-val", uk, "non-trace user attachment must still be copied")
+}
+
+// TestMergeAttachmentToOutgoing_HeaderIsolation verifies that serial calls to
+// mergeAttachmentToOutgoing from the same parent context produce independent outgoing
+// headers. (Regression test for issue #3240, Root Cause 2)
+func TestMergeAttachmentToOutgoing_HeaderIsolation(t *testing.T) {
+	parentCtx := context.Background()
+
+	// First RPC: traceparent for call B
+	invB := invocation.NewRPCInvocationWithOptions(
+		invocation.WithAttachment("traceparent", "00-aaaa-bbbb-01"),
+		invocation.WithAttachment("shared-key", "valueB"),
+	)
+	ctxB, err := mergeAttachmentToOutgoing(parentCtx, invB)
+	require.NoError(t, err)
+
+	headerB := http.Header(tri.ExtractFromOutgoingContext(ctxB))
+	assert.Equal(t, "00-aaaa-bbbb-01", headerB.Get("traceparent"))
+	assert.Equal(t, "valueB", headerB.Get("shared-key"))
+
+	// Second RPC: traceparent for call C — uses same parentCtx
+	invC := invocation.NewRPCInvocationWithOptions(
+		invocation.WithAttachment("traceparent", "00-cccc-dddd-01"),
+		invocation.WithAttachment("shared-key", "valueC"),
+	)
+	ctxC, err := mergeAttachmentToOutgoing(parentCtx, invC)
+	require.NoError(t, err)
+
+	headerC := http.Header(tri.ExtractFromOutgoingContext(ctxC))
+	assert.Equal(t, "00-cccc-dddd-01", headerC.Get("traceparent"),
+		"second RPC must carry its own traceparent, not the first RPC's value")
+	assert.Equal(t, "valueC", headerC.Get("shared-key"))
+
+	// Verify the two headers are completely independent
+	assert.NotEqual(t, headerB.Get("traceparent"), headerC.Get("traceparent"),
+		"serial RPCs must have independent traceparent values")
+
+	// Verify headerB was not mutated by the second call
+	assert.Equal(t, "00-aaaa-bbbb-01", headerB.Get("traceparent"),
+		"first RPC's header must not be mutated by second RPC")
+	// Verify no accumulation: each header should have exactly one traceparent value
+	assert.Len(t, headerB.Values("traceparent"), 1, "headerB must have exactly one traceparent")
+	assert.Len(t, headerC.Values("traceparent"), 1, "headerC must have exactly one traceparent")
+}


### PR DESCRIPTION
## Bug

- **Symptom**: When using `otelClientTrace` filter + Triple protocol, the client-side `traceparent` header gets corrupted, causing downstream spans to reference wrong parents in tracing systems (Jaeger, etc.)
- **Root Cause 1**: `parseAttachments()` copies stale upstream `traceparent` from `ctx.Value(constant.AttachmentKey)` into the invocation, overwriting the correct value injected by the OTEL client filter
- **Root Cause 2**: `mergeAttachmentToOutgoing()` uses `AppendToOutgoingContext()` which mutates a shared `http.Header` pointer. Serial RPCs from the same parent context accumulate `traceparent` values, and `http.Header.Get()` returns the stale first entry

## Fix

1. **`parseAttachments()`**: Skip `traceparent` and `tracestate` keys when copying ctx attachments to invocation, preserving OTEL-injected values
2. **`mergeAttachmentToOutgoing()`**: Reset outgoing headers with `NewOutgoingContext(ctx, http.Header{})` before appending, giving each RPC its own isolated header

## Verification

- 2 new regression tests added:
  - `TestParseAttachments_TraceparentNotOverwritten` — verifies OTEL traceparent is preserved, upstream stale value rejected, normal user keys still copied
  - `TestMergeAttachmentToOutgoing_HeaderIsolation` — verifies serial RPCs get independent headers with no traceparent accumulation
- All existing tests pass unchanged (`go test ./protocol/triple/ -v -count=1` — PASS, 4.533s)
- Validation ladder: stopping point at full-package test (change is internal, no exported API changes)
- Residual risk: untested with non-W3C propagators (B3, Jaeger); `tracePropagationKeys` may need extension

Closes #3240