### PR TITLE
docs: explain Java method name mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,23 @@ Dubbo-go provides robust service governance capabilities:
 - **HA Strategy**: Failover, Failfast, Failsafe/Failback, Available, Broadcast, Forking.
 - **Interoperability**: Full compatibility with Apache Dubbo (Java) via Triple protocol generic calls, group/version wildcard matching, and TLS API redesign.
 
+## Java Interoperability Notes
+
+Go RPC methods must be exported, so their names usually start with an uppercase
+letter. When interoperating with Java services that use lower camel case method
+names, dubbo-go registers the reflected method name and its first-letter case
+variant. For example, a Go method named `GetUser` can match Java `getUser`.
+
+For explicit mappings, define `MethodMapper` on the service:
+
+```go
+func (s *UserService) MethodMapper() map[string]string {
+	return map[string]string{
+		"GetUser": "getUser",
+	}
+}
+```
+
 ## ️ Tools
 
 The `tools/` directory and the `dubbogo/tools` repository provide several utilities to streamline your Dubbo-Go development experience.


### PR DESCRIPTION
## What changed

- Added README guidance for Java method name compatibility.
- Documented first-letter case fallback for exported Go RPC methods.
- Added a `MethodMapper` example for explicit lower camel case Java method mapping.

## Why

Issue #257 is kept open as a beginner-facing interoperability reference. The behavior is already implemented, including the routing improvements from #3277, but the README did not clearly explain how Go `GetUser` maps to Java `getUser` or when to use `MethodMapper`.

Refs #257

## Validation

- `git diff --check`
