### PR TITLE
feat: complete local app metadata lifecycle

### DIFF
--- a/metadata/info/metadata_info.go
+++ b/metadata/info/metadata_info.go
@@ -19,6 +19,7 @@ package info
 
 import (
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -113,7 +114,7 @@ func addUrl(m map[string][]*common.URL, url *common.URL) {
 func removeUrl(m map[string][]*common.URL, url *common.URL) {
 	if urls, ok := m[url.ServiceKey()]; ok {
 		for i, u := range urls {
-			if u == url {
+			if urlEqual(u, url) {
 				m[url.ServiceKey()] = deleteItem(urls, i)
 				break
 			}
@@ -122,6 +123,13 @@ func removeUrl(m map[string][]*common.URL, url *common.URL) {
 			delete(m, url.ServiceKey())
 		}
 	}
+}
+
+func urlEqual(left, right *common.URL) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.String() == right.String() && slices.Equal(left.Methods, right.Methods)
 }
 
 func deleteItem(slice []*common.URL, index int) []*common.URL {

--- a/metadata/info/metadata_info.go
+++ b/metadata/info/metadata_info.go
@@ -140,8 +140,12 @@ func deleteItem(slice []*common.URL, index int) []*common.URL {
 
 func (info *MetadataInfo) RemoveService(url *common.URL) {
 	service := NewServiceInfoWithURL(url)
-	delete(info.Services, service.GetMatchKey())
 	removeUrl(info.exportedServiceURLs, url)
+	if replacement := info.findExportedServiceURL(service.GetMatchKey()); replacement != nil {
+		info.Services[service.GetMatchKey()] = NewServiceInfoWithURL(replacement)
+		return
+	}
+	delete(info.Services, service.GetMatchKey())
 }
 
 // AddSubscribeURL client subscribe a service url
@@ -168,6 +172,25 @@ func (info *MetadataInfo) GetSubscribedURLs() []*common.URL {
 		res = append(res, urls...)
 	}
 	return res
+}
+
+func (info *MetadataInfo) ReplaceExportedServices(urls []*common.URL) {
+	info.Services = make(map[string]*ServiceInfo)
+	info.exportedServiceURLs = make(map[string][]*common.URL)
+	for _, serviceURL := range urls {
+		info.AddService(serviceURL)
+	}
+}
+
+func (info *MetadataInfo) findExportedServiceURL(matchKey string) *common.URL {
+	for _, urls := range info.exportedServiceURLs {
+		for _, serviceURL := range urls {
+			if NewServiceInfoWithURL(serviceURL).GetMatchKey() == matchKey {
+				return serviceURL
+			}
+		}
+	}
+	return nil
 }
 
 // ServiceInfo the information of service

--- a/metadata/info/metadata_info.go
+++ b/metadata/info/metadata_info.go
@@ -19,7 +19,6 @@ package info
 
 import (
 	"net/url"
-	"slices"
 	"strconv"
 	"strings"
 )
@@ -114,7 +113,7 @@ func addUrl(m map[string][]*common.URL, url *common.URL) {
 func removeUrl(m map[string][]*common.URL, url *common.URL) {
 	if urls, ok := m[url.ServiceKey()]; ok {
 		for i, u := range urls {
-			if urlEqual(u, url) {
+			if u.URLEqual(url) {
 				m[url.ServiceKey()] = deleteItem(urls, i)
 				break
 			}
@@ -123,13 +122,6 @@ func removeUrl(m map[string][]*common.URL, url *common.URL) {
 			delete(m, url.ServiceKey())
 		}
 	}
-}
-
-func urlEqual(left, right *common.URL) bool {
-	if left == nil || right == nil {
-		return left == right
-	}
-	return left.String() == right.String() && slices.Equal(left.Methods, right.Methods)
 }
 
 func deleteItem(slice []*common.URL, index int) []*common.URL {

--- a/metadata/info/metadata_info_test.go
+++ b/metadata/info/metadata_info_test.go
@@ -78,6 +78,22 @@ func TestMetadataInfoRemoveServiceWithClonedURL(t *testing.T) {
 	assert.Empty(t, metadataInfo.GetExportedServiceURLs())
 }
 
+func TestMetadataInfoRemoveServiceKeepsRemainingMatchKeyService(t *testing.T) {
+	metadataInfo := NewMetadataInfo("foo", "")
+	url1, err := common.NewURL("dubbo://127.0.0.1:20000?application=foo&interface=com.foo.Bar&methods=GetPetByID&side=provider&version=1.0.0")
+	require.NoError(t, err)
+	url2, err := common.NewURL("dubbo://127.0.0.1:20001?application=foo&interface=com.foo.Bar&methods=GetPetByID&side=provider&version=1.0.0")
+	require.NoError(t, err)
+
+	metadataInfo.AddService(url1)
+	metadataInfo.AddService(url2)
+	metadataInfo.RemoveService(url1.Clone())
+
+	require.Len(t, metadataInfo.Services, 1)
+	assert.Len(t, metadataInfo.GetExportedServiceURLs(), 1)
+	assert.Equal(t, url2, metadataInfo.GetExportedServiceURLs()[0])
+}
+
 func TestHessian(t *testing.T) {
 	metadataInfo := &MetadataInfo{
 		App:                   "test",

--- a/metadata/info/metadata_info_test.go
+++ b/metadata/info/metadata_info_test.go
@@ -66,6 +66,18 @@ func TestMetadataInfoAddService(t *testing.T) {
 	assert.Empty(t, metadataInfo.GetExportedServiceURLs())
 }
 
+func TestMetadataInfoRemoveServiceWithClonedURL(t *testing.T) {
+	metadataInfo := NewMetadataInfo("foo", "")
+	url, err := common.NewURL("dubbo://127.0.0.1:20000?application=foo&interface=com.foo.Bar&methods=GetPetByID%2CGetPetTypes&side=provider&version=1.0.0")
+	require.NoError(t, err)
+
+	metadataInfo.AddService(url)
+	metadataInfo.RemoveService(url.Clone())
+
+	assert.Empty(t, metadataInfo.Services)
+	assert.Empty(t, metadataInfo.GetExportedServiceURLs())
+}
+
 func TestHessian(t *testing.T) {
 	metadataInfo := &MetadataInfo{
 		App:                   "test",
@@ -90,6 +102,13 @@ func TestMetadataInfoAddSubscribeURL(t *testing.T) {
 	info.AddSubscribeURL(serviceUrl)
 	assert.NotEmpty(t, info.GetSubscribedURLs())
 	info.RemoveSubscribeURL(serviceUrl)
+	assert.Empty(t, info.GetSubscribedURLs())
+}
+
+func TestMetadataInfoRemoveSubscribeURLWithClonedURL(t *testing.T) {
+	info := NewMetadataInfo("dubbo", "tag")
+	info.AddSubscribeURL(serviceUrl)
+	info.RemoveSubscribeURL(serviceUrl.Clone())
 	assert.Empty(t, info.GetSubscribedURLs())
 }
 

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -56,3 +56,19 @@ func AddSubscribeURL(registryId string, url *common.URL) {
 	}
 	registryMetadataInfo[registryId].AddSubscribeURL(url)
 }
+
+func RemoveService(registryId string, url *common.URL) {
+	metadataInfo, exist := registryMetadataInfo[registryId]
+	if !exist {
+		return
+	}
+	metadataInfo.RemoveService(url)
+}
+
+func RemoveSubscribeURL(registryId string, url *common.URL) {
+	metadataInfo, exist := registryMetadataInfo[registryId]
+	if !exist {
+		return
+	}
+	metadataInfo.RemoveSubscribeURL(url)
+}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -122,6 +122,47 @@ func TestGetMetadataInfo(t *testing.T) {
 	}
 }
 
+func TestRemoveService(t *testing.T) {
+	registryID := "reg-remove-service"
+	url := common.NewURLWithOptions(
+		common.WithProtocol("dubbo"),
+		common.WithInterface("org.apache.dubbo.metadata.TestService"),
+		common.WithPath("org.apache.dubbo.metadata.TestService"),
+		common.WithMethods([]string{"Test"}),
+		common.WithPort("20880"),
+		common.WithParamsValue(constant.ApplicationKey, "dubbo"),
+		common.WithParamsValue(constant.ApplicationTagKey, "v1"),
+	)
+	defer delete(registryMetadataInfo, registryID)
+
+	AddService(registryID, url)
+	assert.Len(t, registryMetadataInfo[registryID].GetExportedServiceURLs(), 1)
+
+	RemoveService(registryID, url)
+	assert.Empty(t, registryMetadataInfo[registryID].GetExportedServiceURLs())
+	assert.Empty(t, registryMetadataInfo[registryID].Services)
+}
+
+func TestRemoveSubscribeURL(t *testing.T) {
+	registryID := "reg-remove-subscribe"
+	url := common.NewURLWithOptions(
+		common.WithProtocol("tri"),
+		common.WithInterface("org.apache.dubbo.metadata.TestService"),
+		common.WithPath("org.apache.dubbo.metadata.TestService"),
+		common.WithMethods([]string{"Test"}),
+		common.WithPort("20880"),
+		common.WithParamsValue(constant.ApplicationKey, "dubbo"),
+		common.WithParamsValue(constant.ApplicationTagKey, "v1"),
+	)
+	defer delete(registryMetadataInfo, registryID)
+
+	AddSubscribeURL(registryID, url)
+	assert.Len(t, registryMetadataInfo[registryID].GetSubscribedURLs(), 1)
+
+	RemoveSubscribeURL(registryID, url)
+	assert.Empty(t, registryMetadataInfo[registryID].GetSubscribedURLs())
+}
+
 func TestGetMetadataService(t *testing.T) {
 	tests := []struct {
 		name string

--- a/registry/servicediscovery/service_discovery_registry.go
+++ b/registry/servicediscovery/service_discovery_registry.go
@@ -166,12 +166,22 @@ func (s *serviceDiscoveryRegistry) UnRegister(url *common.URL) error {
 	if !shouldRegister(url) {
 		return nil
 	}
+	if id, exist := s.url.GetNonDefaultParam(constant.RegistryIdKey); exist {
+		metadata.RemoveService(id, url)
+		if metadataInfo := metadata.GetMetadataInfo(id); metadataInfo != nil {
+			instance := createInstance(metadataInfo, url)
+			metadataInfo.Revision = instance.GetMetadata()[constant.ExportedServicesRevisionPropertyName]
+		}
+	}
 	return s.UnRegisterService()
 }
 
 func (s *serviceDiscoveryRegistry) UnSubscribe(url *common.URL, listener registry.NotifyListener) error {
 	if !shouldSubscribe(url) {
 		return nil
+	}
+	if id, exist := s.url.GetNonDefaultParam(constant.RegistryIdKey); exist {
+		metadata.RemoveSubscribeURL(id, url)
 	}
 	services := s.getServices(url, nil)
 	if services == nil {

--- a/registry/servicediscovery/service_discovery_registry.go
+++ b/registry/servicediscovery/service_discovery_registry.go
@@ -61,6 +61,7 @@ type serviceDiscoveryRegistry struct {
 	url                     *common.URL
 	serviceDiscovery        registry.ServiceDiscovery
 	instances               []registry.ServiceInstance
+	instanceURLs            map[registry.ServiceInstance]*common.URL
 	serviceNameMapping      mapping.ServiceNameMapping
 	metadataReport          report.MetadataReport
 	serviceListeners        map[string]registry.ServiceInstancesChangedListener
@@ -75,6 +76,7 @@ func newServiceDiscoveryRegistry(url *common.URL) (registry.Registry, error) {
 	return &serviceDiscoveryRegistry{
 		url:                url,
 		serviceDiscovery:   serviceDiscovery,
+		instanceURLs:       make(map[registry.ServiceInstance]*common.URL),
 		serviceNameMapping: extension.GetGlobalServiceNameMapping(),
 		metadataReport:     metadata.GetMetadataReportByRegistry(url.GetParam(constant.RegistryIdKey, "")),
 		serviceListeners:   make(map[string]registry.ServiceInstancesChangedListener),
@@ -107,6 +109,7 @@ func (s *serviceDiscoveryRegistry) RegisterService() error {
 		}
 		s.lock.Lock()
 		s.instances = append(s.instances, instance)
+		s.instanceURLs[instance] = url
 		s.lock.Unlock()
 	}
 	return nil
@@ -147,18 +150,33 @@ func (s *serviceDiscoveryRegistry) UnRegisterService() error {
 	s.lock.Unlock()
 
 	var errs []error
+	var removed []registry.ServiceInstance
+	var removedURLs []*common.URL
 
 	for _, v := range origin {
 		if err := s.serviceDiscovery.Unregister(v); err != nil {
 			// fail to unregister
 			keep = append(keep, v)
 			errs = append(errs, err)
+			continue
 		}
+		removed = append(removed, v)
+		s.lock.RLock()
+		if sourceURL, ok := s.instanceURLs[v]; ok {
+			removedURLs = append(removedURLs, sourceURL)
+		}
+		s.lock.RUnlock()
 	}
 
 	s.lock.Lock()
 	s.instances = keep
+	for _, instance := range removed {
+		delete(s.instanceURLs, instance)
+	}
 	s.lock.Unlock()
+	if err := s.syncExportedMetadataAfterUnregister(removedURLs, keep); err != nil {
+		errs = append(errs, err)
+	}
 	return errors.Join(errs...)
 }
 
@@ -166,22 +184,12 @@ func (s *serviceDiscoveryRegistry) UnRegister(url *common.URL) error {
 	if !shouldRegister(url) {
 		return nil
 	}
-	if id, exist := s.url.GetNonDefaultParam(constant.RegistryIdKey); exist {
-		metadata.RemoveService(id, url)
-		if metadataInfo := metadata.GetMetadataInfo(id); metadataInfo != nil {
-			instance := createInstance(metadataInfo, url)
-			metadataInfo.Revision = instance.GetMetadata()[constant.ExportedServicesRevisionPropertyName]
-		}
-	}
 	return s.UnRegisterService()
 }
 
 func (s *serviceDiscoveryRegistry) UnSubscribe(url *common.URL, listener registry.NotifyListener) error {
 	if !shouldSubscribe(url) {
 		return nil
-	}
-	if id, exist := s.url.GetNonDefaultParam(constant.RegistryIdKey); exist {
-		metadata.RemoveSubscribeURL(id, url)
 	}
 	services := s.getServices(url, nil)
 	if services == nil {
@@ -197,6 +205,50 @@ func (s *serviceDiscoveryRegistry) UnSubscribe(url *common.URL, listener registr
 	err := s.serviceNameMapping.Remove(url)
 	if err != nil {
 		return err
+	}
+	if id, exist := s.url.GetNonDefaultParam(constant.RegistryIdKey); exist {
+		metadata.RemoveSubscribeURL(id, url)
+	}
+	return nil
+}
+
+func (s *serviceDiscoveryRegistry) syncExportedMetadataAfterUnregister(removedURLs []*common.URL, keep []registry.ServiceInstance) error {
+	if len(removedURLs) == 0 {
+		return nil
+	}
+	registryID, exist := s.url.GetNonDefaultParam(constant.RegistryIdKey)
+	if !exist {
+		return nil
+	}
+	metadataInfo := metadata.GetMetadataInfo(registryID)
+	if metadataInfo == nil {
+		return nil
+	}
+	for _, removedURL := range removedURLs {
+		metadata.RemoveService(registryID, removedURL)
+	}
+	remainingURLs := metadataInfo.GetExportedServiceURLs()
+	if len(remainingURLs) == 0 {
+		metadataInfo.Revision = "0"
+		return nil
+	}
+	instance := createInstance(metadataInfo, remainingURLs[0])
+	revision := instance.GetMetadata()[constant.ExportedServicesRevisionPropertyName]
+	metadataInfo.Revision = revision
+	if metadata.GetMetadataType() == constant.RemoteMetadataStorageType {
+		if s.metadataReport == nil {
+			return perrors.New("can not publish app metadata cause report instance not found")
+		}
+		if err := s.metadataReport.PublishAppMetadata(metadataInfo.App, revision, metadataInfo); err != nil {
+			return err
+		}
+	}
+	for _, keepInstance := range keep {
+		keepInstance.SetServiceMetadata(metadataInfo)
+		keepInstance.GetMetadata()[constant.ExportedServicesRevisionPropertyName] = revision
+		if err := s.serviceDiscovery.Update(keepInstance); err != nil {
+			return perrors.WithMessage(err, "Update service failed")
+		}
 	}
 	return nil
 }

--- a/registry/servicediscovery/service_discovery_registry.go
+++ b/registry/servicediscovery/service_discovery_registry.go
@@ -144,37 +144,36 @@ func createInstance(meta *info.MetadataInfo, url *common.URL) registry.ServiceIn
 }
 
 func (s *serviceDiscoveryRegistry) UnRegisterService() error {
+	return s.unregisterService(nil)
+}
+
+func (s *serviceDiscoveryRegistry) unregisterService(targetURL *common.URL) error {
 	s.lock.Lock()
 	keep := s.instances[:0]
 	origin := s.instances[:]
 	s.lock.Unlock()
 
 	var errs []error
-	var removed []registry.ServiceInstance
-	var removedURLs []*common.URL
+	keepInstanceURLs := make(map[registry.ServiceInstance]*common.URL)
 
 	for _, v := range origin {
 		if err := s.serviceDiscovery.Unregister(v); err != nil {
 			// fail to unregister
 			keep = append(keep, v)
 			errs = append(errs, err)
-			continue
+			s.lock.RLock()
+			if sourceURL, ok := s.instanceURLs[v]; ok {
+				keepInstanceURLs[v] = sourceURL
+			}
+			s.lock.RUnlock()
 		}
-		removed = append(removed, v)
-		s.lock.RLock()
-		if sourceURL, ok := s.instanceURLs[v]; ok {
-			removedURLs = append(removedURLs, sourceURL)
-		}
-		s.lock.RUnlock()
 	}
 
 	s.lock.Lock()
 	s.instances = keep
-	for _, instance := range removed {
-		delete(s.instanceURLs, instance)
-	}
+	s.instanceURLs = keepInstanceURLs
 	s.lock.Unlock()
-	if err := s.syncExportedMetadataAfterUnregister(removedURLs, keep); err != nil {
+	if err := s.syncExportedMetadataAfterUnregister(targetURL, origin, keep); err != nil {
 		errs = append(errs, err)
 	}
 	return errors.Join(errs...)
@@ -184,7 +183,7 @@ func (s *serviceDiscoveryRegistry) UnRegister(url *common.URL) error {
 	if !shouldRegister(url) {
 		return nil
 	}
-	return s.UnRegisterService()
+	return s.unregisterService(url)
 }
 
 func (s *serviceDiscoveryRegistry) UnSubscribe(url *common.URL, listener registry.NotifyListener) error {
@@ -212,10 +211,7 @@ func (s *serviceDiscoveryRegistry) UnSubscribe(url *common.URL, listener registr
 	return nil
 }
 
-func (s *serviceDiscoveryRegistry) syncExportedMetadataAfterUnregister(removedURLs []*common.URL, keep []registry.ServiceInstance) error {
-	if len(removedURLs) == 0 {
-		return nil
-	}
+func (s *serviceDiscoveryRegistry) syncExportedMetadataAfterUnregister(targetURL *common.URL, origin []registry.ServiceInstance, keep []registry.ServiceInstance) error {
 	registryID, exist := s.url.GetNonDefaultParam(constant.RegistryIdKey)
 	if !exist {
 		return nil
@@ -224,8 +220,12 @@ func (s *serviceDiscoveryRegistry) syncExportedMetadataAfterUnregister(removedUR
 	if metadataInfo == nil {
 		return nil
 	}
-	for _, removedURL := range removedURLs {
-		metadata.RemoveService(registryID, removedURL)
+
+	keepURLs := s.getInstanceURLs(keep)
+	if len(origin) > 0 {
+		metadataInfo.ReplaceExportedServices(keepURLs)
+	} else if targetURL != nil {
+		metadata.RemoveService(registryID, targetURL)
 	}
 	remainingURLs := metadataInfo.GetExportedServiceURLs()
 	if len(remainingURLs) == 0 {
@@ -235,6 +235,9 @@ func (s *serviceDiscoveryRegistry) syncExportedMetadataAfterUnregister(removedUR
 	instance := createInstance(metadataInfo, remainingURLs[0])
 	revision := instance.GetMetadata()[constant.ExportedServicesRevisionPropertyName]
 	metadataInfo.Revision = revision
+	if len(keepURLs) == 0 {
+		return nil
+	}
 	if metadata.GetMetadataType() == constant.RemoteMetadataStorageType {
 		if s.metadataReport == nil {
 			return perrors.New("can not publish app metadata cause report instance not found")
@@ -251,6 +254,18 @@ func (s *serviceDiscoveryRegistry) syncExportedMetadataAfterUnregister(removedUR
 		}
 	}
 	return nil
+}
+
+func (s *serviceDiscoveryRegistry) getInstanceURLs(instances []registry.ServiceInstance) []*common.URL {
+	urls := make([]*common.URL, 0, len(instances))
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	for _, instance := range instances {
+		if sourceURL, ok := s.instanceURLs[instance]; ok {
+			urls = append(urls, sourceURL)
+		}
+	}
+	return urls
 }
 
 func parseServices(literalServices string) *gxset.HashSet {

--- a/registry/servicediscovery/service_discovery_registry_test.go
+++ b/registry/servicediscovery/service_discovery_registry_test.go
@@ -127,9 +127,11 @@ func TestServiceDiscoveryRegistrySubscribe(t *testing.T) {
 func TestServiceDiscoveryRegistryUnSubscribe(t *testing.T) {
 	mockSD, mockMapping := setupEnvironment(t)
 	mockMapping.data[testInterface] = gxset.NewSet(testApp)
+	regID := fmt.Sprintf("mock-reg-%d", time.Now().UnixNano())
 
 	registryURL, _ := common.NewURL(testRegistryURL,
-		common.WithParamsValue(constant.RegistryKey, "mock"))
+		common.WithParamsValue(constant.RegistryKey, "mock"),
+		common.WithParamsValue(constant.RegistryIdKey, regID))
 
 	reg, err := newServiceDiscoveryRegistry(registryURL)
 	require.NoError(t, err)
@@ -143,9 +145,72 @@ func TestServiceDiscoveryRegistryUnSubscribe(t *testing.T) {
 	_ = reg.Subscribe(consumerURL, &mockNotifyListener{})
 	mockSD.wg.Wait()
 
+	metaInfo := metadata.GetMetadataInfo(regID)
+	require.NotNil(t, metaInfo)
+	assert.Len(t, metaInfo.GetSubscribedURLs(), 1)
+
 	err = reg.UnSubscribe(consumerURL, &mockNotifyListener{})
 	require.NoError(t, err)
 	assert.True(t, mockMapping.removeCalled)
+	assert.Empty(t, metaInfo.GetSubscribedURLs())
+}
+
+func TestServiceDiscoveryRegistryUnRegisterRemovesMetadataAndRefreshesRevision(t *testing.T) {
+	mockSD, mockMapping := setupEnvironment(t)
+	regID := fmt.Sprintf("mock-reg-%d", time.Now().UnixNano())
+
+	registryURL, err := common.NewURL(testRegistryURL,
+		common.WithParamsValue(constant.RegistryKey, "mock"),
+		common.WithParamsValue(constant.RegistryIdKey, regID))
+	require.NoError(t, err)
+
+	reg, err := newServiceDiscoveryRegistry(registryURL)
+	require.NoError(t, err)
+
+	providerURL1, err := common.NewURL("dubbo://127.0.0.1:20880/org.apache.dubbo.test.TestService",
+		common.WithParamsValue(constant.ApplicationKey, testApp),
+		common.WithInterface(testInterface),
+		common.WithMethods([]string{"MethodA"}),
+		common.WithParamsValue(constant.SideKey, constant.SideProvider),
+	)
+	require.NoError(t, err)
+	providerURL2, err := common.NewURL("tri://127.0.0.1:20881/org.apache.dubbo.test.TestService",
+		common.WithParamsValue(constant.ApplicationKey, testApp),
+		common.WithInterface(testInterface),
+		common.WithMethods([]string{"MethodB"}),
+		common.WithParamsValue(constant.SideKey, constant.SideProvider),
+	)
+	require.NoError(t, err)
+
+	err = reg.Register(providerURL1)
+	require.NoError(t, err)
+	err = reg.Register(providerURL2)
+	require.NoError(t, err)
+	assert.True(t, mockMapping.mapCalled)
+
+	sdReg, ok := reg.(*serviceDiscoveryRegistry)
+	require.True(t, ok)
+
+	err = sdReg.RegisterService()
+	require.NoError(t, err)
+
+	metaInfo := metadata.GetMetadataInfo(regID)
+	require.NotNil(t, metaInfo)
+	require.Len(t, metaInfo.GetExportedServiceURLs(), 2)
+	oldRevision := metaInfo.Revision
+	require.NotEmpty(t, oldRevision)
+
+	err = sdReg.UnRegister(providerURL1)
+	require.NoError(t, err)
+
+	require.Len(t, metaInfo.GetExportedServiceURLs(), 1)
+	assert.Equal(t, providerURL2, metaInfo.GetExportedServiceURLs()[0])
+	assert.Len(t, metaInfo.Services, 1)
+
+	expectedRevision := createInstance(metaInfo, providerURL2).GetMetadata()[constant.ExportedServicesRevisionPropertyName]
+	assert.Equal(t, expectedRevision, metaInfo.Revision)
+	assert.NotEqual(t, oldRevision, metaInfo.Revision)
+	assert.True(t, mockSD.unregisterCalled)
 }
 
 // setupEnvironment initializes the test environment.

--- a/registry/servicediscovery/service_discovery_registry_test.go
+++ b/registry/servicediscovery/service_discovery_registry_test.go
@@ -300,6 +300,54 @@ func TestServiceDiscoveryRegistryUnRegisterServicePartialFailSyncsMetadata(t *te
 	assert.Contains(t, mockSD.updatedIDs, providerURL1.Address())
 }
 
+func TestServiceDiscoveryRegistryUnRegisterWithoutTrackedInstancesReconcilesMetadata(t *testing.T) {
+	_, mockMapping := setupEnvironment(t)
+	regID := fmt.Sprintf("mock-reg-%d", time.Now().UnixNano())
+
+	registryURL, err := common.NewURL(testRegistryURL,
+		common.WithParamsValue(constant.RegistryKey, "mock"),
+		common.WithParamsValue(constant.RegistryIdKey, regID))
+	require.NoError(t, err)
+
+	reg, err := newServiceDiscoveryRegistry(registryURL)
+	require.NoError(t, err)
+
+	providerURL1, err := common.NewURL("dubbo://127.0.0.1:20880/org.apache.dubbo.test.TestService",
+		common.WithParamsValue(constant.ApplicationKey, testApp),
+		common.WithInterface(testInterface),
+		common.WithMethods([]string{"MethodA"}),
+		common.WithParamsValue(constant.SideKey, constant.SideProvider),
+	)
+	require.NoError(t, err)
+	providerURL2, err := common.NewURL("tri://127.0.0.1:20881/org.apache.dubbo.test.TestService",
+		common.WithParamsValue(constant.ApplicationKey, testApp),
+		common.WithInterface(testInterface),
+		common.WithMethods([]string{"MethodB"}),
+		common.WithParamsValue(constant.SideKey, constant.SideProvider),
+	)
+	require.NoError(t, err)
+
+	err = reg.Register(providerURL1)
+	require.NoError(t, err)
+	err = reg.Register(providerURL2)
+	require.NoError(t, err)
+	assert.True(t, mockMapping.mapCalled)
+
+	metaInfo := metadata.GetMetadataInfo(regID)
+	require.NotNil(t, metaInfo)
+	require.Len(t, metaInfo.GetExportedServiceURLs(), 2)
+
+	err = reg.UnRegister(providerURL1.Clone())
+	require.NoError(t, err)
+
+	require.Len(t, metaInfo.GetExportedServiceURLs(), 1)
+	assert.Equal(t, providerURL2, metaInfo.GetExportedServiceURLs()[0])
+	assert.Len(t, metaInfo.Services, 1)
+
+	expectedRevision := createInstance(metaInfo, providerURL2).GetMetadata()[constant.ExportedServicesRevisionPropertyName]
+	assert.Equal(t, expectedRevision, metaInfo.Revision)
+}
+
 // setupEnvironment initializes the test environment.
 func setupEnvironment(_ *testing.T) (*mockServiceDiscovery, *mockServiceNameMapping) {
 	appConfig := global.DefaultApplicationConfig()

--- a/registry/servicediscovery/service_discovery_registry_test.go
+++ b/registry/servicediscovery/service_discovery_registry_test.go
@@ -155,7 +155,38 @@ func TestServiceDiscoveryRegistryUnSubscribe(t *testing.T) {
 	assert.Empty(t, metaInfo.GetSubscribedURLs())
 }
 
-func TestServiceDiscoveryRegistryUnRegisterRemovesMetadataAndRefreshesRevision(t *testing.T) {
+func TestServiceDiscoveryRegistryUnSubscribeKeepsMetadataOnRemoveFailure(t *testing.T) {
+	mockSD, mockMapping := setupEnvironment(t)
+	mockMapping.data[testInterface] = gxset.NewSet(testApp)
+	mockMapping.removeErr = errors.New("mock remove failed")
+	regID := fmt.Sprintf("mock-reg-%d", time.Now().UnixNano())
+
+	registryURL, _ := common.NewURL(testRegistryURL,
+		common.WithParamsValue(constant.RegistryKey, "mock"),
+		common.WithParamsValue(constant.RegistryIdKey, regID))
+
+	reg, err := newServiceDiscoveryRegistry(registryURL)
+	require.NoError(t, err)
+
+	consumerURL, _ := common.NewURL("dubbo://127.0.0.1:20000/",
+		common.WithInterface(testInterface),
+		common.WithParamsValue(constant.SideKey, constant.SideConsumer),
+	)
+
+	mockSD.wg.Add(1)
+	_ = reg.Subscribe(consumerURL, &mockNotifyListener{})
+	mockSD.wg.Wait()
+
+	metaInfo := metadata.GetMetadataInfo(regID)
+	require.NotNil(t, metaInfo)
+	require.Len(t, metaInfo.GetSubscribedURLs(), 1)
+
+	err = reg.UnSubscribe(consumerURL.Clone(), &mockNotifyListener{})
+	require.Error(t, err)
+	assert.Len(t, metaInfo.GetSubscribedURLs(), 1)
+}
+
+func TestServiceDiscoveryRegistryUnRegisterSyncsBulkMetadataCleanup(t *testing.T) {
 	mockSD, mockMapping := setupEnvironment(t)
 	regID := fmt.Sprintf("mock-reg-%d", time.Now().UnixNano())
 
@@ -200,17 +231,73 @@ func TestServiceDiscoveryRegistryUnRegisterRemovesMetadataAndRefreshesRevision(t
 	oldRevision := metaInfo.Revision
 	require.NotEmpty(t, oldRevision)
 
-	err = sdReg.UnRegister(providerURL1)
+	err = sdReg.UnRegister(providerURL1.Clone())
 	require.NoError(t, err)
 
+	assert.Empty(t, metaInfo.GetExportedServiceURLs())
+	assert.Empty(t, metaInfo.Services)
+	assert.Equal(t, "0", metaInfo.Revision)
+	assert.True(t, mockSD.unregisterCalled)
+	assert.ElementsMatch(t, []string{providerURL1.Address(), providerURL2.Address()}, mockSD.unregisterIDs)
+	assert.NotEqual(t, oldRevision, metaInfo.Revision)
+}
+
+func TestServiceDiscoveryRegistryUnRegisterServicePartialFailSyncsMetadata(t *testing.T) {
+	mockSD, mockMapping := setupEnvironment(t)
+	regID := fmt.Sprintf("mock-reg-%d", time.Now().UnixNano())
+
+	registryURL, err := common.NewURL(testRegistryURL,
+		common.WithParamsValue(constant.RegistryKey, "mock"),
+		common.WithParamsValue(constant.RegistryIdKey, regID))
+	require.NoError(t, err)
+
+	reg, err := newServiceDiscoveryRegistry(registryURL)
+	require.NoError(t, err)
+
+	providerURL1, err := common.NewURL("dubbo://127.0.0.1:20880/org.apache.dubbo.test.TestService",
+		common.WithParamsValue(constant.ApplicationKey, testApp),
+		common.WithInterface(testInterface),
+		common.WithMethods([]string{"MethodA"}),
+		common.WithParamsValue(constant.SideKey, constant.SideProvider),
+	)
+	require.NoError(t, err)
+	providerURL2, err := common.NewURL("tri://127.0.0.1:20881/org.apache.dubbo.test.TestService",
+		common.WithParamsValue(constant.ApplicationKey, testApp),
+		common.WithInterface(testInterface),
+		common.WithMethods([]string{"MethodB"}),
+		common.WithParamsValue(constant.SideKey, constant.SideProvider),
+	)
+	require.NoError(t, err)
+
+	err = reg.Register(providerURL1)
+	require.NoError(t, err)
+	err = reg.Register(providerURL2)
+	require.NoError(t, err)
+	assert.True(t, mockMapping.mapCalled)
+
+	sdReg, ok := reg.(*serviceDiscoveryRegistry)
+	require.True(t, ok)
+
+	err = sdReg.RegisterService()
+	require.NoError(t, err)
+
+	mockSD.unregisterErrByID = map[string]error{
+		providerURL1.Address(): errors.New("mock unregister failed"),
+	}
+
+	err = sdReg.UnRegisterService()
+	require.Error(t, err)
+
+	metaInfo := metadata.GetMetadataInfo(regID)
+	require.NotNil(t, metaInfo)
 	require.Len(t, metaInfo.GetExportedServiceURLs(), 1)
-	assert.Equal(t, providerURL2, metaInfo.GetExportedServiceURLs()[0])
+	assert.Equal(t, providerURL1, metaInfo.GetExportedServiceURLs()[0])
 	assert.Len(t, metaInfo.Services, 1)
 
-	expectedRevision := createInstance(metaInfo, providerURL2).GetMetadata()[constant.ExportedServicesRevisionPropertyName]
+	expectedRevision := createInstance(metaInfo, providerURL1).GetMetadata()[constant.ExportedServicesRevisionPropertyName]
 	assert.Equal(t, expectedRevision, metaInfo.Revision)
-	assert.NotEqual(t, oldRevision, metaInfo.Revision)
-	assert.True(t, mockSD.unregisterCalled)
+	assert.True(t, mockSD.updateCalled)
+	assert.Contains(t, mockSD.updatedIDs, providerURL1.Address())
 }
 
 // setupEnvironment initializes the test environment.
@@ -247,6 +334,8 @@ type mockServiceDiscovery struct {
 	unregisterCalled  bool
 	unregisterIDs     []string
 	unregisterErrByID map[string]error
+	updateCalled      bool
+	updatedIDs        []string
 }
 
 func (m *mockServiceDiscovery) String() string { return "mock" }
@@ -256,7 +345,13 @@ func (m *mockServiceDiscovery) Register(inst registry.ServiceInstance) error {
 	m.capturedInstance = inst
 	return nil
 }
-func (m *mockServiceDiscovery) Update(inst registry.ServiceInstance) error { return nil }
+func (m *mockServiceDiscovery) Update(inst registry.ServiceInstance) error {
+	m.updateCalled = true
+	if inst != nil {
+		m.updatedIDs = append(m.updatedIDs, inst.GetID())
+	}
+	return nil
+}
 func (m *mockServiceDiscovery) Unregister(inst registry.ServiceInstance) error {
 	m.unregisterCalled = true
 	if inst != nil {
@@ -296,6 +391,7 @@ type mockServiceNameMapping struct {
 	getCalled     bool
 	removeCalled  bool
 	capturedGroup string
+	removeErr     error
 }
 
 func (m *mockServiceNameMapping) Map(url *common.URL) error {
@@ -315,7 +411,10 @@ func (m *mockServiceNameMapping) Get(url *common.URL, _ mapping.MappingListener)
 	}
 	return gxset.NewSet(), nil
 }
-func (m *mockServiceNameMapping) Remove(url *common.URL) error { m.removeCalled = true; return nil }
+func (m *mockServiceNameMapping) Remove(url *common.URL) error {
+	m.removeCalled = true
+	return m.removeErr
+}
 
 type mockNotifyListener struct{}
 


### PR DESCRIPTION
### Description
Fixes #3349   (issue)
 
## What changed

- added `metadata.RemoveService` and `metadata.RemoveSubscribeURL`
- called local metadata cleanup in `UnRegister` and `UnSubscribe`
- refreshed local exported metadata revision after provider unregister
- added tests for unregister/unsubscribe metadata cleanup

## Why

We already update local application-level metadata on register/subscribe, but the unregister/unsubscribe path does not clean it up.

That leaves stale service URLs in local `MetadataInfo`, and the local revision can stay behind the actual exported state.

This change keeps the existing flow as-is and only fills in the missing local cleanup path.

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
