### PR TITLE
docs(echo): note reserved Echo method behavior

### DIFF
--- a/filter/echo/filter.go
+++ b/filter/echo/filter.go
@@ -15,9 +15,18 @@
  * limitations under the License.
  */
 
-// Package echo providers health check filter.
-// RPCService need a Echo method in consumer, if you want to use Filter
-// eg: Echo func(ctx context.Context, arg any, rsp *Xxx) error
+// Package echo provides the health check filter.
+//
+// The filter reserves the Echo method name: when an invocation method is Echo
+// and it has exactly one argument, the filter returns that argument directly.
+// Application services should avoid defining business methods named Echo when
+// this filter is enabled, otherwise the invocation is handled as a built-in
+// echo health check instead of reaching the provider implementation.
+//
+// RPCService needs an Echo method in the consumer if it wants to use this
+// filter, for example:
+//
+//	Echo func(ctx context.Context, arg any, rsp *Xxx) error
 package echo
 
 import (


### PR DESCRIPTION
## What changed

- Expanded the echo filter package comment to explain that `Echo` is a reserved built-in health check method name.
- Documented that services should avoid business methods named `Echo` when the echo filter is enabled.
- Kept runtime behavior unchanged.

## Why

Issue #2084 reports a panic after defining a service named/methoded `Echo`; maintainers clarified that this is caused by conflict with dubbo-go's built-in echo filter behavior and is not a runtime bug. The package comment now makes that behavior explicit.

Refs #2084

## Validation

- `gofmt -w filter/echo/filter.go`
- `git diff --check`

Note: `go test ./filter/echo` was not completed in this sparse checkout because `common/extension` pulls additional packages that are outside the current sparse tree.
