### PR TITLE
refactor(url): clarify append param API

### DIFF
--- a/client/action.go
+++ b/client/action.go
@@ -171,7 +171,7 @@ func (refOpts *ReferenceOptions) refer(srv common.RPCService, info *ClientInfo) 
 	}
 
 	if ref.ForceTag {
-		cfgURL.AddParam(constant.ForceUseTag, "true")
+		cfgURL.SetParam(constant.ForceUseTag, "true")
 	}
 	refOpts.postProcessConfig(cfgURL)
 
@@ -258,7 +258,7 @@ func buildReferenceURL(serviceURL *common.URL, ref *global.ReferenceConfig, cfgU
 	// replace params of serviceURL with params of cfgUrl
 	// other stuff, e.g. IP, port, etc., are same as serviceURL
 	newURL := serviceURL.MergeURL(cfgURL)
-	newURL.AddParam("peer", "true")
+	newURL.SetParam("peer", "true")
 	return newURL
 }
 

--- a/cluster/router/condition/dynamic_router.go
+++ b/cluster/router/condition/dynamic_router.go
@@ -161,8 +161,8 @@ func (d *DynamicRouter) SetStaticConfig(cfg *global.RouterConfig) {
 			logger.Warnf("[Router][Condition] failed to create condition URL: err=%v", err)
 			continue
 		}
-		url.AddParam(constant.RuleKey, conditionRule)
-		url.AddParam(constant.ForceKey, strconv.FormatBool(force))
+		url.SetParam(constant.RuleKey, conditionRule)
+		url.SetParam(constant.ForceKey, strconv.FormatBool(force))
 		conditionRoute, err := NewConditionStateRouter(url)
 		if err != nil {
 			logger.Warnf("[Router][Condition] failed to parse condition rule: rule=%s, err=%v", conditionRule, err)
@@ -304,8 +304,8 @@ func generateConditionsRoute(rawConfig string) (stateRouters, bool, bool, error)
 		if err != nil {
 			return nil, false, false, err
 		}
-		url.AddParam(constant.RuleKey, conditionRule)
-		url.AddParam(constant.ForceKey, strconv.FormatBool(*routerConfig.Force))
+		url.SetParam(constant.RuleKey, conditionRule)
+		url.SetParam(constant.ForceKey, strconv.FormatBool(*routerConfig.Force))
 		conditionRoute, err := NewConditionStateRouter(url)
 		if err != nil {
 			return nil, false, false, err

--- a/common/url.go
+++ b/common/url.go
@@ -536,8 +536,8 @@ func (c *URL) Service() string {
 	return ""
 }
 
-// AddParam will add the key-value pair
-func (c *URL) AddParam(key string, value string) {
+// AppendParam appends the key-value pair without replacing existing values.
+func (c *URL) AppendParam(key string, value string) {
 	c.paramsLock.Lock()
 	defer c.paramsLock.Unlock()
 	if c.params == nil {
@@ -546,14 +546,16 @@ func (c *URL) AddParam(key string, value string) {
 	c.params.Add(key, value)
 }
 
-// AddParamAvoidNil will add key-value pair
+// AddParam will add the key-value pair.
+// Deprecated: use SetParam to replace an existing value or AppendParam to preserve multiple values.
+func (c *URL) AddParam(key string, value string) {
+	c.AppendParam(key, value)
+}
+
+// AddParamAvoidNil will add key-value pair.
+// Deprecated: use AppendParam instead.
 func (c *URL) AddParamAvoidNil(key string, value string) {
-	c.paramsLock.Lock()
-	defer c.paramsLock.Unlock()
-	if c.params == nil {
-		c.params = url.Values{}
-	}
-	c.params.Add(key, value)
+	c.AppendParam(key, value)
 }
 
 // SetParam will put the key-value pair into URL

--- a/common/url.go
+++ b/common/url.go
@@ -537,7 +537,7 @@ func (c *URL) Service() string {
 }
 
 // AppendParam appends the key-value pair without replacing existing values.
-func (c *URL) AppendParam(key string, value string) {
+func (c *URL) AppendParam(key, value string) {
 	c.paramsLock.Lock()
 	defer c.paramsLock.Unlock()
 	if c.params == nil {
@@ -548,13 +548,13 @@ func (c *URL) AppendParam(key string, value string) {
 
 // AddParam will add the key-value pair.
 // Deprecated: use SetParam to replace an existing value or AppendParam to preserve multiple values.
-func (c *URL) AddParam(key string, value string) {
+func (c *URL) AddParam(key, value string) {
 	c.AppendParam(key, value)
 }
 
 // AddParamAvoidNil will add key-value pair.
 // Deprecated: use AppendParam instead.
-func (c *URL) AddParamAvoidNil(key string, value string) {
+func (c *URL) AddParamAvoidNil(key, value string) {
 	c.AppendParam(key, value)
 }
 

--- a/common/url_test.go
+++ b/common/url_test.go
@@ -876,15 +876,24 @@ func TestServiceWithSubURL(t *testing.T) {
 	assert.Equal(t, "com.path.Service", u3.Service())
 }
 
-func TestAddParam(t *testing.T) {
+func TestAppendParam(t *testing.T) {
 	u := &URL{}
-	u.AddParam("key1", "value1")
+	u.AppendParam("key1", "value1")
 	assert.Equal(t, "value1", u.GetParam("key1", ""))
 
 	// add another value to same key
-	u.AddParam("key1", "value2")
+	u.AppendParam("key1", "value2")
 	params := u.GetParams()
 	assert.Len(t, params["key1"], 2)
+}
+
+func TestAddParamCompatibility(t *testing.T) {
+	u := &URL{}
+	u.AddParam("key1", "value1")
+	u.AddParam("key1", "value2")
+
+	params := u.GetParams()
+	assert.Equal(t, []string{"value1", "value2"}, params["key1"])
 }
 
 func TestGetParamsReturnsCopy(t *testing.T) {

--- a/config/logger_config.go
+++ b/config/logger_config.go
@@ -130,10 +130,10 @@ func (l *LoggerConfig) toURL() *common.URL {
 	// Add trace integration parameters if configured
 	if l.TraceIntegration != nil {
 		if l.TraceIntegration.Enabled != nil {
-			url.AddParam(constant.LoggerTraceEnabledKey, strconv.FormatBool(*l.TraceIntegration.Enabled))
+			url.SetParam(constant.LoggerTraceEnabledKey, strconv.FormatBool(*l.TraceIntegration.Enabled))
 		}
 		if l.TraceIntegration.RecordErrorToSpan != nil {
-			url.AddParam(constant.LoggerTraceRecordErrorKey, strconv.FormatBool(*l.TraceIntegration.RecordErrorToSpan))
+			url.SetParam(constant.LoggerTraceRecordErrorKey, strconv.FormatBool(*l.TraceIntegration.RecordErrorToSpan))
 		}
 	}
 

--- a/config/reference_config.go
+++ b/config/reference_config.go
@@ -192,7 +192,7 @@ func (rc *ReferenceConfig) Refer(srv any) {
 
 	SetConsumerServiceByInterfaceName(rc.InterfaceName, srv)
 	if rc.ForceTag {
-		cfgURL.AddParam(constant.ForceUseTag, "true")
+		cfgURL.SetParam(constant.ForceUseTag, "true")
 	}
 	rc.postProcessConfig(cfgURL)
 
@@ -228,7 +228,7 @@ func (rc *ReferenceConfig) Refer(srv any) {
 				// replace params of serviceURL with params of cfgUrl
 				// other stuff, e.g. IP, port, etc., are same as serviceURL
 				newURL := serviceURL.MergeURL(cfgURL)
-				newURL.AddParam("peer", "true")
+				newURL.SetParam("peer", "true")
 				rc.urls = append(rc.urls, newURL)
 			}
 		}

--- a/config/registry_config.go
+++ b/config/registry_config.go
@@ -233,7 +233,7 @@ func LoadRegistries(registryIds []string, registries map[string]*RegistryConfig,
 				panic(err)
 			} else {
 				for _, u := range urls {
-					u.AddParam(constant.RegistryIdKey, k)
+					u.SetParam(constant.RegistryIdKey, k)
 				}
 				registryURLs = append(registryURLs, urls...)
 			}

--- a/config/service_config.go
+++ b/config/service_config.go
@@ -296,7 +296,7 @@ func (s *ServiceConfig) Export() error {
 		}
 
 		if len(s.Tag) > 0 {
-			ivkURL.AddParam(constant.Tagkey, s.Tag)
+			ivkURL.SetParam(constant.Tagkey, s.Tag)
 		}
 
 		// post process the URL to be exported
@@ -348,7 +348,7 @@ func (s *ServiceConfig) generatorInvoker(url *common.URL, info any) base.Invoker
 
 // setRegistrySubURL set registry sub url is ivkURl
 func setRegistrySubURL(ivkURL *common.URL, regUrl *common.URL) {
-	ivkURL.AddParam(constant.RegistryKey, regUrl.GetParam(constant.RegistryKey, ""))
+	ivkURL.SetParam(constant.RegistryKey, regUrl.GetParam(constant.RegistryKey, ""))
 	regUrl.SubURL = ivkURL
 }
 

--- a/instance_options_init.go
+++ b/instance_options_init.go
@@ -582,10 +582,10 @@ func loggerURL(l *global.LoggerConfig) *common.URL {
 
 	if l.TraceIntegration != nil {
 		if l.TraceIntegration.Enabled != nil {
-			u.AddParam(constant.LoggerTraceEnabledKey, strconv.FormatBool(*l.TraceIntegration.Enabled))
+			u.SetParam(constant.LoggerTraceEnabledKey, strconv.FormatBool(*l.TraceIntegration.Enabled))
 		}
 		if l.TraceIntegration.RecordErrorToSpan != nil {
-			u.AddParam(constant.LoggerTraceRecordErrorKey, strconv.FormatBool(*l.TraceIntegration.RecordErrorToSpan))
+			u.SetParam(constant.LoggerTraceRecordErrorKey, strconv.FormatBool(*l.TraceIntegration.RecordErrorToSpan))
 		}
 	}
 

--- a/internal/config.go
+++ b/internal/config.go
@@ -76,7 +76,7 @@ func LoadRegistries(registryIds []string, registries map[string]*global.Registry
 				}
 
 				clonedURL := u.Clone()
-				clonedURL.AddParam(constant.RegistryIdKey, k)
+				clonedURL.SetParam(constant.RegistryIdKey, k)
 				registryURLs = append(registryURLs, clonedURL)
 			}
 		}

--- a/server/action.go
+++ b/server/action.go
@@ -232,7 +232,7 @@ func (svcOpts *ServiceOptions) Export() error {
 		}
 
 		if len(svcConf.Tag) > 0 {
-			ivkURL.AddParam(constant.Tagkey, svcConf.Tag)
+			ivkURL.SetParam(constant.Tagkey, svcConf.Tag)
 		}
 
 		// post process the URL to be exported
@@ -288,8 +288,8 @@ func (svcOpts *ServiceOptions) generatorInvoker(url *common.URL, info *common.Se
 
 // setRegistrySubURL set registry sub url is ivkURl
 func setRegistrySubURL(ivkURL *common.URL, regUrl *common.URL) {
-	ivkURL.AddParam(constant.RegistryKey, regUrl.GetParam(constant.RegistryKey, ""))
-	ivkURL.AddParam(constant.RegistryTypeKey, regUrl.GetParam(constant.RegistryTypeKey, ""))
+	ivkURL.SetParam(constant.RegistryKey, regUrl.GetParam(constant.RegistryKey, ""))
+	ivkURL.SetParam(constant.RegistryTypeKey, regUrl.GetParam(constant.RegistryTypeKey, ""))
 	regUrl.SubURL = ivkURL
 }
 


### PR DESCRIPTION
### Description

Refs #3248.

This PR addresses the URL API hygiene item around `AddParam`/`SetParam` semantics:

- adds `AppendParam` as the explicit API for preserving multiple values for a key
- marks `AddParam` and `AddParamAvoidNil` as deprecated compatibility wrappers
- keeps existing behavior unchanged for current callers
- adds tests for the new explicit append API and legacy compatibility

### Validation

- `go test ./common`
- `make fmt`
- `git diff --check`

### Checklist

- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
