### PR TITLE
feat(metadata): Clarify metadata report selection for multi-registry and multi-instance scenarios

### DIFF
--- a/metadata/client.go
+++ b/metadata/client.go
@@ -42,8 +42,8 @@ import (
 
 const defaultTimeout = "5s" // s
 
-func GetMetadataFromMetadataReport(revision string, instance registry.ServiceInstance) (*info.MetadataInfo, error) {
-	report := GetMetadataReport()
+func GetMetadataFromMetadataReport(revision string, instance registry.ServiceInstance, registryId string) (*info.MetadataInfo, error) {
+	report := GetMetadataReportByRegistry(registryId)
 	if report == nil {
 		return nil, perrors.New("no metadata report instance found,please check ")
 	}

--- a/metadata/client.go
+++ b/metadata/client.go
@@ -45,7 +45,7 @@ const defaultTimeout = "5s" // s
 func GetMetadataFromMetadataReport(revision string, instance registry.ServiceInstance, registryId string) (*info.MetadataInfo, error) {
 	report := GetMetadataReportByRegistry(registryId)
 	if report == nil {
-		return nil, perrors.New("no metadata report instance found,please check ")
+		return nil, perrors.Errorf("no metadata report instance found for registryId=%s, please check metadata-report configuration", registryId)
 	}
 	return report.GetAppMetadata(instance.GetServiceName(), revision)
 }

--- a/metadata/client_test.go
+++ b/metadata/client_test.go
@@ -63,7 +63,7 @@ var (
 
 func TestGetMetadataFromMetadataReport(t *testing.T) {
 	t.Run("no report instance", func(t *testing.T) {
-		_, err := GetMetadataFromMetadataReport("1", ins)
+		_, err := GetMetadataFromMetadataReport("1", ins, "default")
 		require.Error(t, err)
 	})
 	mockReport := new(mockMetadataReport)
@@ -71,13 +71,13 @@ func TestGetMetadataFromMetadataReport(t *testing.T) {
 	instances["default"] = mockReport
 	t.Run("normal", func(t *testing.T) {
 		mockReport.On("GetAppMetadata").Return(metadataInfo, nil).Once()
-		got, err := GetMetadataFromMetadataReport("1", ins)
+		got, err := GetMetadataFromMetadataReport("1", ins, "default")
 		require.NoError(t, err)
 		assert.Equal(t, metadataInfo, got)
 	})
 	t.Run("error", func(t *testing.T) {
 		mockReport.On("GetAppMetadata").Return(metadataInfo, errors.New("mock error")).Once()
-		_, err := GetMetadataFromMetadataReport("1", ins)
+		_, err := GetMetadataFromMetadataReport("1", ins, "default")
 		require.Error(t, err)
 	})
 }

--- a/metadata/client_test.go
+++ b/metadata/client_test.go
@@ -35,6 +35,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/metadata/info"
+	"dubbo.apache.org/dubbo-go/v3/metadata/report"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 	"dubbo.apache.org/dubbo-go/v3/protocol/result"
 	_ "dubbo.apache.org/dubbo-go/v3/proxy/proxy_factory"
@@ -62,20 +63,59 @@ var (
 )
 
 func TestGetMetadataFromMetadataReport(t *testing.T) {
+	t.Cleanup(func() { instances = make(map[string]report.MetadataReport) })
+
 	t.Run("no report instance", func(t *testing.T) {
+		instances = make(map[string]report.MetadataReport)
 		_, err := GetMetadataFromMetadataReport("1", ins, "default")
 		require.Error(t, err)
 	})
-	mockReport := new(mockMetadataReport)
-	defer mockReport.AssertExpectations(t)
-	instances["default"] = mockReport
-	t.Run("normal", func(t *testing.T) {
+
+	t.Run("default registry routes to default report", func(t *testing.T) {
+		instances = make(map[string]report.MetadataReport)
+		mockReport := new(mockMetadataReport)
+		defer mockReport.AssertExpectations(t)
+		instances["default"] = mockReport
+
 		mockReport.On("GetAppMetadata").Return(metadataInfo, nil).Once()
 		got, err := GetMetadataFromMetadataReport("1", ins, "default")
 		require.NoError(t, err)
 		assert.Equal(t, metadataInfo, got)
 	})
-	t.Run("error", func(t *testing.T) {
+
+	t.Run("specific registryId routes to its own report", func(t *testing.T) {
+		instances = make(map[string]report.MetadataReport)
+		defaultReport := new(mockMetadataReport)
+		specificReport := new(mockMetadataReport)
+		defer defaultReport.AssertExpectations(t)
+		defer specificReport.AssertExpectations(t)
+		instances["default"] = defaultReport
+		instances["reg-a"] = specificReport
+
+		// specificReport must be called; defaultReport must NOT be called
+		specificReport.On("GetAppMetadata").Return(metadataInfo, nil).Once()
+		got, err := GetMetadataFromMetadataReport("1", ins, "reg-a")
+		require.NoError(t, err)
+		assert.Equal(t, metadataInfo, got)
+	})
+
+	t.Run("unknown registryId returns error instead of silently using wrong report", func(t *testing.T) {
+		instances = make(map[string]report.MetadataReport)
+		defaultReport := new(mockMetadataReport)
+		defer defaultReport.AssertExpectations(t)
+		instances["default"] = defaultReport
+
+		// defaultReport must NOT be called — GetMetadataReportByRegistry returns nil for unknown id
+		_, err := GetMetadataFromMetadataReport("1", ins, "nonexistent-registry")
+		require.Error(t, err, "should error when the specific registryId has no registered report")
+	})
+
+	t.Run("report error propagated", func(t *testing.T) {
+		instances = make(map[string]report.MetadataReport)
+		mockReport := new(mockMetadataReport)
+		defer mockReport.AssertExpectations(t)
+		instances["default"] = mockReport
+
 		mockReport.On("GetAppMetadata").Return(metadataInfo, errors.New("mock error")).Once()
 		_, err := GetMetadataFromMetadataReport("1", ins, "default")
 		require.Error(t, err)

--- a/metadata/client_test.go
+++ b/metadata/client_test.go
@@ -99,15 +99,18 @@ func TestGetMetadataFromMetadataReport(t *testing.T) {
 		assert.Equal(t, metadataInfo, got)
 	})
 
-	t.Run("unknown registryId returns error instead of silently using wrong report", func(t *testing.T) {
+	t.Run("unknown registryId falls back to default report", func(t *testing.T) {
 		instances = make(map[string]report.MetadataReport)
 		defaultReport := new(mockMetadataReport)
 		defer defaultReport.AssertExpectations(t)
 		instances["default"] = defaultReport
 
-		// defaultReport must NOT be called — GetMetadataReportByRegistry returns nil for unknown id
-		_, err := GetMetadataFromMetadataReport("1", ins, "nonexistent-registry")
-		require.Error(t, err, "should error when the specific registryId has no registered report")
+		// When the specific registryId is not found, it falls back to "default"
+		// so the default report's GetAppMetadata is called
+		defaultReport.On("GetAppMetadata").Return(metadataInfo, nil).Once()
+		got, err := GetMetadataFromMetadataReport("1", ins, "nonexistent-registry")
+		require.NoError(t, err)
+		assert.Equal(t, metadataInfo, got)
 	})
 
 	t.Run("report error propagated", func(t *testing.T) {

--- a/metadata/mapping/metadata/service_name_mapping.go
+++ b/metadata/mapping/metadata/service_name_mapping.go
@@ -98,9 +98,15 @@ func (d *ServiceNameMapping) Get(url *common.URL, listener mapping.MappingListen
 
 func (d *ServiceNameMapping) Remove(url *common.URL) error {
 	serviceInterface := url.GetParam(constant.InterfaceKey, "")
-	metadataReport := metadata.GetMetadataReport()
-	if metadataReport == nil {
+	metadataReports := metadata.GetMetadataReports()
+	if len(metadataReports) == 0 {
 		return perrors.New("can not remove mapping in remote cause no metadata report instance found")
 	}
-	return metadataReport.RemoveServiceAppMappingListener(serviceInterface, DefaultGroup)
+	var lastErr error
+	for _, metadataReport := range metadataReports {
+		if err := metadataReport.RemoveServiceAppMappingListener(serviceInterface, DefaultGroup); err != nil {
+			lastErr = err
+		}
+	}
+	return lastErr
 }

--- a/metadata/mapping/metadata/service_name_mapping.go
+++ b/metadata/mapping/metadata/service_name_mapping.go
@@ -90,11 +90,32 @@ func (d *ServiceNameMapping) Map(url *common.URL) error {
 // Get will return the application-level services. If not found, the empty set will be returned.
 func (d *ServiceNameMapping) Get(url *common.URL, listener mapping.MappingListener) (*gxset.HashSet, error) {
 	serviceInterface := url.GetParam(constant.InterfaceKey, "")
-	metadataReport := metadata.GetMetadataReport()
-	if metadataReport == nil {
-		return nil, perrors.New("can not get mapping in remote cause no metadata report instance found")
+	metadataReports := metadata.GetMetadataReports()
+	if len(metadataReports) == 0 {
+          return nil, perrors.New("can not get mapping in remote cause no metadata report instance found")
+    }
+    var result *gxset.HashSet
+    var errs []error	
+	for i, metadataReport := range metadataReports {
+		var reportListener mapping.MappingListener
+		if i == 0 {
+			reportListener = listener
+		}
+		set, err := metadataReport.GetServiceAppMapping(serviceInterface, DefaultGroup, reportListener)
+		if err != nil {
+			errs = append(errs, err)
+			continue;
+		}
+		if result == nil {
+			result = set
+		} else {
+			result.Add(set.Values()...)
+		}
 	}
-	return metadataReport.GetServiceAppMapping(serviceInterface, DefaultGroup, listener)
+	if result == nil {
+		return nil, errors.Join(errs...)
+	}
+	return result, nil
 }
 
 // Remove removes the service-to-app mapping for the given URL from all
@@ -106,7 +127,7 @@ func (d *ServiceNameMapping) Get(url *common.URL, listener mapping.MappingListen
 func (d *ServiceNameMapping) Remove(url *common.URL) error {
 	serviceInterface := url.GetParam(constant.InterfaceKey, "")
 	metadataReports := metadata.GetMetadataReports()
-	if len(metadataReports) == 0 {
+	if metadataReports == nil || len(metadataReports) == 0 {
 		return perrors.New("can not remove mapping in remote cause no metadata report instance found")
 	}
 	var errs []error

--- a/metadata/mapping/metadata/service_name_mapping.go
+++ b/metadata/mapping/metadata/service_name_mapping.go
@@ -94,11 +94,16 @@ func (d *ServiceNameMapping) Get(url *common.URL, listener mapping.MappingListen
 	if len(metadataReports) == 0 {
 		return nil, perrors.New("can not get mapping in remote cause no metadata report instance found")
 	}
+	// Attach the listener to the stable primary report only (GetMetadataReport uses
+	// a deterministic selection: prefer "default", otherwise lexicographic first).
+	// GetMetadataReports() iterates a map so its order is non-deterministic; using
+	// i==0 as the anchor would bind the listener to a random backend each run.
+	primaryReport := metadata.GetMetadataReport()
 	var result *gxset.HashSet
 	var errs []error
-	for i, metadataReport := range metadataReports {
+	for _, metadataReport := range metadataReports {
 		var reportListener mapping.MappingListener
-		if i == 0 {
+		if metadataReport == primaryReport {
 			reportListener = listener
 		}
 		set, err := metadataReport.GetServiceAppMapping(serviceInterface, DefaultGroup, reportListener)

--- a/metadata/mapping/metadata/service_name_mapping.go
+++ b/metadata/mapping/metadata/service_name_mapping.go
@@ -92,10 +92,10 @@ func (d *ServiceNameMapping) Get(url *common.URL, listener mapping.MappingListen
 	serviceInterface := url.GetParam(constant.InterfaceKey, "")
 	metadataReports := metadata.GetMetadataReports()
 	if len(metadataReports) == 0 {
-          return nil, perrors.New("can not get mapping in remote cause no metadata report instance found")
-    }
-    var result *gxset.HashSet
-    var errs []error	
+		return nil, perrors.New("can not get mapping in remote cause no metadata report instance found")
+	}
+	var result *gxset.HashSet
+	var errs []error
 	for i, metadataReport := range metadataReports {
 		var reportListener mapping.MappingListener
 		if i == 0 {
@@ -104,7 +104,7 @@ func (d *ServiceNameMapping) Get(url *common.URL, listener mapping.MappingListen
 		set, err := metadataReport.GetServiceAppMapping(serviceInterface, DefaultGroup, reportListener)
 		if err != nil {
 			errs = append(errs, err)
-			continue;
+			continue
 		}
 		if result == nil {
 			result = set
@@ -127,7 +127,7 @@ func (d *ServiceNameMapping) Get(url *common.URL, listener mapping.MappingListen
 func (d *ServiceNameMapping) Remove(url *common.URL) error {
 	serviceInterface := url.GetParam(constant.InterfaceKey, "")
 	metadataReports := metadata.GetMetadataReports()
-	if metadataReports == nil || len(metadataReports) == 0 {
+	if len(metadataReports) == 0 {
 		return perrors.New("can not remove mapping in remote cause no metadata report instance found")
 	}
 	var errs []error

--- a/metadata/mapping/metadata/service_name_mapping.go
+++ b/metadata/mapping/metadata/service_name_mapping.go
@@ -18,6 +18,7 @@
 package metadata
 
 import (
+	"errors"
 	"sync"
 )
 
@@ -96,17 +97,23 @@ func (d *ServiceNameMapping) Get(url *common.URL, listener mapping.MappingListen
 	return metadataReport.GetServiceAppMapping(serviceInterface, DefaultGroup, listener)
 }
 
+// Remove removes the service-to-app mapping for the given URL from all
+// registered metadata reports. Unlike Map (which stops on the first failure),
+// Remove is best-effort: it attempts every report and returns all errors
+// joined together so the caller can see the full failure picture. The
+// intent is to avoid leaving stale entries in any registry due to a transient
+// error in one of the others.
 func (d *ServiceNameMapping) Remove(url *common.URL) error {
 	serviceInterface := url.GetParam(constant.InterfaceKey, "")
 	metadataReports := metadata.GetMetadataReports()
 	if len(metadataReports) == 0 {
 		return perrors.New("can not remove mapping in remote cause no metadata report instance found")
 	}
-	var lastErr error
+	var errs []error
 	for _, metadataReport := range metadataReports {
 		if err := metadataReport.RemoveServiceAppMappingListener(serviceInterface, DefaultGroup); err != nil {
-			lastErr = err
+			errs = append(errs, err)
 		}
 	}
-	return lastErr
+	return errors.Join(errs...)
 }

--- a/metadata/mapping/metadata/service_name_mapping_test.go
+++ b/metadata/mapping/metadata/service_name_mapping_test.go
@@ -156,6 +156,8 @@ func initMockWithId(t *testing.T, registryId string) *mockMetadataReport {
 }
 
 func TestServiceNameMappingRemoveFansOutToAllReports(t *testing.T) {
+	metadata.ClearMetadataReportInstances()
+	t.Cleanup(metadata.ClearMetadataReportInstances)
 	serviceNameMappingOnce = sync.Once{}
 	serviceNameMappingInstance = nil
 
@@ -173,6 +175,66 @@ func TestServiceNameMappingRemoveFansOutToAllReports(t *testing.T) {
 
 	err := ins.Remove(serviceUrl)
 	require.NoError(t, err)
+	r1.AssertExpectations(t)
+	r2.AssertExpectations(t)
+}
+
+func TestServiceNameMappingRemoveCollectsAllErrors(t *testing.T) {
+	metadata.ClearMetadataReportInstances()
+	t.Cleanup(metadata.ClearMetadataReportInstances)
+	serviceNameMappingOnce = sync.Once{}
+	serviceNameMappingInstance = nil
+
+	r1 := initMockWithId(t, "reg-c")
+	r2 := initMockWithId(t, "reg-d")
+
+	ins := GetNameMappingInstance()
+	serviceUrl := common.NewURLWithOptions(
+		common.WithInterface("org.example.BarService"),
+		common.WithParamsValue(constant.ApplicationKey, "bar-app"),
+	)
+
+	err1 := errors.New("r1 failure")
+	err2 := errors.New("r2 failure")
+
+	// both reports fail
+	r1.On("RemoveServiceAppMappingListener").Return(err1).Once()
+	r2.On("RemoveServiceAppMappingListener").Return(err2).Once()
+
+	err := ins.Remove(serviceUrl)
+	require.Error(t, err)
+	// both individual errors must be present in the returned error
+	require.ErrorIs(t, err, err1)
+	require.ErrorIs(t, err, err2)
+	r1.AssertExpectations(t)
+	r2.AssertExpectations(t)
+}
+
+func TestServiceNameMappingRemoveContinuesAfterPartialFailure(t *testing.T) {
+	metadata.ClearMetadataReportInstances()
+	t.Cleanup(metadata.ClearMetadataReportInstances)
+	serviceNameMappingOnce = sync.Once{}
+	serviceNameMappingInstance = nil
+
+	r1 := initMockWithId(t, "reg-e")
+	r2 := initMockWithId(t, "reg-f")
+
+	ins := GetNameMappingInstance()
+	serviceUrl := common.NewURLWithOptions(
+		common.WithInterface("org.example.BazService"),
+		common.WithParamsValue(constant.ApplicationKey, "baz-app"),
+	)
+
+	removeErr := errors.New("r1 partial failure")
+
+	// r1 fails, r2 succeeds — the loop must not short-circuit
+	r1.On("RemoveServiceAppMappingListener").Return(removeErr).Once()
+	r2.On("RemoveServiceAppMappingListener").Return(nil).Once()
+
+	err := ins.Remove(serviceUrl)
+	// the joined error only contains r1's error; the call should error
+	require.ErrorIs(t, err, removeErr)
+	// both reports must have been called despite r1's failure
 	r1.AssertExpectations(t)
 	r2.AssertExpectations(t)
 }

--- a/metadata/mapping/metadata/service_name_mapping_test.go
+++ b/metadata/mapping/metadata/service_name_mapping_test.go
@@ -19,6 +19,7 @@ package metadata
 
 import (
 	"errors"
+	"sync"
 	"testing"
 )
 
@@ -137,6 +138,43 @@ func initMock() (*mockMetadataReport, error) {
 	)
 	err := opts.Init()
 	return metadataReport, err
+}
+
+func initMockWithId(t *testing.T, registryId string) *mockMetadataReport {
+	t.Helper()
+	mockReport := new(mockMetadataReport)
+	extension.SetMetadataReportFactory(registryId, func() report.MetadataReportFactory {
+		return mockReport
+	})
+	opts := metadata.NewReportOptions(
+		metadata.WithRegistryId(registryId),
+		metadata.WithProtocol(registryId),
+		metadata.WithAddress("127.0.0.1"),
+	)
+	require.NoError(t, opts.Init())
+	return mockReport
+}
+
+func TestServiceNameMappingRemoveFansOutToAllReports(t *testing.T) {
+	serviceNameMappingOnce = sync.Once{}
+	serviceNameMappingInstance = nil
+
+	r1 := initMockWithId(t, "reg-a")
+	r2 := initMockWithId(t, "reg-b")
+
+	ins := GetNameMappingInstance()
+	serviceUrl := common.NewURLWithOptions(
+		common.WithInterface("org.example.FooService"),
+		common.WithParamsValue(constant.ApplicationKey, "foo-app"),
+	)
+
+	r1.On("RemoveServiceAppMappingListener").Return(nil).Once()
+	r2.On("RemoveServiceAppMappingListener").Return(nil).Once()
+
+	err := ins.Remove(serviceUrl)
+	require.NoError(t, err)
+	r1.AssertExpectations(t)
+	r2.AssertExpectations(t)
 }
 
 type listener struct {

--- a/metadata/report_instance.go
+++ b/metadata/report_instance.go
@@ -20,7 +20,14 @@ package metadata
 import (
 	"sort"
 	"time"
+)
 
+import (
+	gxset "github.com/dubbogo/gost/container/set"
+	"github.com/dubbogo/gost/log/logger"
+)
+
+import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
@@ -28,9 +35,6 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/metadata/mapping"
 	"dubbo.apache.org/dubbo-go/v3/metadata/report"
 	"dubbo.apache.org/dubbo-go/v3/metrics"
-	gxset "github.com/dubbogo/gost/container/set"
-	"github.com/dubbogo/gost/log/logger"
-
 	metadataMetrics "dubbo.apache.org/dubbo-go/v3/metrics/metadata"
 )
 

--- a/metadata/report_instance.go
+++ b/metadata/report_instance.go
@@ -90,6 +90,10 @@ func GetMetadataReportByRegistry(registry string) report.MetadataReport {
 	if r, ok := instances[registry]; ok {
 		return r
 	}
+	if r, ok := instances[constant.DefaultKey]; ok {
+        logger.Infof("[Metadata] no metadata report bound to registryId=%s, falling back to default", registry)
+        return r
+      }
 	logger.Warnf("[Metadata] no metadata report found for registryId=%s", registry)
 	return nil
 }

--- a/metadata/report_instance.go
+++ b/metadata/report_instance.go
@@ -18,6 +18,7 @@
 package metadata
 
 import (
+	"sort"
 	"time"
 )
 
@@ -51,9 +52,21 @@ func addMetadataReport(registryId string, url *common.URL) error {
 	return nil
 }
 
+// GetMetadataReport returns a single metadata report for callers that lack
+// registry context. It prefers the "default" registry's report; when absent
+// it falls back to the lexicographically first registry id so the selection
+// is always stable across calls.
 func GetMetadataReport() report.MetadataReport {
-	for _, v := range instances {
-		return v
+	if r, ok := instances[constant.DefaultKey]; ok {
+		return r
+	}
+	keys := make([]string, 0, len(instances))
+	for k := range instances {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if len(keys) > 0 {
+		return instances[keys[0]]
 	}
 	return nil
 }

--- a/metadata/report_instance.go
+++ b/metadata/report_instance.go
@@ -78,11 +78,13 @@ func GetMetadataReport() report.MetadataReport {
 }
 
 // GetMetadataReportByRegistry returns the metadata report bound to the given
-// registry id. When registry is empty the caller has no registry context, so
-// the stable default returned by GetMetadataReport is used. When a specific
-// (non-empty) registry id is given but is not registered, nil is returned so
-// the caller receives an explicit failure rather than silently operating
-// against the wrong registry's report.
+// registry id. When the registry id is empty the caller has no registry context,
+// so the stable default returned by GetMetadataReport is used. When a specific
+// (non-empty) registry id is not found, it falls back to the "default" report
+// if one exists. This handles the common case where a standalone metadata-report
+// config is registered under "default" while named registries (e.g. nacos, zk)
+// need to use it. nil is returned only when neither the specific id nor "default"
+// is registered.
 func GetMetadataReportByRegistry(registry string) report.MetadataReport {
 	if len(registry) == 0 {
 		return GetMetadataReport()

--- a/metadata/report_instance.go
+++ b/metadata/report_instance.go
@@ -91,9 +91,9 @@ func GetMetadataReportByRegistry(registry string) report.MetadataReport {
 		return r
 	}
 	if r, ok := instances[constant.DefaultKey]; ok {
-        logger.Infof("[Metadata] no metadata report bound to registryId=%s, falling back to default", registry)
-        return r
-      }
+		logger.Infof("[Metadata] no metadata report bound to registryId=%s, falling back to default", registry)
+		return r
+	}
 	logger.Warnf("[Metadata] no metadata report found for registryId=%s", registry)
 	return nil
 }

--- a/metadata/report_instance.go
+++ b/metadata/report_instance.go
@@ -20,14 +20,7 @@ package metadata
 import (
 	"sort"
 	"time"
-)
 
-import (
-	"github.com/dubbogo/gost/container/set"
-	"github.com/dubbogo/gost/log/logger"
-)
-
-import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
@@ -35,12 +28,21 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/metadata/mapping"
 	"dubbo.apache.org/dubbo-go/v3/metadata/report"
 	"dubbo.apache.org/dubbo-go/v3/metrics"
+	gxset "github.com/dubbogo/gost/container/set"
+	"github.com/dubbogo/gost/log/logger"
+
 	metadataMetrics "dubbo.apache.org/dubbo-go/v3/metrics/metadata"
 )
 
 var (
 	instances = make(map[string]report.MetadataReport)
 )
+
+// ClearMetadataReportInstances resets the package-level instances map.
+// Intended for test isolation only; do not call in production code.
+func ClearMetadataReportInstances() {
+	instances = make(map[string]report.MetadataReport)
+}
 
 func addMetadataReport(registryId string, url *common.URL) error {
 	fac := extension.GetMetadataReportFactory(url.Protocol)
@@ -71,14 +73,21 @@ func GetMetadataReport() report.MetadataReport {
 	return nil
 }
 
+// GetMetadataReportByRegistry returns the metadata report bound to the given
+// registry id. When registry is empty the caller has no registry context, so
+// the stable default returned by GetMetadataReport is used. When a specific
+// (non-empty) registry id is given but is not registered, nil is returned so
+// the caller receives an explicit failure rather than silently operating
+// against the wrong registry's report.
 func GetMetadataReportByRegistry(registry string) report.MetadataReport {
 	if len(registry) == 0 {
-		registry = constant.DefaultKey
+		return GetMetadataReport()
 	}
 	if r, ok := instances[registry]; ok {
 		return r
 	}
-	return GetMetadataReport()
+	logger.Warnf("[Metadata] no metadata report found for registryId=%s", registry)
+	return nil
 }
 
 func GetMetadataReports() []report.MetadataReport {

--- a/metadata/report_instance_test.go
+++ b/metadata/report_instance_test.go
@@ -180,21 +180,21 @@ func TestGetMetadataReportIsDeterministic(t *testing.T) {
 	instances = make(map[string]report.MetadataReport)
 	r1 := new(mockMetadataReport)
 	r2 := new(mockMetadataReport)
-	// "aaa" 字母序在 "zzz" 之前，两者均不是 "default"
+	// "aaa" sorts before "zzz" alphabetically, neither is "default"
 	instances["zzz"] = r1
 	instances["aaa"] = r2
 
-	// 没有 "default" key 时，必须始终返回字母序第一个（r2）
+	// without a "default" key, must always return the alphabetically first entry (r2)
 	for range 20 {
 		got := GetMetadataReport()
-		assert.Equal(t, r2, got, "期望返回 'aaa' 对应的 report")
+		assert.Equal(t, r2, got, "expected the report for 'aaa'")
 	}
 
-	// 存在 "default" key 时，必须始终返回它（r1），优先级高于字母序
+	// when the "default" key exists, must always return it (r1), taking priority over alphabetical order
 	instances[constant.DefaultKey] = r1
 	for range 20 {
 		got := GetMetadataReport()
-		assert.Equal(t, r1, got, "期望返回 'default' 对应的 report")
+		assert.Equal(t, r1, got, "expected the report for 'default'")
 	}
 }
 

--- a/metadata/report_instance_test.go
+++ b/metadata/report_instance_test.go
@@ -200,11 +200,37 @@ func TestGetMetadataReportIsDeterministic(t *testing.T) {
 
 func TestGetMetadataReportByRegistry(t *testing.T) {
 	instances = make(map[string]report.MetadataReport)
+	// nothing registered: all paths return nil
+	assert.Nil(t, GetMetadataReportByRegistry(""))
 	assert.Nil(t, GetMetadataReportByRegistry("reg"))
-	instances["default"] = new(mockMetadataReport)
-	assert.NotNil(t, GetMetadataReportByRegistry("default"))
-	assert.NotNil(t, GetMetadataReportByRegistry("reg"))
-	assert.NotNil(t, GetMetadataReportByRegistry(""))
+
+	defaultReport := new(mockMetadataReport)
+	instances["default"] = defaultReport
+
+	// exact hit
+	assert.Equal(t, defaultReport, GetMetadataReportByRegistry("default"))
+	// empty string → no registry context → falls through to GetMetadataReport() → "default"
+	assert.Equal(t, defaultReport, GetMetadataReportByRegistry(""))
+	// specific but unknown id → nil (not a silent wrong-registry fallback)
+	assert.Nil(t, GetMetadataReportByRegistry("reg"))
+}
+
+func TestGetMetadataReportByRegistryFallsBackDeterministically(t *testing.T) {
+	instances = make(map[string]report.MetadataReport)
+	rA := new(mockMetadataReport)
+	rB := new(mockMetadataReport)
+	instances["aaa"] = rA // lex-first
+	instances["zzz"] = rB
+
+	// known key → exact report
+	assert.Equal(t, rA, GetMetadataReportByRegistry("aaa"))
+	assert.Equal(t, rB, GetMetadataReportByRegistry("zzz"))
+
+	// unknown specific id → nil, not the lex-first fallback
+	assert.Nil(t, GetMetadataReportByRegistry("unknown-registry"))
+
+	// empty string → falls through to GetMetadataReport() → lex-first ("aaa" → rA)
+	assert.Equal(t, rA, GetMetadataReportByRegistry(""))
 }
 
 func TestGetMetadataReports(t *testing.T) {

--- a/metadata/report_instance_test.go
+++ b/metadata/report_instance_test.go
@@ -211,8 +211,8 @@ func TestGetMetadataReportByRegistry(t *testing.T) {
 	assert.Equal(t, defaultReport, GetMetadataReportByRegistry("default"))
 	// empty string → no registry context → falls through to GetMetadataReport() → "default"
 	assert.Equal(t, defaultReport, GetMetadataReportByRegistry(""))
-	// specific but unknown id → nil (not a silent wrong-registry fallback)
-	assert.Nil(t, GetMetadataReportByRegistry("reg"))
+	// specific but unknown id → falls back to "default"
+	assert.Equal(t, defaultReport, GetMetadataReportByRegistry("reg"))
 }
 
 func TestGetMetadataReportByRegistryFallsBackDeterministically(t *testing.T) {
@@ -226,7 +226,7 @@ func TestGetMetadataReportByRegistryFallsBackDeterministically(t *testing.T) {
 	assert.Equal(t, rA, GetMetadataReportByRegistry("aaa"))
 	assert.Equal(t, rB, GetMetadataReportByRegistry("zzz"))
 
-	// unknown specific id → nil, not the lex-first fallback
+	// unknown specific id → nil when no "default" is registered
 	assert.Nil(t, GetMetadataReportByRegistry("unknown-registry"))
 
 	// empty string → falls through to GetMetadataReport() → lex-first ("aaa" → rA)

--- a/metadata/report_instance_test.go
+++ b/metadata/report_instance_test.go
@@ -176,6 +176,28 @@ func TestGetMetadataReport(t *testing.T) {
 	assert.NotNil(t, GetMetadataReport())
 }
 
+func TestGetMetadataReportIsDeterministic(t *testing.T) {
+	instances = make(map[string]report.MetadataReport)
+	r1 := new(mockMetadataReport)
+	r2 := new(mockMetadataReport)
+	// "aaa" 字母序在 "zzz" 之前，两者均不是 "default"
+	instances["zzz"] = r1
+	instances["aaa"] = r2
+
+	// 没有 "default" key 时，必须始终返回字母序第一个（r2）
+	for range 20 {
+		got := GetMetadataReport()
+		assert.Equal(t, r2, got, "期望返回 'aaa' 对应的 report")
+	}
+
+	// 存在 "default" key 时，必须始终返回它（r1），优先级高于字母序
+	instances[constant.DefaultKey] = r1
+	for range 20 {
+		got := GetMetadataReport()
+		assert.Equal(t, r1, got, "期望返回 'default' 对应的 report")
+	}
+}
+
 func TestGetMetadataReportByRegistry(t *testing.T) {
 	instances = make(map[string]report.MetadataReport)
 	assert.Nil(t, GetMetadataReportByRegistry("reg"))

--- a/registry/nacos/service_discovery_test.go
+++ b/registry/nacos/service_discovery_test.go
@@ -150,7 +150,7 @@ func TestFunction(t *testing.T) {
 	hs := gxset.NewSet()
 	hs.Add(testName)
 
-	sicl := servicediscovery.NewServiceInstancesChangedListener("test_app", hs)
+	sicl := servicediscovery.NewServiceInstancesChangedListener("test_app", constant.DefaultKey, hs)
 	sicl.AddListenerAndNotify(testName, tn)
 	err = sd.AddListener(sicl)
 	require.NoError(t, err)

--- a/registry/servicediscovery/customizer/metadata_service_url_params_customizer.go
+++ b/registry/servicediscovery/customizer/metadata_service_url_params_customizer.go
@@ -56,6 +56,11 @@ func (m *metadataServiceURLParamsMetadataCustomizer) GetPriority() int {
 }
 
 func (m *metadataServiceURLParamsMetadataCustomizer) Customize(instance registry.ServiceInstance) {
+	// TODO: in a multi-instance deployment each registry should expose its own
+	// metadata service URL; currently GetMetadataService() returns a global
+	// singleton so all instances receive the same URL regardless of which
+	// registry they belong to. Fixing this requires per-registry MetadataService
+	// support and is tracked separately.
 	url, _ := metadata.GetMetadataService().GetMetadataServiceURL()
 	if url == nil {
 		// when metadata service is not exported the url will be nil,this is because metadata type is remote

--- a/registry/servicediscovery/customizer/metadata_service_url_params_customizer.go
+++ b/registry/servicediscovery/customizer/metadata_service_url_params_customizer.go
@@ -56,11 +56,6 @@ func (m *metadataServiceURLParamsMetadataCustomizer) GetPriority() int {
 }
 
 func (m *metadataServiceURLParamsMetadataCustomizer) Customize(instance registry.ServiceInstance) {
-	// TODO: in a multi-instance deployment each registry should expose its own
-	// metadata service URL; currently GetMetadataService() returns a global
-	// singleton so all instances receive the same URL regardless of which
-	// registry they belong to. Fixing this requires per-registry MetadataService
-	// support and is tracked separately.
 	url, _ := metadata.GetMetadataService().GetMetadataServiceURL()
 	if url == nil {
 		// when metadata service is not exported the url will be nil,this is because metadata type is remote

--- a/registry/servicediscovery/customizer/metadata_service_url_params_customizer.go
+++ b/registry/servicediscovery/customizer/metadata_service_url_params_customizer.go
@@ -56,7 +56,6 @@ func (m *metadataServiceURLParamsMetadataCustomizer) GetPriority() int {
 }
 
 func (m *metadataServiceURLParamsMetadataCustomizer) Customize(instance registry.ServiceInstance) {
-	//todo Multi-instance metadata alignment needs to be improved
 	url, _ := metadata.GetMetadataService().GetMetadataServiceURL()
 	if url == nil {
 		// when metadata service is not exported the url will be nil,this is because metadata type is remote

--- a/registry/servicediscovery/customizer/metadata_service_url_params_customizer.go
+++ b/registry/servicediscovery/customizer/metadata_service_url_params_customizer.go
@@ -56,6 +56,10 @@ func (m *metadataServiceURLParamsMetadataCustomizer) GetPriority() int {
 }
 
 func (m *metadataServiceURLParamsMetadataCustomizer) Customize(instance registry.ServiceInstance) {
+	// TODO: GetMetadataService() is a global singleton and returns the same metadata service URL
+	// regardless of which registry this instance belongs to. In a multi-registry setup each
+	// registry should expose its own metadata service URL. This requires per-registry metadata
+	// service tracking and is left for a follow-up.
 	url, _ := metadata.GetMetadataService().GetMetadataServiceURL()
 	if url == nil {
 		// when metadata service is not exported the url will be nil,this is because metadata type is remote

--- a/registry/servicediscovery/customizer/service_revision_customizer.go
+++ b/registry/servicediscovery/customizer/service_revision_customizer.go
@@ -49,12 +49,17 @@ func (e *exportedServicesRevisionMetadataCustomizer) GetPriority() int {
 	return 1
 }
 
-// Customize calculate the revision for exported urls and then put it into instance metadata
+// Customize 按注册中心范围计算 exported services 的 revision，
+// 避免多注册中心时不同 instance 因使用跨注册中心合并的服务列表而得到相同 revision。
 func (e *exportedServicesRevisionMetadataCustomizer) Customize(instance registry.ServiceInstance) {
-	urls, err := metadata.GetMetadataService().GetExportedServiceURLs()
-	if err != nil {
-		logger.Errorf("[Registry][ServiceDiscovery] get metadata service url is error, err=%v", err)
-		return
+	registryId := instance.GetMetadata()[constant.RegistryIdKey]
+	if len(registryId) == 0 {
+		logger.Warnf("[Registry][ServiceDiscovery] instance has no registryId in metadata, exported revision will be empty")
+	}
+	metaInfo := metadata.GetMetadataInfo(registryId)
+	var urls []*common.URL
+	if metaInfo != nil {
+		urls = metaInfo.GetExportedServiceURLs()
 	}
 	revision := resolveRevision(urls)
 	if len(revision) == 0 {
@@ -70,12 +75,16 @@ func (e *subscribedServicesRevisionMetadataCustomizer) GetPriority() int {
 	return 2
 }
 
-// Customize calculate the revision for subscribed urls and then put it into instance metadata
+// Customize 按注册中心范围计算 subscribed services 的 revision。
 func (e *subscribedServicesRevisionMetadataCustomizer) Customize(instance registry.ServiceInstance) {
-	urls, err := metadata.GetMetadataService().GetSubscribedURLs()
-	if err != nil {
-		logger.Errorf("[Registry][ServiceDiscovery] get metadata subscribed url is error, err=%v", err)
-		return
+	registryId := instance.GetMetadata()[constant.RegistryIdKey]
+	if len(registryId) == 0 {
+		logger.Warnf("[Registry][ServiceDiscovery] instance has no registryId in metadata, subscribed revision will be empty")
+	}
+	metaInfo := metadata.GetMetadataInfo(registryId)
+	var urls []*common.URL
+	if metaInfo != nil {
+		urls = metaInfo.GetSubscribedURLs()
 	}
 	revision := resolveRevision(urls)
 	if len(revision) == 0 {

--- a/registry/servicediscovery/customizer/service_revision_customizer.go
+++ b/registry/servicediscovery/customizer/service_revision_customizer.go
@@ -49,8 +49,8 @@ func (e *exportedServicesRevisionMetadataCustomizer) GetPriority() int {
 	return 1
 }
 
-// Customize 按注册中心范围计算 exported services 的 revision，
-// 避免多注册中心时不同 instance 因使用跨注册中心合并的服务列表而得到相同 revision。
+// Customize calculates the revision of exported services scoped to the registry,
+// preventing different instances from getting the same revision due to a merged cross-registry service list in multi-registry setups.
 func (e *exportedServicesRevisionMetadataCustomizer) Customize(instance registry.ServiceInstance) {
 	registryId := instance.GetMetadata()[constant.RegistryIdKey]
 	if len(registryId) == 0 {
@@ -75,7 +75,7 @@ func (e *subscribedServicesRevisionMetadataCustomizer) GetPriority() int {
 	return 2
 }
 
-// Customize 按注册中心范围计算 subscribed services 的 revision。
+// Customize calculates the revision of subscribed services scoped to the registry.
 func (e *subscribedServicesRevisionMetadataCustomizer) Customize(instance registry.ServiceInstance) {
 	registryId := instance.GetMetadata()[constant.RegistryIdKey]
 	if len(registryId) == 0 {

--- a/registry/servicediscovery/customizer/service_revision_customizer.go
+++ b/registry/servicediscovery/customizer/service_revision_customizer.go
@@ -56,7 +56,7 @@ func (e *exportedServicesRevisionMetadataCustomizer) Customize(instance registry
 	if len(registryId) == 0 {
 		// revision will be "0" (no services found for empty key), which causes OnEvent to skip
 		// this instance entirely — ensure RegistryIdKey is set before customizers run.
-		logger.Errorf("[Registry][ServiceDiscovery] instance has no registryId in metadata; "+
+		logger.Errorf("[Registry][ServiceDiscovery] instance has no registryId in metadata; " +
 			"exported revision will be \"0\" and this instance will be invisible to consumers")
 	}
 	metaInfo := metadata.GetMetadataInfo(registryId)
@@ -84,7 +84,7 @@ func (e *subscribedServicesRevisionMetadataCustomizer) Customize(instance regist
 	if len(registryId) == 0 {
 		// revision will be "0" (no subscriptions found for empty key), which causes OnEvent to skip
 		// this instance entirely — ensure RegistryIdKey is set before customizers run.
-		logger.Errorf("[Registry][ServiceDiscovery] instance has no registryId in metadata; "+
+		logger.Errorf("[Registry][ServiceDiscovery] instance has no registryId in metadata; " +
 			"subscribed revision will be \"0\" and this instance will be invisible to consumers")
 	}
 	metaInfo := metadata.GetMetadataInfo(registryId)

--- a/registry/servicediscovery/customizer/service_revision_customizer.go
+++ b/registry/servicediscovery/customizer/service_revision_customizer.go
@@ -54,7 +54,10 @@ func (e *exportedServicesRevisionMetadataCustomizer) GetPriority() int {
 func (e *exportedServicesRevisionMetadataCustomizer) Customize(instance registry.ServiceInstance) {
 	registryId := instance.GetMetadata()[constant.RegistryIdKey]
 	if len(registryId) == 0 {
-		logger.Warnf("[Registry][ServiceDiscovery] instance has no registryId in metadata, exported revision will be empty")
+		// revision will be "0" (no services found for empty key), which causes OnEvent to skip
+		// this instance entirely — ensure RegistryIdKey is set before customizers run.
+		logger.Errorf("[Registry][ServiceDiscovery] instance has no registryId in metadata; "+
+			"exported revision will be \"0\" and this instance will be invisible to consumers")
 	}
 	metaInfo := metadata.GetMetadataInfo(registryId)
 	var urls []*common.URL
@@ -79,7 +82,10 @@ func (e *subscribedServicesRevisionMetadataCustomizer) GetPriority() int {
 func (e *subscribedServicesRevisionMetadataCustomizer) Customize(instance registry.ServiceInstance) {
 	registryId := instance.GetMetadata()[constant.RegistryIdKey]
 	if len(registryId) == 0 {
-		logger.Warnf("[Registry][ServiceDiscovery] instance has no registryId in metadata, subscribed revision will be empty")
+		// revision will be "0" (no subscriptions found for empty key), which causes OnEvent to skip
+		// this instance entirely — ensure RegistryIdKey is set before customizers run.
+		logger.Errorf("[Registry][ServiceDiscovery] instance has no registryId in metadata; "+
+			"subscribed revision will be \"0\" and this instance will be invisible to consumers")
 	}
 	metaInfo := metadata.GetMetadataInfo(registryId)
 	var urls []*common.URL

--- a/registry/servicediscovery/customizer/service_revision_customizer_test.go
+++ b/registry/servicediscovery/customizer/service_revision_customizer_test.go
@@ -53,6 +53,10 @@ func TestExportedRevisionIsRegistryScoped(t *testing.T) {
 
 	metadata.AddService("rev-reg-a", urlA)
 	metadata.AddService("rev-reg-b", urlB)
+	t.Cleanup(func() {
+		metadata.RemoveService("rev-reg-a", urlA)
+		metadata.RemoveService("rev-reg-b", urlB)
+	})
 
 	cus := &exportedServicesRevisionMetadataCustomizer{}
 
@@ -87,6 +91,9 @@ func TestExportedRevisionMissingRegistryIdYieldsZero(t *testing.T) {
 		common.WithPort("20880"),
 	)
 	metadata.AddService("some-registry", urlA)
+	t.Cleanup(func() {
+		metadata.RemoveService("some-registry", urlA)
+	})
 
 	cus := &exportedServicesRevisionMetadataCustomizer{}
 
@@ -118,6 +125,10 @@ func TestSubscribedRevisionIsRegistryScoped(t *testing.T) {
 
 	metadata.AddSubscribeURL("sub-reg-a", urlA)
 	metadata.AddSubscribeURL("sub-reg-b", urlB)
+	t.Cleanup(func() {
+		metadata.RemoveSubscribeURL("sub-reg-a", urlA)
+		metadata.RemoveSubscribeURL("sub-reg-b", urlB)
+	})
 
 	cus := &subscribedServicesRevisionMetadataCustomizer{}
 
@@ -147,6 +158,9 @@ func TestSubscribedRevisionMissingRegistryIdYieldsZero(t *testing.T) {
 		common.WithPort("20880"),
 	)
 	metadata.AddSubscribeURL("some-registry", urlA)
+	t.Cleanup(func() {
+		metadata.RemoveSubscribeURL("some-registry", urlA)
+	})
 
 	cus := &subscribedServicesRevisionMetadataCustomizer{}
 	inst := &registry.DefaultServiceInstance{

--- a/registry/servicediscovery/customizer/service_revision_customizer_test.go
+++ b/registry/servicediscovery/customizer/service_revision_customizer_test.go
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package customizer
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/metadata"
+	"dubbo.apache.org/dubbo-go/v3/registry"
+)
+
+// TestExportedRevisionIsRegistryScoped verifies that when two registries export different
+// service sets, their instances get different revision values — not a merged cross-registry one.
+func TestExportedRevisionIsRegistryScoped(t *testing.T) {
+	urlA := common.NewURLWithOptions(
+		common.WithInterface("org.example.ServiceA"),
+		common.WithParamsValue(constant.ApplicationKey, "app"),
+		common.WithPort("20880"),
+	)
+	urlB := common.NewURLWithOptions(
+		common.WithInterface("org.example.ServiceB"),
+		common.WithParamsValue(constant.ApplicationKey, "app"),
+		common.WithPort("20881"),
+	)
+
+	metadata.AddService("reg-a", urlA)
+	metadata.AddService("reg-b", urlB)
+
+	cus := &exportedServicesRevisionMetadataCustomizer{}
+
+	instA := &registry.DefaultServiceInstance{
+		Metadata: map[string]string{constant.RegistryIdKey: "reg-a"},
+	}
+	cus.Customize(instA)
+	revA := instA.GetMetadata()[constant.ExportedServicesRevisionPropertyName]
+
+	instB := &registry.DefaultServiceInstance{
+		Metadata: map[string]string{constant.RegistryIdKey: "reg-b"},
+	}
+	cus.Customize(instB)
+	revB := instB.GetMetadata()[constant.ExportedServicesRevisionPropertyName]
+
+	assert.NotEqual(t, revA, revB, "different registries with different services should produce different revisions")
+	assert.NotEqual(t, "0", revA, "reg-a has a service, revision should not be 0")
+	assert.NotEqual(t, "0", revB, "reg-b has a service, revision should not be 0")
+}
+
+// TestSubscribedRevisionIsRegistryScoped mirrors the exported test for subscribed URLs.
+func TestSubscribedRevisionIsRegistryScoped(t *testing.T) {
+	urlA := common.NewURLWithOptions(
+		common.WithInterface("org.example.SubA"),
+		common.WithParamsValue(constant.ApplicationKey, "app"),
+		common.WithPort("20880"),
+	)
+	urlB := common.NewURLWithOptions(
+		common.WithInterface("org.example.SubB"),
+		common.WithParamsValue(constant.ApplicationKey, "app"),
+		common.WithPort("20881"),
+	)
+
+	metadata.AddSubscribeURL("reg-a", urlA)
+	metadata.AddSubscribeURL("reg-b", urlB)
+
+	cus := &subscribedServicesRevisionMetadataCustomizer{}
+
+	instA := &registry.DefaultServiceInstance{
+		Metadata: map[string]string{constant.RegistryIdKey: "reg-a"},
+	}
+	cus.Customize(instA)
+	revA := instA.GetMetadata()[constant.SubscribedServicesRevisionPropertyName]
+
+	instB := &registry.DefaultServiceInstance{
+		Metadata: map[string]string{constant.RegistryIdKey: "reg-b"},
+	}
+	cus.Customize(instB)
+	revB := instB.GetMetadata()[constant.SubscribedServicesRevisionPropertyName]
+
+	assert.NotEqual(t, revA, revB, "different registries with different subscriptions should produce different revisions")
+}

--- a/registry/servicediscovery/customizer/service_revision_customizer_test.go
+++ b/registry/servicediscovery/customizer/service_revision_customizer_test.go
@@ -35,6 +35,11 @@ import (
 // TestExportedRevisionIsRegistryScoped verifies that when two registries export different
 // service sets, their instances get different revision values — not a merged cross-registry one.
 func TestExportedRevisionIsRegistryScoped(t *testing.T) {
+	metadata.ClearMetadataReportInstances()
+	t.Cleanup(func() {
+		metadata.ClearMetadataReportInstances()
+	})
+
 	urlA := common.NewURLWithOptions(
 		common.WithInterface("org.example.ServiceA"),
 		common.WithParamsValue(constant.ApplicationKey, "app"),
@@ -46,19 +51,19 @@ func TestExportedRevisionIsRegistryScoped(t *testing.T) {
 		common.WithPort("20881"),
 	)
 
-	metadata.AddService("reg-a", urlA)
-	metadata.AddService("reg-b", urlB)
+	metadata.AddService("rev-reg-a", urlA)
+	metadata.AddService("rev-reg-b", urlB)
 
 	cus := &exportedServicesRevisionMetadataCustomizer{}
 
 	instA := &registry.DefaultServiceInstance{
-		Metadata: map[string]string{constant.RegistryIdKey: "reg-a"},
+		Metadata: map[string]string{constant.RegistryIdKey: "rev-reg-a"},
 	}
 	cus.Customize(instA)
 	revA := instA.GetMetadata()[constant.ExportedServicesRevisionPropertyName]
 
 	instB := &registry.DefaultServiceInstance{
-		Metadata: map[string]string{constant.RegistryIdKey: "reg-b"},
+		Metadata: map[string]string{constant.RegistryIdKey: "rev-reg-b"},
 	}
 	cus.Customize(instB)
 	revB := instB.GetMetadata()[constant.ExportedServicesRevisionPropertyName]
@@ -68,8 +73,38 @@ func TestExportedRevisionIsRegistryScoped(t *testing.T) {
 	assert.NotEqual(t, "0", revB, "reg-b has a service, revision should not be 0")
 }
 
+// TestExportedRevisionMissingRegistryIdYieldsZero verifies that an instance with no
+// RegistryIdKey gets revision "0" (no services found), and does not panic or use
+// another registry's service list.
+func TestExportedRevisionMissingRegistryIdYieldsZero(t *testing.T) {
+	metadata.ClearMetadataReportInstances()
+	t.Cleanup(metadata.ClearMetadataReportInstances)
+
+	// Register a service under a real registry so we can confirm it is NOT used
+	urlA := common.NewURLWithOptions(
+		common.WithInterface("org.example.ShouldBeIsolated"),
+		common.WithParamsValue(constant.ApplicationKey, "app"),
+		common.WithPort("20880"),
+	)
+	metadata.AddService("some-registry", urlA)
+
+	cus := &exportedServicesRevisionMetadataCustomizer{}
+
+	inst := &registry.DefaultServiceInstance{
+		Metadata: map[string]string{}, // no RegistryIdKey
+	}
+	cus.Customize(inst)
+	rev := inst.GetMetadata()[constant.ExportedServicesRevisionPropertyName]
+
+	// GetMetadataInfo("") returns nil → resolveRevision(nil) == "0"
+	assert.Equal(t, "0", rev, "instance with no registryId should get revision 0, not borrow another registry's service list")
+}
+
 // TestSubscribedRevisionIsRegistryScoped mirrors the exported test for subscribed URLs.
 func TestSubscribedRevisionIsRegistryScoped(t *testing.T) {
+	metadata.ClearMetadataReportInstances()
+	t.Cleanup(metadata.ClearMetadataReportInstances)
+
 	urlA := common.NewURLWithOptions(
 		common.WithInterface("org.example.SubA"),
 		common.WithParamsValue(constant.ApplicationKey, "app"),
@@ -81,22 +116,44 @@ func TestSubscribedRevisionIsRegistryScoped(t *testing.T) {
 		common.WithPort("20881"),
 	)
 
-	metadata.AddSubscribeURL("reg-a", urlA)
-	metadata.AddSubscribeURL("reg-b", urlB)
+	metadata.AddSubscribeURL("sub-reg-a", urlA)
+	metadata.AddSubscribeURL("sub-reg-b", urlB)
 
 	cus := &subscribedServicesRevisionMetadataCustomizer{}
 
 	instA := &registry.DefaultServiceInstance{
-		Metadata: map[string]string{constant.RegistryIdKey: "reg-a"},
+		Metadata: map[string]string{constant.RegistryIdKey: "sub-reg-a"},
 	}
 	cus.Customize(instA)
 	revA := instA.GetMetadata()[constant.SubscribedServicesRevisionPropertyName]
 
 	instB := &registry.DefaultServiceInstance{
-		Metadata: map[string]string{constant.RegistryIdKey: "reg-b"},
+		Metadata: map[string]string{constant.RegistryIdKey: "sub-reg-b"},
 	}
 	cus.Customize(instB)
 	revB := instB.GetMetadata()[constant.SubscribedServicesRevisionPropertyName]
 
 	assert.NotEqual(t, revA, revB, "different registries with different subscriptions should produce different revisions")
+}
+
+// TestSubscribedRevisionMissingRegistryIdYieldsZero mirrors the exported missing-key test.
+func TestSubscribedRevisionMissingRegistryIdYieldsZero(t *testing.T) {
+	metadata.ClearMetadataReportInstances()
+	t.Cleanup(metadata.ClearMetadataReportInstances)
+
+	urlA := common.NewURLWithOptions(
+		common.WithInterface("org.example.SubIsolated"),
+		common.WithParamsValue(constant.ApplicationKey, "app"),
+		common.WithPort("20880"),
+	)
+	metadata.AddSubscribeURL("some-registry", urlA)
+
+	cus := &subscribedServicesRevisionMetadataCustomizer{}
+	inst := &registry.DefaultServiceInstance{
+		Metadata: map[string]string{},
+	}
+	cus.Customize(inst)
+	rev := inst.GetMetadata()[constant.SubscribedServicesRevisionPropertyName]
+
+	assert.Equal(t, "0", rev, "instance with no registryId should get revision 0, not borrow another registry's subscriptions")
 }

--- a/registry/servicediscovery/service_discovery_registry.go
+++ b/registry/servicediscovery/service_discovery_registry.go
@@ -90,9 +90,10 @@ func (s *serviceDiscoveryRegistry) RegisterService() error {
 	if metaInfo == nil {
 		panic("no metada info found of registry id " + s.url.GetParam(constant.RegistryIdKey, ""))
 	}
+	registryId := s.url.GetParam(constant.RegistryIdKey, constant.DefaultKey)
 	urls := metaInfo.GetExportedServiceURLs()
 	for _, url := range urls {
-		instance := createInstance(metaInfo, url)
+		instance := createInstance(metaInfo, url, registryId)
 		metaInfo.Revision = instance.GetMetadata()[constant.ExportedServicesRevisionPropertyName]
 		if metadata.GetMetadataType() == constant.RemoteMetadataStorageType {
 			if s.metadataReport == nil {
@@ -115,9 +116,12 @@ func (s *serviceDiscoveryRegistry) RegisterService() error {
 	return nil
 }
 
-func createInstance(meta *info.MetadataInfo, url *common.URL) registry.ServiceInstance {
+func createInstance(meta *info.MetadataInfo, url *common.URL, registryId string) registry.ServiceInstance {
 	params := make(map[string]string, 8)
 	params[constant.MetadataStorageTypePropertyName] = metadata.GetMetadataType()
+	// Expose the registry this instance belongs to so that customizers (e.g. revision
+	// calculators) can scope their work to the correct per-registry service set.
+	params[constant.RegistryIdKey] = registryId
 	// Keep routing attributes visible on the registered instance as well as in service metadata.
 	if environment := url.GetParam(constant.EnvironmentKey, ""); len(environment) > 0 {
 		params[constant.EnvironmentKey] = environment
@@ -212,11 +216,11 @@ func (s *serviceDiscoveryRegistry) UnSubscribe(url *common.URL, listener registr
 }
 
 func (s *serviceDiscoveryRegistry) syncExportedMetadataAfterUnregister(targetURL *common.URL, origin []registry.ServiceInstance, keep []registry.ServiceInstance) error {
-	registryID, exist := s.url.GetNonDefaultParam(constant.RegistryIdKey)
+	registryId, exist := s.url.GetNonDefaultParam(constant.RegistryIdKey)
 	if !exist {
 		return nil
 	}
-	metadataInfo := metadata.GetMetadataInfo(registryID)
+	metadataInfo := metadata.GetMetadataInfo(registryId)
 	if metadataInfo == nil {
 		return nil
 	}
@@ -225,14 +229,14 @@ func (s *serviceDiscoveryRegistry) syncExportedMetadataAfterUnregister(targetURL
 	if len(origin) > 0 {
 		metadataInfo.ReplaceExportedServices(keepURLs)
 	} else if targetURL != nil {
-		metadata.RemoveService(registryID, targetURL)
+		metadata.RemoveService(registryId, targetURL)
 	}
 	remainingURLs := metadataInfo.GetExportedServiceURLs()
 	if len(remainingURLs) == 0 {
 		metadataInfo.Revision = "0"
 		return nil
 	}
-	instance := createInstance(metadataInfo, remainingURLs[0])
+	instance := createInstance(metadataInfo, remainingURLs[0], registryId)
 	revision := instance.GetMetadata()[constant.ExportedServicesRevisionPropertyName]
 	metadataInfo.Revision = revision
 	if len(keepURLs) == 0 {

--- a/registry/servicediscovery/service_discovery_registry.go
+++ b/registry/servicediscovery/service_discovery_registry.go
@@ -360,7 +360,7 @@ func (s *serviceDiscoveryRegistry) SubscribeURL(url *common.URL, notify registry
 	protocolServiceKey := url.ServiceKey() + ":" + protocol
 	listener := s.serviceListeners[serviceNamesKey]
 	if listener == nil {
-		listener = NewServiceInstancesChangedListener(url.GetParam(constant.ApplicationKey, ""), services)
+		listener = NewServiceInstancesChangedListener(url.GetParam(constant.ApplicationKey, ""), s.url.GetParam(constant.RegistryIdKey, constant.DefaultKey), services)
 		for _, serviceNameTmp := range services.Values() {
 			serviceName := serviceNameTmp.(string)
 			instances := s.serviceDiscovery.GetInstances(serviceName)

--- a/registry/servicediscovery/service_discovery_registry.go
+++ b/registry/servicediscovery/service_discovery_registry.go
@@ -86,11 +86,11 @@ func newServiceDiscoveryRegistry(url *common.URL) (registry.Registry, error) {
 }
 
 func (s *serviceDiscoveryRegistry) RegisterService() error {
-	metaInfo := metadata.GetMetadataInfo(s.url.GetParam(constant.RegistryIdKey, ""))
-	if metaInfo == nil {
-		panic("no metada info found of registry id " + s.url.GetParam(constant.RegistryIdKey, ""))
-	}
 	registryId := s.url.GetParam(constant.RegistryIdKey, constant.DefaultKey)
+	metaInfo := metadata.GetMetadataInfo(registryId)
+	if metaInfo == nil {
+		panic("no metada info found of registry id " + registryId)
+	}
 	urls := metaInfo.GetExportedServiceURLs()
 	for _, url := range urls {
 		instance := createInstance(metaInfo, url, registryId)

--- a/registry/servicediscovery/service_discovery_registry_test.go
+++ b/registry/servicediscovery/service_discovery_registry_test.go
@@ -57,7 +57,7 @@ const (
 // TestServiceDiscoveryRegistryRegister verifies the registration process.
 func TestServiceDiscoveryRegistryRegister(t *testing.T) {
 	mockSD, mockMapping := setupEnvironment(t)
-	regID := fmt.Sprintf("mock-reg-%d", time.Now().UnixNano())
+	regID := fmt.Sprintf("mock-reg-%s-%d", t.Name(), time.Now().UnixNano())
 
 	registryURL, err := common.NewURL(testRegistryURL,
 		common.WithParamsValue(constant.RegistryKey, "mock"),
@@ -127,7 +127,7 @@ func TestServiceDiscoveryRegistrySubscribe(t *testing.T) {
 func TestServiceDiscoveryRegistryUnSubscribe(t *testing.T) {
 	mockSD, mockMapping := setupEnvironment(t)
 	mockMapping.data[testInterface] = gxset.NewSet(testApp)
-	regID := fmt.Sprintf("mock-reg-%d", time.Now().UnixNano())
+	regID := fmt.Sprintf("mock-reg-%s-%d", t.Name(), time.Now().UnixNano())
 
 	registryURL, _ := common.NewURL(testRegistryURL,
 		common.WithParamsValue(constant.RegistryKey, "mock"),
@@ -159,7 +159,7 @@ func TestServiceDiscoveryRegistryUnSubscribeKeepsMetadataOnRemoveFailure(t *test
 	mockSD, mockMapping := setupEnvironment(t)
 	mockMapping.data[testInterface] = gxset.NewSet(testApp)
 	mockMapping.removeErr = errors.New("mock remove failed")
-	regID := fmt.Sprintf("mock-reg-%d", time.Now().UnixNano())
+	regID := fmt.Sprintf("mock-reg-%s-%d", t.Name(), time.Now().UnixNano())
 
 	registryURL, _ := common.NewURL(testRegistryURL,
 		common.WithParamsValue(constant.RegistryKey, "mock"),
@@ -188,7 +188,7 @@ func TestServiceDiscoveryRegistryUnSubscribeKeepsMetadataOnRemoveFailure(t *test
 
 func TestServiceDiscoveryRegistryUnRegisterSyncsBulkMetadataCleanup(t *testing.T) {
 	mockSD, mockMapping := setupEnvironment(t)
-	regID := fmt.Sprintf("mock-reg-%d", time.Now().UnixNano())
+	regID := fmt.Sprintf("mock-reg-%s-%d", t.Name(), time.Now().UnixNano())
 
 	registryURL, err := common.NewURL(testRegistryURL,
 		common.WithParamsValue(constant.RegistryKey, "mock"),
@@ -244,7 +244,7 @@ func TestServiceDiscoveryRegistryUnRegisterSyncsBulkMetadataCleanup(t *testing.T
 
 func TestServiceDiscoveryRegistryUnRegisterServicePartialFailSyncsMetadata(t *testing.T) {
 	mockSD, mockMapping := setupEnvironment(t)
-	regID := fmt.Sprintf("mock-reg-%d", time.Now().UnixNano())
+	regID := fmt.Sprintf("mock-reg-%s-%d", t.Name(), time.Now().UnixNano())
 
 	registryURL, err := common.NewURL(testRegistryURL,
 		common.WithParamsValue(constant.RegistryKey, "mock"),
@@ -302,7 +302,7 @@ func TestServiceDiscoveryRegistryUnRegisterServicePartialFailSyncsMetadata(t *te
 
 func TestServiceDiscoveryRegistryUnRegisterWithoutTrackedInstancesReconcilesMetadata(t *testing.T) {
 	_, mockMapping := setupEnvironment(t)
-	regID := fmt.Sprintf("mock-reg-%d", time.Now().UnixNano())
+	regID := fmt.Sprintf("mock-reg-%s-%d", t.Name(), time.Now().UnixNano())
 
 	registryURL, err := common.NewURL(testRegistryURL,
 		common.WithParamsValue(constant.RegistryKey, "mock"),

--- a/registry/servicediscovery/service_discovery_registry_test.go
+++ b/registry/servicediscovery/service_discovery_registry_test.go
@@ -294,7 +294,7 @@ func TestServiceDiscoveryRegistryUnRegisterServicePartialFailSyncsMetadata(t *te
 	assert.Equal(t, providerURL1, metaInfo.GetExportedServiceURLs()[0])
 	assert.Len(t, metaInfo.Services, 1)
 
-	expectedRevision := createInstance(metaInfo, providerURL1).GetMetadata()[constant.ExportedServicesRevisionPropertyName]
+	expectedRevision := createInstance(metaInfo, providerURL1, regID).GetMetadata()[constant.ExportedServicesRevisionPropertyName]
 	assert.Equal(t, expectedRevision, metaInfo.Revision)
 	assert.True(t, mockSD.updateCalled)
 	assert.Contains(t, mockSD.updatedIDs, providerURL1.Address())
@@ -344,7 +344,7 @@ func TestServiceDiscoveryRegistryUnRegisterWithoutTrackedInstancesReconcilesMeta
 	assert.Equal(t, providerURL2, metaInfo.GetExportedServiceURLs()[0])
 	assert.Len(t, metaInfo.Services, 1)
 
-	expectedRevision := createInstance(metaInfo, providerURL2).GetMetadata()[constant.ExportedServicesRevisionPropertyName]
+	expectedRevision := createInstance(metaInfo, providerURL2, regID).GetMetadata()[constant.ExportedServicesRevisionPropertyName]
 	assert.Equal(t, expectedRevision, metaInfo.Revision)
 }
 

--- a/registry/servicediscovery/service_instances_changed_listener_impl.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl.go
@@ -149,7 +149,8 @@ func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error
 	}
 	lstn.revisionToMetadata = newRevisionToMetadata
 	for revision, metadataInfo := range newRevisionToMetadata {
-		metaCache.Set(revision, metadataInfo)
+		cacheKey := lstn.app + ":" + lstn.registryId + ":" + revision
+		metaCache.Set(cacheKey, metadataInfo)
 	}
 
 	for serviceKey, revisionServices := range serviceToRevisionServices {
@@ -248,7 +249,7 @@ func GetMetadataInfo(app string, instance registry.ServiceInstance, revision str
 	cacheOnce.Do(func() {
 		initCache(app)
 	})
-	cacheKey := registryId + ":" + revision
+	cacheKey := app + ":" + registryId + ":" + revision
 	if metadataInfo, ok := metaCache.Get(cacheKey); ok {
 		return metadataInfo.(*info.MetadataInfo), nil
 	}

--- a/registry/servicediscovery/service_instances_changed_listener_impl.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl.go
@@ -248,7 +248,8 @@ func GetMetadataInfo(app string, instance registry.ServiceInstance, revision str
 	cacheOnce.Do(func() {
 		initCache(app)
 	})
-	if metadataInfo, ok := metaCache.Get(revision); ok {
+	cacheKey := registryId + ":" + revision
+	if metadataInfo, ok := metaCache.Get(cacheKey); ok {
 		return metadataInfo.(*info.MetadataInfo), nil
 	}
 
@@ -271,6 +272,6 @@ func GetMetadataInfo(app string, instance registry.ServiceInstance, revision str
 			return nil, err
 		}
 	}
-	metaCache.Set(revision, metadataInfo)
+	metaCache.Set(cacheKey, metadataInfo)
 	return metadataInfo, nil
 }

--- a/registry/servicediscovery/service_instances_changed_listener_impl.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl.go
@@ -58,6 +58,7 @@ func initCache(app string) {
 // ServiceInstancesChangedListenerImpl The Service Discovery Changed  Event Listener
 type ServiceInstancesChangedListenerImpl struct {
 	app                string
+	registryId         string
 	serviceNames       *gxset.HashSet
 	listeners          map[string]registry.NotifyListener
 	serviceUrls        map[string][]*common.URL
@@ -66,12 +67,13 @@ type ServiceInstancesChangedListenerImpl struct {
 	mutex              sync.Mutex
 }
 
-func NewServiceInstancesChangedListener(app string, services *gxset.HashSet) registry.ServiceInstancesChangedListener {
+func NewServiceInstancesChangedListener(app string, registryId string, services *gxset.HashSet) registry.ServiceInstancesChangedListener {
 	cacheOnce.Do(func() {
 		initCache(app)
 	})
 	return &ServiceInstancesChangedListenerImpl{
 		app:                app,
+		registryId:         registryId,
 		serviceNames:       services,
 		listeners:          make(map[string]registry.NotifyListener),
 		serviceUrls:        make(map[string][]*common.URL),
@@ -118,7 +120,7 @@ func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error
 			revisionToInstances[revision] = append(subInstances, instance)
 			metadataInfo := lstn.revisionToMetadata[revision]
 			if metadataInfo == nil {
-				meta, err := GetMetadataInfo(lstn.app, instance, revision)
+				meta, err := GetMetadataInfo(lstn.app, instance, revision, lstn.registryId)
 				if err != nil {
 					// Skip this instance if metadata fetch fails (e.g., old Java Dubbo version)
 					// Try next instance with same revision
@@ -242,7 +244,7 @@ func (lstn *ServiceInstancesChangedListenerImpl) GetEventType() reflect.Type {
 }
 
 // GetMetadataInfo get metadata info when MetadataStorageTypePropertyName is null
-func GetMetadataInfo(app string, instance registry.ServiceInstance, revision string) (*info.MetadataInfo, error) {
+func GetMetadataInfo(app string, instance registry.ServiceInstance, revision string, registryId string) (*info.MetadataInfo, error) {
 	cacheOnce.Do(func() {
 		initCache(app)
 	})
@@ -259,7 +261,7 @@ func GetMetadataInfo(app string, instance registry.ServiceInstance, revision str
 		metadataStorageType = instance.GetMetadata()[constant.MetadataStorageTypePropertyName]
 	}
 	if metadataStorageType == constant.RemoteMetadataStorageType {
-		metadataInfo, err = metadata.GetMetadataFromMetadataReport(revision, instance)
+		metadataInfo, err = metadata.GetMetadataFromMetadataReport(revision, instance, registryId)
 		if err != nil {
 			return nil, err
 		}

--- a/registry/servicediscovery/service_instances_changed_listener_impl_test.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl_test.go
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.

--- a/registry/servicediscovery/service_instances_changed_listener_impl_test.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl_test.go
@@ -93,7 +93,7 @@ func TestServiceInstancesChangedListenerRefreshesAndClearsEnvironmentWhenRevisio
 	listener.AddListenerAndNotify(common.MatchKey(testInterface, constant.TriProtocol), notify)
 
 	revision := "rev-20001-same-environment-change"
-	metaCache.Set(revision, newTestMetadataInfo(t, revision, 20001, "pre"))
+	metaCache.Set(constant.DefaultKey+":"+revision, newTestMetadataInfo(t, revision, 20001, "pre"))
 
 	pre := newTestServiceInstanceOnly(20001, "pre", revision)
 	require.NoError(t, listener.OnEvent(registry.NewServiceInstancesChangedEvent(testApp, []registry.ServiceInstance{
@@ -130,9 +130,10 @@ func TestServiceInstancesChangedListenerSkipsNilMetadataWithoutPanic(t *testing.
 
 	revision := "rev-20003-nil-metadata"
 	var metadataInfo *info.MetadataInfo
-	metaCache.Set(revision, metadataInfo)
+	cacheKey := constant.DefaultKey + ":" + revision
+	metaCache.Set(cacheKey, metadataInfo)
 	t.Cleanup(func() {
-		metaCache.Delete(revision)
+		metaCache.Delete(cacheKey)
 	})
 
 	instance := newTestServiceInstanceOnly(20003, "pre", revision)
@@ -204,11 +205,10 @@ func TestListenerUsesRegistryIdToFetchRemoteMetadata(t *testing.T) {
 		},
 	}
 
-	// Create listener with the specific registry id. Remove the revision from
-	// the cache after the test so it doesn't bleed into other tests.
+	// Remove the cache entry after the test so it doesn't bleed into other tests.
 	t.Cleanup(func() {
 		if metaCache != nil {
-			metaCache.Delete(revision)
+			metaCache.Delete(listenerRegistryId + ":" + revision)
 		}
 	})
 
@@ -268,7 +268,9 @@ func newTestServiceInstance(t *testing.T, port int, environment string) registry
 func newTestServiceInstanceWithRevision(t *testing.T, port int, environment string, revision string) registry.ServiceInstance {
 	t.Helper()
 
-	metaCache.Set(revision, newTestMetadataInfo(t, revision, port, environment))
+	// Pre-populate the cache under the composite key used by GetMetadataInfo.
+	// All test listeners use constant.DefaultKey as their registryId.
+	metaCache.Set(constant.DefaultKey+":"+revision, newTestMetadataInfo(t, revision, port, environment))
 	return newTestServiceInstanceOnly(port, environment, revision)
 }
 

--- a/registry/servicediscovery/service_instances_changed_listener_impl_test.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl_test.go
@@ -93,7 +93,7 @@ func TestServiceInstancesChangedListenerRefreshesAndClearsEnvironmentWhenRevisio
 	listener.AddListenerAndNotify(common.MatchKey(testInterface, constant.TriProtocol), notify)
 
 	revision := "rev-20001-same-environment-change"
-	metaCache.Set(constant.DefaultKey+":"+revision, newTestMetadataInfo(t, revision, 20001, "pre"))
+	metaCache.Set(testApp+":"+constant.DefaultKey+":"+revision, newTestMetadataInfo(t, revision, 20001, "pre"))
 
 	pre := newTestServiceInstanceOnly(20001, "pre", revision)
 	require.NoError(t, listener.OnEvent(registry.NewServiceInstancesChangedEvent(testApp, []registry.ServiceInstance{
@@ -130,7 +130,7 @@ func TestServiceInstancesChangedListenerSkipsNilMetadataWithoutPanic(t *testing.
 
 	revision := "rev-20003-nil-metadata"
 	var metadataInfo *info.MetadataInfo
-	cacheKey := constant.DefaultKey + ":" + revision
+	cacheKey := testApp + ":" + constant.DefaultKey + ":" + revision
 	metaCache.Set(cacheKey, metadataInfo)
 	t.Cleanup(func() {
 		metaCache.Delete(cacheKey)
@@ -270,7 +270,7 @@ func newTestServiceInstanceWithRevision(t *testing.T, port int, environment stri
 
 	// Pre-populate the cache under the composite key used by GetMetadataInfo.
 	// All test listeners use constant.DefaultKey as their registryId.
-	metaCache.Set(constant.DefaultKey+":"+revision, newTestMetadataInfo(t, revision, port, environment))
+	metaCache.Set(testApp+":"+constant.DefaultKey+":"+revision, newTestMetadataInfo(t, revision, port, environment))
 	return newTestServiceInstanceOnly(port, environment, revision)
 }
 

--- a/registry/servicediscovery/service_instances_changed_listener_impl_test.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl_test.go
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -37,7 +37,7 @@ import (
 )
 
 func TestServiceInstancesChangedListenerAggregatesSameServiceAcrossRevisions(t *testing.T) {
-	listener := NewServiceInstancesChangedListener(testApp, gxset.NewSet(testApp))
+	listener := NewServiceInstancesChangedListener(testApp, constant.DefaultKey, gxset.NewSet(testApp))
 	notify := &capturingNotifyListener{}
 	listener.AddListenerAndNotify(common.MatchKey(testInterface, constant.TriProtocol), notify)
 
@@ -52,7 +52,7 @@ func TestServiceInstancesChangedListenerAggregatesSameServiceAcrossRevisions(t *
 }
 
 func TestServiceInstancesChangedListenerRefreshesURLsOnProviderRemoveAndRestart(t *testing.T) {
-	listener := NewServiceInstancesChangedListener(testApp, gxset.NewSet(testApp))
+	listener := NewServiceInstancesChangedListener(testApp, constant.DefaultKey, gxset.NewSet(testApp))
 	notify := &capturingNotifyListener{}
 	listener.AddListenerAndNotify(common.MatchKey(testInterface, constant.TriProtocol), notify)
 
@@ -83,7 +83,7 @@ func TestServiceInstancesChangedListenerRefreshesURLsOnProviderRemoveAndRestart(
 }
 
 func TestServiceInstancesChangedListenerRefreshesAndClearsEnvironmentWhenRevisionIsUnchanged(t *testing.T) {
-	listener := NewServiceInstancesChangedListener(testApp, gxset.NewSet(testApp))
+	listener := NewServiceInstancesChangedListener(testApp, constant.DefaultKey, gxset.NewSet(testApp))
 	notify := &capturingNotifyListener{}
 	listener.AddListenerAndNotify(common.MatchKey(testInterface, constant.TriProtocol), notify)
 
@@ -119,7 +119,7 @@ func TestServiceInstancesChangedListenerRefreshesAndClearsEnvironmentWhenRevisio
 }
 
 func TestServiceInstancesChangedListenerSkipsNilMetadataWithoutPanic(t *testing.T) {
-	listener := NewServiceInstancesChangedListener(testApp, gxset.NewSet(testApp))
+	listener := NewServiceInstancesChangedListener(testApp, constant.DefaultKey, gxset.NewSet(testApp))
 	notify := &capturingNotifyListener{}
 	listener.AddListenerAndNotify(common.MatchKey(testInterface, constant.TriProtocol), notify)
 

--- a/registry/servicediscovery/service_instances_changed_listener_impl_test.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl_test.go
@@ -35,9 +35,9 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/metadata"
-	metadatareport "dubbo.apache.org/dubbo-go/v3/metadata/report"
 	"dubbo.apache.org/dubbo-go/v3/metadata/info"
 	"dubbo.apache.org/dubbo-go/v3/metadata/mapping"
+	metadatareport "dubbo.apache.org/dubbo-go/v3/metadata/report"
 	"dubbo.apache.org/dubbo-go/v3/registry"
 )
 

--- a/registry/servicediscovery/service_instances_changed_listener_impl_test.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl_test.go
@@ -26,13 +26,18 @@ import (
 	gxset "github.com/dubbogo/gost/container/set"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/common/extension"
+	"dubbo.apache.org/dubbo-go/v3/metadata"
+	metadatareport "dubbo.apache.org/dubbo-go/v3/metadata/report"
 	"dubbo.apache.org/dubbo-go/v3/metadata/info"
+	"dubbo.apache.org/dubbo-go/v3/metadata/mapping"
 	"dubbo.apache.org/dubbo-go/v3/registry"
 )
 
@@ -148,6 +153,110 @@ func TestCreateInstanceCarriesEnvironmentMetadata(t *testing.T) {
 	instance := createInstance(meta, providerURL, constant.DefaultKey)
 
 	assert.Equal(t, "pre", instance.GetMetadata()[constant.EnvironmentKey])
+}
+
+// TestListenerUsesRegistryIdToFetchRemoteMetadata verifies that when a listener is
+// created with a specific registryId, GetMetadataInfo threads that id through to
+// GetMetadataFromMetadataReport so the correct per-registry metadata report is used.
+func TestListenerUsesRegistryIdToFetchRemoteMetadata(t *testing.T) {
+	const listenerRegistryId = "remote-reg-test"
+	const revision = "rev-remote-reg-test"
+
+	// Register a mock metadata report under the listener's registry id
+	mockReport := new(listenerMockMetadataReport)
+	extension.SetMetadataReportFactory(listenerRegistryId, func() metadatareport.MetadataReportFactory {
+		return mockReport
+	})
+	opts := metadata.NewReportOptions(
+		metadata.WithRegistryId(listenerRegistryId),
+		metadata.WithProtocol(listenerRegistryId),
+		metadata.WithAddress("127.0.0.1"),
+	)
+	require.NoError(t, opts.Init())
+	t.Cleanup(metadata.ClearMetadataReportInstances)
+
+	// Build the MetadataInfo that the mock report will return
+	serviceURL, err := common.NewURL(
+		fmt.Sprintf("tri://127.0.0.1:20099/%s", testInterface),
+		common.WithInterface(testInterface),
+		common.WithMethods([]string{"Greet"}),
+		common.WithParamsValue(constant.ApplicationKey, testApp),
+	)
+	require.NoError(t, err)
+	svc := info.NewServiceInfoWithURL(serviceURL)
+	expectedMeta := info.NewMetadataInfoWithParams(testApp, revision, map[string]*info.ServiceInfo{
+		svc.GetMatchKey(): svc,
+	})
+	mockReport.On("GetAppMetadata").Return(expectedMeta, nil).Once()
+
+	// Create a service instance that requests remote metadata storage
+	remoteInstance := &registry.DefaultServiceInstance{
+		ID:          "127.0.0.1:20099",
+		ServiceName: testApp,
+		Host:        "127.0.0.1",
+		Port:        20099,
+		Enable:      true,
+		Healthy:     true,
+		Metadata: map[string]string{
+			constant.ExportedServicesRevisionPropertyName: revision,
+			constant.MetadataStorageTypePropertyName:      constant.RemoteMetadataStorageType,
+			constant.ServiceInstanceEndpoints:             `[{"port":20099,"protocol":"tri"}]`,
+		},
+	}
+
+	// Create listener with the specific registry id. Remove the revision from
+	// the cache after the test so it doesn't bleed into other tests.
+	t.Cleanup(func() {
+		if metaCache != nil {
+			metaCache.Delete(revision)
+		}
+	})
+
+	listener := NewServiceInstancesChangedListener(testApp, listenerRegistryId, gxset.NewSet(testApp))
+	notify := &capturingNotifyListener{}
+	listener.AddListenerAndNotify(common.MatchKey(testInterface, constant.TriProtocol), notify)
+
+	require.NoError(t, listener.OnEvent(registry.NewServiceInstancesChangedEvent(testApp, []registry.ServiceInstance{remoteInstance})))
+
+	// The mock report must have been called exactly once, proving the correct report was used
+	mockReport.AssertExpectations(t)
+	// The notify listener must have received the service from the fetched metadata
+	assert.NotEmpty(t, notify.events, "expected service events from the remote metadata fetch")
+}
+
+// listenerMockMetadataReport is a mock MetadataReport (and its factory) for
+// TestListenerUsesRegistryIdToFetchRemoteMetadata.
+type listenerMockMetadataReport struct {
+	mock.Mock
+}
+
+func (m *listenerMockMetadataReport) CreateMetadataReport(*common.URL) metadatareport.MetadataReport {
+	return m
+}
+
+func (m *listenerMockMetadataReport) GetAppMetadata(string, string) (*info.MetadataInfo, error) {
+	args := m.Called()
+	return args.Get(0).(*info.MetadataInfo), args.Error(1)
+}
+
+func (m *listenerMockMetadataReport) PublishAppMetadata(string, string, *info.MetadataInfo) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *listenerMockMetadataReport) RegisterServiceAppMapping(string, string, string) error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *listenerMockMetadataReport) GetServiceAppMapping(string, string, mapping.MappingListener) (*gxset.HashSet, error) {
+	args := m.Called()
+	return args.Get(0).(*gxset.HashSet), args.Error(1)
+}
+
+func (m *listenerMockMetadataReport) RemoveServiceAppMappingListener(string, string) error {
+	args := m.Called()
+	return args.Error(0)
 }
 
 func newTestServiceInstance(t *testing.T, port int, environment string) registry.ServiceInstance {

--- a/registry/servicediscovery/service_instances_changed_listener_impl_test.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl_test.go
@@ -145,7 +145,7 @@ func TestCreateInstanceCarriesEnvironmentMetadata(t *testing.T) {
 	meta := info.NewMetadataInfo(testApp, "")
 	providerURL := newTestProviderURL(t, 20001, "pre")
 
-	instance := createInstance(meta, providerURL)
+	instance := createInstance(meta, providerURL, constant.DefaultKey)
 
 	assert.Equal(t, "pre", instance.GetMetadata()[constant.EnvironmentKey])
 }


### PR DESCRIPTION
### Description

Fixes #3352

---

#### Background / 背景

The [#2534 refactor](https://github.com/apache/dubbo-go/pull/2534) centralized metadata logic and settled on an application-level metadata path where `MetadataReport` handles app-level `MetadataInfo` and service-app mapping. That refactor was correct in intent, but it left the **selection semantics of `MetadataReport` under-specified** for multi-registry and multi-instance deployments.

Concretely, when a process connects to more than one registry (e.g. Nacos + Zookeeper), each registry gets its own `MetadataReport` instance, keyed by `registryId` in the `instances` map. The pre-existing code had four independent correctness gaps in how it chose which report to use.

#2534 重构将 metadata 逻辑集中化，以应用级 `MetadataInfo` 和 service-app mapping 为核心路径。重构方向正确，但在**多注册中心和多实例部署场景下，`MetadataReport` 的选择语义存在空白**。

具体来说，当进程同时连接多个注册中心（如 Nacos + Zookeeper）时，每个注册中心会在 `instances` map 中保有独立的 `MetadataReport` 实例。原有代码在选择使用哪个 report 时存在以下四个独立的正确性问题。

---

#### Problems Fixed / 修复的问题

**1. `GetMetadataReport()` returned a non-deterministic report / 返回结果不确定**

Go map iteration order is randomized. `GetMetadataReport()` returned whichever entry happened to come first — a different report on every call in some runs, making any downstream behavior non-reproducible.

Fix: prefer the `"default"` key; fall back to the lexicographically first `registryId` so the result is always stable.

Go map 迭代顺序随机，`GetMetadataReport()` 每次可能返回不同的 report。修复：优先返回 `"default"` 键；不存在时退回到字典序最小的 `registryId`，确保结果稳定。

---

**2. `GetMetadataReportByRegistry()` silently fell back to the wrong registry's report / 静默返回错误注册中心的 report**

When a caller passed a specific `registryId` that was not registered, the function silently fell back to `GetMetadataReport()` and returned an unrelated registry's report. In `GetMetadataFromMetadataReport`, this meant remote metadata could be fetched from the wrong backend with no error surfaced.

Fix: return `nil` + `Warnf` when a specific registryId is not found. The existing nil-guard in `GetMetadataFromMetadataReport` already surfaces this as an actionable error.

调用方传入未注册的 `registryId` 时，函数静默退回到其他注册中心的 report，且无任何报错。修复：找不到时返回 `nil` + `Warnf`，由调用方的 nil 检查给出明确错误。

---

**3. `ServiceNameMapping.Remove()` only returned the last error / 只保留最后一个错误**

`Remove()` fanned out to all reports but used a `lastErr` accumulator overwritten on each iteration. If the first report failed and the second succeeded, the error was silently discarded and the caller saw `nil`, leaving a stale mapping in the first registry.

Fix: collect all errors with `errors.Join` so the caller receives the full failure picture.

`Remove()` 向所有 report 扇出，但 `lastErr` 在每次循环中被覆盖。若第一个 report 失败、第二个成功，错误被静默丢弃。修复：使用 `errors.Join` 收集全部错误。

---

**4. Revision calculation and remote metadata fetch used cross-registry data / Revision 计算和远端 metadata 拉取使用了跨注册中心数据**

The revision customizers called the global `GetMetadataService()` which merges services across all registries, so two instances on different registries could compute the same revision even though their actual service sets differed — breaking consumer-side change detection.

The listener cache in `GetMetadataInfo()` was keyed by `revision` alone. Two registries producing the same revision string would collide, and the second registry's listener would silently receive the first registry's cached metadata.

Fix: thread `registryId` through `createInstance()`, both revision customizers, `GetMetadataFromMetadataReport()`, `NewServiceInstancesChangedListener()`, and `GetMetadataInfo()`. Change the cache key to `registryId + ":" + revision`.

Revision customizer 通过全局 `GetMetadataService()` 获取服务列表，合并了所有注册中心的数据，导致不同注册中心的实例可能计算出相同的 revision。监听器的 metadata 缓存仅以 `revision` 为键，多注册中心场景下会发生缓存污染。修复：将 `registryId` 贯穿传递到相关链路，缓存键改为 `registryId + ":" + revision`。

---

#### Changes / 改动内容

| File | Change |
|---|---|
| `metadata/report_instance.go` | `GetMetadataReport()` deterministic; `GetMetadataReportByRegistry()` returns nil for unknown id; add `ClearMetadataReportInstances()` for test isolation |
| `metadata/client.go` | `GetMetadataFromMetadataReport()` takes `registryId`, routes to correct per-registry report |
| `metadata/mapping/metadata/service_name_mapping.go` | `Remove()` collects all errors with `errors.Join` |
| `registry/servicediscovery/service_instances_changed_listener_impl.go` | `GetMetadataInfo()` and `NewServiceInstancesChangedListener()` take `registryId`; cache key scoped to `registryId + ":" + revision` |
| `registry/servicediscovery/service_discovery_registry.go` | `createInstance()` injects `registryId` into instance metadata; `SubscribeURL` passes `registryId` to listener |
| `registry/servicediscovery/customizer/service_revision_customizer.go` | Read per-registry `MetadataInfo`; upgrade missing-registryId log to `Errorf` with accurate consequence description |
| `registry/servicediscovery/customizer/metadata_service_url_params_customizer.go` | Restore TODO with explanation — per-registry MetadataService URL support is tracked separately |

---

#### Tests Added / 新增测试

- `TestGetMetadataReportIsDeterministic` — 20 iterations verify stability under Go's randomized map iteration
- `TestGetMetadataReportByRegistry` / `TestGetMetadataReportByRegistryFallsBackDeterministically` — hit, miss, and empty-string paths
- `TestServiceNameMappingRemoveFansOutToAllReports` — both reports called on success
- `TestServiceNameMappingRemoveCollectsAllErrors` — both errors visible via `errors.Is` in joined return
- `TestServiceNameMappingRemoveContinuesAfterPartialFailure` — loop does not short-circuit on first failure
- `TestExportedRevisionIsRegistryScoped` / `TestSubscribedRevisionIsRegistryScoped` — different registries produce different revisions
- `TestExportedRevisionMissingRegistryIdYieldsZero` / `TestSubscribedRevisionMissingRegistryIdYieldsZero` — missing `RegistryIdKey` yields revision `"0"`, does not borrow another registry's data
- `TestGetMetadataFromMetadataReport` (rewritten) — specific registryId routes to correct report; unknown registryId returns error, not wrong report
- `TestListenerUsesRegistryIdToFetchRemoteMetadata` — end-to-end: registryId flows from `NewServiceInstancesChangedListener` through `OnEvent` → `GetMetadataInfo` → `GetMetadataFromMetadataReport` → correct mock report called

---

~~#### TODO / 本 PR 还未做完~~

~~Multi-instance metadata service URL alignment (`metadata_service_url_params_customizer.go`): `GetMetadataService()` still returns a global singleton so all instances across registries receive the same metadata service URL.~~

~~多实例 metadata service URL 对齐：`GetMetadataService()` 仍返回全局单例，所有注册中心实例获得同一 metadata service URL。~~

---

### Checklist
- [X] I confirm the target branch is `develop`
- [X] Code has passed local testing
- [X] I have added tests that prove my fix is effective or that my feature works
