### PR TITLE
fix: add compatibility support for response attachments in generic invoke

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -161,6 +161,24 @@ func (cli *Client) NewGenericService(referenceStr string, opts ...ReferenceOptio
 	return genericService, nil
 }
 
+// NewGenericService2 creates a GenericService2 for making generic calls and reading response attachments.
+func (cli *Client) NewGenericService2(referenceStr string, opts ...ReferenceOption) (*generic.GenericService2, error) {
+	finalOpts := []ReferenceOption{
+		WithIDL(constant.NONIDL),
+		WithGeneric(),
+		WithSerialization(constant.Hessian2Serialization),
+	}
+	finalOpts = append(finalOpts, opts...)
+
+	genericService := generic.NewGenericService2(referenceStr)
+	_, err := cli.DialWithService(referenceStr, genericService, finalOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return genericService, nil
+}
+
 func (cli *Client) Dial(interfaceName string, opts ...ReferenceOption) (*Connection, error) {
 	return cli.dial(interfaceName, nil, nil, opts...)
 }

--- a/config/generic/generic_service.go
+++ b/config/generic/generic_service.go
@@ -27,6 +27,14 @@ import (
 // Deprecated: Use dubbo.apache.org/dubbo-go/v3/filter/generic.GenericService instead.
 type GenericService = generic.GenericService
 
+// GenericService2 is an alias for backward compatibility.
+// Deprecated: Use dubbo.apache.org/dubbo-go/v3/filter/generic.GenericService2 instead.
+type GenericService2 = generic.GenericService2
+
 // NewGenericService is an alias for backward compatibility.
 // Deprecated: Use dubbo.apache.org/dubbo-go/v3/filter/generic.NewGenericService instead.
 var NewGenericService = generic.NewGenericService
+
+// NewGenericService2 is an alias for backward compatibility.
+// Deprecated: Use dubbo.apache.org/dubbo-go/v3/filter/generic.NewGenericService2 instead.
+var NewGenericService2 = generic.NewGenericService2

--- a/filter/generic/service.go
+++ b/filter/generic/service.go
@@ -20,6 +20,7 @@ package generic
 import (
 	"context"
 	"reflect"
+	"sync"
 )
 
 import (
@@ -34,6 +35,14 @@ import (
 type GenericService struct {
 	Invoke       func(ctx context.Context, methodName string, types []string, args []hessian.Object) (any, error) `dubbo:"$invoke"`
 	referenceStr string
+	attachments  sync.Map
+}
+
+// GenericService2 keeps the legacy generic invoke surface for attachment access compatibility.
+type GenericService2 struct {
+	Invoke       func(ctx context.Context, methodName string, types []string, args []hessian.Object) (any, error) `dubbo:"$invoke"`
+	referenceStr string
+	attachments  sync.Map
 }
 
 // NewGenericService returns a GenericService instance
@@ -41,9 +50,85 @@ func NewGenericService(referenceStr string) *GenericService {
 	return &GenericService{referenceStr: referenceStr}
 }
 
+// NewGenericService2 returns a GenericService2 instance.
+func NewGenericService2(referenceStr string) *GenericService2 {
+	return &GenericService2{referenceStr: referenceStr}
+}
+
 // Reference gets referenceStr from GenericService
 func (s *GenericService) Reference() string {
 	return s.referenceStr
+}
+
+// Reference gets referenceStr from GenericService2
+func (s *GenericService2) Reference() string {
+	return s.referenceStr
+}
+
+// SetResponseAttachments stores response attachments for the provided context.
+func (s *GenericService) SetResponseAttachments(ctx context.Context, attachments map[string]any) {
+	setResponseAttachments(&s.attachments, ctx, attachments)
+}
+
+// GetResponseAttachments returns response attachments of the provided context.
+func (s *GenericService) GetResponseAttachments(ctx context.Context) map[string]any {
+	return getResponseAttachments(&s.attachments, ctx)
+}
+
+// SetResponseAttachments stores response attachments for the provided context.
+func (s *GenericService2) SetResponseAttachments(ctx context.Context, attachments map[string]any) {
+	setResponseAttachments(&s.attachments, ctx, attachments)
+}
+
+// GetResponseAttachments returns response attachments of the provided context.
+func (s *GenericService2) GetResponseAttachments(ctx context.Context) map[string]any {
+	return getResponseAttachments(&s.attachments, ctx)
+}
+
+func setResponseAttachments(store *sync.Map, ctx context.Context, attachments map[string]any) {
+	if ctx == nil {
+		return
+	}
+	key := contextKey(ctx)
+	if key == nil {
+		return
+	}
+	store.Store(key, cloneAttachments(attachments))
+}
+
+func getResponseAttachments(store *sync.Map, ctx context.Context) map[string]any {
+	if ctx == nil {
+		return nil
+	}
+	key := contextKey(ctx)
+	if key == nil {
+		return nil
+	}
+	value, ok := store.Load(key)
+	if !ok {
+		return nil
+	}
+	attachments, _ := value.(map[string]any)
+	return cloneAttachments(attachments)
+}
+
+func contextKey(ctx context.Context) any {
+	value := reflect.ValueOf(ctx)
+	if !value.IsValid() || value.Kind() != reflect.Ptr || value.IsNil() {
+		return nil
+	}
+	return value.Pointer()
+}
+
+func cloneAttachments(attachments map[string]any) map[string]any {
+	if attachments == nil {
+		return nil
+	}
+	cloned := make(map[string]any, len(attachments))
+	for k, v := range attachments {
+		cloned[k] = v
+	}
+	return cloned
 }
 
 // InvokeWithType invokes the remote method and deserializes the result into the reply struct.

--- a/filter/generic/service_test.go
+++ b/filter/generic/service_test.go
@@ -47,6 +47,57 @@ func TestGenericService(t *testing.T) {
 	assert.Equal(t, "HelloService", reference)
 }
 
+func TestGenericService2(t *testing.T) {
+	service := NewGenericService2("HelloService")
+	reference := service.Reference()
+	assert.Equal(t, "HelloService", reference)
+}
+
+func TestGenericServiceResponseAttachments(t *testing.T) {
+	type testCtxKey struct{}
+
+	service := NewGenericService("HelloService")
+	service2 := NewGenericService2("HelloService")
+
+	testCases := []struct {
+		name         string
+		getter       func(context.Context) map[string]any
+		setter       func(context.Context, map[string]any)
+		expectedAttr map[string]any
+	}{
+		{
+			name:   "generic service",
+			getter: service.GetResponseAttachments,
+			setter: service.SetResponseAttachments,
+			expectedAttr: map[string]any{
+				"test-key": "test-value-1",
+			},
+		},
+		{
+			name:   "generic service2",
+			getter: service2.GetResponseAttachments,
+			setter: service2.SetResponseAttachments,
+			expectedAttr: map[string]any{
+				"test-key": "test-value-2",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.WithValue(context.Background(), testCtxKey{}, tc.name)
+
+			tc.setter(ctx, tc.expectedAttr)
+			attachments := tc.getter(ctx)
+			require.Equal(t, tc.expectedAttr, attachments)
+
+			attachments["test-key"] = "changed"
+			require.Equal(t, tc.expectedAttr, tc.getter(ctx))
+			require.Nil(t, tc.getter(context.Background()))
+		})
+	}
+}
+
 func TestGenericService_InvokeWithType(t *testing.T) {
 	t.Run("simple struct", func(t *testing.T) {
 		service := NewGenericService("TestService")

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -201,6 +201,11 @@ func DefaultProxyImplementFunc(p *Proxy, v common.RPCService) {
 			}
 
 			result := p.invoke.Invoke(invCtx, inv)
+			if setter, ok := v.(interface {
+				SetResponseAttachments(context.Context, map[string]any)
+			}); ok {
+				setter.SetResponseAttachments(invCtx, result.Attachments())
+			}
 			err = result.Error()
 			// cause is raw user level error
 			cause := perrors.Cause(err)


### PR DESCRIPTION
### Description
Fixes #2582  (issue)

## Background

After `GenericService2` was removed in v3, generic invoke no longer had a stable way to access response attachments.
This affects migration scenarios from older versions: the generic call itself still works, but callers can no longer read provider-side response attachments as before.

## Solution

This change uses a compatibility-focused approach and does not modify the existing generic filter, protocol invokers, or the core invocation chain.

Specifically, it:

1. restores a `GenericService2` compatibility entry
2. adds response attachment storage/access support to `GenericService` and `GenericService2`
3. stores result attachments back into the generic service instance after proxy invocation returns
4. allows callers to read response attachments via `GetResponseAttachments(ctx)`

## Changes

- add compatible `GenericService2` type and constructor
- add `Client.NewGenericService2(...)`
- add response attachment save/read capability for generic services
- persist response attachments after generic proxy invocation returns
- add focused unit tests

## Compatibility

This is a backward-compatible enhancement:

- it does not change the current `GenericService` invocation style
- it does not modify existing protocol handling logic
- it only restores response attachment access for generic invoke

## Tests

Verified with targeted tests:

- `go test ./filter/generic ./proxy ./config/generic ./client`

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
