### PR TITLE
Feat: add benchmarks for common.URL

### DIFF
--- a/common/url_benchmark_test.go
+++ b/common/url_benchmark_test.go
@@ -199,7 +199,7 @@ func makeBenchmarkURLWithSubURL(paramCount int) *URL {
 	return u
 }
 
-func makeBenchmarkURLWithParamStart(paramCount int, genericStart int) *URL {
+func makeBenchmarkURLWithParamStart(paramCount, genericStart int) *URL {
 	u := NewURLWithOptions(
 		WithProtocol(benchmarkURLProtocol),
 		WithIp(benchmarkURLIP),
@@ -213,38 +213,28 @@ func makeBenchmarkURLWithParamStart(paramCount int, genericStart int) *URL {
 }
 
 func makeBenchmarkMergeHalfOverlapPair(paramCount int) (*URL, *URL) {
-	genericCount := paramCount - len(benchmarkURLIdentityParams)
-	if genericCount < 0 {
-		genericCount = 0
-	}
-	return makeBenchmarkURL(paramCount), makeBenchmarkURLWithParamStart(paramCount, genericCount/2)
+	return makeBenchmarkURL(paramCount), makeBenchmarkURLWithParamStart(paramCount, paramCount/2)
 }
 
-func makeBenchmarkParams(paramCount int, genericStart int) url.Values {
-	params := make(url.Values, paramCount)
-	for i, param := range benchmarkURLIdentityParams {
-		if i >= paramCount {
-			return params
-		}
+func makeBenchmarkParams(paramCount, genericStart int) url.Values {
+	params := make(url.Values, len(benchmarkURLIdentityParams)+paramCount)
+	for _, param := range benchmarkURLIdentityParams {
 		params.Set(param.key, param.value)
 	}
-	for i := len(benchmarkURLIdentityParams); i < paramCount; i++ {
-		genericIndex := genericStart + i - len(benchmarkURLIdentityParams)
+	for i := 0; i < paramCount; i++ {
+		genericIndex := genericStart + i
 		params.Set(fmt.Sprintf("key%d", genericIndex), fmt.Sprintf("value%d", genericIndex))
 	}
 	return params
 }
 
 func makeBenchmarkParamKeys(paramCount int) []string {
-	keys := make([]string, 0, paramCount)
-	for i, param := range benchmarkURLIdentityParams {
-		if i >= paramCount {
-			return keys
-		}
+	keys := make([]string, 0, len(benchmarkURLIdentityParams)+paramCount)
+	for _, param := range benchmarkURLIdentityParams {
 		keys = append(keys, param.key)
 	}
-	for i := len(benchmarkURLIdentityParams); i < paramCount; i++ {
-		keys = append(keys, fmt.Sprintf("key%d", i-len(benchmarkURLIdentityParams)))
+	for i := 0; i < paramCount; i++ {
+		keys = append(keys, fmt.Sprintf("key%d", i))
 	}
 	return keys
 }
@@ -264,7 +254,7 @@ func makeBenchmarkReserveKeys(paramCount int) []string {
 
 func makeBenchmarkFilterKeys(paramCount int) []string {
 	keys := makeBenchmarkParamKeys(paramCount)
-	filterCount := paramCount / 5
+	filterCount := len(keys) / 5
 	if filterCount < 1 {
 		filterCount = 1
 	}

--- a/common/url_benchmark_test.go
+++ b/common/url_benchmark_test.go
@@ -1,0 +1,304 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+)
+
+import (
+	gxset "github.com/dubbogo/gost/container/set"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+)
+
+const (
+	benchmarkURLProtocol  = "dubbo"
+	benchmarkURLIP        = "127.0.0.1"
+	benchmarkURLPort      = "20000"
+	benchmarkURLInterface = "com.test.BenchmarkService"
+	benchmarkURLGroup     = "benchmark"
+	benchmarkURLVersion   = "1.0.0"
+	benchmarkURLTimestamp = "1234567890"
+	benchmarkURLMeshID    = "benchmark-mesh"
+)
+
+var (
+	benchmarkURLParamSizes = []int{1, 32, 256, 1024}
+
+	benchmarkURLStringSink string
+	benchmarkURLSink       *URL
+	benchmarkURLParamsSink url.Values
+	benchmarkURLMapSink    map[string]string
+	benchmarkURLBoolSink   bool
+)
+
+func BenchmarkURLString(b *testing.B) {
+	runBenchmarkURLByParamSize(b, func(u *URL) {
+		benchmarkURLStringSink = u.String()
+	})
+}
+
+func BenchmarkURLKey(b *testing.B) {
+	runBenchmarkURLByParamSize(b, func(u *URL) {
+		benchmarkURLStringSink = u.Key()
+	})
+}
+
+func BenchmarkURLGetCacheInvokerMapKey(b *testing.B) {
+	runBenchmarkURLByParamSize(b, func(u *URL) {
+		benchmarkURLStringSink = u.GetCacheInvokerMapKey()
+	})
+}
+
+func BenchmarkURLServiceKey(b *testing.B) {
+	runBenchmarkURLByParamSize(b, func(u *URL) {
+		benchmarkURLStringSink = u.ServiceKey()
+	})
+}
+
+func BenchmarkURLCopyParams(b *testing.B) {
+	runBenchmarkURLByParamSize(b, func(u *URL) {
+		benchmarkURLParamsSink = u.CopyParams()
+	})
+}
+
+func BenchmarkURLGetParams(b *testing.B) {
+	runBenchmarkURLByParamSize(b, func(u *URL) {
+		benchmarkURLParamsSink = u.GetParams()
+	})
+}
+
+func BenchmarkURLClone(b *testing.B) {
+	runBenchmarkURLByParamSize(b, func(u *URL) {
+		benchmarkURLSink = u.Clone()
+	})
+
+	for _, paramCount := range benchmarkURLParamSizes {
+		paramCount := paramCount
+		b.Run(fmt.Sprintf("params_%d_with_suburl", paramCount), func(b *testing.B) {
+			u := makeBenchmarkURLWithSubURL(paramCount)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkURLSink = u.Clone()
+			}
+		})
+	}
+}
+
+func BenchmarkURLCloneWithFilter(b *testing.B) {
+	runBenchmarkURLByParamSize(b, func(u *URL) {
+		benchmarkURLSink = u.CloneWithFilter(nil, nil)
+	})
+
+	for _, paramCount := range benchmarkURLParamSizes {
+		paramCount := paramCount
+		b.Run(fmt.Sprintf("params_%d_exclude_20_percent", paramCount), func(b *testing.B) {
+			u := makeBenchmarkURL(paramCount)
+			excludeParams := makeBenchmarkExcludeSet(paramCount)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkURLSink = u.CloneWithFilter(excludeParams, nil)
+			}
+		})
+	}
+
+	for _, paramCount := range benchmarkURLParamSizes {
+		paramCount := paramCount
+		b.Run(fmt.Sprintf("params_%d_reserve_20_percent", paramCount), func(b *testing.B) {
+			u := makeBenchmarkURL(paramCount)
+			reserveParams := makeBenchmarkReserveKeys(paramCount)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkURLSink = u.CloneWithFilter(nil, reserveParams)
+			}
+		})
+	}
+}
+
+func BenchmarkURLMergeURL(b *testing.B) {
+	for _, paramCount := range benchmarkURLParamSizes {
+		paramCount := paramCount
+		b.Run(fmt.Sprintf("params_%d_with_method_params", paramCount), func(b *testing.B) {
+			left, right := makeBenchmarkMergeHalfOverlapPair(paramCount)
+			addBenchmarkMethodParams(right)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkURLSink = left.MergeURL(right)
+			}
+		})
+	}
+}
+
+func BenchmarkURLToMap(b *testing.B) {
+	runBenchmarkURLByParamSize(b, func(u *URL) {
+		benchmarkURLMapSink = u.ToMap()
+	})
+}
+
+func BenchmarkURLIsEquals(b *testing.B) {
+	for _, paramCount := range benchmarkURLParamSizes {
+		paramCount := paramCount
+		b.Run(fmt.Sprintf("params_%d", paramCount), func(b *testing.B) {
+			left := makeBenchmarkURL(paramCount)
+			right := makeBenchmarkURL(paramCount)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkURLBoolSink = IsEquals(left, right)
+			}
+		})
+	}
+}
+
+func runBenchmarkURLByParamSize(b *testing.B, run func(*URL)) {
+	b.Helper()
+	for _, paramCount := range benchmarkURLParamSizes {
+		paramCount := paramCount
+		b.Run(fmt.Sprintf("params_%d", paramCount), func(b *testing.B) {
+			u := makeBenchmarkURL(paramCount)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				run(u)
+			}
+		})
+	}
+}
+
+func makeBenchmarkURL(paramCount int) *URL {
+	return makeBenchmarkURLWithParamStart(paramCount, 0)
+}
+
+func makeBenchmarkURLWithSubURL(paramCount int) *URL {
+	u := makeBenchmarkURL(paramCount)
+	u.SubURL = makeBenchmarkURL(paramCount)
+	return u
+}
+
+func makeBenchmarkURLWithParamStart(paramCount int, genericStart int) *URL {
+	u := NewURLWithOptions(
+		WithProtocol(benchmarkURLProtocol),
+		WithIp(benchmarkURLIP),
+		WithPort(benchmarkURLPort),
+		WithPath(benchmarkURLInterface),
+		WithMethods(makeBenchmarkMethods()),
+		WithParams(makeBenchmarkParams(paramCount, genericStart)),
+	)
+	u.primitiveTS = u.GetParam(constant.TimestampKey, "")
+	return u
+}
+
+func makeBenchmarkMergeHalfOverlapPair(paramCount int) (*URL, *URL) {
+	genericCount := paramCount - len(benchmarkURLIdentityParams)
+	if genericCount < 0 {
+		genericCount = 0
+	}
+	return makeBenchmarkURL(paramCount), makeBenchmarkURLWithParamStart(paramCount, genericCount/2)
+}
+
+func makeBenchmarkParams(paramCount int, genericStart int) url.Values {
+	params := make(url.Values, paramCount)
+	for i, param := range benchmarkURLIdentityParams {
+		if i >= paramCount {
+			return params
+		}
+		params.Set(param.key, param.value)
+	}
+	for i := len(benchmarkURLIdentityParams); i < paramCount; i++ {
+		genericIndex := genericStart + i - len(benchmarkURLIdentityParams)
+		params.Set(fmt.Sprintf("key%d", genericIndex), fmt.Sprintf("value%d", genericIndex))
+	}
+	return params
+}
+
+func makeBenchmarkParamKeys(paramCount int) []string {
+	keys := make([]string, 0, paramCount)
+	for i, param := range benchmarkURLIdentityParams {
+		if i >= paramCount {
+			return keys
+		}
+		keys = append(keys, param.key)
+	}
+	for i := len(benchmarkURLIdentityParams); i < paramCount; i++ {
+		keys = append(keys, fmt.Sprintf("key%d", i-len(benchmarkURLIdentityParams)))
+	}
+	return keys
+}
+
+func makeBenchmarkExcludeSet(paramCount int) *gxset.HashSet {
+	keys := makeBenchmarkFilterKeys(paramCount)
+	values := make([]any, 0, len(keys))
+	for _, key := range keys {
+		values = append(values, key)
+	}
+	return gxset.NewSet(values...)
+}
+
+func makeBenchmarkReserveKeys(paramCount int) []string {
+	return makeBenchmarkFilterKeys(paramCount)
+}
+
+func makeBenchmarkFilterKeys(paramCount int) []string {
+	keys := makeBenchmarkParamKeys(paramCount)
+	filterCount := paramCount / 5
+	if filterCount < 1 {
+		filterCount = 1
+	}
+	if filterCount > len(keys) {
+		filterCount = len(keys)
+	}
+	return keys[:filterCount]
+}
+
+func makeBenchmarkMethods() []string {
+	return []string{"method0", "method1", "method2"}
+}
+
+func addBenchmarkMethodParams(u *URL) {
+	u.Methods = makeBenchmarkMethods()
+	u.SetParam(constant.LoadbalanceKey, "random")
+	u.SetParam(constant.ClusterKey, "failover")
+	u.SetParam(constant.RetriesKey, "2")
+	u.SetParam(constant.TimeoutKey, "3000")
+	for _, method := range u.Methods {
+		u.SetParam("methods."+method+"."+constant.LoadbalanceKey, "roundrobin")
+		u.SetParam("methods."+method+"."+constant.ClusterKey, "failfast")
+		u.SetParam("methods."+method+"."+constant.RetriesKey, "1")
+		u.SetParam("methods."+method+"."+constant.TimeoutKey, "1000")
+	}
+}
+
+var benchmarkURLIdentityParams = []struct {
+	key   string
+	value string
+}{
+	{constant.InterfaceKey, benchmarkURLInterface},
+	{constant.GroupKey, benchmarkURLGroup},
+	{constant.VersionKey, benchmarkURLVersion},
+	{constant.TimestampKey, benchmarkURLTimestamp},
+	{constant.MeshClusterIDKey, benchmarkURLMeshID},
+}

--- a/common/url_benchmark_test.go
+++ b/common/url_benchmark_test.go
@@ -126,8 +126,34 @@ func BenchmarkURLCloneWithFilter(b *testing.B) {
 
 	for _, paramCount := range benchmarkURLParamSizes {
 		paramCount := paramCount
+		b.Run(fmt.Sprintf("params_%d_exclude_20_percent_with_suburl", paramCount), func(b *testing.B) {
+			u := makeBenchmarkURLWithSubURL(paramCount)
+			excludeParams := makeBenchmarkExcludeSet(paramCount)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkURLSink = u.CloneWithFilter(excludeParams, nil)
+			}
+		})
+	}
+
+	for _, paramCount := range benchmarkURLParamSizes {
+		paramCount := paramCount
 		b.Run(fmt.Sprintf("params_%d_reserve_20_percent", paramCount), func(b *testing.B) {
 			u := makeBenchmarkURL(paramCount)
+			reserveParams := makeBenchmarkReserveKeys(paramCount)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				benchmarkURLSink = u.CloneWithFilter(nil, reserveParams)
+			}
+		})
+	}
+
+	for _, paramCount := range benchmarkURLParamSizes {
+		paramCount := paramCount
+		b.Run(fmt.Sprintf("params_%d_reserve_20_percent_with_suburl", paramCount), func(b *testing.B) {
+			u := makeBenchmarkURLWithSubURL(paramCount)
 			reserveParams := makeBenchmarkReserveKeys(paramCount)
 			b.ReportAllocs()
 			b.ResetTimer()


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

**What this PR does**:

Add focused benchmarks for `common.URL` to establish a quantifiable baseline (throughput + memory allocation) for future optimization, so changes can be evaluated with data rather than intuition.

This PR only adds `common/url_benchmark_test.go` and does not change any production code.

Methods covered:

- `URL.String()`
- `URL.Key()`
- `URL.GetCacheInvokerMapKey()`
- `URL.ServiceKey()`
- `URL.Clone()` / `URL.CloneWithFilter()`
- `URL.MergeURL()`
- `URL.CopyParams()` / `URL.GetParams()`
- `URL.IsEquals()` / `URL.ToMap()`

Test dimensions:

- Parameter sizes use four tiers: `1 / 32 / 256 / 1024`.
- `Clone` / `CloneWithFilter` include cases with `SubURL` to surface deep-copy costs.
- All methods with return values write their results to package-level sink variables to prevent the compiler from optimizing the calls away and skewing the data.

**Which issue(s) this PR fixes**:

Fixes #3391

**Special notes for your reviewer**:

Benchmark command:

```bash
go test ./common -bench 'BenchmarkURL' -benchmem -run '^$'
```

Output:

```text
goos: darwin
goarch: arm64
pkg: dubbo.apache.org/dubbo-go/v3/common
cpu: Apple M5
BenchmarkURLString/params_1-10                   5456774               200.9 ns/op           384 B/op          9 allocs/op
BenchmarkURLString/params_32-10                   843082              1515 ns/op            2297 B/op         15 allocs/op
BenchmarkURLString/params_256-10                   67254             17780 ns/op           21698 B/op         20 allocs/op
BenchmarkURLString/params_1024-10                  10000            109537 ns/op           98024 B/op         25 allocs/op
BenchmarkURLKey/params_1-10                      7146849               166.9 ns/op           144 B/op          5 allocs/op
BenchmarkURLKey/params_32-10                     6561790               181.4 ns/op           192 B/op          7 allocs/op
BenchmarkURLKey/params_256-10                    6466377               182.3 ns/op           192 B/op          7 allocs/op
BenchmarkURLKey/params_1024-10                   5680776               211.8 ns/op           192 B/op          7 allocs/op
BenchmarkURLGetCacheInvokerMapKey/params_1-10            5943622               196.2 ns/op           176 B/op          5 allocs/op
BenchmarkURLGetCacheInvokerMapKey/params_32-10           5188357               236.4 ns/op           272 B/op          9 allocs/op
BenchmarkURLGetCacheInvokerMapKey/params_256-10          4854295               235.6 ns/op           272 B/op          9 allocs/op
BenchmarkURLGetCacheInvokerMapKey/params_1024-10         5031062               238.2 ns/op           272 B/op          9 allocs/op
BenchmarkURLServiceKey/params_1-10                      26704621                43.71 ns/op           96 B/op          2 allocs/op
BenchmarkURLServiceKey/params_32-10                     21432190                56.21 ns/op          112 B/op          2 allocs/op
BenchmarkURLServiceKey/params_256-10                    21643898                54.96 ns/op          112 B/op          2 allocs/op
BenchmarkURLServiceKey/params_1024-10                   21134046                56.68 ns/op          112 B/op          2 allocs/op
BenchmarkURLCopyParams/params_1-10                      11519364               103.3 ns/op           416 B/op          3 allocs/op
BenchmarkURLCopyParams/params_32-10                      1290672               951.0 ns/op          3288 B/op         36 allocs/op
BenchmarkURLCopyParams/params_256-10                      166741              7114 ns/op           25944 B/op        260 allocs/op
BenchmarkURLCopyParams/params_1024-10                      39529             30732 ns/op          114816 B/op       1030 allocs/op
BenchmarkURLGetParams/params_1-10                       11502212               104.6 ns/op           416 B/op          3 allocs/op
BenchmarkURLGetParams/params_32-10                       1274205               950.0 ns/op          3288 B/op         36 allocs/op
BenchmarkURLGetParams/params_256-10                       167067              7076 ns/op           25944 B/op        260 allocs/op
BenchmarkURLGetParams/params_1024-10                       39504             30974 ns/op          114816 B/op       1030 allocs/op
BenchmarkURLClone/params_1-10                            6889875               174.7 ns/op           752 B/op          6 allocs/op
BenchmarkURLClone/params_32-10                            580028              2054 ns/op            6152 B/op         44 allocs/op
BenchmarkURLClone/params_256-10                            75308             15982 ns/op           47848 B/op        274 allocs/op
BenchmarkURLClone/params_1024-10                           18219             66097 ns/op          207704 B/op       1049 allocs/op
BenchmarkURLClone/params_1_with_suburl-10                3433593               351.6 ns/op          1504 B/op         12 allocs/op
BenchmarkURLClone/params_32_with_suburl-10                285583              5181 ns/op           12304 B/op         88 allocs/op
BenchmarkURLClone/params_256_with_suburl-10                31632             32658 ns/op           95696 B/op        548 allocs/op
BenchmarkURLClone/params_1024_with_suburl-10                8587            142742 ns/op          415408 B/op       2098 allocs/op
BenchmarkURLCloneWithFilter/params_1-10                  6699319               176.1 ns/op           752 B/op          6 allocs/op
BenchmarkURLCloneWithFilter/params_32-10                  575073              2080 ns/op            6152 B/op         44 allocs/op
BenchmarkURLCloneWithFilter/params_256-10                  75116             16063 ns/op           47848 B/op        274 allocs/op
BenchmarkURLCloneWithFilter/params_1024-10                 17505             65511 ns/op          207704 B/op       1049 allocs/op
BenchmarkURLCloneWithFilter/params_1_exclude_20_percent-10               9886900               121.3 ns/op           384 B/op          4 allocs/op
BenchmarkURLCloneWithFilter/params_32_exclude_20_percent-10               713469              1613 ns/op            3336 B/op         36 allocs/op
BenchmarkURLCloneWithFilter/params_256_exclude_20_percent-10               89206             13946 ns/op           25240 B/op        221 allocs/op
BenchmarkURLCloneWithFilter/params_1024_exclude_20_percent-10              21150             55510 ns/op          106056 B/op        840 allocs/op
BenchmarkURLCloneWithFilter/params_1_reserve_20_percent-10               6833206               174.9 ns/op           752 B/op          6 allocs/op
BenchmarkURLCloneWithFilter/params_32_reserve_20_percent-10              2262472               526.4 ns/op           832 B/op         11 allocs/op
BenchmarkURLCloneWithFilter/params_256_reserve_20_percent-10              104593             11450 ns/op            6456 B/op         63 allocs/op
BenchmarkURLCloneWithFilter/params_1024_reserve_20_percent-10               6982            172265 ns/op           25224 B/op        220 allocs/op
BenchmarkURLMergeURL/params_1_with_method_params-10                       407398              2933 ns/op            6152 B/op         90 allocs/op
BenchmarkURLMergeURL/params_32_with_method_params-10                      147805              8156 ns/op           19600 B/op        200 allocs/op
BenchmarkURLMergeURL/params_256_with_method_params-10                      29161             41295 ns/op          102992 B/op        988 allocs/op
BenchmarkURLMergeURL/params_1024_with_method_params-10                      6880            175043 ns/op          446737 B/op       3687 allocs/op
BenchmarkURLToMap/params_1-10                                            7867472               171.8 ns/op           400 B/op          4 allocs/op
BenchmarkURLToMap/params_32-10                                            638270              1844 ns/op            4536 B/op         11 allocs/op
BenchmarkURLToMap/params_256-10                                            86206             13509 ns/op           37400 B/op         17 allocs/op
BenchmarkURLToMap/params_1024-10                                           21568             56515 ns/op          160392 B/op         24 allocs/op
BenchmarkURLIsEquals/params_1-10                                         2960374               398.3 ns/op           800 B/op          8 allocs/op
BenchmarkURLIsEquals/params_32-10                                         298500              7196 ns/op            9072 B/op         22 allocs/op
BenchmarkURLIsEquals/params_256-10                                         34377             32492 ns/op           74800 B/op         34 allocs/op
BenchmarkURLIsEquals/params_1024-10                                         9354            127971 ns/op          320784 B/op         48 allocs/op
PASS
ok      dubbo.apache.org/dubbo-go/v3/common     84.654s
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```