### PR TITLE
test(hessian2): cover pointer long response fields

### DIFF
--- a/protocol/dubbo/hessian2/hessian_dubbo_test.go
+++ b/protocol/dubbo/hessian2/hessian_dubbo_test.go
@@ -48,8 +48,16 @@ type CaseB struct {
 	B CaseA
 }
 
+type PointerLongResp struct {
+	Total *int64
+}
+
 func (c *CaseB) JavaClassName() string {
 	return "com.test.caseb"
+}
+
+func (p PointerLongResp) JavaClassName() string {
+	return "com.test.PointerLongResp"
 }
 
 func (c CaseA) JavaClassName() string {
@@ -174,6 +182,20 @@ func TestResponse(t *testing.T) {
 		}
 		assert.Len(t, mapValueArr, 1)
 		assert.Equal(t, &caseObj, mapValueArr[0])
+	})
+}
+
+func TestResponseWithPointerLongField(t *testing.T) {
+	total := int64(123456789)
+	body := &PointerLongResp{Total: &total}
+	decodedResponse := &DubboResponse{}
+	hessian.RegisterPOJO(body)
+
+	doTestResponse(t, PackageResponse, Response_OK, body, decodedResponse, func() {
+		resp, ok := decodedResponse.RspObj.(*PointerLongResp)
+		require.True(t, ok)
+		require.NotNil(t, resp.Total)
+		assert.Equal(t, total, *resp.Total)
 	})
 }
 


### PR DESCRIPTION
## What changed

- Added a Dubbo Hessian response regression test for a POJO containing a `*int64` field.
- The test encodes a provider response, decodes it back, and verifies the pointer field remains a non-nil `*int64` with the expected value.

## Why

Issue #2410 reported Java consumers failing to deserialize a Go provider response when the returned struct contains a pointer `int64` field mapped to Java `Long`. The current dependency already uses `dubbo-go-hessian2 v1.12.5`, which includes the upstream fix mentioned in the issue thread. This test keeps that compatibility covered in dubbo-go.

Refs #2410

## Validation

- `go test ./protocol/dubbo/hessian2 -run 'TestResponseWithPointerLongField|TestResponse'`
- `git diff --check`
