### PR TITLE
docs(generic): explain response attachment access

### DIFF
--- a/filter/README.md
+++ b/filter/README.md
@@ -39,3 +39,46 @@ import _ "dubbo.apache.org/dubbo-go/v3/filter/filter_impl"
 - token: Token Filter(https://github.com/apache/dubbo-go/pull/202)
 - tps: Tps Limit Filter(https://github.com/apache/dubbo-go/pull/237)
 - tracing: Tracing Filter(https://github.com/apache/dubbo-go/pull/335)
+
+## Generic response attachments
+
+In dubbo-go 3.x, `GenericService2` is no longer the response attachment access
+point used by older 1.5.x applications. For Triple generic calls, provider-side
+result attachments are written back as response trailers and can be read from
+the call context after the generic invocation returns.
+
+Initialize the context with Triple outgoing metadata before the call. This also
+enables the client-side Triple transport to copy response trailers back into
+the context.
+
+```go
+package demo
+
+import (
+	"context"
+	"net/http"
+
+	hessian "github.com/apache/dubbo-go-hessian2"
+
+	"dubbo.apache.org/dubbo-go/v3/filter/generic"
+	triple "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol"
+)
+
+func invokeWithResponseAttachments(genericService *generic.GenericService) (http.Header, error) {
+	ctx := triple.NewOutgoingContext(context.Background(), http.Header{})
+
+	_, err := genericService.Invoke(ctx, "echo", []string{"java.lang.String"}, []hessian.Object{"hello"})
+	if err != nil {
+		return nil, err
+	}
+
+	trailers, ok := triple.FromIncomingContext(ctx)
+	if !ok {
+		return nil, nil
+	}
+	return trailers, nil
+}
+```
+
+On the provider side, attachments set on the invocation result are propagated to
+the Triple response trailers for unary calls.


### PR DESCRIPTION
## What changed

- Documented how dubbo-go 3.x callers can read response attachments after a Triple generic invocation.
- Added a migration-oriented example for applications that previously relied on `GenericService2` in dubbo-go 1.5.x.
- Clarified that provider-side result attachments are propagated through Triple response trailers for unary calls.

## Why

Issue #2582 asks how to get response attachments after upgrading from the old `GenericService2` API. The current Triple path already propagates unary result attachments as response trailers, but the replacement usage pattern was not documented in this repository.

Refs #2582

## Validation

- `git diff --check`
