### PR TITLE
refactor(extension): use registry for shutdown callbacks

### DIFF
--- a/common/extension/graceful_shutdown.go
+++ b/common/extension/graceful_shutdown.go
@@ -36,8 +36,7 @@ var (
 	customShutdownCallbacks     = list.New()
 	customShutdownCallbacksLock sync.RWMutex
 	customShutdownCallbacksMu   = &customShutdownCallbacksLock
-	gracefulShutdownCallbacksMu sync.RWMutex
-	gracefulShutdownCallbacks   = make(map[string]GracefulShutdownCallback)
+	gracefulShutdownCallbacks   = NewRegistry[GracefulShutdownCallback]("graceful shutdown callback")
 )
 
 /**
@@ -81,41 +80,22 @@ func GetAllCustomShutdownCallbacks() *list.List {
 
 // RegisterGracefulShutdownCallback registers a protocol-level graceful shutdown callback.
 func RegisterGracefulShutdownCallback(name string, f GracefulShutdownCallback) {
-	gracefulShutdownCallbacksMu.Lock()
-	defer gracefulShutdownCallbacksMu.Unlock()
-
-	if _, exists := gracefulShutdownCallbacks[name]; exists {
+	if ok := gracefulShutdownCallbacks.RegisterIfAbsent(name, f); !ok {
 		logger.Warnf("[GracefulShutdown] graceful shutdown callback %q already registered, duplicate registration ignored", name)
-		return
 	}
-
-	gracefulShutdownCallbacks[name] = f
 }
 
 // LookupGracefulShutdownCallback returns a protocol graceful shutdown callback by name.
 func LookupGracefulShutdownCallback(name string) (GracefulShutdownCallback, bool) {
-	gracefulShutdownCallbacksMu.RLock()
-	defer gracefulShutdownCallbacksMu.RUnlock()
-	f, ok := gracefulShutdownCallbacks[name]
-	return f, ok
+	return gracefulShutdownCallbacks.Get(name)
 }
 
 // UnregisterGracefulShutdownCallback removes a protocol graceful shutdown callback by name.
 func UnregisterGracefulShutdownCallback(name string) {
-	gracefulShutdownCallbacksMu.Lock()
-	defer gracefulShutdownCallbacksMu.Unlock()
-	delete(gracefulShutdownCallbacks, name)
+	gracefulShutdownCallbacks.Unregister(name)
 }
 
 // GracefulShutdownCallbacks returns a snapshot of all protocol graceful shutdown callbacks.
 func GracefulShutdownCallbacks() map[string]GracefulShutdownCallback {
-	gracefulShutdownCallbacksMu.RLock()
-	defer gracefulShutdownCallbacksMu.RUnlock()
-
-	callbacks := make(map[string]GracefulShutdownCallback, len(gracefulShutdownCallbacks))
-	for name, callback := range gracefulShutdownCallbacks {
-		callbacks[name] = callback
-	}
-
-	return callbacks
+	return gracefulShutdownCallbacks.Snapshot()
 }

--- a/common/extension/graceful_shutdown.go
+++ b/common/extension/graceful_shutdown.go
@@ -80,7 +80,7 @@ func GetAllCustomShutdownCallbacks() *list.List {
 
 // RegisterGracefulShutdownCallback registers a protocol-level graceful shutdown callback.
 func RegisterGracefulShutdownCallback(name string, f GracefulShutdownCallback) {
-	if ok := gracefulShutdownCallbacks.RegisterIfAbsent(name, f); !ok {
+	if !gracefulShutdownCallbacks.RegisterIfAbsent(name, f) {
 		logger.Warnf("[GracefulShutdown] graceful shutdown callback %q already registered, duplicate registration ignored", name)
 	}
 }

--- a/common/extension/graceful_shutdown_test.go
+++ b/common/extension/graceful_shutdown_test.go
@@ -40,6 +40,27 @@ func TestGracefulShutdownCallbacksReturnsSnapshot(t *testing.T) {
 	}
 }
 
+func TestRegisterGracefulShutdownCallbackIgnoresDuplicate(t *testing.T) {
+	t.Cleanup(func() {
+		UnregisterGracefulShutdownCallback("duplicate-test")
+	})
+
+	RegisterGracefulShutdownCallback("duplicate-test", func(context.Context) error {
+		return context.Canceled
+	})
+	RegisterGracefulShutdownCallback("duplicate-test", func(context.Context) error {
+		return context.DeadlineExceeded
+	})
+
+	callback, ok := LookupGracefulShutdownCallback("duplicate-test")
+	if !ok {
+		t.Fatal("expected registered callback")
+	}
+	if err := callback(context.Background()); err != context.Canceled {
+		t.Fatalf("expected first callback to remain registered, got %v", err)
+	}
+}
+
 func TestGetAllCustomShutdownCallbacksReturnsSnapshot(t *testing.T) {
 	customShutdownCallbacksMu.Lock()
 	original := customShutdownCallbacks

--- a/common/extension/registry_type.go
+++ b/common/extension/registry_type.go
@@ -41,6 +41,16 @@ func (r *Registry[T]) Register(name string, v T) {
 	r.items[name] = v
 }
 
+func (r *Registry[T]) RegisterIfAbsent(name string, v T) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if _, ok := r.items[name]; ok {
+		return false
+	}
+	r.items[name] = v
+	return true
+}
+
 func (r *Registry[T]) Get(name string) (T, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/common/extension/registry_type_test.go
+++ b/common/extension/registry_type_test.go
@@ -38,11 +38,21 @@ func TestRegistryBasicOps(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, 1, v)
 
+	assert.False(t, r.RegisterIfAbsent("a", 2))
+	v, ok = r.Get("a")
+	assert.True(t, ok)
+	assert.Equal(t, 1, v)
+
+	assert.True(t, r.RegisterIfAbsent("b", 2))
+	v, ok = r.Get("b")
+	assert.True(t, ok)
+	assert.Equal(t, 2, v)
+
 	must := r.MustGet("a")
 	assert.Equal(t, 1, must)
 
 	snapshot := r.Snapshot()
-	assert.Equal(t, map[string]int{"a": 1}, snapshot)
+	assert.Equal(t, map[string]int{"a": 1, "b": 2}, snapshot)
 	snapshot["a"] = 99
 
 	v, ok = r.Get("a")
@@ -50,8 +60,7 @@ func TestRegistryBasicOps(t *testing.T) {
 	assert.Equal(t, 1, v)
 
 	names := r.Names()
-	assert.Len(t, names, 1)
-	assert.Equal(t, "a", names[0])
+	assert.ElementsMatch(t, []string{"a", "b"}, names)
 
 	r.Unregister("a")
 	_, ok = r.Get("a")


### PR DESCRIPTION
### Description

Refs #3248.

This PR continues the extension safety cleanup by moving protocol-level graceful shutdown callbacks from a hand-rolled `map + RWMutex` to the shared generic `Registry[T]` abstraction:

- adds `Registry.RegisterIfAbsent` for atomic duplicate-preserving registration
- uses `Registry[GracefulShutdownCallback]` for graceful shutdown callback lookup/unregister/snapshot
- keeps the existing duplicate registration behavior: the first callback remains registered and later duplicates are ignored with a warning

### Validation

- `go test ./common/extension`
- `go test -race ./common/extension`
- `make fmt`
- `git diff --check`

### Checklist

- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
