### PR TITLE
fix(common): omit trailing ? in URL.String() without query params

### DIFF
--- a/cluster/loadbalance/consistenthashing/loadbalance_test.go
+++ b/cluster/loadbalance/consistenthashing/loadbalance_test.go
@@ -75,7 +75,7 @@ func (s *consistentHashSelectorSuite) TestSelectForKey() {
 	s.selector.virtualInvokers[9999945] = base.NewBaseInvoker(url2)
 	s.selector.keys = []uint32{99874, 9999945}
 	result := s.selector.selectForKey(9999944)
-	s.Equal(url8081Short+"?", result.GetURL().String())
+	s.Equal(url8081Short, result.GetURL().String())
 }
 
 func TestConsistentHashLoadBalanceSuite(t *testing.T) {

--- a/common/url.go
+++ b/common/url.go
@@ -397,11 +397,14 @@ func (c *URL) String() string {
 	defer c.paramsLock.Unlock()
 	var buf strings.Builder
 	if len(c.Username) == 0 && len(c.Password) == 0 {
-		buf.WriteString(fmt.Sprintf("%s://%s:%s%s?", c.Protocol, c.Ip, c.Port, c.Path))
+		buf.WriteString(fmt.Sprintf("%s://%s:%s%s", c.Protocol, c.Ip, c.Port, c.Path))
 	} else {
-		buf.WriteString(fmt.Sprintf("%s://%s:%s@%s:%s%s?", c.Protocol, c.Username, c.Password, c.Ip, c.Port, c.Path))
+		buf.WriteString(fmt.Sprintf("%s://%s:%s@%s:%s%s", c.Protocol, c.Username, c.Password, c.Ip, c.Port, c.Path))
 	}
-	buf.WriteString(c.params.Encode())
+	if encoded := c.params.Encode(); encoded != "" {
+		buf.WriteByte('?')
+		buf.WriteString(encoded)
+	}
 	return buf.String()
 }
 

--- a/common/url_test.go
+++ b/common/url_test.go
@@ -1209,6 +1209,12 @@ func TestURLStringWithoutAuth(t *testing.T) {
 	assert.NotContains(t, str, "@")
 }
 
+func TestURLStringWithoutQuery(t *testing.T) {
+	u, err := NewURL("dubbo://127.0.0.1:20000/com.test.Service")
+	require.NoError(t, err)
+	assert.Equal(t, "dubbo://127.0.0.1:20000/com.test.Service", u.String())
+}
+
 func TestGetParamAndDecodedError(t *testing.T) {
 	u := &URL{}
 	params := url.Values{}


### PR DESCRIPTION
## Summary
- `URL.String()` no longer appends a bare `?` when the URL has no parameters.
- Added `TestURLStringWithoutQuery` regression test.

Fixes #3327.

## Test plan
- [x] `go test ./common/... -run TestURLString`