### PR TITLE
fix(config): remove legacy protocol timeout fallback

### DIFF
--- a/common/constant/default.go
+++ b/common/constant/default.go
@@ -35,23 +35,22 @@ const (
 )
 
 const (
-	DefaultWeight                 = 100
-	DefaultWarmup                 = 10 * 60 // in java here is 10*60*1000 because of System.currentTimeMillis() is measured in milliseconds & in go time.Unix() is second
-	DefaultLoadBalance            = "random"
-	DefaultRetries                = "2"
-	DefaultRetriesInt             = 2
-	DefaultProtocol               = "dubbo"
-	DefaultConsumerRequestTimeout = "3s"
-	DefaultRegTimeout             = "5s"
-	DefaultRegTTL                 = "15m"
-	DefaultCluster                = "failover"
-	DefaultFailbackTimes          = "3"
-	DefaultFailbackTimesInt       = 3
-	DefaultFailbackTasks          = 100
-	DefaultRestClient             = "resty"
-	DefaultRestServer             = "go-restful"
-	DefaultPort                   = 20000
-	DefaultTripleProtocolPort     = "50051"
+	DefaultWeight             = 100
+	DefaultWarmup             = 10 * 60 // in java here is 10*60*1000 because of System.currentTimeMillis() is measured in milliseconds & in go time.Unix() is second
+	DefaultLoadBalance        = "random"
+	DefaultRetries            = "2"
+	DefaultRetriesInt         = 2
+	DefaultProtocol           = "dubbo"
+	DefaultRegTimeout         = "5s"
+	DefaultRegTTL             = "15m"
+	DefaultCluster            = "failover"
+	DefaultFailbackTimes      = "3"
+	DefaultFailbackTimesInt   = 3
+	DefaultFailbackTasks      = 100
+	DefaultRestClient         = "resty"
+	DefaultRestServer         = "go-restful"
+	DefaultPort               = 20000
+	DefaultTripleProtocolPort = "50051"
 )
 
 const (

--- a/common/constant/default.go
+++ b/common/constant/default.go
@@ -35,22 +35,23 @@ const (
 )
 
 const (
-	DefaultWeight             = 100
-	DefaultWarmup             = 10 * 60 // in java here is 10*60*1000 because of System.currentTimeMillis() is measured in milliseconds & in go time.Unix() is second
-	DefaultLoadBalance        = "random"
-	DefaultRetries            = "2"
-	DefaultRetriesInt         = 2
-	DefaultProtocol           = "dubbo"
-	DefaultRegTimeout         = "5s"
-	DefaultRegTTL             = "15m"
-	DefaultCluster            = "failover"
-	DefaultFailbackTimes      = "3"
-	DefaultFailbackTimesInt   = 3
-	DefaultFailbackTasks      = 100
-	DefaultRestClient         = "resty"
-	DefaultRestServer         = "go-restful"
-	DefaultPort               = 20000
-	DefaultTripleProtocolPort = "50051"
+	DefaultWeight                 = 100
+	DefaultWarmup                 = 10 * 60 // in java here is 10*60*1000 because of System.currentTimeMillis() is measured in milliseconds & in go time.Unix() is second
+	DefaultLoadBalance            = "random"
+	DefaultRetries                = "2"
+	DefaultRetriesInt             = 2
+	DefaultProtocol               = "dubbo"
+	DefaultConsumerRequestTimeout = "3s"
+	DefaultRegTimeout             = "5s"
+	DefaultRegTTL                 = "15m"
+	DefaultCluster                = "failover"
+	DefaultFailbackTimes          = "3"
+	DefaultFailbackTimesInt       = 3
+	DefaultFailbackTasks          = 100
+	DefaultRestClient             = "resty"
+	DefaultRestServer             = "go-restful"
+	DefaultPort                   = 20000
+	DefaultTripleProtocolPort     = "50051"
 )
 
 const (

--- a/config/reference_config.go
+++ b/config/reference_config.go
@@ -117,6 +117,9 @@ func (rc *ReferenceConfig) Init(root *RootConfig) error {
 		if rc.Protocol == "" {
 			rc.Protocol = root.Consumer.Protocol
 		}
+		if rc.RequestTimeout == "" && root.Consumer.RequestTimeout != "" {
+			rc.RequestTimeout = root.Consumer.RequestTimeout
+		}
 		if rc.TracingKey == "" {
 			rc.TracingKey = root.Consumer.TracingKey
 		}

--- a/config/reference_config_test.go
+++ b/config/reference_config_test.go
@@ -467,3 +467,16 @@ func TestReferenceConfigInitWithoutConsumerConfig(t *testing.T) {
 	err := NewReferenceConfigBuilder().Build().Init(testRootConfig)
 	assert.NoError(t, err)
 }
+
+func TestReferenceConfigInitInheritsConsumerRequestTimeout(t *testing.T) {
+	root := NewRootConfigBuilder().
+		SetApplication(NewApplicationConfigBuilder().SetName("test-app").Build()).
+		SetConsumer(NewConsumerConfigBuilder().SetRequestTimeout("5s").Build()).
+		Build()
+
+	ref := NewReferenceConfigBuilder().Build()
+	err := ref.Init(root)
+	assert.NoError(t, err)
+	assert.Equal(t, "5s", ref.RequestTimeout)
+	assert.Equal(t, "5s", ref.getURLMap().Get(constant.TimeoutKey))
+}

--- a/config/reference_config_test.go
+++ b/config/reference_config_test.go
@@ -23,6 +23,7 @@ import (
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 import (
@@ -476,7 +477,7 @@ func TestReferenceConfigInitInheritsConsumerRequestTimeout(t *testing.T) {
 
 	ref := NewReferenceConfigBuilder().Build()
 	err := ref.Init(root)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "5s", ref.RequestTimeout)
 	assert.Equal(t, "5s", ref.getURLMap().Get(constant.TimeoutKey))
 }

--- a/global/consumer_config.go
+++ b/global/consumer_config.go
@@ -17,9 +17,7 @@
 
 package global
 
-import (
-	"dubbo.apache.org/dubbo-go/v3/common/constant"
-)
+const DefaultConsumerRequestTimeout = "3s"
 
 type ConsumerConfig struct {
 	Filter          string   `yaml:"filter" json:"filter,omitempty" property:"filter"`
@@ -39,7 +37,7 @@ type ConsumerConfig struct {
 
 func DefaultConsumerConfig() *ConsumerConfig {
 	return &ConsumerConfig{
-		RequestTimeout: constant.DefaultConsumerRequestTimeout,
+		RequestTimeout: DefaultConsumerRequestTimeout,
 		Check:          true,
 		References:     make(map[string]*ReferenceConfig),
 	}

--- a/global/consumer_config.go
+++ b/global/consumer_config.go
@@ -17,6 +17,10 @@
 
 package global
 
+import (
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+)
+
 type ConsumerConfig struct {
 	Filter          string   `yaml:"filter" json:"filter,omitempty" property:"filter"`
 	RegistryIDs     []string `yaml:"registry-ids" json:"registry-ids,omitempty" property:"registry-ids"`
@@ -35,7 +39,7 @@ type ConsumerConfig struct {
 
 func DefaultConsumerConfig() *ConsumerConfig {
 	return &ConsumerConfig{
-		RequestTimeout: "3s",
+		RequestTimeout: constant.DefaultConsumerRequestTimeout,
 		Check:          true,
 		References:     make(map[string]*ReferenceConfig),
 	}

--- a/protocol/dubbo/dubbo_invoker.go
+++ b/protocol/dubbo/dubbo_invoker.go
@@ -34,7 +34,6 @@ import (
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
-	"dubbo.apache.org/dubbo-go/v3/config"
 	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
@@ -57,10 +56,9 @@ type DubboInvoker struct {
 
 // NewDubboInvoker constructor
 func NewDubboInvoker(url *common.URL, client *remoting.ExchangeClient) *DubboInvoker {
-	// TODO: Temporary compatibility with old APIs, can be removed later
-	rt := config.GetConsumerConfig().RequestTimeout
+	rt := global.DefaultConsumerConfig().RequestTimeout
 	if consumerConfRaw, ok := url.GetAttribute(constant.ConsumerConfigKey); ok {
-		if consumerConf, ok := consumerConfRaw.(*global.ConsumerConfig); ok {
+		if consumerConf, ok := consumerConfRaw.(*global.ConsumerConfig); ok && consumerConf.RequestTimeout != "" {
 			rt = consumerConf.RequestTimeout
 		}
 	}

--- a/protocol/dubbo/dubbo_invoker.go
+++ b/protocol/dubbo/dubbo_invoker.go
@@ -45,6 +45,8 @@ var attachmentKey = []string{
 	constant.InterfaceKey, constant.GroupKey, constant.TokenKey, constant.VersionKey,
 }
 
+const defaultConsumerRequestTimeout = "3s"
+
 // DubboInvoker is implement of protocol.Invoker. A dubboInvoker refers to one service and ip.
 type DubboInvoker struct {
 	base.BaseInvoker
@@ -56,7 +58,7 @@ type DubboInvoker struct {
 
 // NewDubboInvoker constructor
 func NewDubboInvoker(url *common.URL, client *remoting.ExchangeClient) *DubboInvoker {
-	rt := ""
+	rt := defaultConsumerRequestTimeout
 	if consumerConfRaw, ok := url.GetAttribute(constant.ConsumerConfigKey); ok {
 		if consumerConf, ok := consumerConfRaw.(*global.ConsumerConfig); ok && consumerConf.RequestTimeout != "" {
 			rt = consumerConf.RequestTimeout

--- a/protocol/dubbo/dubbo_invoker.go
+++ b/protocol/dubbo/dubbo_invoker.go
@@ -56,7 +56,7 @@ type DubboInvoker struct {
 
 // NewDubboInvoker constructor
 func NewDubboInvoker(url *common.URL, client *remoting.ExchangeClient) *DubboInvoker {
-	rt := global.DefaultConsumerConfig().RequestTimeout
+	rt := ""
 	if consumerConfRaw, ok := url.GetAttribute(constant.ConsumerConfigKey); ok {
 		if consumerConf, ok := consumerConfRaw.(*global.ConsumerConfig); ok && consumerConf.RequestTimeout != "" {
 			rt = consumerConf.RequestTimeout

--- a/protocol/dubbo/dubbo_invoker.go
+++ b/protocol/dubbo/dubbo_invoker.go
@@ -56,7 +56,7 @@ type DubboInvoker struct {
 
 // NewDubboInvoker constructor
 func NewDubboInvoker(url *common.URL, client *remoting.ExchangeClient) *DubboInvoker {
-	rt := constant.DefaultConsumerRequestTimeout
+	rt := global.DefaultConsumerRequestTimeout
 	if consumerConfRaw, ok := url.GetAttribute(constant.ConsumerConfigKey); ok {
 		if consumerConf, ok := consumerConfRaw.(*global.ConsumerConfig); ok && consumerConf.RequestTimeout != "" {
 			rt = consumerConf.RequestTimeout

--- a/protocol/dubbo/dubbo_invoker.go
+++ b/protocol/dubbo/dubbo_invoker.go
@@ -45,8 +45,6 @@ var attachmentKey = []string{
 	constant.InterfaceKey, constant.GroupKey, constant.TokenKey, constant.VersionKey,
 }
 
-const defaultConsumerRequestTimeout = "3s"
-
 // DubboInvoker is implement of protocol.Invoker. A dubboInvoker refers to one service and ip.
 type DubboInvoker struct {
 	base.BaseInvoker
@@ -58,7 +56,7 @@ type DubboInvoker struct {
 
 // NewDubboInvoker constructor
 func NewDubboInvoker(url *common.URL, client *remoting.ExchangeClient) *DubboInvoker {
-	rt := defaultConsumerRequestTimeout
+	rt := constant.DefaultConsumerRequestTimeout
 	if consumerConfRaw, ok := url.GetAttribute(constant.ConsumerConfigKey); ok {
 		if consumerConf, ok := consumerConfRaw.(*global.ConsumerConfig); ok && consumerConf.RequestTimeout != "" {
 			rt = consumerConf.RequestTimeout

--- a/protocol/dubbo/dubbo_invoker_test.go
+++ b/protocol/dubbo/dubbo_invoker_test.go
@@ -17,6 +17,43 @@
 
 package dubbo
 
+import (
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/global"
+)
+
+func TestNewDubboInvokerUsesGlobalDefaultTimeout(t *testing.T) {
+	url, err := common.NewURL("dubbo://127.0.0.1:20880/org.apache.dubbo.UserProvider")
+	require.NoError(t, err)
+
+	invoker := NewDubboInvoker(url, nil)
+
+	assert.Equal(t, 3*time.Second, invoker.timeout)
+}
+
+func TestNewDubboInvokerUsesConsumerAttributeTimeout(t *testing.T) {
+	url, err := common.NewURL("dubbo://127.0.0.1:20880/org.apache.dubbo.UserProvider")
+	require.NoError(t, err)
+	url.SetAttribute(constant.ConsumerConfigKey, &global.ConsumerConfig{
+		RequestTimeout: "5s",
+	})
+
+	invoker := NewDubboInvoker(url, nil)
+
+	assert.Equal(t, 5*time.Second, invoker.timeout)
+}
+
 //
 //import (
 //	"bytes"

--- a/protocol/dubbo/dubbo_invoker_test.go
+++ b/protocol/dubbo/dubbo_invoker_test.go
@@ -54,6 +54,15 @@ func TestNewDubboInvokerUsesConsumerAttributeTimeout(t *testing.T) {
 	assert.Equal(t, 5*time.Second, invoker.timeout)
 }
 
+func TestNewDubboInvokerUsesTimeoutParam(t *testing.T) {
+	url, err := common.NewURL("dubbo://127.0.0.1:20880/org.apache.dubbo.UserProvider?timeout=5s")
+	require.NoError(t, err)
+
+	invoker := NewDubboInvoker(url, nil)
+
+	assert.Equal(t, 5*time.Second, invoker.timeout)
+}
+
 //
 //import (
 //	"bytes"

--- a/protocol/jsonrpc/jsonrpc_protocol.go
+++ b/protocol/jsonrpc/jsonrpc_protocol.go
@@ -31,7 +31,6 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
-	"dubbo.apache.org/dubbo-go/v3/config"
 	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 )
@@ -80,18 +79,17 @@ func (jp *JsonrpcProtocol) Export(invoker base.Invoker) base.Exporter {
 
 // Refer a remote JSON PRC service from registry
 func (jp *JsonrpcProtocol) Refer(url *common.URL) base.Invoker {
-	// TODO: Temporary compatibility with old APIs, can be removed later
-	rt := config.GetConsumerConfig().RequestTimeout
+	rt := global.DefaultConsumerConfig().RequestTimeout
 	if consumerConfRaw, ok := url.GetAttribute(constant.ConsumerConfigKey); ok {
-		if consumerConf, ok := consumerConfRaw.(*global.ConsumerConfig); ok {
+		if consumerConf, ok := consumerConfRaw.(*global.ConsumerConfig); ok && consumerConf.RequestTimeout != "" {
 			rt = consumerConf.RequestTimeout
 		}
 	}
-	// the read order of requestTimeout is from url , if nil then from consumer config , if nil then default 3s. requestTimeout can be dynamically updated from config center.
+	// The read order of request timeout is URL params, URL consumer config attribute, then global default.
 	requestTimeout := url.GetParamDuration(constant.TimeoutKey, rt)
 	// New Json rpc Invoker
 	invoker := NewJsonrpcInvoker(url, NewHTTPClient(&HTTPOptions{
-		HandshakeTimeout: time.Second, // todo config timeout config.GetConsumerConfig().ConnectTimeout,
+		HandshakeTimeout: time.Second, // todo support configurable handshake timeout
 		HTTPTimeout:      requestTimeout,
 	}))
 	jp.SetInvokers(invoker)

--- a/protocol/jsonrpc/jsonrpc_protocol.go
+++ b/protocol/jsonrpc/jsonrpc_protocol.go
@@ -41,8 +41,6 @@ const (
 	JSONRPC = "jsonrpc"
 )
 
-const defaultConsumerRequestTimeout = "3s"
-
 func init() {
 	extension.SetProtocol(JSONRPC, GetProtocol)
 }
@@ -81,7 +79,7 @@ func (jp *JsonrpcProtocol) Export(invoker base.Invoker) base.Exporter {
 
 // Refer a remote JSON PRC service from registry
 func (jp *JsonrpcProtocol) Refer(url *common.URL) base.Invoker {
-	rt := defaultConsumerRequestTimeout
+	rt := constant.DefaultConsumerRequestTimeout
 	if consumerConfRaw, ok := url.GetAttribute(constant.ConsumerConfigKey); ok {
 		if consumerConf, ok := consumerConfRaw.(*global.ConsumerConfig); ok && consumerConf.RequestTimeout != "" {
 			rt = consumerConf.RequestTimeout

--- a/protocol/jsonrpc/jsonrpc_protocol.go
+++ b/protocol/jsonrpc/jsonrpc_protocol.go
@@ -41,6 +41,8 @@ const (
 	JSONRPC = "jsonrpc"
 )
 
+const defaultConsumerRequestTimeout = "3s"
+
 func init() {
 	extension.SetProtocol(JSONRPC, GetProtocol)
 }
@@ -79,7 +81,7 @@ func (jp *JsonrpcProtocol) Export(invoker base.Invoker) base.Exporter {
 
 // Refer a remote JSON PRC service from registry
 func (jp *JsonrpcProtocol) Refer(url *common.URL) base.Invoker {
-	rt := ""
+	rt := defaultConsumerRequestTimeout
 	if consumerConfRaw, ok := url.GetAttribute(constant.ConsumerConfigKey); ok {
 		if consumerConf, ok := consumerConfRaw.(*global.ConsumerConfig); ok && consumerConf.RequestTimeout != "" {
 			rt = consumerConf.RequestTimeout

--- a/protocol/jsonrpc/jsonrpc_protocol.go
+++ b/protocol/jsonrpc/jsonrpc_protocol.go
@@ -79,7 +79,7 @@ func (jp *JsonrpcProtocol) Export(invoker base.Invoker) base.Exporter {
 
 // Refer a remote JSON PRC service from registry
 func (jp *JsonrpcProtocol) Refer(url *common.URL) base.Invoker {
-	rt := constant.DefaultConsumerRequestTimeout
+	rt := global.DefaultConsumerRequestTimeout
 	if consumerConfRaw, ok := url.GetAttribute(constant.ConsumerConfigKey); ok {
 		if consumerConf, ok := consumerConfRaw.(*global.ConsumerConfig); ok && consumerConf.RequestTimeout != "" {
 			rt = consumerConf.RequestTimeout

--- a/protocol/jsonrpc/jsonrpc_protocol.go
+++ b/protocol/jsonrpc/jsonrpc_protocol.go
@@ -79,13 +79,12 @@ func (jp *JsonrpcProtocol) Export(invoker base.Invoker) base.Exporter {
 
 // Refer a remote JSON PRC service from registry
 func (jp *JsonrpcProtocol) Refer(url *common.URL) base.Invoker {
-	rt := global.DefaultConsumerConfig().RequestTimeout
+	rt := ""
 	if consumerConfRaw, ok := url.GetAttribute(constant.ConsumerConfigKey); ok {
 		if consumerConf, ok := consumerConfRaw.(*global.ConsumerConfig); ok && consumerConf.RequestTimeout != "" {
 			rt = consumerConf.RequestTimeout
 		}
 	}
-	// The read order of request timeout is URL params, URL consumer config attribute, then global default.
 	requestTimeout := url.GetParamDuration(constant.TimeoutKey, rt)
 	// New Json rpc Invoker
 	invoker := NewJsonrpcInvoker(url, NewHTTPClient(&HTTPOptions{

--- a/protocol/jsonrpc/jsonrpc_protocol_test.go
+++ b/protocol/jsonrpc/jsonrpc_protocol_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 )
 
 import (
@@ -76,7 +77,7 @@ func TestJsonrpcProtocolRefer(t *testing.T) {
 		"side=provider&timeout=3000&timestamp=1556509797245")
 	require.NoError(t, err)
 
-	// Pass ConsumerConfig via URL attribute instead of using config.SetConsumerConfig()
+	// Pass ConsumerConfig via URL attribute.
 	consumerConf := &global.ConsumerConfig{
 		RequestTimeout: "5s",
 	}
@@ -94,4 +95,31 @@ func TestJsonrpcProtocolRefer(t *testing.T) {
 	proto.Destroy()
 	invokersLen = len(proto.(*JsonrpcProtocol).Invokers())
 	assert.Equal(t, 0, invokersLen)
+}
+
+func TestJsonrpcProtocolReferUsesGlobalDefaultTimeout(t *testing.T) {
+	proto := NewJsonrpcProtocol()
+	url, err := common.NewURL("jsonrpc://127.0.0.1:20000/com.ikurento.user.UserProvider")
+	require.NoError(t, err)
+
+	invoker := proto.Refer(url)
+
+	jsonrpcInvoker, ok := invoker.(*JsonrpcInvoker)
+	require.True(t, ok)
+	assert.Equal(t, 3*time.Second, jsonrpcInvoker.client.options.HTTPTimeout)
+}
+
+func TestJsonrpcProtocolReferUsesConsumerAttributeTimeout(t *testing.T) {
+	proto := NewJsonrpcProtocol()
+	url, err := common.NewURL("jsonrpc://127.0.0.1:20000/com.ikurento.user.UserProvider")
+	require.NoError(t, err)
+	url.SetAttribute(constant.ConsumerConfigKey, &global.ConsumerConfig{
+		RequestTimeout: "5s",
+	})
+
+	invoker := proto.Refer(url)
+
+	jsonrpcInvoker, ok := invoker.(*JsonrpcInvoker)
+	require.True(t, ok)
+	assert.Equal(t, 5*time.Second, jsonrpcInvoker.client.options.HTTPTimeout)
 }

--- a/protocol/jsonrpc/jsonrpc_protocol_test.go
+++ b/protocol/jsonrpc/jsonrpc_protocol_test.go
@@ -123,3 +123,15 @@ func TestJsonrpcProtocolReferUsesConsumerAttributeTimeout(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, 5*time.Second, jsonrpcInvoker.client.options.HTTPTimeout)
 }
+
+func TestJsonrpcProtocolReferUsesTimeoutParam(t *testing.T) {
+	proto := NewJsonrpcProtocol()
+	url, err := common.NewURL("jsonrpc://127.0.0.1:20000/com.ikurento.user.UserProvider?timeout=5s")
+	require.NoError(t, err)
+
+	invoker := proto.Refer(url)
+
+	jsonrpcInvoker, ok := invoker.(*JsonrpcInvoker)
+	require.True(t, ok)
+	assert.Equal(t, 5*time.Second, jsonrpcInvoker.client.options.HTTPTimeout)
+}


### PR DESCRIPTION
## What

Continue #3204 by removing the legacy `config.GetConsumerConfig()` timeout fallback from protocol invokers.

This PR updates:

- `protocol/dubbo`
- `protocol/jsonrpc`

Both now read request timeout in this order:

1. URL `timeout` param
2. URL `ConsumerConfigKey` attribute
3. `global.DefaultConsumerConfig().RequestTimeout`

## Why

After #3320, `global / InstanceOptions` should be the runtime source of truth, and `config.RootConfig` should only remain as a legacy mirror/input adapter.

These two protocol packages only used `config.GetConsumerConfig().RequestTimeout` as a fallback. Using `global.DefaultConsumerConfig()` keeps the same default value (`3s`) while removing the direct runtime dependency on `config`.

## Tests

- `go test ./protocol/dubbo ./protocol/jsonrpc -run 'TestNewDubboInvokerUses|TestJsonrpcProtocolRefer' -count=1`
- `go test ./protocol/dubbo ./protocol/jsonrpc -count=1`
- `go test ./...`

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
