### PR TITLE
fix(registry): make base configurators thread-safe

### DIFF
--- a/registry/base_configuration_listener.go
+++ b/registry/base_configuration_listener.go
@@ -18,6 +18,10 @@
 package registry
 
 import (
+	"sync"
+)
+
+import (
 	"github.com/dubbogo/gost/log/logger"
 
 	perrors "github.com/pkg/errors"
@@ -33,6 +37,7 @@ import (
 
 // BaseConfigurationListener provides shared logic for processing configuration center updates.
 type BaseConfigurationListener struct {
+	lock                    sync.RWMutex
 	configurators           []config_center.Configurator
 	dynamicConfiguration    config_center.DynamicConfiguration
 	defaultConfiguratorFunc func(url *common.URL) config_center.Configurator
@@ -40,25 +45,29 @@ type BaseConfigurationListener struct {
 
 // Configurators gets Configurator from config center
 func (bcl *BaseConfigurationListener) Configurators() []config_center.Configurator {
-	return bcl.configurators
+	return bcl.snapshotConfigurators()
 }
 
 // InitWith will init BaseConfigurationListener by @key+@Listener+@f
 func (bcl *BaseConfigurationListener) InitWith(key string, listener config_center.ConfigurationListener,
 	f func(url *common.URL) config_center.Configurator) {
 
+	bcl.lock.Lock()
 	bcl.dynamicConfiguration = config.GetEnvInstance().GetDynamicConfiguration()
 	if bcl.dynamicConfiguration == nil {
 		//set configurators to empty
 		bcl.configurators = []config_center.Configurator{}
+		bcl.lock.Unlock()
 		return
 	}
 	bcl.defaultConfiguratorFunc = f
-	bcl.dynamicConfiguration.AddListener(key, listener)
-	if rawConfig, err := bcl.dynamicConfiguration.GetRule(key,
+	dynamicConfiguration := bcl.dynamicConfiguration
+	bcl.lock.Unlock()
+	dynamicConfiguration.AddListener(key, listener)
+	if rawConfig, err := dynamicConfiguration.GetRule(key,
 		config_center.WithGroup(constant.Dubbo)); err != nil {
 		//set configurators to empty
-		bcl.configurators = []config_center.Configurator{}
+		bcl.setConfigurators([]config_center.Configurator{})
 		return
 	} else if len(rawConfig) > 0 {
 		if err := bcl.genConfiguratorFromRawRule(rawConfig); err != nil {
@@ -71,7 +80,7 @@ func (bcl *BaseConfigurationListener) InitWith(key string, listener config_cente
 func (bcl *BaseConfigurationListener) Process(event *config_center.ConfigChangeEvent) {
 	logger.Infof("Notification of overriding rule, change type is: %v , raw config content is:%v", event.ConfigType, event.Value)
 	if event.ConfigType == remoting.EventTypeDel {
-		bcl.configurators = nil
+		bcl.setConfigurators(nil)
 	} else {
 		if err := bcl.genConfiguratorFromRawRule(event.Value.(string)); err != nil {
 			logger.Error(perrors.WithStack(err))
@@ -80,20 +89,42 @@ func (bcl *BaseConfigurationListener) Process(event *config_center.ConfigChangeE
 }
 
 func (bcl *BaseConfigurationListener) genConfiguratorFromRawRule(rawConfig string) error {
-	urls, err := bcl.dynamicConfiguration.Parser().ParseToUrls(rawConfig)
+	bcl.lock.RLock()
+	dynamicConfiguration := bcl.dynamicConfiguration
+	defaultConfiguratorFunc := bcl.defaultConfiguratorFunc
+	bcl.lock.RUnlock()
+
+	urls, err := dynamicConfiguration.Parser().ParseToUrls(rawConfig)
 	if err != nil {
 		return perrors.WithMessage(err, "Failed to parse raw dynamic config and it will not take effect, the raw config is: "+
 			rawConfig)
 	}
-	bcl.configurators = ToConfigurators(urls, bcl.defaultConfiguratorFunc)
+	bcl.setConfigurators(ToConfigurators(urls, defaultConfiguratorFunc))
 	return nil
 }
 
 // OverrideUrl gets existing configuration rule and overrides provider url before exporting.
 func (bcl *BaseConfigurationListener) OverrideUrl(url *common.URL) {
-	for _, v := range bcl.configurators {
+	for _, v := range bcl.Configurators() {
 		v.Configure(url)
 	}
+}
+
+func (bcl *BaseConfigurationListener) setConfigurators(configurators []config_center.Configurator) {
+	bcl.lock.Lock()
+	defer bcl.lock.Unlock()
+	bcl.configurators = configurators
+}
+
+func (bcl *BaseConfigurationListener) snapshotConfigurators() []config_center.Configurator {
+	bcl.lock.RLock()
+	defer bcl.lock.RUnlock()
+	if bcl.configurators == nil {
+		return nil
+	}
+	configurators := make([]config_center.Configurator, len(bcl.configurators))
+	copy(configurators, bcl.configurators)
+	return configurators
 }
 
 // ToConfigurators converts @urls by @f to config_center.Configurators

--- a/registry/base_configuration_listener_test.go
+++ b/registry/base_configuration_listener_test.go
@@ -19,6 +19,7 @@ package registry
 
 import (
 	"net/url"
+	"sync"
 	"testing"
 )
 
@@ -30,6 +31,8 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/config_center"
+	"dubbo.apache.org/dubbo-go/v3/config_center/parser"
+	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
 
 type testConfigurator struct {
@@ -44,6 +47,16 @@ func (c *testConfigurator) GetUrl() *common.URL {
 func (c *testConfigurator) Configure(_ *common.URL) {
 	c.configured = true
 }
+
+type noopTestConfigurator struct {
+	url *common.URL
+}
+
+func (c *noopTestConfigurator) GetUrl() *common.URL {
+	return c.url
+}
+
+func (*noopTestConfigurator) Configure(*common.URL) {}
 
 func TestToConfigurators(t *testing.T) {
 	makeConfigurator := func(u *common.URL) config_center.Configurator {
@@ -76,4 +89,74 @@ func TestBaseConfigurationListenerOverrideUrl(t *testing.T) {
 
 	bcl.OverrideUrl(target)
 	assert.True(t, cfg.configured)
+}
+
+func TestBaseConfigurationListenerConfiguratorsSnapshot(t *testing.T) {
+	cfg := &testConfigurator{}
+	bcl := &BaseConfigurationListener{configurators: []config_center.Configurator{cfg}}
+
+	configurators := bcl.Configurators()
+	configurators[0] = &testConfigurator{}
+
+	assert.Equal(t, cfg, bcl.Configurators()[0])
+}
+
+func TestBaseConfigurationListenerConfiguratorsConcurrentAccess(t *testing.T) {
+	t.Run("should keep configurator snapshots safe if config updates concurrently", func(t *testing.T) {
+		dynamicConfiguration := &config_center.MockDynamicConfiguration{}
+		dynamicConfiguration.SetParser(&parser.DefaultConfigurationParser{})
+		bcl := &BaseConfigurationListener{
+			dynamicConfiguration: dynamicConfiguration,
+			defaultConfiguratorFunc: func(u *common.URL) config_center.Configurator {
+				return &noopTestConfigurator{url: u}
+			},
+		}
+		rawConfig := `configVersion: 2.7.1
+scope: notApplication
+key: groupA/test:1
+enabled: true
+configs:
+- type: application
+  enabled: true
+  addresses:
+  - 0.0.0.0
+  providerAddresses: []
+  services:
+  - org.apache.dubbo-go.mockService
+  applications: []
+  parameters:
+    cluster: mock1
+  side: provider`
+		target := common.NewURLWithOptions()
+
+		assert.NoError(t, bcl.genConfiguratorFromRawRule(rawConfig))
+		assert.Len(t, bcl.Configurators(), 1)
+
+		var wg sync.WaitGroup
+		for i := 0; i < 100; i++ {
+			wg.Add(4)
+			go func() {
+				defer wg.Done()
+				bcl.Process(&config_center.ConfigChangeEvent{
+					ConfigType: remoting.EventTypeUpdate,
+					Value:      rawConfig,
+				})
+			}()
+			go func() {
+				defer wg.Done()
+				bcl.Process(&config_center.ConfigChangeEvent{
+					ConfigType: remoting.EventTypeDel,
+				})
+			}()
+			go func() {
+				defer wg.Done()
+				_ = bcl.Configurators()
+			}()
+			go func() {
+				defer wg.Done()
+				bcl.OverrideUrl(target)
+			}()
+		}
+		wg.Wait()
+	})
 }

--- a/registry/base_configuration_listener_test.go
+++ b/registry/base_configuration_listener_test.go
@@ -18,23 +18,44 @@
 package registry
 
 import (
+	"errors"
 	"net/url"
 	"sync"
 	"testing"
 )
 
 import (
+	gxset "github.com/dubbogo/gost/container/set"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
+	commonConfig "dubbo.apache.org/dubbo-go/v3/common/config"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/config_center"
 	"dubbo.apache.org/dubbo-go/v3/config_center/parser"
 	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
+
+const testRawConfiguratorConfig = `configVersion: 2.7.1
+scope: notApplication
+key: groupA/test:1
+enabled: true
+configs:
+- type: application
+  enabled: true
+  addresses:
+  - 0.0.0.0
+  providerAddresses: []
+  services:
+  - org.apache.dubbo-go.mockService
+  applications: []
+  parameters:
+    cluster: mock1
+  side: provider`
 
 type testConfigurator struct {
 	url        *common.URL
@@ -58,6 +79,50 @@ func (c *noopTestConfigurator) GetUrl() *common.URL {
 }
 
 func (*noopTestConfigurator) Configure(*common.URL) {}
+
+type testDynamicConfiguration struct {
+	parser parser.ConfigurationParser
+	raw    string
+	err    error
+}
+
+func (c *testDynamicConfiguration) Parser() parser.ConfigurationParser {
+	return c.parser
+}
+
+func (c *testDynamicConfiguration) SetParser(p parser.ConfigurationParser) {
+	c.parser = p
+}
+
+func (c *testDynamicConfiguration) AddListener(string, config_center.ConfigurationListener, ...config_center.Option) {
+}
+
+func (c *testDynamicConfiguration) RemoveListener(string, config_center.ConfigurationListener, ...config_center.Option) {
+}
+
+func (c *testDynamicConfiguration) GetProperties(string, ...config_center.Option) (string, error) {
+	return c.raw, c.err
+}
+
+func (c *testDynamicConfiguration) GetRule(string, ...config_center.Option) (string, error) {
+	return c.raw, c.err
+}
+
+func (c *testDynamicConfiguration) GetInternalProperty(string, ...config_center.Option) (string, error) {
+	return c.raw, c.err
+}
+
+func (*testDynamicConfiguration) PublishConfig(string, string, string) error {
+	return nil
+}
+
+func (*testDynamicConfiguration) RemoveConfig(string, string) error {
+	return nil
+}
+
+func (*testDynamicConfiguration) GetConfigKeysByGroup(string) (*gxset.HashSet, error) {
+	return gxset.NewSet(), nil
+}
 
 func TestToConfigurators(t *testing.T) {
 	makeConfigurator := func(u *common.URL) config_center.Configurator {
@@ -102,35 +167,69 @@ func TestBaseConfigurationListenerConfiguratorsSnapshot(t *testing.T) {
 	assert.Equal(t, cfg, bcl.Configurators()[0])
 }
 
+func TestBaseConfigurationListenerInitWith(t *testing.T) {
+	t.Run("should clear configurators if dynamic configuration is missing", func(t *testing.T) {
+		resetDynamicConfiguration(t, nil)
+		cfg := &testConfigurator{}
+		bcl := &BaseConfigurationListener{configurators: []config_center.Configurator{cfg}}
+
+		bcl.InitWith("key", bcl, newNoopConfigurator)
+
+		assert.Empty(t, bcl.Configurators())
+	})
+
+	t.Run("should clear configurators if initial rule lookup fails", func(t *testing.T) {
+		resetDynamicConfiguration(t, &testDynamicConfiguration{err: errors.New("rule lookup failed")})
+		cfg := &testConfigurator{}
+		bcl := &BaseConfigurationListener{configurators: []config_center.Configurator{cfg}}
+
+		bcl.InitWith("key", bcl, newNoopConfigurator)
+
+		assert.Empty(t, bcl.Configurators())
+	})
+
+	t.Run("should initialize configurators if initial rule exists", func(t *testing.T) {
+		resetDynamicConfiguration(t, &testDynamicConfiguration{
+			parser: &parser.DefaultConfigurationParser{},
+			raw:    testRawConfiguratorConfig,
+		})
+		bcl := &BaseConfigurationListener{}
+
+		bcl.InitWith("key", bcl, newNoopConfigurator)
+
+		assert.Len(t, bcl.Configurators(), 1)
+	})
+}
+
+func TestBaseConfigurationListenerProcessInvalidConfig(t *testing.T) {
+	t.Run("should keep configurators unchanged if update config cannot be parsed", func(t *testing.T) {
+		cfg := &testConfigurator{}
+		bcl := &BaseConfigurationListener{
+			configurators:           []config_center.Configurator{cfg},
+			dynamicConfiguration:    &testDynamicConfiguration{parser: &parser.DefaultConfigurationParser{}},
+			defaultConfiguratorFunc: newNoopConfigurator,
+		}
+
+		bcl.Process(&config_center.ConfigChangeEvent{
+			ConfigType: remoting.EventTypeUpdate,
+			Value:      "invalid: [",
+		})
+
+		assert.Equal(t, cfg, bcl.Configurators()[0])
+	})
+}
+
 func TestBaseConfigurationListenerConfiguratorsConcurrentAccess(t *testing.T) {
 	t.Run("should keep configurator snapshots safe if config updates concurrently", func(t *testing.T) {
 		dynamicConfiguration := &config_center.MockDynamicConfiguration{}
 		dynamicConfiguration.SetParser(&parser.DefaultConfigurationParser{})
 		bcl := &BaseConfigurationListener{
-			dynamicConfiguration: dynamicConfiguration,
-			defaultConfiguratorFunc: func(u *common.URL) config_center.Configurator {
-				return &noopTestConfigurator{url: u}
-			},
+			dynamicConfiguration:    dynamicConfiguration,
+			defaultConfiguratorFunc: newNoopConfigurator,
 		}
-		rawConfig := `configVersion: 2.7.1
-scope: notApplication
-key: groupA/test:1
-enabled: true
-configs:
-- type: application
-  enabled: true
-  addresses:
-  - 0.0.0.0
-  providerAddresses: []
-  services:
-  - org.apache.dubbo-go.mockService
-  applications: []
-  parameters:
-    cluster: mock1
-  side: provider`
 		target := common.NewURLWithOptions()
 
-		require.NoError(t, bcl.genConfiguratorFromRawRule(rawConfig))
+		require.NoError(t, bcl.genConfiguratorFromRawRule(testRawConfiguratorConfig))
 		assert.Len(t, bcl.Configurators(), 1)
 
 		var wg sync.WaitGroup
@@ -140,7 +239,7 @@ configs:
 				defer wg.Done()
 				bcl.Process(&config_center.ConfigChangeEvent{
 					ConfigType: remoting.EventTypeUpdate,
-					Value:      rawConfig,
+					Value:      testRawConfiguratorConfig,
 				})
 			}()
 			go func() {
@@ -159,5 +258,19 @@ configs:
 			}()
 		}
 		wg.Wait()
+	})
+}
+
+func newNoopConfigurator(u *common.URL) config_center.Configurator {
+	return &noopTestConfigurator{url: u}
+}
+
+func resetDynamicConfiguration(t *testing.T, dc config_center.DynamicConfiguration) {
+	t.Helper()
+	env := commonConfig.GetEnvInstance()
+	previous := env.GetDynamicConfiguration()
+	env.SetDynamicConfiguration(dc)
+	t.Cleanup(func() {
+		env.SetDynamicConfiguration(previous)
 	})
 }

--- a/registry/base_configuration_listener_test.go
+++ b/registry/base_configuration_listener_test.go
@@ -25,6 +25,7 @@ import (
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 import (
@@ -129,7 +130,7 @@ configs:
   side: provider`
 		target := common.NewURLWithOptions()
 
-		assert.NoError(t, bcl.genConfiguratorFromRawRule(rawConfig))
+		require.NoError(t, bcl.genConfiguratorFromRawRule(rawConfig))
 		assert.Len(t, bcl.Configurators(), 1)
 
 		var wg sync.WaitGroup

--- a/registry/base_configuration_listener_test.go
+++ b/registry/base_configuration_listener_test.go
@@ -199,6 +199,18 @@ func TestBaseConfigurationListenerInitWith(t *testing.T) {
 
 		assert.Len(t, bcl.Configurators(), 1)
 	})
+
+	t.Run("should ignore initial rule if it cannot be parsed", func(t *testing.T) {
+		resetDynamicConfiguration(t, &testDynamicConfiguration{
+			parser: &parser.DefaultConfigurationParser{},
+			raw:    "invalid: [",
+		})
+		bcl := &BaseConfigurationListener{}
+
+		bcl.InitWith("key", bcl, newNoopConfigurator)
+
+		assert.Nil(t, bcl.Configurators())
+	})
 }
 
 func TestBaseConfigurationListenerProcessInvalidConfig(t *testing.T) {


### PR DESCRIPTION
## What changed

- Guard BaseConfigurationListener state with an RWMutex.
- Return copied configurator snapshots from Configurators.
- Make OverrideUrl iterate a snapshot instead of the live slice.
- Add tests for snapshot isolation and concurrent Process / Configurators / OverrideUrl access.

## Why

Config center callbacks can replace BaseConfigurationListener.configurators while provider or consumer override paths read or iterate it. That leaves the shared slice exposed to data races during dynamic config updates.

Fixes #3332

## Tests

- go test ./registry -run 'TestBaseConfigurationListener'
- go test -race ./registry -run 'TestBaseConfigurationListener'
- go test ./registry
- go test -race ./registry
- go test ./...