### PR TITLE
docs(triple): document header and trailer usage

### DIFF
--- a/protocol/triple/triple_protocol/header.go
+++ b/protocol/triple/triple_protocol/header.go
@@ -111,10 +111,19 @@ func newIncomingContext(ctx context.Context, data http.Header) context.Context {
 	return context.WithValue(ctx, extraDataKey{}, extraData)
 }
 
-// NewOutgoingContext sets headers entirely. If there are existing headers, they would be replaced.
-// It is used for passing headers to server-side.
-// It is like grpc.NewOutgoingContext.
-// Please refer to https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#sending-metadata.
+// NewOutgoingContext sets outgoing request headers on ctx. If ctx already has
+// outgoing headers, they are replaced.
+//
+// For example:
+//
+//	ctx := NewOutgoingContext(context.Background(), http.Header{
+//		"hello": []string{"triple"},
+//	})
+//	resp, err := client.Greet(ctx, &greet.GreetRequest{})
+//
+// Use AppendToOutgoingContext to add more values without replacing existing
+// outgoing headers. These APIs follow the same pattern as grpc metadata:
+// https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#sending-metadata.
 func NewOutgoingContext(ctx context.Context, data http.Header) context.Context {
 	var header = http.Header{}
 
@@ -144,10 +153,20 @@ func cloneExtraData(data map[string]http.Header) map[string]http.Header {
 	return cloned
 }
 
-// AppendToOutgoingContext merges kv pairs from user and existing headers.
-// It is used for passing headers to server-side.
-// It is like grpc.AppendToOutgoingContext.
-// Please refer to https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#sending-metadata.
+// AppendToOutgoingContext appends key-value pairs to outgoing request headers.
+// It panics when kv contains an odd number of strings.
+//
+// For example:
+//
+//	ctx := NewOutgoingContext(context.Background(), http.Header{
+//		"hello": []string{"triple"},
+//	})
+//	ctx = AppendToOutgoingContext(ctx, "hello", "dubbo", "hey", "hessian")
+//	resp, err := client.Greet(ctx, &greet.GreetRequest{})
+//
+// The example sends "hello: triple", "hello: dubbo", and "hey: hessian" to the
+// server. This API follows the same pattern as grpc metadata:
+// https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#sending-metadata.
 func AppendToOutgoingContext(ctx context.Context, kv ...string) context.Context {
 	if len(kv)%2 == 1 {
 		panic(fmt.Sprintf("AppendToOutgoingContext got an odd number of input pairs for header: %d", len(kv)))
@@ -181,9 +200,21 @@ func ExtractFromOutgoingContext(ctx context.Context) http.Header {
 	}
 }
 
-// FromIncomingContext retrieves headers passed by client-side. It is like grpc.FromIncomingContext.
-// it must call after append/setOutgoingContext to return current value
-// Please refer to https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#receiving-metadata-1.
+// FromIncomingContext retrieves request headers received by a server handler.
+//
+// For example:
+//
+//	func (srv *Server) Greet(ctx context.Context, req *greet.GreetRequest) (*greet.GreetResponse, error) {
+//		headers, ok := FromIncomingContext(ctx)
+//		if ok {
+//			values := headers.Values("hello")
+//			// Use values.
+//		}
+//		return &greet.GreetResponse{}, nil
+//	}
+//
+// This API follows the same pattern as grpc metadata:
+// https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#receiving-metadata-1.
 func FromIncomingContext(ctx context.Context) (http.Header, bool) {
 	data, ok := ctx.Value(extraDataKey{}).(map[string]http.Header)
 	if !ok {
@@ -195,9 +226,20 @@ func FromIncomingContext(ctx context.Context) (http.Header, bool) {
 	}
 }
 
-// SetHeader is used for setting response header in server-side. It is like grpc.SendHeader(ctx, header) but
-// not send header.
-// Please refer to https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#unary-call-2.
+// SetHeader appends response headers from a server handler. The headers are
+// buffered and sent with the response instead of being sent immediately.
+//
+// For example:
+//
+//	func (srv *Server) Greet(ctx context.Context, req *greet.GreetRequest) (*greet.GreetResponse, error) {
+//		if err := SetHeader(ctx, http.Header{"hi": []string{"triple"}}); err != nil {
+//			return nil, err
+//		}
+//		return &greet.GreetResponse{}, nil
+//	}
+//
+// This API follows the same pattern as grpc metadata:
+// https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#unary-call-2.
 func SetHeader(ctx context.Context, header http.Header) error {
 	conn, ok := ctx.Value(handlerOutgoingKey{}).(StreamingHandlerConn)
 	if !ok {
@@ -208,8 +250,19 @@ func SetHeader(ctx context.Context, header http.Header) error {
 	return nil
 }
 
-// SetTrailer is used for setting response trailers in server-side. It is like grpc.SetTrailer(ctx, header).
-// Please refer to https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#unary-call-2.
+// SetTrailer appends response trailers from a server handler.
+//
+// For example:
+//
+//	func (srv *Server) Greet(ctx context.Context, req *greet.GreetRequest) (*greet.GreetResponse, error) {
+//		if err := SetTrailer(ctx, http.Header{"end": []string{"end"}}); err != nil {
+//			return nil, err
+//		}
+//		return &greet.GreetResponse{}, nil
+//	}
+//
+// This API follows the same pattern as grpc metadata:
+// https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#unary-call-2.
 func SetTrailer(ctx context.Context, trailer http.Header) error {
 	conn, ok := ctx.Value(handlerOutgoingKey{}).(StreamingHandlerConn)
 	if !ok {
@@ -220,8 +273,21 @@ func SetTrailer(ctx context.Context, trailer http.Header) error {
 	return nil
 }
 
-// SendHeader is used for setting response headers in server-side and send them directly. It is like grpc.SendHeader(ctx, header).
-// Please refer to https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#unary-call-2.
+// SendHeader appends response headers from a server handler and sends them
+// immediately. This is useful for streaming handlers that need to flush headers
+// before the first message.
+//
+// For example:
+//
+//	func (srv *Server) GreetStream(ctx context.Context, stream greet.GreetService_GreetStreamServer) error {
+//		if err := SendHeader(ctx, http.Header{"hi": []string{"triple"}}); err != nil {
+//			return err
+//		}
+//		return stream.Send(&greet.GreetResponse{})
+//	}
+//
+// This API follows the same pattern as grpc metadata:
+// https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md#unary-call-2.
 func SendHeader(ctx context.Context, header http.Header) error {
 	conn, ok := ctx.Value(handlerOutgoingKey{}).(StreamingHandlerConn)
 	if !ok {


### PR DESCRIPTION
## What changed

- Expanded Triple header/trailer API comments with concrete usage examples.
- Documented client-side outgoing headers, server-side incoming headers, buffered response headers, response trailers, and immediate streaming headers.
- Kept the examples aligned with the existing non-generic APIs: `NewOutgoingContext`, `AppendToOutgoingContext`, `FromIncomingContext`, `SetHeader`, `SetTrailer`, and `SendHeader`.

## Why

Issue #2422 proposes a clear usage pattern for Triple headers and trailers after the non-generic API decision. The functions already exist, but their comments did not show the end-to-end pattern or valid `http.Header` literals.

Refs #2422

## Validation

- `go test ./protocol/triple/triple_protocol -run 'Test.*Header|Test.*Trailer'`
- `git diff --check`
