### PR TITLE
ci: add race test for core packages

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -77,6 +77,39 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true # optional (default = false)
 
+  Race-Test:
+    name: Race Test (${{ matrix.os }} - Go ${{ matrix.go_version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        go_version:
+          - '1.23'
+        os:
+          - ubuntu-latest
+
+    steps:
+    - name: Setup Go ${{ matrix.go_version }}
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go_version }}
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-race-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-race-
+          ${{ runner.os }}-go-
+
+    - name: Race Test
+      run: make test-race-core
+
   Integration-Test:
     name: Integration Test (${{ matrix.os }} - Go ${{ matrix.go_version }})
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,12 @@ MAKEFLAGS += --no-print-directory
 CLI_DIR = tools/dubbogo-cli
 IMPORTS_FORMATTER_DIR = tools/imports-formatter
 
-.PHONY: help test fmt clean lint check-fmt rpc-contract-check
+.PHONY: help test test-race-core fmt clean lint check-fmt rpc-contract-check
 
 help:
 	@echo "Available commands:"
 	@echo "  test       - Run unit tests"
+	@echo "  test-race-core - Run race detector tests for core packages"
 	@echo "  clean      - Clean test generate files"
 	@echo "  fmt        - Format code"
 	@echo "  lint       - Run golangci-lint"
@@ -40,6 +41,10 @@ help:
 test: clean
 	GOTOOLCHAIN=go1.25.0+auto go test ./... -coverprofile=coverage.txt -covermode=atomic
 	cd $(CLI_DIR) && GOTOOLCHAIN=go1.25.0+auto go test ./...
+
+# Run race detector tests for packages that guard shared framework state.
+test-race-core: clean
+	GOTOOLCHAIN=go1.25.0+auto go test -race ./common/... ./cluster/router/chain ./protocol/base ./registry/directory
 
 fmt: install-imports-formatter
 	# replace interface{} with any


### PR DESCRIPTION
### Description

Refs #3248.

This PR adds a focused race-detector CI path for core packages that guard shared framework state:

- adds `make test-race-core`
- runs `go test -race` for `common/...`, `cluster/router/chain`, `protocol/base`, and `registry/directory`
- wires the target into a separate GitHub Actions `Race Test` job so race failures are reported independently from the existing unit-test/coverage job

### Validation

- `make test-race-core`
- YAML parse check for `.github/workflows/github-actions.yml`
- `git diff --check`

### Checklist

- [x] Code has passed local testing
