### PR TITLE
docs(filter): describe Java overload dispatch

### DIFF
--- a/filter/README.md
+++ b/filter/README.md
@@ -36,3 +36,45 @@ import _ "dubbo.apache.org/dubbo-go/v3/filter/filter_impl"
 - token: Token Filter(https://github.com/apache/dubbo-go/pull/202)
 - tps: Tps Limit Filter(https://github.com/apache/dubbo-go/pull/237)
 - tracing: Tracing Filter(https://github.com/apache/dubbo-go/pull/335)
+
+## Java overloaded methods
+
+Go does not support Java-style method overloading. When a Java interface has
+multiple methods with the same name and different arguments, expose one Go
+method for that Java name and dispatch by argument count or argument type inside
+the method.
+
+```go
+import (
+	"context"
+	"fmt"
+)
+
+type CommentServiceProvider struct{}
+
+func (p *CommentServiceProvider) IsForbidsSpeak(ctx context.Context, params []any) (any, error) {
+	switch len(params) {
+	case 2:
+		bookID, userID := params[0], params[1]
+		// Handle: isForbidsSpeak(Long bookId, Long userId)
+		_, _ = bookID, userID
+	case 3:
+		bookID, userID, ip := params[0], params[1], params[2]
+		// Handle: isForbidsSpeak(Long bookId, Long userId, String ip)
+		_, _, _ = bookID, userID, ip
+	default:
+		return nil, fmt.Errorf("unsupported isForbidsSpeak argument count: %d", len(params))
+	}
+	return true, nil
+}
+
+func (p *CommentServiceProvider) MethodMapper() map[string]string {
+	return map[string]string{
+		"IsForbidsSpeak": "isForbidsSpeak",
+	}
+}
+```
+
+For stricter dispatch, check both the argument count and the concrete argument
+types. This keeps the exported Go service shape explicit while still matching
+the overloaded Java method name through `MethodMapper`.


### PR DESCRIPTION
## What changed

- Added README guidance for implementing Java-style overloaded methods in dubbo-go.
- Documented the single Go entrypoint plus `MethodMapper` pattern.
- Included an argument-count dispatch example for `isForbidsSpeak`.

## Why

Issue #1780 asks how to handle Java overloaded methods from Go. Maintainer discussion points to dispatching by argument count or type instead of relying on Go method overloading, which the language does not support. This documents that pattern in the repo.

Refs #1780

## Validation

- `git diff --check`
