### PR TITLE
refactor(getty): remove legacy config dependency from remoting/getty

### DIFF
--- a/remoting/getty/getty_client.go
+++ b/remoting/getty/getty_client.go
@@ -65,12 +65,8 @@ func initClient(url *common.URL) {
 	// Ensure application config is available via URL attribute
 	commonCfg.EnsureApplicationAttribute(url)
 
-	if _, ok := url.GetAttribute(constant.ProtocolConfigKey); !ok {
-		return
-	}
-
 	protocolConfRaw, ok := url.GetAttribute(constant.ProtocolConfigKey)
-	if !ok {
+	if !ok || protocolConfRaw == nil {
 		logger.Warn("[Remoting][Getty] protocolConfig not found in URL attributes")
 		return
 	}

--- a/remoting/getty/getty_client.go
+++ b/remoting/getty/getty_client.go
@@ -38,10 +38,9 @@ import (
 )
 
 import (
-	"dubbo.apache.org/dubbo-go/v3"
 	"dubbo.apache.org/dubbo-go/v3/common"
+	commonCfg "dubbo.apache.org/dubbo-go/v3/common/config"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
-	"dubbo.apache.org/dubbo-go/v3/config"
 	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/remoting"
 	dubbotls "dubbo.apache.org/dubbo-go/v3/tls"
@@ -63,33 +62,24 @@ func initClient(url *common.URL) {
 		return
 	}
 
-	// load client config from rootConfig.Protocols
-	// default use dubbo
-	// TODO: Temporary compatibility with old APIs, can be removed later
-	if url.GetParam(constant.ApplicationKey, "") == "" && config.GetApplicationConfig() == nil {
-		return
-	}
+	// Ensure application config is available via URL attribute
+	commonCfg.EnsureApplicationAttribute(url)
 
-	// TODO: Temporary compatibility with old APIs, can be removed later
-	if url.GetParam(constant.ProtocolKey, "") == "" && config.GetRootConfig().Protocols == nil {
-		return
-	}
-
-	// TODO: Temporary compatibility with old APIs, can be removed later
-	protocolConfMap := dubbo.CompatGlobalProtocolConfigMap(config.GetRootConfig().Protocols)
-	if protocolConfMap == nil {
-		if protocolConfRaw, ok := url.GetAttribute(constant.ProtocolConfigKey); ok {
-			protocolConfig, ok := protocolConfRaw.(map[string]*global.ProtocolConfig)
-			if !ok {
-				logger.Warn("[Remoting][Getty] protocolConfig assert failed")
-				return
-			}
-			if protocolConfig == nil {
-				logger.Warn("[Remoting][Getty] protocolConfig is nil")
-				return
-			}
-			protocolConfMap = protocolConfig
+	if url.GetParam(constant.ProtocolKey, "") == "" {
+		if _, ok := url.GetAttribute(constant.ProtocolConfigKey); !ok {
+			return
 		}
+	}
+
+	protocolConfRaw, ok := url.GetAttribute(constant.ProtocolConfigKey)
+	if !ok {
+		logger.Warn("[Remoting][Getty] protocolConfig not found in URL attributes")
+		return
+	}
+	protocolConfMap, ok := protocolConfRaw.(map[string]*global.ProtocolConfig)
+	if !ok || protocolConfMap == nil {
+		logger.Warn("[Remoting][Getty] protocolConfig assert failed or is nil")
+		return
 	}
 
 	protocolConf := protocolConfMap[url.Protocol]
@@ -97,37 +87,12 @@ func initClient(url *common.URL) {
 		logger.Info("[Remoting][Getty] use default getty client config")
 		return
 	} else {
-		//client tls config
-		tlsConfig := dubbo.CompatGlobalTLSConfig(config.GetRootConfig().TLSConfig)
-
-		if tlsConfig == nil {
-			if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
-				tlsConf, ok := tlsConfRaw.(*global.TLSConfig)
-				if !ok {
-					logger.Error("[Remoting][Getty] getty client initialized the TLSConfig configuration failed")
-					return
-				}
-				tlsConfig = tlsConf
-			}
-		}
-
-		if tlsConfig != nil {
-			clientConf.SSLEnabled = true
-			clientConf.TLSBuilder = &getty.ClientTlsConfigBuilder{
-				ClientKeyCertChainPath:        tlsConfig.TLSCertFile,
-				ClientPrivateKeyPath:          tlsConfig.TLSKeyFile,
-				ClientTrustCertCollectionPath: tlsConfig.CACertFile,
-			}
-		} else if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
-			// use global TLSConfig handle tls
+		// client tls config
+		if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
 			tlsConf, ok := tlsConfRaw.(*global.TLSConfig)
-			if !ok {
-				logger.Error("[Remoting][Getty] getty client initialized the TLSConfig configuration failed")
-				return
-			}
-			if dubbotls.IsClientTLSValid(tlsConf) {
-				srvConf.SSLEnabled = true
-				srvConf.TLSBuilder = &getty.ClientTlsConfigBuilder{
+			if ok && dubbotls.IsClientTLSValid(tlsConf) {
+				clientConf.SSLEnabled = true
+				clientConf.TLSBuilder = &getty.ClientTlsConfigBuilder{
 					ClientKeyCertChainPath:        tlsConf.TLSCertFile,
 					ClientPrivateKeyPath:          tlsConf.TLSKeyFile,
 					ClientTrustCertCollectionPath: tlsConf.CACertFile,

--- a/remoting/getty/getty_client.go
+++ b/remoting/getty/getty_client.go
@@ -83,7 +83,12 @@ func initClient(url *common.URL) {
 	} else {
 		// client tls config
 		if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
-			if tlsConf, ok := tlsConfRaw.(*global.TLSConfig); ok && dubbotls.IsClientTLSValid(tlsConf) {
+			tlsConf, ok := tlsConfRaw.(*global.TLSConfig)
+			if !ok {
+				logger.Error("[Remoting][Getty] getty client initialized the TLSConfig configuration failed")
+				return
+			}
+			if dubbotls.IsClientTLSValid(tlsConf) {
 				clientConf.SSLEnabled = true
 				clientConf.TLSBuilder = &getty.ClientTlsConfigBuilder{
 					ClientKeyCertChainPath:        tlsConf.TLSCertFile,

--- a/remoting/getty/getty_client.go
+++ b/remoting/getty/getty_client.go
@@ -83,8 +83,7 @@ func initClient(url *common.URL) {
 	} else {
 		// client tls config
 		if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
-			tlsConf, ok := tlsConfRaw.(*global.TLSConfig)
-			if ok && dubbotls.IsClientTLSValid(tlsConf) {
+			if tlsConf, ok := tlsConfRaw.(*global.TLSConfig); ok && dubbotls.IsClientTLSValid(tlsConf) {
 				clientConf.SSLEnabled = true
 				clientConf.TLSBuilder = &getty.ClientTlsConfigBuilder{
 					ClientKeyCertChainPath:        tlsConf.TLSCertFile,

--- a/remoting/getty/getty_client.go
+++ b/remoting/getty/getty_client.go
@@ -65,10 +65,8 @@ func initClient(url *common.URL) {
 	// Ensure application config is available via URL attribute
 	commonCfg.EnsureApplicationAttribute(url)
 
-	if url.GetParam(constant.ProtocolKey, "") == "" {
-		if _, ok := url.GetAttribute(constant.ProtocolConfigKey); !ok {
-			return
-		}
+	if _, ok := url.GetAttribute(constant.ProtocolConfigKey); !ok {
+		return
 	}
 
 	protocolConfRaw, ok := url.GetAttribute(constant.ProtocolConfigKey)

--- a/remoting/getty/getty_client_test.go
+++ b/remoting/getty/getty_client_test.go
@@ -285,3 +285,49 @@ func TestInitClient(t *testing.T) {
 	url.SetAttribute(constant.ApplicationKey, global.ApplicationConfig{})
 	initClient(url)
 }
+
+func TestInitClientTLS(t *testing.T) {
+	newURL := func() *common.URL {
+		url, err := common.NewURL("dubbo://127.0.0.1:20003/test")
+		require.NoError(t, err)
+		url.SetAttribute(constant.ProtocolConfigKey, map[string]*global.ProtocolConfig{
+			"dubbo": {
+				Name:   "dubbo",
+				Ip:     "127.0.0.1",
+				Port:   "20003",
+				Params: map[string]any{},
+			},
+		})
+		url.SetAttribute(constant.ApplicationKey, global.ApplicationConfig{})
+		return url
+	}
+
+	t.Run("valid TLS config enables SSLEnabled and TLSBuilder", func(t *testing.T) {
+		clientConf = GetDefaultClientConfig()
+		url := newURL()
+		url.SetAttribute(constant.TLSConfigKey, &global.TLSConfig{
+			CACertFile: "/path/to/ca.crt",
+		})
+		initClient(url)
+		assert.True(t, clientConf.SSLEnabled)
+		assert.NotNil(t, clientConf.TLSBuilder)
+	})
+
+	t.Run("invalid TLS config keeps TLS disabled", func(t *testing.T) {
+		clientConf = GetDefaultClientConfig()
+		url := newURL()
+		url.SetAttribute(constant.TLSConfigKey, &global.TLSConfig{
+			CACertFile: "",
+		})
+		initClient(url)
+		assert.False(t, clientConf.SSLEnabled)
+	})
+
+	t.Run("wrong TLSConfigKey type returns early without panic", func(t *testing.T) {
+		clientConf = GetDefaultClientConfig()
+		url := newURL()
+		url.SetAttribute(constant.TLSConfigKey, "not a *global.TLSConfig")
+		initClient(url)
+		assert.False(t, clientConf.SSLEnabled)
+	})
+}

--- a/remoting/getty/getty_server.go
+++ b/remoting/getty/getty_server.go
@@ -75,8 +75,7 @@ func initServer(url *common.URL) {
 	} else {
 		// server tls config
 		if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
-			tlsConf, ok := tlsConfRaw.(*global.TLSConfig)
-			if ok && dubbotls.IsServerTLSValid(tlsConf) {
+			if tlsConf, ok := tlsConfRaw.(*global.TLSConfig); ok && dubbotls.IsServerTLSValid(tlsConf) {
 				srvConf.SSLEnabled = true
 				srvConf.TLSBuilder = &getty.ServerTlsConfigBuilder{
 					ServerKeyCertChainPath:        tlsConf.TLSCertFile,

--- a/remoting/getty/getty_server.go
+++ b/remoting/getty/getty_server.go
@@ -57,12 +57,8 @@ func initServer(url *common.URL) {
 	// Ensure application config is available via URL attribute
 	commonCfg.EnsureApplicationAttribute(url)
 
-	if _, ok := url.GetAttribute(constant.ProtocolConfigKey); !ok {
-		return
-	}
-
 	protocolConfRaw, ok := url.GetAttribute(constant.ProtocolConfigKey)
-	if !ok {
+	if !ok || protocolConfRaw == nil {
 		logger.Warn("[Remoting][Getty] protocolConfig not found in URL attributes")
 		return
 	}

--- a/remoting/getty/getty_server.go
+++ b/remoting/getty/getty_server.go
@@ -75,7 +75,12 @@ func initServer(url *common.URL) {
 	} else {
 		// server tls config
 		if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
-			if tlsConf, ok := tlsConfRaw.(*global.TLSConfig); ok && dubbotls.IsServerTLSValid(tlsConf) {
+			tlsConf, ok := tlsConfRaw.(*global.TLSConfig)
+			if !ok {
+				logger.Error("[Remoting][Getty] getty server initialized the TLSConfig configuration failed")
+				return
+			}
+			if dubbotls.IsServerTLSValid(tlsConf) {
 				srvConf.SSLEnabled = true
 				srvConf.TLSBuilder = &getty.ServerTlsConfigBuilder{
 					ServerKeyCertChainPath:        tlsConf.TLSCertFile,

--- a/remoting/getty/getty_server.go
+++ b/remoting/getty/getty_server.go
@@ -35,10 +35,9 @@ import (
 )
 
 import (
-	"dubbo.apache.org/dubbo-go/v3"
 	"dubbo.apache.org/dubbo-go/v3/common"
+	commonCfg "dubbo.apache.org/dubbo-go/v3/common/config"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
-	"dubbo.apache.org/dubbo-go/v3/config"
 	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
 	"dubbo.apache.org/dubbo-go/v3/protocol/result"
@@ -55,33 +54,24 @@ func initServer(url *common.URL) {
 		return
 	}
 
-	// load server config from rootConfig.Protocols
-	// default use dubbo
-	// TODO: Temporary compatibility with old APIs, can be removed later
-	if url.GetParam(constant.ApplicationKey, "") == "" && config.GetApplicationConfig() == nil {
-		return
-	}
+	// Ensure application config is available via URL attribute
+	commonCfg.EnsureApplicationAttribute(url)
 
-	// TODO: Temporary compatibility with old APIs, can be removed later
-	if url.GetParam(constant.ProtocolKey, "") == "" && config.GetRootConfig().Protocols == nil {
-		return
-	}
-
-	//TODO: Temporary compatibility with old APIs, can be removed later
-	protocolConfMap := dubbo.CompatGlobalProtocolConfigMap(config.GetRootConfig().Protocols)
-	if protocolConfMap == nil {
-		if protocolConfRaw, ok := url.GetAttribute(constant.ProtocolConfigKey); ok {
-			protocolConfig, ok := protocolConfRaw.(map[string]*global.ProtocolConfig)
-			if !ok {
-				logger.Warn("[Remoting][Getty] protocolConfig assert failed")
-				return
-			}
-			if protocolConfig == nil {
-				logger.Warn("[Remoting][Getty] protocolConfig is nil")
-				return
-			}
-			protocolConfMap = protocolConfig
+	if url.GetParam(constant.ProtocolKey, "") == "" {
+		if _, ok := url.GetAttribute(constant.ProtocolConfigKey); !ok {
+			return
 		}
+	}
+
+	protocolConfRaw, ok := url.GetAttribute(constant.ProtocolConfigKey)
+	if !ok {
+		logger.Warn("[Remoting][Getty] protocolConfig not found in URL attributes")
+		return
+	}
+	protocolConfMap, ok := protocolConfRaw.(map[string]*global.ProtocolConfig)
+	if !ok || protocolConfMap == nil {
+		logger.Warn("[Remoting][Getty] protocolConfig assert failed or is nil")
+		return
 	}
 
 	protocolConf := protocolConfMap[url.Protocol]
@@ -89,28 +79,18 @@ func initServer(url *common.URL) {
 		logger.Debug("[Remoting][Getty] use default getty server config")
 		return
 	} else {
-		//server tls config
-		tlsConfig := dubbo.CompatGlobalTLSConfig(config.GetRootConfig().TLSConfig)
-
-		if tlsConfig == nil {
-			if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
-				tlsConf, ok := tlsConfRaw.(*global.TLSConfig)
-				if !ok {
-					logger.Error("[Remoting][Getty] getty server initialized the TLSConfig configuration failed")
-					return
+		// server tls config
+		if tlsConfRaw, ok := url.GetAttribute(constant.TLSConfigKey); ok {
+			tlsConf, ok := tlsConfRaw.(*global.TLSConfig)
+			if ok && dubbotls.IsServerTLSValid(tlsConf) {
+				srvConf.SSLEnabled = true
+				srvConf.TLSBuilder = &getty.ServerTlsConfigBuilder{
+					ServerKeyCertChainPath:        tlsConf.TLSCertFile,
+					ServerPrivateKeyPath:          tlsConf.TLSKeyFile,
+					ServerTrustCertCollectionPath: tlsConf.CACertFile,
 				}
-				tlsConfig = tlsConf
+				logger.Info("[Remoting][Getty] getty server initialized the TLSConfig configuration")
 			}
-		}
-
-		if tlsConfig != nil && dubbotls.IsServerTLSValid(tlsConfig) {
-			srvConf.SSLEnabled = true
-			srvConf.TLSBuilder = &getty.ServerTlsConfigBuilder{
-				ServerKeyCertChainPath:        tlsConfig.TLSCertFile,
-				ServerPrivateKeyPath:          tlsConfig.TLSKeyFile,
-				ServerTrustCertCollectionPath: tlsConfig.CACertFile,
-			}
-			logger.Info("[Remoting][Getty] getty server initialized the TLSConfig configuration")
 		}
 		//getty params
 		gettyServerConfig := protocolConf.Params

--- a/remoting/getty/getty_server.go
+++ b/remoting/getty/getty_server.go
@@ -57,10 +57,8 @@ func initServer(url *common.URL) {
 	// Ensure application config is available via URL attribute
 	commonCfg.EnsureApplicationAttribute(url)
 
-	if url.GetParam(constant.ProtocolKey, "") == "" {
-		if _, ok := url.GetAttribute(constant.ProtocolConfigKey); !ok {
-			return
-		}
+	if _, ok := url.GetAttribute(constant.ProtocolConfigKey); !ok {
+		return
 	}
 
 	protocolConfRaw, ok := url.GetAttribute(constant.ProtocolConfigKey)

--- a/remoting/getty/getty_server_test.go
+++ b/remoting/getty/getty_server_test.go
@@ -22,6 +22,7 @@ import (
 )
 
 import (
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -43,4 +44,52 @@ func TestInitServer(t *testing.T) {
 	})
 	url.SetAttribute(constant.ApplicationKey, global.ApplicationConfig{})
 	initServer(url)
+}
+
+func TestInitServerTLS(t *testing.T) {
+	newURL := func() *common.URL {
+		url, err := common.NewURL("dubbo://127.0.0.1:20003/test")
+		require.NoError(t, err)
+		url.SetAttribute(constant.ProtocolConfigKey, map[string]*global.ProtocolConfig{
+			"dubbo": {
+				Name:   "dubbo",
+				Ip:     "127.0.0.1",
+				Port:   "20003",
+				Params: map[string]any{},
+			},
+		})
+		url.SetAttribute(constant.ApplicationKey, global.ApplicationConfig{})
+		return url
+	}
+
+	t.Run("valid TLS config enables SSLEnabled and TLSBuilder", func(t *testing.T) {
+		srvConf = GetDefaultServerConfig()
+		url := newURL()
+		url.SetAttribute(constant.TLSConfigKey, &global.TLSConfig{
+			TLSCertFile: "/path/to/server.crt",
+			TLSKeyFile:  "/path/to/server.key",
+		})
+		initServer(url)
+		assert.True(t, srvConf.SSLEnabled)
+		assert.NotNil(t, srvConf.TLSBuilder)
+	})
+
+	t.Run("invalid TLS config keeps TLS disabled", func(t *testing.T) {
+		srvConf = GetDefaultServerConfig()
+		url := newURL()
+		url.SetAttribute(constant.TLSConfigKey, &global.TLSConfig{
+			TLSCertFile: "",
+			TLSKeyFile:  "",
+		})
+		initServer(url)
+		assert.False(t, srvConf.SSLEnabled)
+	})
+
+	t.Run("wrong TLSConfigKey type returns early without panic", func(t *testing.T) {
+		srvConf = GetDefaultServerConfig()
+		url := newURL()
+		url.SetAttribute(constant.TLSConfigKey, "not a *global.TLSConfig")
+		initServer(url)
+		assert.False(t, srvConf.SSLEnabled)
+	})
 }


### PR DESCRIPTION
Replace all config.Get*() calls in initClient and initServer with URL attribute reads, following the pattern already used by triple/grpc/dubbo3 protocols. The URL attributes (ProtocolConfigKey, TLSConfigKey, ApplicationKey) are already populated by callers in server/action.go and client/action.go, so the legacy config fallback path is redundant.

Changes:
- getty_client.go: replace config.GetApplicationConfig() / config.GetRootConfig().Protocols / config.GetRootConfig().TLSConfig with url.GetAttribute() reads. Collapse two redundant TLS blocks into one, fixing a copy-paste bug where srvConf was used instead of clientConf. Add IsClientTLSValid validation that was missing in the legacy TLS path.
- getty_server.go: same config → URL attribute migration.
- Imports: remove dubbo.apache.org/dubbo-go/v3/config and dubbo.apache.org/dubbo-go/v3, add common/config for EnsureApplicationAttribute.
- Update stale comments referencing rootConfig.

### Description
Fixes #3396 

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
