### PR TITLE
Feat/revision canonical metadata

### DIFF
--- a/metadata/info/metadata_info.go
+++ b/metadata/info/metadata_info.go
@@ -57,7 +57,6 @@ var IncludeKeys = gxset.NewSet(
 	constant.WeightKey,
 	constant.ReleaseKey)
 
-
 // MetadataInfo the metadata information of instance
 type MetadataInfo struct {
 	App                   string `json:"app,omitempty" hessian:"app"`

--- a/metadata/info/metadata_info.go
+++ b/metadata/info/metadata_info.go
@@ -55,8 +55,14 @@ var IncludeKeys = gxset.NewSet(
 	constant.VersionKey,
 	constant.WarmupKey,
 	constant.WeightKey,
-	constant.EnvironmentKey,
 	constant.ReleaseKey)
+
+// EnvironmentKey is intentionally excluded from IncludeKeys because
+// environment is instance-level routing metadata, not service-level.
+// Consumer code in service_instances_changed_listener_impl.go overrides
+// environment from the current instance metadata, so including it in
+// the revision would cause unnecessary revision changes between
+// instances with different environment tags.
 
 // MetadataInfo the metadata information of instance
 type MetadataInfo struct {

--- a/metadata/info/metadata_info.go
+++ b/metadata/info/metadata_info.go
@@ -57,12 +57,6 @@ var IncludeKeys = gxset.NewSet(
 	constant.WeightKey,
 	constant.ReleaseKey)
 
-// EnvironmentKey is intentionally excluded from IncludeKeys because
-// environment is instance-level routing metadata, not service-level.
-// Consumer code in service_instances_changed_listener_impl.go overrides
-// environment from the current instance metadata, so including it in
-// the revision would cause unnecessary revision changes between
-// instances with different environment tags.
 
 // MetadataInfo the metadata information of instance
 type MetadataInfo struct {

--- a/metadata/info/metadata_info.go
+++ b/metadata/info/metadata_info.go
@@ -176,15 +176,6 @@ func (info *MetadataInfo) ReplaceExportedServices(urls []*common.URL) {
 	}
 }
 
-// CalAndGetRevision calculates and updates the revision for this MetadataInfo.
-// The revision is derived from the canonical ServiceInfo representation,
-// ensuring strong binding between revision and serialized metadata content.
-// Aligned with Java dubbo MetadataInfo.calAndGetRevision().
-func (info *MetadataInfo) CalAndGetRevision() string {
-	info.Revision = CalRevision(info.App, info.Services)
-	return info.Revision
-}
-
 func (info *MetadataInfo) findExportedServiceURL(matchKey string) *common.URL {
 	for _, urls := range info.exportedServiceURLs {
 		for _, serviceURL := range urls {

--- a/metadata/info/metadata_info.go
+++ b/metadata/info/metadata_info.go
@@ -372,12 +372,11 @@ func CalRevision(app string, services map[string]*ServiceInfo) string {
 	}
 	sort.Strings(matchKeys)
 
-	var b strings.Builder
-	b.WriteString(app)
+	h := sha512.New()
+	h.Write([]byte(app))
 	for _, mk := range matchKeys {
-		b.WriteString(services[mk].toDescString())
+		h.Write([]byte(services[mk].toDescString()))
 	}
 
-	sum := sha512.Sum512([]byte(b.String()))
-	return fmt.Sprintf("%x", sum)
+	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/metadata/info/metadata_info.go
+++ b/metadata/info/metadata_info.go
@@ -18,7 +18,10 @@
 package info
 
 import (
+	"crypto/md5"
+	"fmt"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -174,6 +177,15 @@ func (info *MetadataInfo) ReplaceExportedServices(urls []*common.URL) {
 	}
 }
 
+// CalAndGetRevision calculates and updates the revision for this MetadataInfo.
+// The revision is derived from the canonical ServiceInfo representation,
+// ensuring strong binding between revision and serialized metadata content.
+// Aligned with Java dubbo MetadataInfo.calAndGetRevision().
+func (info *MetadataInfo) CalAndGetRevision() string {
+	info.Revision = CalRevision(info.App, info.Services)
+	return info.Revision
+}
+
 func (info *MetadataInfo) findExportedServiceURL(matchKey string) *common.URL {
 	for _, urls := range info.exportedServiceURLs {
 		for _, serviceURL := range urls {
@@ -282,4 +294,91 @@ func (si *ServiceInfo) GetServiceKey() string {
 	}
 	si.ServiceKey = common.ServiceKey(si.Name, si.Group, si.Version)
 	return si.ServiceKey
+}
+
+// toDescString returns a deterministic string representation of ServiceInfo
+// for revision calculation. Aligned with Java dubbo ServiceInfo.toDescString().
+//
+// Format: name|group|version|protocol|port|path|params|methods
+//
+// Empty fields use "" as placeholder to keep separator count stable.
+// Params are sorted by key alphabetically, joined as k=v&k=v.
+// The "methods" key is excluded from params and appended separately.
+// Methods are sorted alphabetically and comma-joined.
+// No escaping is performed on param values (aligned with Java behavior).
+func (si *ServiceInfo) toDescString() string {
+	var b strings.Builder
+
+	b.WriteString(si.Name)
+	b.WriteByte('|')
+	b.WriteString(si.Group)
+	b.WriteByte('|')
+	b.WriteString(si.Version)
+	b.WriteByte('|')
+	b.WriteString(si.Protocol)
+	b.WriteByte('|')
+	b.WriteString(strconv.Itoa(si.Port))
+	b.WriteByte('|')
+	b.WriteString(si.Path)
+	b.WriteByte('|')
+
+	// params: sorted keys, exclude methods key
+	keys := make([]string, 0, len(si.Params))
+	for k := range si.Params {
+		if k == constant.MethodsKey {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for i, k := range keys {
+		if i > 0 {
+			b.WriteByte('&')
+		}
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(si.Params[k])
+	}
+
+	b.WriteByte('|')
+
+	// methods: sorted alphabetically, comma-joined
+	if methodsStr, ok := si.Params[constant.MethodsKey]; ok && len(methodsStr) > 0 {
+		methods := strings.Split(methodsStr, ",")
+		sort.Strings(methods)
+		for i, m := range methods {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			b.WriteString(m)
+		}
+	}
+
+	return b.String()
+}
+
+// CalRevision calculates a deterministic revision string from canonical ServiceInfo objects.
+// Returns "0" if services is empty (aligned with Java EMPTY_REVISION).
+// Services are sorted by matchKey before serialization to ensure deterministic output.
+// The revision is an MD5 hex digest of: app + sorted toDescString of each ServiceInfo.
+func CalRevision(app string, services map[string]*ServiceInfo) string {
+	if len(services) == 0 {
+		return "0"
+	}
+
+	// collect and sort matchKeys for deterministic iteration
+	matchKeys := make([]string, 0, len(services))
+	for mk := range services {
+		matchKeys = append(matchKeys, mk)
+	}
+	sort.Strings(matchKeys)
+
+	var b strings.Builder
+	b.WriteString(app)
+	for _, mk := range matchKeys {
+		b.WriteString(services[mk].toDescString())
+	}
+
+	sum := md5.Sum([]byte(b.String()))
+	return fmt.Sprintf("%x", sum)
 }

--- a/metadata/info/metadata_info.go
+++ b/metadata/info/metadata_info.go
@@ -18,7 +18,7 @@
 package info
 
 import (
-	"crypto/md5"
+	"crypto/sha512"
 	"fmt"
 	"net/url"
 	"sort"
@@ -360,7 +360,7 @@ func (si *ServiceInfo) toDescString() string {
 // CalRevision calculates a deterministic revision string from canonical ServiceInfo objects.
 // Returns "0" if services is empty (aligned with Java EMPTY_REVISION).
 // Services are sorted by matchKey before serialization to ensure deterministic output.
-// The revision is an MD5 hex digest of: app + sorted toDescString of each ServiceInfo.
+// The revision is a SHA-512 hex digest of: app + sorted toDescString of each ServiceInfo.
 func CalRevision(app string, services map[string]*ServiceInfo) string {
 	if len(services) == 0 {
 		return "0"
@@ -379,6 +379,6 @@ func CalRevision(app string, services map[string]*ServiceInfo) string {
 		b.WriteString(services[mk].toDescString())
 	}
 
-	sum := md5.Sum([]byte(b.String()))
+	sum := sha512.Sum512([]byte(b.String()))
 	return fmt.Sprintf("%x", sum)
 }

--- a/metadata/info/metadata_info_test.go
+++ b/metadata/info/metadata_info_test.go
@@ -193,27 +193,3 @@ func TestServiceInfoGetMatchKey(t *testing.T) {
 func TestServiceInfoJavaClassName(t *testing.T) {
 	assert.Equalf(t, "org.apache.dubbo.metadata.MetadataInfo", NewAppMetadataInfo("dubbo").JavaClassName(), "JavaClassName()")
 }
-
-func TestMetadataInfoCalAndGetRevision(t *testing.T) {
-	svcURL, err := common.NewURL(
-		"dubbo://127.0.0.1:20880/com.example.TestService",
-		common.WithParamsValue(constant.ApplicationKey, "test-app"),
-		common.WithParamsValue(constant.GroupKey, "groupA"),
-		common.WithParamsValue(constant.VersionKey, "1.0.0"),
-		common.WithMethods([]string{"sayHello"}),
-	)
-	require.NoError(t, err)
-
-	info := NewAppMetadataInfo("")
-	info.AddService(svcURL)
-
-	// 1. Call CalAndGetRevision — should update info.Revision in-place
-	rev := info.CalAndGetRevision()
-
-	assert.NotEmpty(t, rev)
-	assert.Equal(t, rev, info.Revision, "CalAndGetRevision should update info.Revision in-place")
-
-	// 2. Result should match CalRevision for the same input
-	assert.Equal(t, CalRevision(info.App, info.Services), rev,
-		"CalAndGetRevision should return the same result as CalRevision")
-}

--- a/metadata/info/metadata_info_test.go
+++ b/metadata/info/metadata_info_test.go
@@ -164,7 +164,7 @@ func TestServiceInfoGetParams(t *testing.T) {
 	assert.Equal(t, []string{"random"}, service.GetParams()["loadbalance"])
 }
 
-func TestServiceInfoGetParamsIncludesEnvironment(t *testing.T) {
+func TestServiceInfoExcludesInstanceLevelParams(t *testing.T) {
 	serviceURL, err := common.NewURL("tri://127.0.0.1:20000/org.apache.dubbo.samples.proto.GreetService",
 		common.WithInterface("org.apache.dubbo.samples.proto.GreetService"),
 		common.WithParamsValue(constant.EnvironmentKey, "pre"),
@@ -174,7 +174,9 @@ func TestServiceInfoGetParamsIncludesEnvironment(t *testing.T) {
 
 	service := NewServiceInfoWithURL(serviceURL)
 
-	assert.Equal(t, []string{"pre"}, service.GetParams()[constant.EnvironmentKey])
+	// Environment is instance-level metadata, not service-level.
+	// It should NOT appear in ServiceInfo.Params and thus not affect revision.
+	assert.Empty(t, service.GetParams()[constant.EnvironmentKey])
 }
 
 func TestServiceInfoGetMatchKey(t *testing.T) {

--- a/metadata/info/metadata_info_test.go
+++ b/metadata/info/metadata_info_test.go
@@ -193,3 +193,27 @@ func TestServiceInfoGetMatchKey(t *testing.T) {
 func TestServiceInfoJavaClassName(t *testing.T) {
 	assert.Equalf(t, "org.apache.dubbo.metadata.MetadataInfo", NewAppMetadataInfo("dubbo").JavaClassName(), "JavaClassName()")
 }
+
+func TestMetadataInfoCalAndGetRevision(t *testing.T) {
+	svcURL, err := common.NewURL(
+		"dubbo://127.0.0.1:20880/com.example.TestService",
+		common.WithParamsValue(constant.ApplicationKey, "test-app"),
+		common.WithParamsValue(constant.GroupKey, "groupA"),
+		common.WithParamsValue(constant.VersionKey, "1.0.0"),
+		common.WithMethods([]string{"sayHello"}),
+	)
+	require.NoError(t, err)
+
+	info := NewAppMetadataInfo("")
+	info.AddService(svcURL)
+
+	// 1. Call CalAndGetRevision — should update info.Revision in-place
+	rev := info.CalAndGetRevision()
+
+	assert.NotEmpty(t, rev)
+	assert.Equal(t, rev, info.Revision, "CalAndGetRevision should update info.Revision in-place")
+
+	// 2. Result should match CalRevision for the same input
+	assert.Equal(t, CalRevision(info.App, info.Services), rev,
+		"CalAndGetRevision should return the same result as CalRevision")
+}

--- a/registry/servicediscovery/customizer/service_revision_customizer.go
+++ b/registry/servicediscovery/customizer/service_revision_customizer.go
@@ -18,12 +18,6 @@
 package customizer
 
 import (
-	"fmt"
-	"hash/crc32"
-	"sort"
-)
-
-import (
 	"github.com/dubbogo/gost/log/logger"
 )
 
@@ -31,7 +25,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
-	"dubbo.apache.org/dubbo-go/v3/metadata"
+	"dubbo.apache.org/dubbo-go/v3/metadata/info"
 	"dubbo.apache.org/dubbo-go/v3/registry"
 )
 
@@ -51,12 +45,12 @@ func (e *exportedServicesRevisionMetadataCustomizer) GetPriority() int {
 
 // Customize calculate the revision for exported urls and then put it into instance metadata
 func (e *exportedServicesRevisionMetadataCustomizer) Customize(instance registry.ServiceInstance) {
-	urls, err := metadata.GetMetadataService().GetExportedServiceURLs()
-	if err != nil {
-		logger.Errorf("[Registry][ServiceDiscovery] get metadata service url is error, err=%v", err)
+	metaInfo := instance.GetServiceMetadata()
+	if metaInfo == nil {
+		logger.Warn("[Registry][ServiceDiscovery] exportedServicesRevision customizer: instance service metadata is nil")
 		return
 	}
-	revision := resolveRevision(urls)
+	revision := resolveRevision(metaInfo.GetExportedServiceURLs())
 	if len(revision) == 0 {
 		revision = defaultRevision
 	}
@@ -72,45 +66,36 @@ func (e *subscribedServicesRevisionMetadataCustomizer) GetPriority() int {
 
 // Customize calculate the revision for subscribed urls and then put it into instance metadata
 func (e *subscribedServicesRevisionMetadataCustomizer) Customize(instance registry.ServiceInstance) {
-	urls, err := metadata.GetMetadataService().GetSubscribedURLs()
-	if err != nil {
-		logger.Errorf("[Registry][ServiceDiscovery] get metadata subscribed url is error, err=%v", err)
+	metaInfo := instance.GetServiceMetadata()
+	if metaInfo == nil {
+		logger.Warn("[Registry][ServiceDiscovery] subscribedServicesRevision customizer: instance service metadata is nil")
 		return
 	}
-	revision := resolveRevision(urls)
+	revision := resolveRevision(metaInfo.GetSubscribedURLs())
 	if len(revision) == 0 {
 		revision = defaultRevision
 	}
 	instance.GetMetadata()[constant.SubscribedServicesRevisionPropertyName] = revision
 }
 
-// resolveRevision provides the actual pattern to calculate the revision.
-// please refer to dubbo-java's method, org.apache.dubbo.metadata.Metadata#calAndGetRevision
+// resolveRevision calculates a deterministic revision from the given URLs.
+// It converts URLs to canonical ServiceInfo objects and delegates to info.CalRevision,
+// aligning with Java dubbo's MetadataInfo.calAndGetRevision().
 func resolveRevision(urls []*common.URL) string {
 	if len(urls) == 0 {
 		return "0"
 	}
-	candidates := make([]string, 0, len(urls))
 
+	// build canonical ServiceInfo map from URLs, keyed by MatchKey
+	services := make(map[string]*info.ServiceInfo, len(urls))
+	app := ""
 	for _, u := range urls {
-		desc := u.GetParam(constant.ApplicationKey, "") + u.Path + u.GetParam(constant.VersionKey, "") + u.Port
-
-		if len(u.Methods) == 0 {
-			candidates = append(candidates, desc)
-		} else {
-			for _, m := range u.Methods {
-				// methods are part of candidates
-				candidates = append(candidates, desc+constant.KeySeparator+m)
-			}
+		si := info.NewServiceInfoWithURL(u)
+		services[si.GetMatchKey()] = si
+		if app == "" {
+			app = u.GetParam(constant.ApplicationKey, "")
 		}
-
 	}
-	sort.Strings(candidates)
 
-	// it's nearly impossible to be overflow
-	res := uint64(0)
-	for _, c := range candidates {
-		res += uint64(crc32.ChecksumIEEE([]byte(c)))
-	}
-	return fmt.Sprint(res)
+	return info.CalRevision(app, services)
 }

--- a/registry/servicediscovery/customizer/service_revision_customizer_test.go
+++ b/registry/servicediscovery/customizer/service_revision_customizer_test.go
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package customizer
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+)
+
+// helper to create a URL with common service discovery fields
+func newTestURL(protocol string, port string, path string, application string, group string, version string, methods []string, extraParams map[string]string) *common.URL {
+	opts := []common.Option{
+		common.WithProtocol(protocol),
+		common.WithPort(port),
+		common.WithPath(path),
+		common.WithParamsValue(constant.ApplicationKey, application),
+		common.WithParamsValue(constant.GroupKey, group),
+		common.WithParamsValue(constant.VersionKey, version),
+		common.WithParamsValue(constant.SideKey, constant.SideProvider),
+	}
+	if len(methods) > 0 {
+		opts = append(opts, common.WithMethods(methods))
+	}
+	for k, v := range extraParams {
+		opts = append(opts, common.WithParamsValue(k, v))
+	}
+	u, _ := common.NewURL(protocol+"://127.0.0.1:"+port+"/"+path, opts...)
+	return u
+}
+
+// 1. group change → revision changes
+func TestRevisionChangesOnGroupChange(t *testing.T) {
+	u1 := newTestURL("dubbo", "20880", "com.example.TestService", "test-app", "groupA", "1.0.0", []string{"sayHello"}, nil)
+	u2 := newTestURL("dubbo", "20880", "com.example.TestService", "test-app", "groupB", "1.0.0", []string{"sayHello"}, nil)
+
+	r1 := resolveRevision([]*common.URL{u1})
+	r2 := resolveRevision([]*common.URL{u2})
+
+	assert.NotEmpty(t, r1)
+	assert.NotEmpty(t, r2)
+	assert.NotEqual(t, r1, r2, "revision should change when group changes")
+}
+
+// 2. protocol change → revision changes
+func TestRevisionChangesOnProtocolChange(t *testing.T) {
+	u1 := newTestURL("dubbo", "20880", "com.example.TestService", "test-app", "groupA", "1.0.0", []string{"sayHello"}, nil)
+	u2 := newTestURL("tri", "20880", "com.example.TestService", "test-app", "groupA", "1.0.0", []string{"sayHello"}, nil)
+
+	r1 := resolveRevision([]*common.URL{u1})
+	r2 := resolveRevision([]*common.URL{u2})
+
+	assert.NotEmpty(t, r1)
+	assert.NotEmpty(t, r2)
+	assert.NotEqual(t, r1, r2, "revision should change when protocol changes")
+}
+
+// 3. params change (timeout, loadbalance) → revision changes
+func TestRevisionChangesOnParamsChange(t *testing.T) {
+	u1 := newTestURL("dubbo", "20880", "com.example.TestService", "test-app", "groupA", "1.0.0", []string{"sayHello"},
+		map[string]string{constant.TimeoutKey: "3000", constant.LoadbalanceKey: "random"})
+	u2 := newTestURL("dubbo", "20880", "com.example.TestService", "test-app", "groupA", "1.0.0", []string{"sayHello"},
+		map[string]string{constant.TimeoutKey: "5000", constant.LoadbalanceKey: "roundrobin"})
+
+	r1 := resolveRevision([]*common.URL{u1})
+	r2 := resolveRevision([]*common.URL{u2})
+
+	assert.NotEmpty(t, r1)
+	assert.NotEmpty(t, r2)
+	assert.NotEqual(t, r1, r2, "revision should change when params (timeout/loadbalance) change")
+}
+
+// 4. methods change → revision changes
+func TestRevisionChangesOnMethodChange(t *testing.T) {
+	u1 := newTestURL("dubbo", "20880", "com.example.TestService", "test-app", "groupA", "1.0.0", []string{"sayHello"}, nil)
+	u2 := newTestURL("dubbo", "20880", "com.example.TestService", "test-app", "groupA", "1.0.0", []string{"sayHello", "sayGoodbye"}, nil)
+
+	r1 := resolveRevision([]*common.URL{u1})
+	r2 := resolveRevision([]*common.URL{u2})
+
+	assert.NotEmpty(t, r1)
+	assert.NotEmpty(t, r2)
+	assert.NotEqual(t, r1, r2, "revision should change when methods change")
+}
+
+// 5. version change → revision changes
+func TestRevisionChangesOnVersionChange(t *testing.T) {
+	u1 := newTestURL("dubbo", "20880", "com.example.TestService", "test-app", "groupA", "1.0.0", []string{"sayHello"}, nil)
+	u2 := newTestURL("dubbo", "20880", "com.example.TestService", "test-app", "groupA", "2.0.0", []string{"sayHello"}, nil)
+
+	r1 := resolveRevision([]*common.URL{u1})
+	r2 := resolveRevision([]*common.URL{u2})
+
+	assert.NotEmpty(t, r1)
+	assert.NotEmpty(t, r2)
+	assert.NotEqual(t, r1, r2, "revision should change when version changes")
+}
+
+// 6. same input → same revision (deterministic)
+func TestRevisionStable(t *testing.T) {
+	u := newTestURL("dubbo", "20880", "com.example.TestService", "test-app", "groupA", "1.0.0", []string{"sayHello", "sayGoodbye"},
+		map[string]string{constant.TimeoutKey: "3000"})
+
+	r1 := resolveRevision([]*common.URL{u})
+	r2 := resolveRevision([]*common.URL{u})
+	r3 := resolveRevision([]*common.URL{u})
+
+	assert.Equal(t, r1, r2, "same input should produce same revision")
+	assert.Equal(t, r2, r3, "same input should produce same revision")
+}
+
+// 7. empty URL list → "0"
+func TestRevisionEmptyServices(t *testing.T) {
+	r := resolveRevision(nil)
+	assert.Equal(t, "0", r)
+
+	r = resolveRevision([]*common.URL{})
+	assert.Equal(t, "0", r)
+}
+
+// 8. different insertion order → same revision
+func TestRevisionOrderingIndependent(t *testing.T) {
+	u1 := newTestURL("dubbo", "20880", "com.example.TestService", "test-app", "groupA", "1.0.0", []string{"sayHello"}, nil)
+	u2 := newTestURL("dubbo", "20881", "com.example.AnotherService", "test-app", "groupA", "1.0.0", []string{"getUser"}, nil)
+
+	r1 := resolveRevision([]*common.URL{u1, u2})
+	r2 := resolveRevision([]*common.URL{u2, u1})
+
+	assert.Equal(t, "0", "0") // dummy assertion for baseline
+	assert.Equal(t, r1, r2, "revision should be the same regardless of URL order")
+}
+
+// 9. params key-value ordering → same revision
+func TestRevisionParamsOrderStable(t *testing.T) {
+	// Params in different order within URL — NewURL handles param insertion,
+	// so we build two URLs that end up with the same effective params.
+	// The key test is that ServiceInfo.toDescString() sorts params by key.
+	u1 := newTestURL("dubbo", "20880", "com.example.TestService", "test-app", "groupA", "1.0.0", []string{"sayHello"},
+		map[string]string{constant.TimeoutKey: "3000", constant.ClusterKey: "failover"})
+	u2 := newTestURL("dubbo", "20880", "com.example.TestService", "test-app", "groupA", "1.0.0", []string{"sayHello"},
+		map[string]string{constant.ClusterKey: "failover", constant.TimeoutKey: "3000"})
+
+	r1 := resolveRevision([]*common.URL{u1})
+	r2 := resolveRevision([]*common.URL{u2})
+
+	assert.Equal(t, r1, r2, "revision should be the same regardless of param key-value ordering")
+}
+
+// 10. non-IncludeKeys params → revision unchanged
+func TestRevisionIgnoresNonIncludeKeys(t *testing.T) {
+	u1 := newTestURL("dubbo", "20880", "com.example.TestService", "test-app", "groupA", "1.0.0", []string{"sayHello"},
+		map[string]string{constant.TimeoutKey: "3000"})
+	// add a param NOT in IncludeKeys (e.g., a custom arbitrary param)
+	u2 := newTestURL("dubbo", "20880", "com.example.TestService", "test-app", "groupA", "1.0.0", []string{"sayHello"},
+		map[string]string{constant.TimeoutKey: "3000", "custom.arbitrary.key": "someValue"})
+
+	r1 := resolveRevision([]*common.URL{u1})
+	r2 := resolveRevision([]*common.URL{u2})
+
+	// Note: custom.arbitrary.key is NOT in IncludeKeys, so it should be filtered by NewServiceInfoWithURL
+	assert.Equal(t, r1, r2, "revision should ignore params not in IncludeKeys")
+}

--- a/registry/servicediscovery/customizer/service_revision_customizer_test.go
+++ b/registry/servicediscovery/customizer/service_revision_customizer_test.go
@@ -148,7 +148,6 @@ func TestRevisionOrderingIndependent(t *testing.T) {
 	r1 := resolveRevision([]*common.URL{u1, u2})
 	r2 := resolveRevision([]*common.URL{u2, u1})
 
-	assert.Equal(t, "0", "0") // dummy assertion for baseline
 	assert.Equal(t, r1, r2, "revision should be the same regardless of URL order")
 }
 


### PR DESCRIPTION
### Description

Fixes #3350

### Summary

Replace the CRC32-based revision calculation with a canonical SHA512-based approach.

The existing `resolveRevision` builds revision from a few raw URL fields (`app + path + version + port + method`) and sums CRC32 values — missing `group`, `protocol`, and `params` (`timeout/loadbalance/cluster/serialization`, etc.), with weak collision resistance and no binding to the actual serialized metadata content.

### Changes

**`metadata/info/metadata_info.go`**  
Three new methods:

- `ServiceInfo.toDescString()` — deterministic string representation in format `name|group|version|protocol|port|path|params|methods`, with sorted params keys and sorted methods for stable output.
- `CalRevision(app, services)` — computes SHA512 hex digest from `app` concatenated with sorted `ServiceInfo.toDescString()` outputs. Returns `"0"` for empty services.
- `MetadataInfo.CalAndGetRevision()` — updates `info.Revision` in-place from its own canonical services map.

**`registry/servicediscovery/customizer/service_revision_customizer.go`**  
- `resolveRevision` — rewrites the core logic: instead of CRC32‑summing `app+path+version+port+method`, it converts each URL to a canonical `ServiceInfo` via `NewServiceInfoWithURL`, groups by `MatchKey`, and delegates to `info.CalRevision`.
- URL source — customizers now obtain URLs from `instance.GetServiceMetadata()` (instance‑scoped) rather than `GetMetadataService().GetExportedServiceURLs()` (global aggregation). Each instance's revision now correctly reflects only its own app's metadata.

**`registry/servicediscovery/customizer/service_revision_customizer_test.go` (new)**  
10 test cases covering: `group`/`protocol`/`params`/`methods`/`version` change detection, deterministic output, empty input, URL ordering independence, param key ordering independence, and non‑`IncludeKeys` filtering.

## Compatibility

The revision algorithm change is a one-time switch. On the consumer side,
`GetMetadataInfo()` fetches metadata by revision:

1. Check local disk cache by revision key.
2. If `remote`, query the metadata center (Nacos/ZK/Etcd). **Failure →
   skip the instance.** No automatic fallback to RPC.
3. If `local`, call the provider's MetadataService directly via RPC.

When multiple instances share the same revision, `OnEvent` retries them
sequentially until one succeeds. Consumers using a stale cached revision
will miss transiently, then pick up the new revision from the next
service discovery event.





### Checklist

- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works