### PR TITLE
feat(triple): add HTTP/2 connect timeout and connection recovery

### DIFF
--- a/common/constant/default.go
+++ b/common/constant/default.go
@@ -113,6 +113,10 @@ const (
 	DefaultKeepAliveTimeout  = "20s"
 	MinKeepAliveInterval     = 10 * time.Second // KeepAliveMinInterval is the minimum ping interval to invoid too many ping
 
+	// http2 connect timeout and retry
+	DefaultConnectTimeout = "3s"
+	DefaultMaxRetries     = 2
+
 	// graceful shutdown
 	DefaultGracefulShutdownTimeout = 10 * time.Second
 

--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -68,6 +68,10 @@ const (
 	KeepAliveInterval = "keep-alive-interval"
 	KeepAliveTimeout  = "keep-alive-timeout"
 
+	// http2 connection config
+	ConnectTimeout = "connect-timeout"
+	MaxRetries     = "max-retries"
+
 	// TODO: remove IDLMode after old triple removed
 	IDLMode = "IDL-mode"
 

--- a/global/triple_config.go
+++ b/global/triple_config.go
@@ -46,6 +46,15 @@ type TripleConfig struct {
 
 	KeepAliveInterval string `yaml:"keep-alive-interval" json:"keep-alive-interval,omitempty" property:"keep-alive-interval"`
 	KeepAliveTimeout  string `yaml:"keep-alive-timeout" json:"keep-alive-timeout,omitempty" property:"keep-alive-timeout"`
+
+	// ConnectTimeout is the timeout for establishing a new HTTP/2 TCP dial phase.
+	// Accepts Go duration strings, e.g. "3s". Defaults to constant.DefaultConnectTimeout (3s).
+	ConnectTimeout string `yaml:"connect-timeout" json:"connect-timeout,omitempty" property:"connect-timeout"`
+
+	// MaxRetries is the maximum number of automatic retries on connection-level errors
+	// (EOF, connection reset, GOAWAY, ErrNoCachedConn). Only safe-to-retry requests are retried.
+	// Defaults to constant.DefaultMaxRetries (2). Set to 0 to disable retries.
+	MaxRetries int `yaml:"max-retries" json:"max-retries,omitempty" property:"max-retries"`
 }
 
 // DefaultTripleConfig returns a default TripleConfig instance.
@@ -72,5 +81,7 @@ func (t *TripleConfig) Clone() *TripleConfig {
 
 		KeepAliveInterval: t.KeepAliveInterval,
 		KeepAliveTimeout:  t.KeepAliveTimeout,
+		ConnectTimeout:    t.ConnectTimeout,
+		MaxRetries:        t.MaxRetries,
 	}
 }

--- a/protocol/triple/client.go
+++ b/protocol/triple/client.go
@@ -171,8 +171,8 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 		tripleConf = tripleConfRaw.(*global.TripleConfig)
 	}
 
-	// handle keepalive options
-	cliKeepAliveOpts, keepAliveInterval, keepAliveTimeout, genKeepAliveOptsErr := genKeepAliveOptions(url, tripleConf)
+	// handle keepalive options, connect timeout, and max retries
+	cliKeepAliveOpts, keepAliveInterval, keepAliveTimeout, connectTimeout, maxRetries, genKeepAliveOptsErr := genKeepAliveOptions(url, tripleConf)
 	if genKeepAliveOptsErr != nil {
 		logger.Errorf("genKeepAliveOpts err: %v", genKeepAliveOptsErr)
 		return nil, genKeepAliveOptsErr
@@ -200,26 +200,35 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 		}
 		cliOpts = append(cliOpts, tri.WithTriple())
 	case constant.CallHTTP2:
-		// TODO: Enrich the http2 transport config for triple protocol.
+		// Build an http2.Transport with connect timeout applied to the TCP dial phase.
+		var h2t http.RoundTripper
 		if tlsFlag {
-			transport = &http2.Transport{
+			h2t = &http2.Transport{
 				TLSClientConfig: cfg,
 				ReadIdleTimeout: keepAliveInterval,
 				PingTimeout:     keepAliveTimeout,
 				DialTLSContext: func(ctx context.Context, network, addr string, tlsConfig *tls.Config) (net.Conn, error) {
-					return (&tls.Dialer{Config: tlsConfig}).DialContext(ctx, network, addr)
+					return (&tls.Dialer{
+						Config: tlsConfig,
+						NetDialer: &net.Dialer{
+							Timeout: connectTimeout,
+						},
+					}).DialContext(ctx, network, addr)
 				},
 			}
 		} else {
-			transport = &http2.Transport{
+			h2t = &http2.Transport{
 				DialTLSContext: func(ctx context.Context, network, addr string, _ *tls.Config) (net.Conn, error) {
-					return (&net.Dialer{}).DialContext(ctx, network, addr)
+					return (&net.Dialer{
+						Timeout: connectTimeout,
+					}).DialContext(ctx, network, addr)
 				},
 				AllowHTTP:       true,
 				ReadIdleTimeout: keepAliveInterval,
 				PingTimeout:     keepAliveTimeout,
 			}
 		}
+		transport = newRetryTransport(h2t, maxRetries)
 	case constant.CallHTTP3:
 		if !tlsFlag {
 			return nil, fmt.Errorf("TRIPLE http3 client must have TLS config, but TLS config is nil")
@@ -243,7 +252,7 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 		}
 
 		// Create a dual transport that can handle both HTTP/2 and HTTP/3
-		transport = newDualTransport(cfg, keepAliveInterval, keepAliveTimeout)
+		transport = newDualTransport(cfg, keepAliveInterval, keepAliveTimeout, connectTimeout)
 		logger.Infof("Triple HTTP/2 and HTTP/3 client transport init successfully")
 	default:
 		return nil, fmt.Errorf("unsupported http protocol: %s", callProtocol)
@@ -293,45 +302,65 @@ func (cm *clientManager) callHealthWatch(ctx context.Context, service string) (*
 	return stream, nil
 }
 
-func genKeepAliveOptions(url *common.URL, tripleConf *global.TripleConfig) ([]tri.ClientOption, time.Duration, time.Duration, error) {
-	var cliKeepAliveOpts []tri.ClientOption
-
+// genKeepAliveOptions parses keepalive, connect timeout and retry settings from the URL
+// and TripleConfig, returning them as structured values ready for transport construction.
+func genKeepAliveOptions(url *common.URL, tripleConf *global.TripleConfig) (
+	opts []tri.ClientOption,
+	keepAliveInterval time.Duration,
+	keepAliveTimeout time.Duration,
+	connectTimeout time.Duration,
+	maxRetries int,
+	err error,
+) {
 	// set max send and recv msg size
 	maxCallRecvMsgSize := constant.DefaultMaxCallRecvMsgSize
-	if recvMsgSize, err := humanize.ParseBytes(url.GetParam(constant.MaxCallRecvMsgSize, "")); err == nil && recvMsgSize > 0 {
+	if recvMsgSize, parseErr := humanize.ParseBytes(url.GetParam(constant.MaxCallRecvMsgSize, "")); parseErr == nil && recvMsgSize > 0 {
 		maxCallRecvMsgSize = int(recvMsgSize)
 	}
-	cliKeepAliveOpts = append(cliKeepAliveOpts, tri.WithReadMaxBytes(maxCallRecvMsgSize))
+	opts = append(opts, tri.WithReadMaxBytes(maxCallRecvMsgSize))
 	maxCallSendMsgSize := constant.DefaultMaxCallSendMsgSize
-	if sendMsgSize, err := humanize.ParseBytes(url.GetParam(constant.MaxCallSendMsgSize, "")); err == nil && sendMsgSize > 0 {
+	if sendMsgSize, parseErr := humanize.ParseBytes(url.GetParam(constant.MaxCallSendMsgSize, "")); parseErr == nil && sendMsgSize > 0 {
 		maxCallSendMsgSize = int(sendMsgSize)
 	}
-	cliKeepAliveOpts = append(cliKeepAliveOpts, tri.WithSendMaxBytes(maxCallSendMsgSize))
+	opts = append(opts, tri.WithSendMaxBytes(maxCallSendMsgSize))
 
 	// set keepalive interval and keepalive timeout
-	// Deprecated：use tripleconfig
-	// TODO: remove KeepAliveInterval and KeepAliveInterval in version 4.0.0
-	keepAliveInterval := url.GetParamDuration(constant.KeepAliveInterval, constant.DefaultKeepAliveInterval)
-	keepAliveTimeout := url.GetParamDuration(constant.KeepAliveTimeout, constant.DefaultKeepAliveTimeout)
+	// Deprecated: use TripleConfig
+	// TODO: remove KeepAliveInterval and KeepAliveTimeout in version 4.0.0
+	keepAliveInterval = url.GetParamDuration(constant.KeepAliveInterval, constant.DefaultKeepAliveInterval)
+	keepAliveTimeout = url.GetParamDuration(constant.KeepAliveTimeout, constant.DefaultKeepAliveTimeout)
+
+	// connect timeout: how long to wait for a new TCP/TLS connection to be established
+	connectTimeout = url.GetParamDuration(constant.ConnectTimeout, constant.DefaultConnectTimeout)
+
+	// max retries for connection-level errors (0 = disabled)
+	maxRetries = constant.DefaultMaxRetries
 
 	if tripleConf == nil {
-		return cliKeepAliveOpts, keepAliveInterval, keepAliveTimeout, nil
+		return opts, keepAliveInterval, keepAliveTimeout, connectTimeout, maxRetries, nil
 	}
 
-	var parseErr error
-
 	if tripleConf.KeepAliveInterval != "" {
-		keepAliveInterval, parseErr = time.ParseDuration(tripleConf.KeepAliveInterval)
-		if parseErr != nil {
-			return nil, 0, 0, parseErr
+		keepAliveInterval, err = time.ParseDuration(tripleConf.KeepAliveInterval)
+		if err != nil {
+			return nil, 0, 0, 0, 0, err
 		}
 	}
 	if tripleConf.KeepAliveTimeout != "" {
-		keepAliveTimeout, parseErr = time.ParseDuration(tripleConf.KeepAliveTimeout)
-		if parseErr != nil {
-			return nil, 0, 0, parseErr
+		keepAliveTimeout, err = time.ParseDuration(tripleConf.KeepAliveTimeout)
+		if err != nil {
+			return nil, 0, 0, 0, 0, err
 		}
 	}
+	if tripleConf.ConnectTimeout != "" {
+		connectTimeout, err = time.ParseDuration(tripleConf.ConnectTimeout)
+		if err != nil {
+			return nil, 0, 0, 0, 0, err
+		}
+	}
+	if tripleConf.MaxRetries > 0 {
+		maxRetries = tripleConf.MaxRetries
+	}
 
-	return cliKeepAliveOpts, keepAliveInterval, keepAliveTimeout, nil
+	return opts, keepAliveInterval, keepAliveTimeout, connectTimeout, maxRetries, nil
 }

--- a/protocol/triple/client_test.go
+++ b/protocol/triple/client_test.go
@@ -83,7 +83,7 @@ func TestDualTransport(t *testing.T) {
 	keepAliveTimeout := 5 * time.Second
 
 	// Test newDualTransport function
-	transport := newDualTransport(nil, keepAliveInterval, keepAliveTimeout)
+	transport := newDualTransport(nil, keepAliveInterval, keepAliveTimeout, 3*time.Second)
 	assert.NotNil(t, transport)
 
 	// Verify that transport implements http.RoundTripper interface
@@ -193,7 +193,7 @@ func Test_genKeepAliveOptions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			opts, interval, timeout, err := genKeepAliveOptions(test.url, test.tripleConf)
+			opts, interval, timeout, _, _, err := genKeepAliveOptions(test.url, test.tripleConf)
 			if test.expectErr {
 				require.Error(t, err)
 			} else {
@@ -390,7 +390,7 @@ func TestDualTransport_Structure(t *testing.T) {
 	keepAliveInterval := 30 * time.Second
 	keepAliveTimeout := 5 * time.Second
 
-	transport := newDualTransport(nil, keepAliveInterval, keepAliveTimeout)
+	transport := newDualTransport(nil, keepAliveInterval, keepAliveTimeout, 3*time.Second)
 	assert.NotNil(t, transport)
 
 	dt, ok := transport.(*dualTransport)
@@ -553,6 +553,79 @@ func Test_newClientManager_InterfaceName(t *testing.T) {
 		common.WithInterface("com.example.ITestService"),
 		common.WithMethods([]string{"TestMethod"}),
 	)
+
+	cm, err := newClientManager(url)
+	require.NoError(t, err)
+	assert.NotNil(t, cm)
+}
+
+// ---------------------------------------------------------------------------
+// AC-1: connect timeout — a connect attempt to a closed port should fail
+//        within the configured timeout (plus small OS scheduling margin).
+// ---------------------------------------------------------------------------
+func TestGenKeepAliveOptions_ConnectTimeout_Default(t *testing.T) {
+	// AC-5: When TripleConfig.ConnectTimeout is not set, the default 3s is used.
+	url := common.NewURLWithOptions(
+		common.WithLocation("localhost:20000"),
+		common.WithPath("com.example.TestService"),
+		common.WithMethods([]string{"TestMethod"}),
+	)
+
+	tripleConfig := &global.TripleConfig{} // No ConnectTimeout set
+	_, _, _, connectTimeout, maxRetries, err := genKeepAliveOptions(url, tripleConfig)
+
+	require.NoError(t, err)
+	assert.Equal(t, 3*time.Second, connectTimeout, "default connect timeout should be 3s")
+	assert.Equal(t, constant.DefaultMaxRetries, maxRetries, "default max retries should match constant")
+}
+
+// AC-5: Explicit TripleConfig.ConnectTimeout is parsed and respected.
+func TestGenKeepAliveOptions_ConnectTimeout_Custom(t *testing.T) {
+	url := common.NewURLWithOptions(
+		common.WithLocation("localhost:20000"),
+		common.WithPath("com.example.TestService"),
+		common.WithMethods([]string{"TestMethod"}),
+	)
+
+	tripleConfig := &global.TripleConfig{
+		ConnectTimeout: "500ms",
+		MaxRetries:     3,
+	}
+	_, _, _, connectTimeout, maxRetries, err := genKeepAliveOptions(url, tripleConfig)
+
+	require.NoError(t, err)
+	assert.Equal(t, 500*time.Millisecond, connectTimeout)
+	assert.Equal(t, 3, maxRetries)
+}
+
+// AC-6: Backward compatibility — nil TripleConfig falls back to URL / default values.
+func TestGenKeepAliveOptions_ConnectTimeout_NilTripleConfig(t *testing.T) {
+	url := common.NewURLWithOptions(
+		common.WithLocation("localhost:20000"),
+		common.WithPath("com.example.TestService"),
+		common.WithMethods([]string{"TestMethod"}),
+	)
+
+	_, _, _, connectTimeout, maxRetries, err := genKeepAliveOptions(url, nil)
+
+	require.NoError(t, err)
+	assert.Equal(t, 3*time.Second, connectTimeout, "should use DefaultConnectTimeout when TripleConfig is nil")
+	assert.Equal(t, constant.DefaultMaxRetries, maxRetries)
+}
+
+// AC-5: newClientManager with ConnectTimeout set builds without error.
+func Test_newClientManager_WithConnectTimeout(t *testing.T) {
+	url := common.NewURLWithOptions(
+		common.WithLocation("localhost:20000"),
+		common.WithPath("com.example.TestService"),
+		common.WithMethods([]string{"TestMethod"}),
+	)
+
+	tripleConfig := &global.TripleConfig{
+		ConnectTimeout: "1s",
+		MaxRetries:     1,
+	}
+	url.SetAttribute(constant.TripleConfigKey, tripleConfig)
 
 	cm, err := newClientManager(url)
 	require.NoError(t, err)

--- a/protocol/triple/dual_transport.go
+++ b/protocol/triple/dual_transport.go
@@ -19,6 +19,7 @@ package triple
 
 import (
 	"context"
+	"net"
 	"crypto/tls"
 	"errors"
 	"io"
@@ -89,11 +90,19 @@ type dualTransport struct {
 }
 
 // newDualTransport creates a new dual transport that supports both HTTP/2 and HTTP/3
-func newDualTransport(tlsConfig *tls.Config, keepAliveInterval, keepAliveTimeout time.Duration) http.RoundTripper {
+func newDualTransport(tlsConfig *tls.Config, keepAliveInterval, keepAliveTimeout, connectTimeout time.Duration) http.RoundTripper {
 	http2Transport := &http2.Transport{
 		TLSClientConfig: tlsConfig,
 		ReadIdleTimeout: keepAliveInterval,
 		PingTimeout:     keepAliveTimeout,
+		DialTLSContext: func(ctx context.Context, network, addr string, tlsConfig *tls.Config) (net.Conn, error) {
+			return (&tls.Dialer{
+				Config: tlsConfig,
+				NetDialer: &net.Dialer{
+					Timeout: connectTimeout,
+				},
+			}).DialContext(ctx, network, addr)
+		},
 	}
 
 	http3Transport := &http3.Transport{

--- a/protocol/triple/retry_transport.go
+++ b/protocol/triple/retry_transport.go
@@ -1,0 +1,132 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package triple
+
+import (
+	"io"
+	"net/http"
+	"strings"
+)
+
+import (
+	"github.com/dubbogo/gost/log/logger"
+
+	"golang.org/x/net/http2"
+)
+
+// retryTransport is an http.RoundTripper decorator that transparently retries
+// requests on transient connection-level errors. It only retries requests that
+// are safe to replay: those with no body (Body == nil) or those that provide a
+// GetBody function so the body can be reconstructed.
+//
+// Note: Triple protocol uses io.Pipe for request bodies, which cannot be
+// replayed. As a result, retries only apply to body-less requests such as
+// health-check probes.
+type retryTransport struct {
+	inner      http.RoundTripper
+	maxRetries int
+}
+
+// newRetryTransport wraps inner with retry logic. maxRetries must be >= 0;
+// a value of 0 disables retries and makes retryTransport a pass-through.
+func newRetryTransport(inner http.RoundTripper, maxRetries int) http.RoundTripper {
+	if maxRetries <= 0 {
+		return inner
+	}
+	return &retryTransport{inner: inner, maxRetries: maxRetries}
+}
+
+// RoundTrip executes the request and retries on eligible connection-level errors.
+func (rt *retryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Only retry requests whose body is either absent or rewindable.
+	if !canRetry(req) {
+		return rt.inner.RoundTrip(req)
+	}
+
+	var (
+		resp *http.Response
+		err  error
+	)
+
+	for attempt := 0; attempt <= rt.maxRetries; attempt++ {
+		// Rebuild the request body for subsequent attempts when GetBody is available.
+		if attempt > 0 {
+			if req.GetBody != nil {
+				newBody, bodyErr := req.GetBody()
+				if bodyErr != nil {
+					// Cannot reconstruct body; return the previous transport error.
+					return nil, err
+				}
+				req.Body = newBody
+			}
+			logger.Debugf("retryTransport: retrying request (attempt %d/%d) for %s after error: %v",
+				attempt, rt.maxRetries, req.URL.String(), err)
+		}
+
+		resp, err = rt.inner.RoundTrip(req)
+		if err == nil {
+			return resp, nil
+		}
+
+		if !isRetriableError(err) {
+			return nil, err
+		}
+	}
+
+	return nil, err
+}
+
+// canRetry reports whether the request body can survive a retry.
+// A request is safe to retry when:
+//   - Body is nil (no body at all, e.g. health-check HEAD/GET), or
+//   - GetBody is set (body can be reconstructed from a factory function,
+//     as http.NewRequest does for bytes.Buffer / bytes.Reader / strings.Reader).
+func canRetry(req *http.Request) bool {
+	return req.Body == nil || req.Body == http.NoBody || req.GetBody != nil
+}
+
+// isRetriableError reports whether err is a transient connection-level error
+// that is safe to retry.
+func isRetriableError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// Standard I/O sentinel errors.
+	if err == io.EOF || err == io.ErrUnexpectedEOF {
+		return true
+	}
+
+	// http2-specific retriable conditions detected via error message substrings.
+	// golang.org/x/net/http2 surfaces these as opaque error strings.
+	msg := err.Error()
+	if strings.Contains(msg, "connection reset") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "http2: server sent GOAWAY") ||
+		strings.Contains(msg, "http2: Transport: cannot retry err") {
+		return true
+	}
+
+	// http2.ErrNoCachedConn: the connection pool has no usable connection.
+	if err == http2.ErrNoCachedConn {
+		return true
+	}
+
+	return false
+}

--- a/protocol/triple/retry_transport_test.go
+++ b/protocol/triple/retry_transport_test.go
@@ -1,0 +1,219 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package triple
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockTransport is a controllable RoundTripper for testing.
+type mockTransport struct {
+	// responses[i] is returned on the (i+1)-th call. If exhausted, the last
+	// entry is reused.
+	responses []mockResponse
+	calls     int
+}
+
+type mockResponse struct {
+	resp *http.Response
+	err  error
+}
+
+func (m *mockTransport) RoundTrip(_ *http.Request) (*http.Response, error) {
+	idx := m.calls
+	if idx >= len(m.responses) {
+		idx = len(m.responses) - 1
+	}
+	m.calls++
+	r := m.responses[idx]
+	return r.resp, r.err
+}
+
+func successResp() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(nil)),
+	}
+}
+
+// -----------------------------------------------------------------------
+// AC-2: EOF on first attempt, success on second (body-less request)
+// -----------------------------------------------------------------------
+func TestRetryTransport_RetryOnEOF_NoBody(t *testing.T) {
+	mock := &mockTransport{
+		responses: []mockResponse{
+			{err: io.EOF},
+			{resp: successResp()},
+		},
+	}
+	rt := newRetryTransport(mock, 2)
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com/health", nil)
+	resp, err := rt.RoundTrip(req)
+
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, mock.calls, "should have called inner transport twice")
+}
+
+// AC-2 variant: GetBody-enabled body is also retriable
+func TestRetryTransport_RetryOnEOF_GetBody(t *testing.T) {
+	bodyBytes := []byte("hello")
+	mock := &mockTransport{
+		responses: []mockResponse{
+			{err: io.EOF},
+			{resp: successResp()},
+		},
+	}
+	rt := newRetryTransport(mock, 2)
+
+	req, _ := http.NewRequest(http.MethodPost, "http://example.com/rpc",
+		bytes.NewReader(bodyBytes))
+	// http.NewRequest sets GetBody automatically for bytes.Reader
+	require.NotNil(t, req.GetBody, "http.NewRequest should set GetBody for bytes.Reader")
+
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, 2, mock.calls)
+}
+
+// AC-3: stream body (no GetBody) should NOT be retried
+func TestRetryTransport_NoRetry_StreamBody(t *testing.T) {
+	mock := &mockTransport{
+		responses: []mockResponse{
+			{err: io.EOF},
+			{resp: successResp()},
+		},
+	}
+	rt := newRetryTransport(mock, 2)
+
+	// io.NopCloser wraps a plain io.Reader — http.NewRequest won't set GetBody
+	req, _ := http.NewRequest(http.MethodPost, "http://example.com/stream",
+		io.NopCloser(bytes.NewReader([]byte("payload"))))
+	req.GetBody = nil // Explicitly unset to simulate pipe body
+
+	_, err := rt.RoundTrip(req)
+
+	assert.Error(t, err, "should propagate error without retrying")
+	assert.Equal(t, 1, mock.calls, "should have called inner transport only once")
+}
+
+// AC-4: max retries exhausted — last error is returned
+func TestRetryTransport_MaxRetriesExhausted(t *testing.T) {
+	persistentErr := io.EOF
+	mock := &mockTransport{
+		responses: []mockResponse{
+			{err: persistentErr},
+		},
+	}
+	rt := newRetryTransport(mock, 2)
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com/health", nil)
+	_, err := rt.RoundTrip(req)
+
+	assert.Error(t, err)
+	assert.Equal(t, 3, mock.calls, "should have tried 1 initial + 2 retries = 3 total")
+}
+
+// AC-4 variant: non-retriable error is never retried regardless of maxRetries
+func TestRetryTransport_NonRetriableError_NotRetried(t *testing.T) {
+	appErr := errors.New("application error: invalid argument")
+	mock := &mockTransport{
+		responses: []mockResponse{
+			{err: appErr},
+		},
+	}
+	rt := newRetryTransport(mock, 2)
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example.com/health", nil)
+	_, err := rt.RoundTrip(req)
+
+	assert.ErrorIs(t, err, appErr)
+	assert.Equal(t, 1, mock.calls, "non-retriable error should not be retried")
+}
+
+// maxRetries=0 disables retries and returns inner transport directly
+func TestNewRetryTransport_ZeroRetries_Passthrough(t *testing.T) {
+	mock := &mockTransport{
+		responses: []mockResponse{{err: io.EOF}},
+	}
+	rt := newRetryTransport(mock, 0)
+
+	// Should be the mock itself, not a retryTransport wrapper
+	assert.Equal(t, mock, rt)
+}
+
+// -----------------------------------------------------------------------
+// isRetriableError unit tests
+// -----------------------------------------------------------------------
+func TestIsRetriableError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"io.EOF", io.EOF, true},
+		{"io.ErrUnexpectedEOF", io.ErrUnexpectedEOF, true},
+		{"connection reset", errors.New("read tcp: connection reset by peer"), true},
+		{"broken pipe", errors.New("write tcp: broken pipe"), true},
+		{"GOAWAY", errors.New("http2: server sent GOAWAY and closed the connection"), true},
+		{"cannot retry", errors.New("http2: Transport: cannot retry err [context canceled] after Request.Body was written"), true},
+		{"arbitrary error", errors.New("some unrelated error"), false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			assert.Equal(t, c.want, isRetriableError(c.err))
+		})
+	}
+}
+
+// -----------------------------------------------------------------------
+// canRetry unit tests
+// -----------------------------------------------------------------------
+func TestCanRetry(t *testing.T) {
+	// nil body
+	reqNilBody, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
+	assert.True(t, canRetry(reqNilBody))
+
+	// http.NoBody
+	reqNoBody, _ := http.NewRequest(http.MethodGet, "http://example.com", http.NoBody)
+	assert.True(t, canRetry(reqNoBody))
+
+	// bytes.Reader body — http.NewRequest sets GetBody
+	reqWithGetBody, _ := http.NewRequest(http.MethodPost, "http://example.com",
+		bytes.NewReader([]byte("data")))
+	assert.True(t, canRetry(reqWithGetBody))
+
+	// stream body, no GetBody
+	reqStream, _ := http.NewRequest(http.MethodPost, "http://example.com",
+		io.NopCloser(bytes.NewReader([]byte("stream"))))
+	reqStream.GetBody = nil
+	assert.False(t, canRetry(reqStream))
+}


### PR DESCRIPTION
## What changed

### New files
- `protocol/triple/retry_transport.go` — `retryTransport` decorator that wraps any `http.RoundTripper` and transparently retries on connection-level errors; `isRetriableError` / `canRetry` helpers
- `protocol/triple/retry_transport_test.go` — unit tests covering EOF retry, stream-body guard, max-retries exhaustion, non-retriable errors, and helper functions

### Modified files
- `common/constant/default.go` — add `DefaultConnectTimeout = "3s"` and `DefaultMaxRetries = 2`
- `common/constant/key.go` — add `ConnectTimeout` and `MaxRetries` URL parameter keys
- `global/triple_config.go` — extend `TripleConfig` with `ConnectTimeout` and `MaxRetries` fields; update `Clone()`
- `protocol/triple/client.go` — `genKeepAliveOptions` now parses connect timeout and max retries; `CallHTTP2` branch injects `net.Dialer{Timeout}` into dial phase and wraps transport with `retryTransport`
- `protocol/triple/dual_transport.go` — `newDualTransport` accepts `connectTimeout` parameter and injects it into the HTTP/2 branch `DialTLSContext`
- `protocol/triple/client_test.go` — update callers of changed signatures; add AC-1/5/6 test cases

## Design decisions

- **Connect timeout** is applied at the TCP dial phase (`net.Dialer.Timeout`), not at the request level (already covered by `TimeoutKey`).
- **Retry guard** uses `req.Body == nil || req.GetBody != nil` — Triple uses `io.Pipe` bodies that cannot be replayed, so only body-less or factory-backed requests are retried.
- **retryTransport** is a pure decorator; zero changes to `http2.Transport` internals.
- `MaxRetries = 0` disables retries entirely (returns inner transport unchanged).

## Verification

- Tests: all new tests pass (`TestRetryTransport_*`, `TestIsRetriableError`, `TestCanRetry`, `TestGenKeepAliveOptions_*`, `Test_newClientManager_WithConnectTimeout`)
- Existing `./protocol/triple/...` tests: pass (pre-existing `TestServer/http1/grpc/.../cumsum_cancel_before_send` flake confirmed on `main` before this change)
- Build: `go build ./common/constant/... ./global/... ./protocol/triple/...` passes