### PR TITLE
Refactor/config center filter logger

### DIFF
--- a/config_center/apollo/impl.go
+++ b/config_center/apollo/impl.go
@@ -71,7 +71,7 @@ func newApolloConfiguration(url *common.URL) (*apolloConfiguration, error) {
 		IsBackupConfig:   url.GetParamBool(constant.ConfigBackupConfigKey, true),
 		BackupConfigPath: url.GetParam(constant.ConfigBackupConfigPathKey, ""),
 	}
-	logger.Infof("[ConfigCenter][Apollo] New Apollo ConfigCenter with Configuration, appConf=%v url=%v", c.appConf, c.url)
+	logger.Infof("[ConfigCenter][Apollo] new Apollo ConfigCenter with Configuration, appConf=%v url=%v", c.appConf, c.url)
 	client, err := agollo.StartWithConfig(func() (*config.AppConfig, error) {
 		return c.appConf, nil
 	})

--- a/config_center/apollo/impl.go
+++ b/config_center/apollo/impl.go
@@ -71,7 +71,7 @@ func newApolloConfiguration(url *common.URL) (*apolloConfiguration, error) {
 		IsBackupConfig:   url.GetParamBool(constant.ConfigBackupConfigKey, true),
 		BackupConfigPath: url.GetParam(constant.ConfigBackupConfigPathKey, ""),
 	}
-	logger.Infof("[Apollo ConfigCenter] New Apollo ConfigCenter with Configuration: %+v, url = %+v", c.appConf, c.url)
+	logger.Infof("[ConfigCenter][Apollo] New Apollo ConfigCenter with Configuration, appConf=%v url=%v", c.appConf, c.url)
 	client, err := agollo.StartWithConfig(func() (*config.AppConfig, error) {
 		return c.appConf, nil
 	})

--- a/config_center/apollo/listener.go
+++ b/config_center/apollo/listener.go
@@ -49,8 +49,7 @@ func (a *apolloListener) OnChange(changeEvent *storage.ChangeEvent) {
 func (a *apolloListener) OnNewestChange(changeEvent *storage.FullChangeEvent) {
 	b, err := yaml.Marshal(changeEvent.Changes)
 	if err != nil {
-		logger.Errorf("apollo onNewestChange err %+v",
-			err)
+		logger.Errorf("[ConfigCenter][Apollo] onNewestChange err=%v", err)
 		return
 	}
 	content := string(b)

--- a/config_center/file/listener.go
+++ b/config_center/file/listener.go
@@ -86,7 +86,7 @@ func NewCacheListener(rootPath string) *CacheListener {
 	// start watcher
 	watch, err := fsnotify.NewWatcher()
 	if err != nil {
-		logger.Errorf("file : listen config fail, error:%v ", err)
+		logger.Errorf("[ConfigCenter][File] listen config fail, err=%v", err)
 	}
 	go func() {
 		for {
@@ -99,7 +99,7 @@ func NewCacheListener(rootPath string) *CacheListener {
 				if key == "" {
 					continue
 				}
-				logger.Debugf("watcher %s, event %v", cl.rootPath, event)
+				logger.Debugf("[ConfigCenter][File] watcher event, rootPath=%s event=%v", cl.rootPath, event)
 				if event.Op&fsnotify.Remove == fsnotify.Remove {
 					cl.contentCache.Delete(key)
 					if l, ok := cl.keyListeners.Load(key); ok {
@@ -137,7 +137,7 @@ func NewCacheListener(rootPath string) *CacheListener {
 					return
 				}
 				if err != nil {
-					logger.Warnf("file : listen watch fail:%+v", err)
+					logger.Warnf("[ConfigCenter][File] listen watch fail, err=%v", err)
 				}
 			}
 		}
@@ -153,7 +153,7 @@ func NewCacheListener(rootPath string) *CacheListener {
 
 func removeCallback(listeners []config_center.ConfigurationListener, key string, event remoting.EventType) {
 	if len(listeners) == 0 {
-		logger.Warnf("file watch callback but configuration listener is empty, key:%s, event:%v", key, event)
+		logger.Warnf("[ConfigCenter][File] file watch callback but configuration listener is empty, key=%s event=%v", key, event)
 		return
 	}
 	for _, l := range listeners {
@@ -163,7 +163,7 @@ func removeCallback(listeners []config_center.ConfigurationListener, key string,
 
 func dataChangeCallback(listeners []config_center.ConfigurationListener, key, content string, event remoting.EventType) {
 	if len(listeners) == 0 {
-		logger.Warnf("file watch callback but configuration listener is empty, key:%s, event:%v", key, event)
+		logger.Warnf("[ConfigCenter][File] file watch callback but configuration listener is empty, key=%s event=%v", key, event)
 		return
 	}
 	for _, l := range listeners {
@@ -195,7 +195,7 @@ func (cl *CacheListener) AddListener(key string, listener config_center.Configur
 		return
 	}
 	if err := cl.watch.Add(key); err != nil {
-		logger.Errorf("watcher add path:%s err:%v", key, err)
+		logger.Errorf("[ConfigCenter][File] watcher add path, path=%s err=%v", key, err)
 	}
 }
 
@@ -209,7 +209,7 @@ func (cl *CacheListener) RemoveListener(key string, listener config_center.Confi
 		cl.keyListeners.Delete(key)
 		cl.contentCache.Delete(key)
 		if err := cl.watch.Remove(key); err != nil {
-			logger.Errorf("watcher remove path:%s err:%v", key, err)
+			logger.Errorf("[ConfigCenter][File] watcher remove path, path=%s err=%v", key, err)
 		}
 	}
 }
@@ -217,7 +217,7 @@ func (cl *CacheListener) RemoveListener(key string, listener config_center.Confi
 func getFileContent(path string) string {
 	c, err := os.ReadFile(path)
 	if err != nil {
-		logger.Errorf("read file path:%s err:%v", path, err)
+		logger.Errorf("[ConfigCenter][File] read file, path=%s err=%v", path, err)
 		return ""
 	}
 

--- a/config_center/nacos/client.go
+++ b/config_center/nacos/client.go
@@ -66,7 +66,7 @@ func ValidateNacosClient(container nacosClientFacade) error {
 		// in dubbo ,every registry only connect one node ,so this is []string{r.Address}
 		newClient, err := nacos.NewNacosConfigClientByUrl(url)
 		if err != nil {
-			logger.Errorf("[ConfigCenter][Nacos] ValidateNacosClient nacos address, address=%v err=%v", url.Location, err)
+			logger.Errorf("[ConfigCenter][Nacos] validateNacosClient nacos address, address=%v err=%v", url.Location, err)
 			return perrors.WithMessagef(err, "newNacosClient(address:%+v)", url.Location)
 		}
 		container.SetNacosClient(newClient)

--- a/config_center/nacos/client.go
+++ b/config_center/nacos/client.go
@@ -66,7 +66,7 @@ func ValidateNacosClient(container nacosClientFacade) error {
 		// in dubbo ,every registry only connect one node ,so this is []string{r.Address}
 		newClient, err := nacos.NewNacosConfigClientByUrl(url)
 		if err != nil {
-			logger.Errorf("ValidateNacosClient(nacos address{%v} = error{%v}", url.Location, err)
+			logger.Errorf("[ConfigCenter][Nacos] ValidateNacosClient nacos address, address=%v err=%v", url.Location, err)
 			return perrors.WithMessagef(err, "newNacosClient(address:%+v)", url.Location)
 		}
 		container.SetNacosClient(newClient)

--- a/config_center/nacos/facade.go
+++ b/config_center/nacos/facade.go
@@ -44,7 +44,7 @@ type nacosClientFacade interface {
 func HandleClientRestart(r nacosClientFacade) {
 	defer r.WaitGroup().Done()
 	for range r.GetDone() {
-		logger.Warnf("(NacosProviderRegistry)reconnectNacosRegistry goroutine exit now...")
+		logger.Warn("[ConfigCenter][Nacos] reconnectNacosRegistry goroutine exit now")
 		return
 	}
 }

--- a/config_center/nacos/impl.go
+++ b/config_center/nacos/impl.go
@@ -74,7 +74,7 @@ func newNacosDynamicConfiguration(url *common.URL) (*nacosDynamicConfiguration, 
 		done: make(chan struct{}),
 	}
 	c.GetURL()
-	logger.Infof("[ConfigCenter][Nacos] New Nacos ConfigCenter with Configuration, nacosConfig=%v url=%v", c, c.GetURL())
+	logger.Infof("[ConfigCenter][Nacos] new Nacos ConfigCenter with Configuration, nacosConfig=%v url=%v", c, c.GetURL())
 	err := ValidateNacosClient(c)
 	if err != nil {
 		logger.Errorf("[ConfigCenter][Nacos] nacos configClient start error, err=%v", err)

--- a/config_center/nacos/impl.go
+++ b/config_center/nacos/impl.go
@@ -74,10 +74,10 @@ func newNacosDynamicConfiguration(url *common.URL) (*nacosDynamicConfiguration, 
 		done: make(chan struct{}),
 	}
 	c.GetURL()
-	logger.Infof("[Nacos ConfigCenter] New Nacos ConfigCenter with Configuration: %+v, url = %+v", c, c.GetURL())
+	logger.Infof("[ConfigCenter][Nacos] New Nacos ConfigCenter with Configuration, nacosConfig=%v url=%v", c, c.GetURL())
 	err := ValidateNacosClient(c)
 	if err != nil {
-		logger.Errorf("nacos configClient start error ,error message is %v", err)
+		logger.Errorf("[ConfigCenter][Nacos] nacos configClient start error, err=%v", err)
 		return nil, err
 	}
 	c.wg.Add(1)
@@ -174,12 +174,12 @@ func (n *nacosDynamicConfiguration) GetRule(key string, opts ...config_center.Op
 
 	// Handle "config not exist" gracefully (normal during initialization)
 	if isConfigNotExistErr(err) {
-		logger.Warnf("config not found, key=%s, group=%s, err=%v", key, group, err)
+		logger.Warnf("[ConfigCenter][Nacos] config not found, key=%s group=%s err=%v", key, group, err)
 		return "", nil
 	}
 
 	// Other unexpected errors
-	logger.Errorf("failed to query rule, key=%s, group=%s, err=%+v", key, group, err)
+	logger.Errorf("[ConfigCenter][Nacos] failed to query rule, key=%s group=%s err=%v", key, group, err)
 	return "", perrors.WithStack(err)
 }
 
@@ -255,5 +255,5 @@ func (n *nacosDynamicConfiguration) IsAvailable() bool {
 func (n *nacosDynamicConfiguration) closeConfigs() {
 	// Close the old configClient first to close the tmp node
 	n.client.Close()
-	logger.Infof("begin to close provider n configClient")
+	logger.Infof("[ConfigCenter][Nacos] begin to close provider n configClient")
 }

--- a/config_center/nacos/listener.go
+++ b/config_center/nacos/listener.go
@@ -64,7 +64,7 @@ func (n *nacosDynamicConfiguration) addListener(key string, listener config_cent
 			})
 			if err != nil {
 				n.keyListeners.Delete(key)
-				logger.Errorf("nacos : listen config fail, error:%v ", err)
+				logger.Errorf("[ConfigCenter][Nacos] listen config fail, err=%v", err)
 				return
 			}
 			return
@@ -78,7 +78,7 @@ func (n *nacosDynamicConfiguration) addListener(key string, listener config_cent
 func (n *nacosDynamicConfiguration) removeListener(key string, listener config_center.ConfigurationListener) {
 	rawListenersMap, loaded := n.keyListeners.Load(key)
 	if !loaded {
-		logger.Errorf("nacos : key:%s is not be listened", key)
+		logger.Errorf("[ConfigCenter][Nacos] key is not be listened, key=%s", key)
 	} else {
 		listenersMap := rawListenersMap.(*sync.Map)
 		listenersMap.Delete(listener)

--- a/config_center/parser/configuration_parser.go
+++ b/config_center/parser/configuration_parser.go
@@ -108,7 +108,7 @@ func (c *ConditionMatch) IsMatch(host string, url *common.URL) bool {
 func (parser *DefaultConfigurationParser) Parse(content string) (map[string]string, error) {
 	pps, err := properties.LoadString(content)
 	if err != nil {
-		logger.Errorf("Parse the content {%v} in DefaultConfigurationParser error ,error message is {%v}", content, err)
+		logger.Errorf("[ConfigCenter][Parser] Parse the content in DefaultConfigurationParser error, content=%v err=%v", content, err)
 		return nil, err
 	}
 	return pps.Map(), nil

--- a/config_center/parser/configuration_parser.go
+++ b/config_center/parser/configuration_parser.go
@@ -108,7 +108,7 @@ func (c *ConditionMatch) IsMatch(host string, url *common.URL) bool {
 func (parser *DefaultConfigurationParser) Parse(content string) (map[string]string, error) {
 	pps, err := properties.LoadString(content)
 	if err != nil {
-		logger.Errorf("[ConfigCenter][Parser] Parse the content in DefaultConfigurationParser error, content=%v err=%v", content, err)
+		logger.Errorf("[ConfigCenter][Parser] parse the content in DefaultConfigurationParser error, content=%v err=%v", content, err)
 		return nil, err
 	}
 	return pps.Map(), nil

--- a/config_center/zookeeper/impl.go
+++ b/config_center/zookeeper/impl.go
@@ -71,7 +71,7 @@ func newZookeeperDynamicConfiguration(url *common.URL) (*zookeeperDynamicConfigu
 		url:      url,
 		rootPath: rootPath,
 	}
-	logger.Infof("[Zookeeper ConfigCenter] New Zookeeper ConfigCenter with Configuration: %+v, url = %+v", c, c.GetURL())
+	logger.Infof("[ConfigCenter][Zookeeper] New Zookeeper ConfigCenter with Configuration, zkConfig=%v url=%v", c, c.GetURL())
 	if v := url.GetParam("base64", ""); v != "" {
 		base64Enabled, err := strconv.ParseBool(v)
 		if err != nil {
@@ -82,7 +82,7 @@ func newZookeeperDynamicConfiguration(url *common.URL) (*zookeeperDynamicConfigu
 
 	err := zookeeper.ValidateZookeeperClient(c, url.Location)
 	if err != nil {
-		logger.Errorf("zookeeper client start error ,error message is %v", err)
+		logger.Errorf("[ConfigCenter][Zookeeper] zookeeper client start error, err=%v", err)
 		return nil, err
 	}
 	err = c.client.Create(c.rootPath)
@@ -136,7 +136,7 @@ func (c *zookeeperDynamicConfiguration) GetProperties(key string, opts ...config
 	}
 	content, _, err := c.client.GetContent(c.rootPath + "/" + key)
 	if errors.Is(err, zk.ErrNoNode) {
-		logger.Warnf("query rule fail, key=%s, err=%v", key, err)
+		logger.Warnf("[ConfigCenter][Zookeeper] query rule fail, key=%s err=%v", key, err)
 		return "", nil
 	}
 	if err != nil {
@@ -266,7 +266,7 @@ func (c *zookeeperDynamicConfiguration) IsAvailable() bool {
 }
 
 func (c *zookeeperDynamicConfiguration) closeConfigs() {
-	logger.Infof("begin to close provider zk client")
+	logger.Info("[ConfigCenter][Zookeeper] begin to close provider zk client")
 	c.cltLock.Lock()
 	defer c.cltLock.Unlock()
 	c.client.Close()

--- a/config_center/zookeeper/impl.go
+++ b/config_center/zookeeper/impl.go
@@ -71,7 +71,7 @@ func newZookeeperDynamicConfiguration(url *common.URL) (*zookeeperDynamicConfigu
 		url:      url,
 		rootPath: rootPath,
 	}
-	logger.Infof("[ConfigCenter][Zookeeper] New Zookeeper ConfigCenter with Configuration, zkConfig=%v url=%v", c, c.GetURL())
+	logger.Infof("[ConfigCenter][Zookeeper] new Zookeeper ConfigCenter with Configuration, zkConfig=%v url=%v", c, c.GetURL())
 	if v := url.GetParam("base64", ""); v != "" {
 		base64Enabled, err := strconv.ParseBool(v)
 		if err != nil {

--- a/filter/accesslog/filter.go
+++ b/filter/accesslog/filter.go
@@ -127,7 +127,7 @@ func (f *Filter) logIntoChannel(accessLogData Data) {
 	case f.logChan <- accessLogData:
 		return
 	default:
-		logger.Warn("[Filter][AccessLog] The channel is full and the access logIntoChannel data will be dropped")
+		logger.Warn("[Filter][AccessLog] the channel is full and the access logIntoChannel data will be dropped")
 		return
 	}
 }
@@ -193,7 +193,7 @@ func (f *Filter) OnResponse(_ context.Context, result result.Result, _ base.Invo
 func (f *Filter) processLogs() {
 	defer func() {
 		if r := recover(); r != nil {
-			logger.Errorf("[Filter][AccessLog] AccessLog processLogs panic, err=%v", r)
+			logger.Errorf("[Filter][AccessLog] accessLog processLogs panic, err=%v", r)
 		}
 		f.drainLogs()
 	}()
@@ -222,7 +222,7 @@ func (f *Filter) drainLogs() {
 			}
 			f.writeLogToFileWithTimeout(accessLogData, 1*time.Second)
 		case <-timeout:
-			logger.Warn("[Filter][AccessLog] AccessLog drain timeout, some logs may be lost")
+			logger.Warn("[Filter][AccessLog] accessLog drain timeout, some logs may be lost")
 			return
 		default:
 			return
@@ -240,9 +240,9 @@ func (f *Filter) writeLogToFileWithTimeout(data Data, timeout time.Duration) {
 
 	select {
 	case <-done:
-		logger.Debugf("[Filter][AccessLog] AccessLog successfully written for, accessLog=%s", data.accessLog)
+		logger.Debugf("[Filter][AccessLog] accessLog successfully written for, accessLog=%s", data.accessLog)
 	case <-time.After(timeout):
-		logger.Warnf("[Filter][AccessLog] AccessLog writeLogToFile timeout, accessLog=%s", data.accessLog)
+		logger.Warnf("[Filter][AccessLog] accessLog writeLogToFile timeout, accessLog=%s", data.accessLog)
 	}
 }
 
@@ -256,15 +256,15 @@ func (f *Filter) writeLogToFile(data Data) {
 
 	logFile, err := f.getOrOpenLogFile(accessLog)
 	if err != nil {
-		logger.Warnf("Can not open the access log file: %s, %v", accessLog, err)
+		logger.Warnf("[Filter][AccessLog] can not open the access log file: %s, %v", accessLog, err)
 		return
 	}
-	logger.Debugf("[Filter][AccessLog] Append log to %s", accessLog)
+	logger.Debugf("[Filter][AccessLog] append log to %s", accessLog)
 	message := data.toLogMessage()
 	message = message + "\n"
 	_, err = logFile.WriteString(message)
 	if err != nil {
-		logger.Warnf("[Filter][AccessLog] Can not write the log into access log file, accessLog=%s err=%v", accessLog, err)
+		logger.Warnf("[Filter][AccessLog] can not write the log into access log file, accessLog=%s err=%v", accessLog, err)
 	}
 }
 
@@ -301,7 +301,7 @@ func (f *Filter) getOrOpenLogFile(accessLog string) (*os.File, error) {
 		}
 		// Close the old file before rotation
 		if err := logFile.Close(); err != nil {
-			logger.Warnf("[Filter][AccessLog] Failed to close old log file, accessLog=%s err=%v", accessLog, err)
+			logger.Warnf("[Filter][AccessLog] failed to close old log file, accessLog=%s err=%v", accessLog, err)
 		}
 		delete(f.fileCache, accessLog)
 	}
@@ -321,13 +321,13 @@ func (f *Filter) getOrOpenLogFile(accessLog string) (*os.File, error) {
 func (f *Filter) openLogFile(accessLog string) (*os.File, error) {
 	logFile, err := os.OpenFile(accessLog, os.O_CREATE|os.O_APPEND|os.O_RDWR, LogFileMode)
 	if err != nil {
-		logger.Warnf("[Filter][AccessLog] Can not open the access log file, accessLog=%s err=%v", accessLog, err)
+		logger.Warnf("[Filter][AccessLog] can not open the access log file, accessLog=%s err=%v", accessLog, err)
 		return nil, err
 	}
 	now := time.Now().Format(FileDateFormat)
 	fileInfo, err := logFile.Stat()
 	if err != nil {
-		logger.Warnf("[Filter][AccessLog] Can not get the info of access log file, accessLog=%s err=%v", accessLog, err)
+		logger.Warnf("[Filter][AccessLog] can not get the info of access log file, accessLog=%s err=%v", accessLog, err)
 		return nil, err
 	}
 	last := fileInfo.ModTime().Format(FileDateFormat)
@@ -341,7 +341,7 @@ func (f *Filter) openLogFile(accessLog string) (*os.File, error) {
 	if now != last {
 		err = os.Rename(accessLog, accessLog+"."+now)
 		if err != nil {
-			logger.Warnf("[Filter][AccessLog] Can not rename access log file, accessLog=%s err=%v", accessLog, err)
+			logger.Warnf("[Filter][AccessLog] can not rename access log file, accessLog=%s err=%v", accessLog, err)
 			return nil, err
 		}
 		logFile, err = os.OpenFile(accessLog, os.O_CREATE|os.O_APPEND|os.O_RDWR, LogFileMode)
@@ -422,7 +422,7 @@ func (f *Filter) shutdown() {
 		defer f.fileLock.Unlock()
 		for path, file := range f.fileCache {
 			if err := file.Close(); err != nil {
-				logger.Warnf("[Filter][AccessLog] Error closing access log file, path=%s err=%v", path, err)
+				logger.Warnf("[Filter][AccessLog] error closing access log file, path=%s err=%v", path, err)
 			}
 			delete(f.fileCache, path)
 		}

--- a/filter/accesslog/filter.go
+++ b/filter/accesslog/filter.go
@@ -127,7 +127,7 @@ func (f *Filter) logIntoChannel(accessLogData Data) {
 	case f.logChan <- accessLogData:
 		return
 	default:
-		logger.Warn("The channel is full and the access logIntoChannel data will be dropped")
+		logger.Warn("[Filter][AccessLog] The channel is full and the access logIntoChannel data will be dropped")
 		return
 	}
 }
@@ -193,7 +193,7 @@ func (f *Filter) OnResponse(_ context.Context, result result.Result, _ base.Invo
 func (f *Filter) processLogs() {
 	defer func() {
 		if r := recover(); r != nil {
-			logger.Errorf("AccessLog processLogs panic: %v", r)
+			logger.Errorf("[Filter][AccessLog] AccessLog processLogs panic, err=%v", r)
 		}
 		f.drainLogs()
 	}()
@@ -222,7 +222,7 @@ func (f *Filter) drainLogs() {
 			}
 			f.writeLogToFileWithTimeout(accessLogData, 1*time.Second)
 		case <-timeout:
-			logger.Warnf("AccessLog drain timeout, some logs may be lost")
+			logger.Warn("[Filter][AccessLog] AccessLog drain timeout, some logs may be lost")
 			return
 		default:
 			return
@@ -240,9 +240,9 @@ func (f *Filter) writeLogToFileWithTimeout(data Data, timeout time.Duration) {
 
 	select {
 	case <-done:
-		logger.Debugf("AccessLog successfully written for: %s", data.accessLog)
+		logger.Debugf("[Filter][AccessLog] AccessLog successfully written for, accessLog=%s", data.accessLog)
 	case <-time.After(timeout):
-		logger.Warnf("AccessLog writeLogToFile timeout for: %s", data.accessLog)
+		logger.Warnf("[Filter][AccessLog] AccessLog writeLogToFile timeout, accessLog=%s", data.accessLog)
 	}
 }
 
@@ -250,7 +250,7 @@ func (f *Filter) writeLogToFileWithTimeout(data Data, timeout time.Duration) {
 func (f *Filter) writeLogToFile(data Data) {
 	accessLog := data.accessLog
 	if isDefault(accessLog) {
-		logger.Info(data.toLogMessage())
+		logger.Infof("[Filter][AccessLog] %s", data.toLogMessage())
 		return
 	}
 
@@ -259,12 +259,12 @@ func (f *Filter) writeLogToFile(data Data) {
 		logger.Warnf("Can not open the access log file: %s, %v", accessLog, err)
 		return
 	}
-	logger.Debugf("Append log to %s", accessLog)
+	logger.Debugf("[Filter][AccessLog] Append log to %s", accessLog)
 	message := data.toLogMessage()
 	message = message + "\n"
 	_, err = logFile.WriteString(message)
 	if err != nil {
-		logger.Warnf("Can not write the log into access log file: %s, %v", accessLog, err)
+		logger.Warnf("[Filter][AccessLog] Can not write the log into access log file, accessLog=%s err=%v", accessLog, err)
 	}
 }
 
@@ -301,7 +301,7 @@ func (f *Filter) getOrOpenLogFile(accessLog string) (*os.File, error) {
 		}
 		// Close the old file before rotation
 		if err := logFile.Close(); err != nil {
-			logger.Warnf("Failed to close old log file %s: %v", accessLog, err)
+			logger.Warnf("[Filter][AccessLog] Failed to close old log file, accessLog=%s err=%v", accessLog, err)
 		}
 		delete(f.fileCache, accessLog)
 	}
@@ -321,13 +321,13 @@ func (f *Filter) getOrOpenLogFile(accessLog string) (*os.File, error) {
 func (f *Filter) openLogFile(accessLog string) (*os.File, error) {
 	logFile, err := os.OpenFile(accessLog, os.O_CREATE|os.O_APPEND|os.O_RDWR, LogFileMode)
 	if err != nil {
-		logger.Warnf("Can not open the access log file: %s, %v", accessLog, err)
+		logger.Warnf("[Filter][AccessLog] Can not open the access log file, accessLog=%s err=%v", accessLog, err)
 		return nil, err
 	}
 	now := time.Now().Format(FileDateFormat)
 	fileInfo, err := logFile.Stat()
 	if err != nil {
-		logger.Warnf("Can not get the info of access log file: %s, %v", accessLog, err)
+		logger.Warnf("[Filter][AccessLog] Can not get the info of access log file, accessLog=%s err=%v", accessLog, err)
 		return nil, err
 	}
 	last := fileInfo.ModTime().Format(FileDateFormat)
@@ -341,7 +341,7 @@ func (f *Filter) openLogFile(accessLog string) (*os.File, error) {
 	if now != last {
 		err = os.Rename(accessLog, accessLog+"."+now)
 		if err != nil {
-			logger.Warnf("Can not rename access log file: %s, %v", accessLog, err)
+			logger.Warnf("[Filter][AccessLog] Can not rename access log file, accessLog=%s err=%v", accessLog, err)
 			return nil, err
 		}
 		logFile, err = os.OpenFile(accessLog, os.O_CREATE|os.O_APPEND|os.O_RDWR, LogFileMode)
@@ -422,7 +422,7 @@ func (f *Filter) shutdown() {
 		defer f.fileLock.Unlock()
 		for path, file := range f.fileCache {
 			if err := file.Close(); err != nil {
-				logger.Warnf("Error closing access log file %s: %v", path, err)
+				logger.Warnf("[Filter][AccessLog] Error closing access log file, path=%s err=%v", path, err)
 			}
 			delete(f.fileCache, path)
 		}

--- a/filter/active/filter.go
+++ b/filter/active/filter.go
@@ -91,14 +91,14 @@ func (f *activeFilter) OnResponse(ctx context.Context, result result.Result, inv
 	// If the URL is missing or invalid, it means the Invoke phase was likely interrupted.
 	// Skip EndCount to prevent statistic inconsistency or panics.
 	if !ok || url == nil {
-		logger.Warnf("activeFilter cannot get cached URL from attribute, skip EndCount. Invoker may not have passed Invoke phase.")
+		logger.Warn("[Filter][Active] activeFilter cannot get cached URL from attribute, skip EndCount. Invoker may not have passed Invoke phase.")
 		return result
 	}
 
 	startTime, err := strconv.ParseInt(rpcInv.GetAttachmentWithDefaultValue(dubboInvokeStartTime, "0"), 10, 64)
 	if err != nil {
 		result.SetError(err)
-		logger.Errorf("parse dubbo_invoke_start_time to int64 failed")
+		logger.Error("[Filter][Active] parse dubbo_invoke_start_time to int64 failed")
 		// When err is not nil, use default elapsed value of 1
 		base.EndCount(url, inv.MethodName(), 1, false)
 		return result

--- a/filter/adaptivesvc/filter.go
+++ b/filter/adaptivesvc/filter.go
@@ -122,33 +122,33 @@ func (f *adaptiveServiceProviderFilter) OnResponse(_ context.Context, res result
 	// get updater from the attributes
 	updaterIface, _ := invocation.GetAttribute(constant.AdaptiveServiceUpdaterKey)
 	if updaterIface == nil {
-		logger.Errorf("[adasvc filter] The updater is not found on the attributes: %#v",
+		logger.Errorf("[Filter][AdaptiveSvc] The updater is not found on the attributes, attrs=%#v",
 			invocation.Attributes())
 		return &result.RPCResult{Err: ErrUpdaterNotFound}
 	}
 	updater, ok := updaterIface.(limiter.Updater)
 	if !ok {
-		logger.Errorf("[adasvc filter] The type of the updater is not unexpected, we got %#v", updaterIface)
+		logger.Errorf("[Filter][AdaptiveSvc] The type of the updater is not unexpected, we got %#v", updaterIface)
 		return &result.RPCResult{Err: ErrUnexpectedUpdaterType}
 	}
 
 	err := updater.DoUpdate()
 	if err != nil {
-		logger.Errorf("[adasvc filter] The DoUpdate method was failed, err: %s.", err)
+		logger.Errorf("[Filter][AdaptiveSvc] The DoUpdate method failed, err=%v", err)
 		return &result.RPCResult{Err: err}
 	}
 
 	// get limiter for the mapper
 	l, err := limiterMapperSingleton.getMethodLimiter(invoker.GetURL(), invocation.MethodName())
 	if err != nil {
-		logger.Errorf("[adasvc filter] The method limiter for \"%s\" is not found.", invocation.MethodName())
+		logger.Errorf("[Filter][AdaptiveSvc] The method limiter for %q is not found.", invocation.MethodName())
 		return &result.RPCResult{Err: err}
 	}
 
 	// set attachments to inform consumer of provider status
 	res.AddAttachment(constant.AdaptiveServiceRemainingKey, fmt.Sprintf("%d", l.Remaining()))
 	res.AddAttachment(constant.AdaptiveServiceInflightKey, fmt.Sprintf("%d", l.Inflight()))
-	logger.Debugf("[adasvc filter] The attachments are set, %s: %d, %s: %d.",
+	logger.Debugf("[Filter][AdaptiveSvc] The attachments are set, %s=%d %s=%d.",
 		constant.AdaptiveServiceRemainingKey, l.Remaining(),
 		constant.AdaptiveServiceInflightKey, l.Inflight())
 

--- a/filter/adaptivesvc/filter.go
+++ b/filter/adaptivesvc/filter.go
@@ -122,33 +122,33 @@ func (f *adaptiveServiceProviderFilter) OnResponse(_ context.Context, res result
 	// get updater from the attributes
 	updaterIface, _ := invocation.GetAttribute(constant.AdaptiveServiceUpdaterKey)
 	if updaterIface == nil {
-		logger.Errorf("[Filter][AdaptiveSvc] The updater is not found on the attributes, attrs=%#v",
+		logger.Errorf("[Filter][AdaptiveSvc] the updater is not found on the attributes, attrs=%#v",
 			invocation.Attributes())
 		return &result.RPCResult{Err: ErrUpdaterNotFound}
 	}
 	updater, ok := updaterIface.(limiter.Updater)
 	if !ok {
-		logger.Errorf("[Filter][AdaptiveSvc] The type of the updater is not unexpected, we got %#v", updaterIface)
+		logger.Errorf("[Filter][AdaptiveSvc] the type of the updater is not unexpected, we got %#v", updaterIface)
 		return &result.RPCResult{Err: ErrUnexpectedUpdaterType}
 	}
 
 	err := updater.DoUpdate()
 	if err != nil {
-		logger.Errorf("[Filter][AdaptiveSvc] The DoUpdate method failed, err=%v", err)
+		logger.Errorf("[Filter][AdaptiveSvc] the DoUpdate method failed, err=%v", err)
 		return &result.RPCResult{Err: err}
 	}
 
 	// get limiter for the mapper
 	l, err := limiterMapperSingleton.getMethodLimiter(invoker.GetURL(), invocation.MethodName())
 	if err != nil {
-		logger.Errorf("[Filter][AdaptiveSvc] The method limiter for %q is not found.", invocation.MethodName())
+		logger.Errorf("[Filter][AdaptiveSvc] the method limiter for %q is not found.", invocation.MethodName())
 		return &result.RPCResult{Err: err}
 	}
 
 	// set attachments to inform consumer of provider status
 	res.AddAttachment(constant.AdaptiveServiceRemainingKey, fmt.Sprintf("%d", l.Remaining()))
 	res.AddAttachment(constant.AdaptiveServiceInflightKey, fmt.Sprintf("%d", l.Inflight()))
-	logger.Debugf("[Filter][AdaptiveSvc] The attachments are set, %s=%d %s=%d.",
+	logger.Debugf("[Filter][AdaptiveSvc] the attachments are set, %s=%d %s=%d.",
 		constant.AdaptiveServiceRemainingKey, l.Remaining(),
 		constant.AdaptiveServiceInflightKey, l.Inflight())
 

--- a/filter/adaptivesvc/limiter/utils.go
+++ b/filter/adaptivesvc/limiter/utils.go
@@ -29,7 +29,7 @@ func VerboseDebugf(msg string, args ...any) {
 	if !Verbose {
 		return
 	}
-	logger.Debugf(msg, args...)
+	logger.Debugf("[Filter][AdaptiveSvc] "+msg, args...)
 }
 
 func minDuration(lhs, rhs time.Duration) time.Duration {

--- a/filter/auth/provider_auth_filter.go
+++ b/filter/auth/provider_auth_filter.go
@@ -63,7 +63,7 @@ func (paf *authFilter) Invoke(ctx context.Context, invoker base.Invoker, invocat
 		return authenticator.Authenticate(invocation, url)
 	})
 	if err != nil {
-		logger.Errorf("auth the request: %v occur exception, cause: %s", invocation, err.Error())
+		logger.Errorf("[Filter][Auth] auth the request occur exception, invocation=%v err=%v", invocation, err)
 		return &result.RPCResult{
 			Err: err,
 		}

--- a/filter/auth/sign_util.go
+++ b/filter/auth/sign_util.go
@@ -60,7 +60,7 @@ func toBytes(data []any) ([]byte, error) {
 func doSign(bytes []byte, key string) string {
 	mac := hmac.New(sha256.New, []byte(key))
 	if _, err := mac.Write(bytes); err != nil {
-		logger.Error(err)
+		logger.Errorf("[Filter][Auth] sign HMAC write failed, err=%v", err)
 	}
 	signature := mac.Sum(nil)
 	return base64.URLEncoding.EncodeToString(signature)

--- a/filter/exec_limit/filter.go
+++ b/filter/exec_limit/filter.go
@@ -112,7 +112,7 @@ func (f *executeLimitFilter) Invoke(ctx context.Context, invoker base.Invoker, i
 
 	limitRate, err := strconv.ParseInt(limitRateConfig, 0, 0)
 	if err != nil {
-		logger.Errorf("The configuration of execute.limit is invalid: %s", limitRateConfig)
+		logger.Errorf("[Filter][ExecLimit] The configuration of execute.limit is invalid, limitRateConfig=%s", limitRateConfig)
 		return &result.RPCResult{}
 	}
 
@@ -127,12 +127,12 @@ func (f *executeLimitFilter) Invoke(ctx context.Context, invoker base.Invoker, i
 	concurrentCount := state.(*ExecuteState).increase()
 	defer state.(*ExecuteState).decrease()
 	if concurrentCount > limitRate {
-		logger.Errorf("The invocation was rejected due to over the execute limitation, url: %s ", ivkURL.String())
+		logger.Errorf("[Filter][ExecLimit] The invocation was rejected due to over the execute limitation, url=%s", ivkURL.String())
 		rejectedHandlerConfig := ivkURL.GetParam(methodConfigPrefix+constant.ExecuteRejectedExecutionHandlerKey,
 			ivkURL.GetParam(constant.ExecuteRejectedExecutionHandlerKey, constant.DefaultKey))
 		rejectedExecutionHandler, err := extension.GetRejectedExecutionHandler(rejectedHandlerConfig)
 		if err != nil {
-			logger.Warn(err)
+			logger.Warnf("[Filter][ExecLimit] get rejected execution handler failed, err=%v", err)
 		} else {
 			return rejectedExecutionHandler.RejectedExecution(ivkURL, invocation)
 		}

--- a/filter/exec_limit/filter.go
+++ b/filter/exec_limit/filter.go
@@ -112,7 +112,7 @@ func (f *executeLimitFilter) Invoke(ctx context.Context, invoker base.Invoker, i
 
 	limitRate, err := strconv.ParseInt(limitRateConfig, 0, 0)
 	if err != nil {
-		logger.Errorf("[Filter][ExecLimit] The configuration of execute.limit is invalid, limitRateConfig=%s", limitRateConfig)
+		logger.Errorf("[Filter][ExecLimit] the configuration of execute.limit is invalid, limitRateConfig=%s", limitRateConfig)
 		return &result.RPCResult{}
 	}
 
@@ -127,7 +127,7 @@ func (f *executeLimitFilter) Invoke(ctx context.Context, invoker base.Invoker, i
 	concurrentCount := state.(*ExecuteState).increase()
 	defer state.(*ExecuteState).decrease()
 	if concurrentCount > limitRate {
-		logger.Errorf("[Filter][ExecLimit] The invocation was rejected due to over the execute limitation, url=%s", ivkURL.String())
+		logger.Errorf("[Filter][ExecLimit] the invocation was rejected due to over the execute limitation, url=%s", ivkURL.String())
 		rejectedHandlerConfig := ivkURL.GetParam(methodConfigPrefix+constant.ExecuteRejectedExecutionHandlerKey,
 			ivkURL.GetParam(constant.ExecuteRejectedExecutionHandlerKey, constant.DefaultKey))
 		rejectedExecutionHandler, err := extension.GetRejectedExecutionHandler(rejectedHandlerConfig)

--- a/filter/generic/filter.go
+++ b/filter/generic/filter.go
@@ -79,11 +79,11 @@ func (f *genericFilter) Invoke(ctx context.Context, invoker base.Invoker, inv ba
 			// use the default generalizer(MapGeneralizer)
 			typ, err := g.GetType(arg)
 			if err != nil {
-				logger.Errorf("failed to get type, %v", err)
+				logger.Errorf("[Filter][Generic] failed to get type, err=%v", err)
 			}
 			obj, err := g.Generalize(arg)
 			if err != nil {
-				logger.Errorf("generalization failed, %v", err)
+				logger.Errorf("[Filter][Generic] generalization failed, err=%v", err)
 				return invoker.Invoke(ctx, inv)
 			}
 			types = append(types, typ)
@@ -203,7 +203,7 @@ func (f *genericFilter) OnResponse(_ context.Context, res result.Result, invoker
 	// Realize the map/slice to the target struct using shared helper
 	realized, err := realizeResult(data, replyElemType, g)
 	if err != nil {
-		logger.Warnf("failed to deserialize generic result: %v", err)
+		logger.Warnf("[Filter][Generic] failed to deserialize generic result, err=%v", err)
 		return res
 	}
 

--- a/filter/generic/generalizer/gson.go
+++ b/filter/generic/generalizer/gson.go
@@ -92,10 +92,10 @@ func (GsonGeneralizer) GetType(obj any) (typ string, err error) {
 
 	typ = "java.lang.Object"
 	if err == hessian2.NilError {
-		logger.Debugf("the type of nil object couldn't be inferred, use the default value(\"%s\")", typ)
+		logger.Debugf("[Filter][Generic] the type of nil object couldn't be inferred, use the default value, type=%s", typ)
 		return
 	}
 
-	logger.Debugf("the type of object(=%T) couldn't be recognized as a POJO, use the default value(\"%s\")", obj, typ)
+	logger.Debugf("[Filter][Generic] the type of object couldn't be recognized as a POJO, use the default value, objType=%T type=%s", obj, typ)
 	return
 }

--- a/filter/generic/generalizer/map.go
+++ b/filter/generic/generalizer/map.go
@@ -85,11 +85,11 @@ func (g *MapGeneralizer) GetType(obj any) (typ string, err error) {
 
 	typ = "java.lang.Object"
 	if err == hessian2.NilError {
-		logger.Debugf("the type of nil object couldn't be inferred, use the default value(\"%s\")", typ)
+		logger.Debugf("[Filter][Generic] the type of nil object couldn't be inferred, use the default value, type=%q", typ)
 		return
 	}
 
-	logger.Debugf("the type of object(=%T) couldn't be recognized as a POJO, use the default value(\"%s\")", obj, typ)
+	logger.Debugf("[Filter][Generic] the type of object couldn't be recognized as a POJO, use the default value, objType=%T type=%q", obj, typ)
 	return
 }
 
@@ -105,7 +105,7 @@ func getGenericIncludeClass() bool {
 		if exist, val := conf.GetProperty(constant.GenericIncludeClassKey); exist {
 			parsed, err := strconv.ParseBool(val)
 			if err != nil {
-				logger.Warnf("generic.include.class value %q is invalid, fallback to true", val)
+				logger.Warnf("[Filter][Generic] generic.include.class value is invalid, fallback to true, val=%q", val)
 				return true
 			}
 			return parsed
@@ -177,7 +177,7 @@ func objToMap(obj any) any {
 			value := v.Field(i)
 			kind := value.Kind()
 			if !value.CanInterface() {
-				logger.Debugf("objToMap for %v is skipped because it couldn't be converted to interface", field)
+				logger.Debugf("[Filter][Generic] objToMap is skipped because it couldn't be converted to interface, field=%v", field)
 				continue
 			}
 			valueIface := value.Interface()
@@ -190,9 +190,7 @@ func objToMap(obj any) any {
 				setInMap(result, field, objToMap(valueIface))
 			case reflect.Struct, reflect.Slice, reflect.Map:
 				if isPrimitive(valueIface) {
-					logger.Warnf("\"%s\" is primitive. The application may crash if it's transferred between "+
-						"systems implemented by different languages, e.g. dubbo-go <-> dubbo-java. We recommend "+
-						"you represent the object by basic types, like string.", value.Type())
+					logger.Warnf("[Filter][Generic] %q is primitive. Cross-language transfer (e.g., dubbo-go <-> dubbo-java) may crash. Use basic types like string.", value.Type())
 					setInMap(result, field, valueIface)
 					continue
 				}

--- a/filter/generic/service_filter.go
+++ b/filter/generic/service_filter.go
@@ -75,11 +75,7 @@ func (f *genericServiceFilter) Invoke(ctx context.Context, invoker base.Invoker,
 	types := inv.Arguments()[1]
 	args := inv.Arguments()[2].([]hessian.Object)
 
-	logger.Debugf(`received a generic invocation:
-		MethodName: %s,
-		Types: %s,
-		Args: %s
-	`, mtdName, types, args)
+	logger.Debugf("[Filter][Generic] received a generic invocation, methodName=%s types=%v args=%v", mtdName, types, args)
 
 	// get the type of the argument
 	ivkURL := invoker.GetURL()

--- a/filter/generic/util.go
+++ b/filter/generic/util.go
@@ -69,7 +69,7 @@ func getGeneralizer(generic string) (g generalizer.Generalizer) {
 	case strings.EqualFold(generic, constant.GenericSerializationBean):
 		g = generalizer.GetBeanGeneralizer()
 	default:
-		logger.Debugf("\"%s\" is not supported, use the default generalizer(MapGeneralizer)", generic)
+		logger.Debugf("[Filter][Generic] generic type not supported, use the default generalizer, generic=%s", generic)
 		g = generalizer.GetMapGeneralizer()
 	}
 	return

--- a/filter/graceful_shutdown/consumer_filter.go
+++ b/filter/graceful_shutdown/consumer_filter.go
@@ -80,7 +80,7 @@ func newConsumerGracefulShutdownFilter() filter.Filter {
 func (f *consumerGracefulShutdownFilter) Invoke(ctx context.Context, invoker base.Invoker, invocation base.Invocation) result.Result {
 	// check if invoker is closing
 	if f.isClosingInvoker(invoker) {
-		logger.Warnf("Graceful shutdown --- Skipping closing invoker --- %s", invoker.GetURL().String())
+		logger.Warnf("[Filter][GracefulShutdown] Graceful shutdown, skipping closing invoker, url=%s", invoker.GetURL().String())
 		return &result.RPCResult{Err: errors.New("provider is closing")}
 	}
 
@@ -126,7 +126,7 @@ func (f *consumerGracefulShutdownFilter) Set(name string, conf any) {
 		case *config.ShutdownConfig:
 			f.shutdownConfig = compatGlobalShutdownConfig(ct)
 		default:
-			logger.Warnf("the type of config for {%s} should be *global.ShutdownConfig", constant.GracefulShutdownFilterShutdownConfig)
+			logger.Warnf("[Filter][GracefulShutdown] the type of config for %s should be *global.ShutdownConfig", constant.GracefulShutdownFilterShutdownConfig)
 		}
 		return
 	default:
@@ -144,7 +144,7 @@ func (f *consumerGracefulShutdownFilter) isClosingInvoker(invoker base.Invoker) 
 		f.closingInvokers.Delete(key)
 		if setter, ok := invoker.(base.AvailabilitySetter); ok {
 			setter.SetAvailable(true)
-			logger.Infof("Graceful shutdown --- Recovered invoker availability after closing TTL --- %s", key)
+			logger.Infof("[Filter][GracefulShutdown] Graceful shutdown, recovered invoker availability after closing TTL, key=%s", key)
 		}
 	}
 	return false
@@ -168,12 +168,12 @@ func (f *consumerGracefulShutdownFilter) markClosingInvoker(invoker base.Invoker
 	expireTime := time.Now().Add(f.getClosingInvokerExpireTime())
 	f.closingInvokers.Store(key, expireTime)
 
-	logger.Infof("Graceful shutdown --- Marked invoker as closing --- %s, will expire at %v, IsAvailable=%v",
+	logger.Infof("[Filter][GracefulShutdown] Graceful shutdown, marked invoker as closing, key=%s expireTime=%v isAvailable=%v",
 		key, expireTime, invoker.IsAvailable())
 
 	if setter, ok := invoker.(base.AvailabilitySetter); ok {
 		setter.SetAvailable(false)
-		logger.Infof("Graceful shutdown --- Set invoker unavailable --- %s, IsAvailable now=%v",
+		logger.Infof("[Filter][GracefulShutdown] Graceful shutdown, set invoker unavailable, key=%s isAvailable=%v",
 			key, invoker.IsAvailable())
 	}
 }

--- a/filter/graceful_shutdown/consumer_filter.go
+++ b/filter/graceful_shutdown/consumer_filter.go
@@ -80,7 +80,7 @@ func newConsumerGracefulShutdownFilter() filter.Filter {
 func (f *consumerGracefulShutdownFilter) Invoke(ctx context.Context, invoker base.Invoker, invocation base.Invocation) result.Result {
 	// check if invoker is closing
 	if f.isClosingInvoker(invoker) {
-		logger.Warnf("[Filter][GracefulShutdown] Graceful shutdown, skipping closing invoker, url=%s", invoker.GetURL().String())
+		logger.Warnf("[Filter][GracefulShutdown] skipping closing invoker, url=%s", invoker.GetURL().String())
 		return &result.RPCResult{Err: errors.New("provider is closing")}
 	}
 
@@ -144,7 +144,7 @@ func (f *consumerGracefulShutdownFilter) isClosingInvoker(invoker base.Invoker) 
 		f.closingInvokers.Delete(key)
 		if setter, ok := invoker.(base.AvailabilitySetter); ok {
 			setter.SetAvailable(true)
-			logger.Infof("[Filter][GracefulShutdown] Graceful shutdown, recovered invoker availability after closing TTL, key=%s", key)
+			logger.Infof("[Filter][GracefulShutdown] recovered invoker availability after closing TTL, key=%s", key)
 		}
 	}
 	return false
@@ -168,12 +168,12 @@ func (f *consumerGracefulShutdownFilter) markClosingInvoker(invoker base.Invoker
 	expireTime := time.Now().Add(f.getClosingInvokerExpireTime())
 	f.closingInvokers.Store(key, expireTime)
 
-	logger.Infof("[Filter][GracefulShutdown] Graceful shutdown, marked invoker as closing, key=%s expireTime=%v isAvailable=%v",
+	logger.Infof("[Filter][GracefulShutdown] marked invoker as closing, key=%s expireTime=%v isAvailable=%v",
 		key, expireTime, invoker.IsAvailable())
 
 	if setter, ok := invoker.(base.AvailabilitySetter); ok {
 		setter.SetAvailable(false)
-		logger.Infof("[Filter][GracefulShutdown] Graceful shutdown, set invoker unavailable, key=%s isAvailable=%v",
+		logger.Infof("[Filter][GracefulShutdown] set invoker unavailable, key=%s isAvailable=%v",
 			key, invoker.IsAvailable())
 	}
 }

--- a/filter/graceful_shutdown/provider_filter.go
+++ b/filter/graceful_shutdown/provider_filter.go
@@ -70,14 +70,14 @@ func (f *providerGracefulShutdownFilter) Invoke(ctx context.Context, invoker bas
 	}
 
 	if f.rejectNewRequest() {
-		logger.Info("The application is closing, new request will be rejected.")
+		logger.Info("[Filter][GracefulShutdown] The application is closing, new request will be rejected.")
 		handler := constant.DefaultKey
 		if f.shutdownConfig != nil && len(f.shutdownConfig.RejectRequestHandler) > 0 {
 			handler = f.shutdownConfig.RejectRequestHandler
 		}
 		rejectedExecutionHandler, err := extension.GetRejectedExecutionHandler(handler)
 		if err != nil {
-			logger.Warn(err)
+			logger.Warnf("[Filter][GracefulShutdown] get rejected execution handler failed, err=%v", err)
 		} else {
 			return rejectedExecutionHandler.RejectedExecution(invoker.GetURL(), invocation)
 		}
@@ -118,7 +118,7 @@ func (f *providerGracefulShutdownFilter) Set(name string, conf any) {
 		case *config.ShutdownConfig:
 			f.shutdownConfig = compatGlobalShutdownConfig(ct)
 		default:
-			logger.Warnf("the type of config for {%s} should be *global.ShutdownConfig", constant.GracefulShutdownFilterShutdownConfig)
+			logger.Warnf("[Filter][GracefulShutdown] the type of config for %s should be *global.ShutdownConfig", constant.GracefulShutdownFilterShutdownConfig)
 		}
 		return
 	default:

--- a/filter/graceful_shutdown/provider_filter.go
+++ b/filter/graceful_shutdown/provider_filter.go
@@ -70,7 +70,7 @@ func (f *providerGracefulShutdownFilter) Invoke(ctx context.Context, invoker bas
 	}
 
 	if f.rejectNewRequest() {
-		logger.Info("[Filter][GracefulShutdown] The application is closing, new request will be rejected.")
+		logger.Info("[Filter][GracefulShutdown] the application is closing, new request will be rejected.")
 		handler := constant.DefaultKey
 		if f.shutdownConfig != nil && len(f.shutdownConfig.RejectRequestHandler) > 0 {
 			handler = f.shutdownConfig.RejectRequestHandler

--- a/filter/handler/rejected_execution_handler_only_log.go
+++ b/filter/handler/rejected_execution_handler_only_log.go
@@ -71,7 +71,7 @@ type OnlyLogRejectedExecutionHandler struct{}
 func (handler *OnlyLogRejectedExecutionHandler) RejectedExecution(url *common.URL,
 	_ base.Invocation) result.Result {
 
-	logger.Errorf("The invocation was rejected. url: %s", url.String())
+	logger.Errorf("[Filter][Handler] The invocation was rejected, url=%s", url.String())
 	return &result.RPCResult{}
 }
 

--- a/filter/handler/rejected_execution_handler_only_log.go
+++ b/filter/handler/rejected_execution_handler_only_log.go
@@ -71,7 +71,7 @@ type OnlyLogRejectedExecutionHandler struct{}
 func (handler *OnlyLogRejectedExecutionHandler) RejectedExecution(url *common.URL,
 	_ base.Invocation) result.Result {
 
-	logger.Errorf("[Filter][Handler] The invocation was rejected, url=%s", url.String())
+	logger.Errorf("[Filter][Handler] the invocation was rejected, url=%s", url.String())
 	return &result.RPCResult{}
 }
 

--- a/filter/polaris/limit/limiter.go
+++ b/filter/polaris/limit/limiter.go
@@ -46,7 +46,7 @@ type polarisTpsLimiter struct {
 
 func (pl *polarisTpsLimiter) IsAllowable(url *common.URL, invocation base.Invocation) bool {
 	if err := remotingpolaris.Check(); errors.Is(err, remotingpolaris.ErrorNoOpenPolarisAbility) {
-		logger.Debug("[Filter][Polaris] not open polaris ratelimit ability")
+		logger.Debug("[Filter][Polaris][TPS] not open polaris ratelimit ability")
 		return true
 	}
 
@@ -54,7 +54,7 @@ func (pl *polarisTpsLimiter) IsAllowable(url *common.URL, invocation base.Invoca
 
 	pl.limitAPI, err = remotingpolaris.GetLimiterAPI()
 	if err != nil {
-		logger.Errorf("[Filter][Polaris] create polaris LimitAPI fail, err=%+v", err)
+		logger.Errorf("[Filter][Polaris][TPS] create polaris LimitAPI fail, err=%+v", err)
 		return true
 	}
 
@@ -62,11 +62,11 @@ func (pl *polarisTpsLimiter) IsAllowable(url *common.URL, invocation base.Invoca
 	if req == nil {
 		return true
 	}
-	logger.Debugf("[Filter][Polaris] quota req: %+v", req)
+	logger.Debugf("[Filter][Polaris][TPS] quota req: %+v", req)
 
 	resp, err := pl.limitAPI.GetQuota(req)
 	if err != nil {
-		logger.Errorf("[Filter][Polaris] ns=%s svc=%s get quota fail, err=%+v", remotingpolaris.GetNamespace(), url.Service(), err)
+		logger.Errorf("[Filter][Polaris][TPS] ns=%s svc=%s get quota fail, err=%+v", remotingpolaris.GetNamespace(), url.Service(), err)
 		return true
 	}
 
@@ -143,19 +143,19 @@ func (pl *polarisTpsLimiter) buildArguments(req *model.QuotaRequestImpl) ([]*v1.
 	}
 
 	if err := engine.SyncGetResources(getRuleReq); err != nil {
-		logger.Errorf("[Filter][Polaris] ns=%s svc=%s get RateLimit Rule fail, err=%+v", req.GetNamespace(), req.GetService(), err)
+		logger.Errorf("[Filter][Polaris][TPS] ns=%s svc=%s get RateLimit Rule fail, err=%+v", req.GetNamespace(), req.GetService(), err)
 		return nil, false
 	}
 
 	svcRule := getRuleReq.RateLimitRule
 	if svcRule == nil || svcRule.GetValue() == nil {
-		logger.Warnf("[Filter][Polaris] ns=%s svc=%s get RateLimit Rule is nil", req.GetNamespace(), req.GetService())
+		logger.Warnf("[Filter][Polaris][TPS] ns=%s svc=%s get RateLimit Rule is nil", req.GetNamespace(), req.GetService())
 		return nil, false
 	}
 
 	rules, ok := svcRule.GetValue().(*v1.RateLimit)
 	if !ok {
-		logger.Errorf("[Filter][Polaris] ns:%s svc:%s get RateLimit Rule invalid", req.GetNamespace(), req.GetService())
+		logger.Errorf("[Filter][Polaris][TPS] ns:%s svc:%s get RateLimit Rule invalid", req.GetNamespace(), req.GetService())
 		return nil, false
 	}
 

--- a/filter/polaris/limit/limiter.go
+++ b/filter/polaris/limit/limiter.go
@@ -46,7 +46,7 @@ type polarisTpsLimiter struct {
 
 func (pl *polarisTpsLimiter) IsAllowable(url *common.URL, invocation base.Invocation) bool {
 	if err := remotingpolaris.Check(); errors.Is(err, remotingpolaris.ErrorNoOpenPolarisAbility) {
-		logger.Debug("[TpsLimiter][Polaris] not open polaris ratelimit ability")
+		logger.Debug("[Filter][Polaris] not open polaris ratelimit ability")
 		return true
 	}
 
@@ -54,7 +54,7 @@ func (pl *polarisTpsLimiter) IsAllowable(url *common.URL, invocation base.Invoca
 
 	pl.limitAPI, err = remotingpolaris.GetLimiterAPI()
 	if err != nil {
-		logger.Error("[TpsLimiter][Polaris] create polaris LimitAPI fail : %+v", err)
+		logger.Errorf("[Filter][Polaris] create polaris LimitAPI fail, err=%+v", err)
 		return true
 	}
 
@@ -62,11 +62,11 @@ func (pl *polarisTpsLimiter) IsAllowable(url *common.URL, invocation base.Invoca
 	if req == nil {
 		return true
 	}
-	logger.Debugf("[TpsLimiter][Polaris] quota req : %+v", req)
+	logger.Debugf("[Filter][Polaris] quota req: %+v", req)
 
 	resp, err := pl.limitAPI.GetQuota(req)
 	if err != nil {
-		logger.Error("[TpsLimiter][Polaris] ns:%s svc:%s get quota fail : %+v", remotingpolaris.GetNamespace(), url.Service(), err)
+		logger.Errorf("[Filter][Polaris] ns=%s svc=%s get quota fail, err=%+v", remotingpolaris.GetNamespace(), url.Service(), err)
 		return true
 	}
 
@@ -143,19 +143,19 @@ func (pl *polarisTpsLimiter) buildArguments(req *model.QuotaRequestImpl) ([]*v1.
 	}
 
 	if err := engine.SyncGetResources(getRuleReq); err != nil {
-		logger.Error("[TpsLimiter][Polaris] ns:%s svc:%s get RateLimit Rule fail : %+v", req.GetNamespace(), req.GetService(), err)
+		logger.Errorf("[Filter][Polaris] ns=%s svc=%s get RateLimit Rule fail, err=%+v", req.GetNamespace(), req.GetService(), err)
 		return nil, false
 	}
 
 	svcRule := getRuleReq.RateLimitRule
 	if svcRule == nil || svcRule.GetValue() == nil {
-		logger.Warnf("[TpsLimiter][Polaris] ns:%s svc:%s get RateLimit Rule is nil", req.GetNamespace(), req.GetService())
+		logger.Warnf("[Filter][Polaris] ns=%s svc=%s get RateLimit Rule is nil", req.GetNamespace(), req.GetService())
 		return nil, false
 	}
 
 	rules, ok := svcRule.GetValue().(*v1.RateLimit)
 	if !ok {
-		logger.Error("[TpsLimiter][Polaris] ns:%s svc:%s get RateLimit Rule invalid", req.GetNamespace(), req.GetService())
+		logger.Errorf("[Filter][Polaris] ns:%s svc:%s get RateLimit Rule invalid", req.GetNamespace(), req.GetService())
 		return nil, false
 	}
 

--- a/filter/seata/filter.go
+++ b/filter/seata/filter.go
@@ -64,7 +64,7 @@ func newSeataFilter() filter.Filter {
 func (f *seataFilter) Invoke(ctx context.Context, invoker base.Invoker, invocation base.Invocation) result.Result {
 	xid := invocation.GetAttachmentWithDefaultValue(string(SEATA_XID), "")
 	if len(strings.TrimSpace(xid)) > 0 {
-		logger.Debugf("[Filter][Seata] Method and XID, method=%v xid=%v", invocation.MethodName(), xid)
+		logger.Debugf("[Filter][Seata] method and XID, method=%v xid=%v", invocation.MethodName(), xid)
 		return invoker.Invoke(context.WithValue(ctx, SEATA_XID, xid), invocation)
 	}
 	return invoker.Invoke(ctx, invocation)

--- a/filter/seata/filter.go
+++ b/filter/seata/filter.go
@@ -64,7 +64,7 @@ func newSeataFilter() filter.Filter {
 func (f *seataFilter) Invoke(ctx context.Context, invoker base.Invoker, invocation base.Invocation) result.Result {
 	xid := invocation.GetAttachmentWithDefaultValue(string(SEATA_XID), "")
 	if len(strings.TrimSpace(xid)) > 0 {
-		logger.Debugf("Method: %v,Xid: %v", invocation.MethodName(), xid)
+		logger.Debugf("[Filter][Seata] Method and XID, method=%v xid=%v", invocation.MethodName(), xid)
 		return invoker.Invoke(context.WithValue(ctx, SEATA_XID, xid), invocation)
 	}
 	return invoker.Invoke(ctx, invocation)

--- a/filter/sentinel/filter.go
+++ b/filter/sentinel/filter.go
@@ -49,7 +49,7 @@ func init() {
 	extension.SetFilter(constant.SentinelConsumerFilterKey, newSentinelConsumerFilter)
 	extension.SetFilter(constant.SentinelProviderFilterKey, newSentinelProviderFilter)
 	if err := logging.ResetGlobalLogger(DubboLoggerWrapper{Logger: logger.GetLogger()}); err != nil {
-		logger.Errorf("[Sentinel Filter] fail to ingest dubbo logger into sentinel")
+		logger.Error("[Filter][Sentinel] fail to ingest dubbo logger into sentinel")
 	}
 }
 

--- a/filter/tps/filter.go
+++ b/filter/tps/filter.go
@@ -79,17 +79,17 @@ func (t *tpsLimitFilter) Invoke(ctx context.Context, invoker base.Invoker, invoc
 	if len(tpsLimiter) > 0 {
 		limiter, err := extension.GetTpsLimiter(tpsLimiter)
 		if err != nil {
-			logger.Warn(err)
+			logger.Warnf("[Filter][TPS] get TPS limiter failed, err=%v", err)
 			return invoker.Invoke(ctx, invocation)
 		}
 		allow := limiter.IsAllowable(invoker.GetURL(), invocation)
 		if allow {
 			return invoker.Invoke(ctx, invocation)
 		}
-		logger.Errorf("The invocation was rejected due to over the limiter limitation, url: %s ", url.String())
+		logger.Errorf("[Filter][TPS] The invocation was rejected due to over the limiter limitation, url=%s", url.String())
 		rejectedExecutionHandler, err := extension.GetRejectedExecutionHandler(rejectedExeHandler)
 		if err != nil {
-			logger.Warn(err)
+			logger.Warnf("[Filter][TPS] get rejected execution handler failed, err=%v", err)
 		} else {
 			return rejectedExecutionHandler.RejectedExecution(url, invocation)
 		}

--- a/filter/tps/filter.go
+++ b/filter/tps/filter.go
@@ -86,7 +86,7 @@ func (t *tpsLimitFilter) Invoke(ctx context.Context, invoker base.Invoker, invoc
 		if allow {
 			return invoker.Invoke(ctx, invocation)
 		}
-		logger.Errorf("[Filter][TPS] The invocation was rejected due to over the limiter limitation, url=%s", url.String())
+		logger.Errorf("[Filter][TPS] the invocation was rejected due to over the limiter limitation, url=%s", url.String())
 		rejectedExecutionHandler, err := extension.GetRejectedExecutionHandler(rejectedExeHandler)
 		if err != nil {
 			logger.Warnf("[Filter][TPS] get rejected execution handler failed, err=%v", err)

--- a/filter/tps/limiter/method_service.go
+++ b/filter/tps/limiter/method_service.go
@@ -18,7 +18,6 @@
 package limiter
 
 import (
-	"fmt"
 	"strconv"
 	"sync"
 )
@@ -152,7 +151,7 @@ func (limiter MethodServiceTpsLimiter) IsAllowable(url *common.URL, invocation b
 
 	if limitRate < 0 {
 		// the limitTarget is not necessary to be limited.
-		logger.Errorf("Found error configuration value of tps.limit.rate for the invocation %s, ignores TPS Limiter", url.ServiceKey()+"#"+invocation.MethodName())
+		logger.Errorf("[Filter][TPS] Found error configuration value of tps.limit.rate for the invocation, ignores TPS Limiter, invocation=%s", url.ServiceKey()+"#"+invocation.MethodName())
 		return true
 	}
 
@@ -160,7 +159,7 @@ func (limiter MethodServiceTpsLimiter) IsAllowable(url *common.URL, invocation b
 		constant.TPSLimitIntervalKey,
 		constant.DefaultTPSLimitInterval)
 	if limitInterval <= 0 {
-		logger.Errorf(fmt.Sprintf("Found error configuration value of tps.limit.interval for the invocation %s, ignores TPS Limiter", url.ServiceKey()+"#"+invocation.MethodName()))
+		logger.Errorf("[Filter][TPS] Found error configuration value of tps.limit.interval for the invocation, ignores TPS Limiter, invocation=%s", url.ServiceKey()+"#"+invocation.MethodName())
 		return true
 	}
 
@@ -169,7 +168,7 @@ func (limiter MethodServiceTpsLimiter) IsAllowable(url *common.URL, invocation b
 		url.GetParam(constant.TPSLimitStrategyKey, constant.DefaultKey))
 	limitStateCreator, err := extension.GetTpsLimitStrategyCreator(limitStrategyConfig)
 	if err != nil {
-		logger.Warn(err)
+		logger.Warnf("[Filter][TPS] get TPS limit strategy creator failed, err=%v", err)
 		return true
 	}
 
@@ -191,8 +190,8 @@ func getLimitConfig(methodLevelConfig string,
 	if len(methodLevelConfig) > 0 {
 		result, err := strconv.ParseInt(methodLevelConfig, 0, 0)
 		if err != nil {
-			logger.Error(fmt.Sprintf("The %s for invocation %s # %s must be positive, please check your configuration!",
-				configKey, url.ServiceKey(), invocation.MethodName()))
+			logger.Errorf("[Filter][TPS] The %s for invocation must be positive, please check your configuration, configKey=%s serviceKey=%s methodName=%s",
+				configKey, configKey, url.ServiceKey(), invocation.MethodName())
 			return defaultVal
 		}
 		return result
@@ -202,7 +201,7 @@ func getLimitConfig(methodLevelConfig string,
 
 	result, err := strconv.ParseInt(url.GetParam(configKey, ""), 0, 0)
 	if err != nil {
-		logger.Errorf(fmt.Sprintf("Cannot parse the configuration %s, please check your configuration!", configKey))
+		logger.Errorf("[Filter][TPS] Cannot parse the configuration, please check your configuration, configKey=%s", configKey)
 		return defaultVal
 	}
 	return result

--- a/filter/tps/limiter/method_service.go
+++ b/filter/tps/limiter/method_service.go
@@ -151,7 +151,7 @@ func (limiter MethodServiceTpsLimiter) IsAllowable(url *common.URL, invocation b
 
 	if limitRate < 0 {
 		// the limitTarget is not necessary to be limited.
-		logger.Errorf("[Filter][TPS] Found error configuration value of tps.limit.rate for the invocation, ignores TPS Limiter, invocation=%s", url.ServiceKey()+"#"+invocation.MethodName())
+		logger.Errorf("[Filter][TPS] found error configuration value of tps.limit.rate for the invocation, ignores TPS Limiter, invocation=%s", url.ServiceKey()+"#"+invocation.MethodName())
 		return true
 	}
 
@@ -159,7 +159,7 @@ func (limiter MethodServiceTpsLimiter) IsAllowable(url *common.URL, invocation b
 		constant.TPSLimitIntervalKey,
 		constant.DefaultTPSLimitInterval)
 	if limitInterval <= 0 {
-		logger.Errorf("[Filter][TPS] Found error configuration value of tps.limit.interval for the invocation, ignores TPS Limiter, invocation=%s", url.ServiceKey()+"#"+invocation.MethodName())
+		logger.Errorf("[Filter][TPS] found error configuration value of tps.limit.interval for the invocation, ignores TPS Limiter, invocation=%s", url.ServiceKey()+"#"+invocation.MethodName())
 		return true
 	}
 
@@ -190,7 +190,7 @@ func getLimitConfig(methodLevelConfig string,
 	if len(methodLevelConfig) > 0 {
 		result, err := strconv.ParseInt(methodLevelConfig, 0, 0)
 		if err != nil {
-			logger.Errorf("[Filter][TPS] The %s for invocation must be positive, please check your configuration, configKey=%s serviceKey=%s methodName=%s",
+			logger.Errorf("[Filter][TPS] the %s for invocation must be positive, please check your configuration, configKey=%s serviceKey=%s methodName=%s",
 				configKey, configKey, url.ServiceKey(), invocation.MethodName())
 			return defaultVal
 		}
@@ -201,7 +201,7 @@ func getLimitConfig(methodLevelConfig string,
 
 	result, err := strconv.ParseInt(url.GetParam(configKey, ""), 0, 0)
 	if err != nil {
-		logger.Errorf("[Filter][TPS] Cannot parse the configuration, please check your configuration, configKey=%s", configKey)
+		logger.Errorf("[Filter][TPS] can not parse the configuration, please check your configuration, configKey=%s", configKey)
 		return defaultVal
 	}
 	return result


### PR DESCRIPTION
### Description
Standardize log format across config_center and filter directories with unified prefixes, consistent key naming, and proper format specifiers.
### Changes
1. Unified two-level prefix [Parent][Child]
2. Fixed buggy logger calls
logger.Error(err) / logger.Warn(err) without descriptive messages → logger.Errorf / logger.Warnf with context
logger.Warnf missing format args → logger.Warn
*f(fmt.Sprintf(...)) → direct *f call
3. Standardized key names and separators
Colon-space : → comma-space ,
Removed unnecessary wrapping like {%v}, {%s}
4. Cleaned up formatting issues
Removed decorative characters (---, !, ...)
Removed \n newlines from log messages
Flattened multi-line log statements to single-line key=value pairs

Fixes #3295

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
