### PR TITLE
fix(consistenthashing): add mutex to protect global selectors map from concurrent access

### DIFF
--- a/cluster/loadbalance/consistenthashing/loadbalance.go
+++ b/cluster/loadbalance/consistenthashing/loadbalance.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"hash/crc32"
 	"regexp"
+	"sync"
 )
 
 import (
@@ -38,8 +39,9 @@ const (
 )
 
 var (
-	selectors = make(map[string]*selector)
-	re        = regexp.MustCompile(constant.CommaSplitPattern)
+	selectors   = make(map[string]*selector)
+	selectorsMu sync.RWMutex
+	re          = regexp.MustCompile(constant.CommaSplitPattern)
 )
 
 func init() {
@@ -71,10 +73,19 @@ func (lb *conshashLoadBalance) Select(invokers []base.Invoker, invocation base.I
 		bs = append(bs, b...)
 	}
 	hashCode := crc32.ChecksumIEEE(bs)
+
+	selectorsMu.RLock()
 	selector, ok := selectors[key]
+	selectorsMu.RUnlock()
+
 	if !ok || selector.hashCode != hashCode {
-		selectors[key] = newSelector(invokers, methodName, hashCode)
+		selectorsMu.Lock()
+		selector, ok = selectors[key]
+		if !ok || selector.hashCode != hashCode {
+			selectors[key] = newSelector(invokers, methodName, hashCode)
+		}
 		selector = selectors[key]
+		selectorsMu.Unlock()
 	}
 	return selector.Select(invocation)
 }

--- a/cluster/loadbalance/consistenthashing/loadbalance_test.go
+++ b/cluster/loadbalance/consistenthashing/loadbalance_test.go
@@ -19,6 +19,7 @@ package consistenthashing
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 )
 
@@ -119,4 +120,22 @@ func (s *consistentHashLoadBalanceSuite) TestSelect() {
 	args = []any{"ok", "abc"}
 	invoker = s.lb.Select(s.invokers, invocation.NewRPCInvocation("echo", args, nil))
 	s.Equal(fmt.Sprintf("%s:%d", ip, port8080), invoker.GetURL().Location)
+}
+
+// TestConcurrentSelect reproduces the race condition on the global `selectors` map.
+// Run with: go test -race -run TestConsistentHashLoadBalanceSuite/TestConcurrentSelect -count=1 ./cluster/loadbalance/consistenthashing/
+func (s *consistentHashLoadBalanceSuite) TestConcurrentSelect() {
+	const goroutines = 10
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func(id int) {
+			defer wg.Done()
+			args := []any{fmt.Sprintf("user-%d", id), "password"}
+			invoker := s.lb.Select(s.invokers, invocation.NewRPCInvocation("echo", args, nil))
+			s.NotNilf(invoker, "Select returned nil for goroutine %d", id)
+		}(i)
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
### Description
Fixes #3316 

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
