### PR TITLE
perf(common): reduce URL CloneWithFilter and MergeURL params copying

### DIFF
--- a/common/url.go
+++ b/common/url.go
@@ -678,23 +678,34 @@ func (c *URL) GetParams() url.Values {
 	return c.CopyParams()
 }
 
+func copyURLValues(src url.Values) url.Values {
+	if src == nil {
+		return nil
+	}
+
+	dst := make(url.Values, len(src))
+	for k, vs := range src {
+		copied := make([]string, len(vs))
+		copy(copied, vs)
+		dst[k] = copied
+	}
+
+	return dst
+}
+
+func valuesHasNonDefaultParam(values url.Values, key string) bool {
+	if len(values) == 0 {
+		return false
+	}
+	return values.Get(key) != ""
+}
+
 // CopyParams returns a deep copy of params.
 func (c *URL) CopyParams() url.Values {
 	c.paramsLock.RLock()
 	defer c.paramsLock.RUnlock()
 
-	if c.params == nil {
-		return nil
-	}
-
-	params := make(url.Values, len(c.params))
-	for k, vs := range c.params {
-		copied := make([]string, len(vs))
-		copy(copied, vs)
-		params[k] = copied
-	}
-
-	return params
+	return copyURLValues(c.params)
 }
 
 // GetParamAndDecoded gets values and decode
@@ -880,41 +891,53 @@ func (c *URL) ToMap() map[string]string {
 func (c *URL) MergeURL(anotherUrl *URL) *URL {
 	// After Clone, it is a new URL that there is no thread safe issue.
 	mergedURL := c.Clone()
-	params := mergedURL.GetParams()
-	// iterator the anotherUrl if c not have the key ,merge in
-	// anotherUrl usually will not changed. so change RangeParams to GetParams to avoid the string value copy.// Group get group
-	for key, value := range anotherUrl.GetParams() {
-		if _, ok := mergedURL.GetNonDefaultParam(key); !ok {
-			if len(value) > 0 {
-				params[key] = make([]string, len(value))
-				copy(params[key], value)
+	params := mergedURL.params
+	if params == nil {
+		params = url.Values{}
+		mergedURL.params = params
+	}
+	baseTimestamp := params.Get(constant.TimestampKey)
+	baseHasTimestamp := baseTimestamp != ""
+
+	func() {
+		anotherUrl.paramsLock.RLock()
+		defer anotherUrl.paramsLock.RUnlock()
+
+		// Merge params from anotherUrl under one read lock.
+		for key, value := range anotherUrl.params {
+			if !valuesHasNonDefaultParam(params, key) {
+				if len(value) > 0 {
+					params[key] = make([]string, len(value))
+					copy(params[key], value)
+				}
 			}
 		}
-	}
 
-	// remote timestamp
-	if v, ok := c.GetNonDefaultParam(constant.TimestampKey); !ok {
-		params[constant.RemoteTimestampKey] = []string{v}
-		params[constant.TimestampKey] = []string{anotherUrl.GetParam(constant.TimestampKey, "")}
-	}
-
-	// finally execute methodConfigMergeFcn
-	mergedURL.Methods = make([]string, len(anotherUrl.Methods))
-	for i, method := range anotherUrl.Methods {
-		for _, paramKey := range []string{constant.LoadbalanceKey, constant.ClusterKey, constant.RetriesKey, constant.TimeoutKey} {
-			if v := anotherUrl.GetParam(paramKey, ""); len(v) > 0 {
-				params[paramKey] = []string{v}
-			}
-
-			methodsKey := "methods." + method + "." + paramKey
-			// if len(mergedURL.GetParam(methodsKey, "")) == 0 {
-			if v := anotherUrl.GetParam(methodsKey, ""); len(v) > 0 {
-				params[methodsKey] = []string{v}
-			}
-			// }
-			mergedURL.Methods[i] = method
+		// remote timestamp
+		if !baseHasTimestamp {
+			params[constant.RemoteTimestampKey] = []string{baseTimestamp}
+			params[constant.TimestampKey] = []string{anotherUrl.params.Get(constant.TimestampKey)}
 		}
-	}
+
+		// finally execute methodConfigMergeFcn
+		mergedURL.Methods = make([]string, len(anotherUrl.Methods))
+		for i, method := range anotherUrl.Methods {
+			for _, paramKey := range []string{constant.LoadbalanceKey, constant.ClusterKey, constant.RetriesKey, constant.TimeoutKey} {
+				if v := anotherUrl.params.Get(paramKey); len(v) > 0 {
+					params[paramKey] = []string{v}
+				}
+
+				methodsKey := "methods." + method + "." + paramKey
+				// if len(mergedURL.GetParam(methodsKey, "")) == 0 {
+				if v := anotherUrl.params.Get(methodsKey); len(v) > 0 {
+					params[methodsKey] = []string{v}
+				}
+				// }
+				mergedURL.Methods[i] = method
+			}
+		}
+	}()
+
 	// merge attributes
 	anotherUrl.RangeAttributes(func(attrK string, attrV any) bool {
 		if _, ok := mergedURL.GetAttribute(attrK); !ok {
@@ -931,36 +954,8 @@ func (c *URL) MergeURL(anotherUrl *URL) *URL {
 // excludeParams: the set of parameters to exclude from the cloned URL
 // reserveParams: the set of parameters to retain in the cloned URL
 func (c *URL) CloneWithFilter(excludeParams *gxset.HashSet, reserveParams []string) *URL {
-	newURL := &URL{
-		Protocol:     c.Protocol,
-		Location:     c.Location,
-		Ip:           c.Ip,
-		Port:         c.Port,
-		PrimitiveURL: c.PrimitiveURL,
-		primitiveTS:  c.primitiveTS,
-		Path:         c.Path,
-		Username:     c.Username,
-		Password:     c.Password,
-		Methods:      append(make([]string, 0), c.Methods...),
-		attributes:   make(map[string]any),
-		params:       url.Values{},
-	}
-
-	// Copy and filter params based on excludeParams or reserveParams
-	c.RangeParams(
-		func(key, value string) bool {
-			// If the param is in excludeParams or not in reserveParams, skip it
-			if excludeParams != nil && excludeParams.Contains(key) {
-				return true
-			}
-			if len(reserveParams) > 0 && !slices.Contains(reserveParams, key) {
-				return true
-			}
-			// Set the param if it passes the filter
-			newURL.SetParam(key, value)
-			return true
-		},
-	)
+	newURL := c.newURLForClone()
+	newURL.params = c.copyFilteredParams(newURL.params, excludeParams, reserveParams)
 
 	// Copy attributes
 	c.RangeAttributes(
@@ -976,6 +971,77 @@ func (c *URL) CloneWithFilter(excludeParams *gxset.HashSet, reserveParams []stri
 	}
 
 	return newURL
+}
+
+func (c *URL) newURLForClone() *URL {
+	return &URL{
+		Protocol:     c.Protocol,
+		Location:     c.Location,
+		Ip:           c.Ip,
+		Port:         c.Port,
+		PrimitiveURL: c.PrimitiveURL,
+		primitiveTS:  c.primitiveTS,
+		Path:         c.Path,
+		Username:     c.Username,
+		Password:     c.Password,
+		Methods:      append(make([]string, 0), c.Methods...),
+		attributes:   make(map[string]any),
+		params:       url.Values{},
+	}
+}
+
+func (c *URL) copyFilteredParams(params url.Values, excludeParams *gxset.HashSet, reserveParams []string) url.Values {
+	c.paramsLock.RLock()
+	defer c.paramsLock.RUnlock()
+
+	if excludeParams == nil && len(reserveParams) == 0 {
+		if len(c.params) > 8 {
+			copiedParams := copyURLValues(c.params)
+			if copiedParams != nil {
+				return copiedParams
+			}
+		}
+		for key, values := range c.params {
+			copied := make([]string, len(values))
+			copy(copied, values)
+			params[key] = copied
+		}
+		return params
+	}
+
+	if capacity := paramsCapacityForClone(len(c.params), excludeParams, reserveParams); capacity > 8 {
+		params = make(url.Values, capacity)
+	}
+
+	for key, values := range c.params {
+		if shouldCopyParam(key, excludeParams, reserveParams) {
+			copied := make([]string, len(values))
+			copy(copied, values)
+			params[key] = copied
+		}
+	}
+
+	return params
+}
+
+func paramsCapacityForClone(paramsLen int, excludeParams *gxset.HashSet, reserveParams []string) int {
+	if len(reserveParams) > 0 && len(reserveParams) < paramsLen {
+		paramsLen = len(reserveParams)
+	}
+	if excludeParams != nil {
+		paramsLen -= excludeParams.Size()
+	}
+	if paramsLen < 0 {
+		return 0
+	}
+	return paramsLen
+}
+
+func shouldCopyParam(key string, excludeParams *gxset.HashSet, reserveParams []string) bool {
+	if excludeParams != nil && excludeParams.Contains(key) {
+		return false
+	}
+	return len(reserveParams) == 0 || slices.Contains(reserveParams, key)
 }
 
 // Clone will copy the URL

--- a/common/url_test.go
+++ b/common/url_test.go
@@ -1075,6 +1075,29 @@ func TestCloneWithParams(t *testing.T) {
 	assert.Equal(t, []string{"method1", "method2"}, cloned.Methods)
 }
 
+func TestCloneWithFilterPreservesMultiValueParams(t *testing.T) {
+	u := &URL{}
+	u.SetParams(url.Values{
+		"group": {"a", "b"},
+		"drop":  {"drop-value"},
+		"other": {"other-value"},
+	})
+
+	excludeSet := gxset.NewSet("drop")
+	cloned := u.CloneWithFilter(excludeSet, []string{"group", "drop"})
+
+	clonedParams := cloned.GetParams()
+	assert.Equal(t, []string{"a", "b"}, clonedParams["group"])
+	assert.NotContains(t, clonedParams, "drop")
+	assert.NotContains(t, clonedParams, "other")
+
+	cloned.paramsLock.Lock()
+	cloned.params["group"][0] = "changed"
+	cloned.paramsLock.Unlock()
+
+	assert.Equal(t, []string{"a", "b"}, u.GetParams()["group"])
+}
+
 func TestURLCompare(t *testing.T) {
 	u1, _ := NewURL("dubbo://127.0.0.1:20000/a.Service")
 	u2, _ := NewURL("dubbo://127.0.0.1:20000/b.Service")
@@ -1357,6 +1380,47 @@ func TestMergeURLWithMethodParams(t *testing.T) {
 	mergedUrl := serviceUrl.MergeURL(referenceUrl)
 	assert.Equal(t, "random", mergedUrl.GetParam(constant.LoadbalanceKey, ""))
 	assert.Equal(t, "5000", mergedUrl.GetParam("methods.testMethod."+constant.TimeoutKey, ""))
+}
+
+func TestMergeURLPreservesMultiValueParams(t *testing.T) {
+	local := &URL{}
+	local.SetParams(url.Values{
+		"group": {"local-a", "local-b"},
+	})
+
+	remote := &URL{}
+	remote.SetParams(url.Values{
+		"group":   {"remote-a", "remote-b"},
+		"version": {"remote-v1", "remote-v2"},
+	})
+
+	merged := local.MergeURL(remote)
+	mergedParams := merged.GetParams()
+
+	assert.Equal(t, []string{"local-a", "local-b"}, mergedParams["group"])
+	assert.Equal(t, []string{"remote-v1", "remote-v2"}, mergedParams["version"])
+
+	remote.paramsLock.Lock()
+	remote.params["version"][0] = "changed"
+	remote.paramsLock.Unlock()
+
+	assert.Equal(t, []string{"remote-v1", "remote-v2"}, merged.GetParams()["version"])
+}
+
+func TestMergeURLUsesNonDefaultParamSemantics(t *testing.T) {
+	local := &URL{}
+	local.SetParams(url.Values{
+		"group": {"", "local-b"},
+	})
+
+	remote := &URL{}
+	remote.SetParams(url.Values{
+		"group": {"remote-a", "remote-b"},
+	})
+
+	merged := local.MergeURL(remote)
+
+	assert.Equal(t, []string{"remote-a", "remote-b"}, merged.GetParams()["group"])
 }
 
 func TestURLWithPathAlreadyHasSlash(t *testing.T) {


### PR DESCRIPTION
## What is changed

This PR optimizes `common.URL.CloneWithFilter()` and `common.URL.MergeURL()` to reduce unnecessary params copying and repeated locking on clone/merge paths.

Changes are limited to:

- `common/url.go`
- `common/url_test.go`

Main changes:

1. Add internal helper `copyURLValues`
   - Deep-copies `url.Values`
   - Preserves multi-value params
   - Keeps `nil` input as `nil`
   - Reuses the helper in `CopyParams()` without changing its public behavior
2. Add internal helper `valuesHasNonDefaultParam`
   - Preserves the existing `GetNonDefaultParam()` semantics
   - Treats missing keys or `values.Get(key) == ""` as not found
   - Avoids replacing this behavior with a simple map key-existence check
3. Optimize `CloneWithFilter()`
   - Avoids `RangeParams()` + calling `SetParam()` for each param
   - Copies filtered params directly under a single read lock
   - Deep-copies `[]string` values to preserve multi-value params
   - Preallocates the params map for larger param sets to reduce map growth
   - Avoids aggressive preallocation for small param sets
4. Optimize `MergeURL()`
   - Keeps `mergedURL := c.Clone()` to preserve existing clone behavior
   - Reuses the cloned local `mergedURL.params` directly
   - Avoids the extra `mergedURL.GetParams()` deep copy
   - Reads `anotherUrl.params` under a single read lock
   - Deep-copies remote `[]string` values when merging
   - Preserves existing timestamp, method params, attributes, `Methods`, and `SubURL` behavior
5. Add tests
   - `TestCloneWithFilterPreservesMultiValueParams`
   - `TestMergeURLPreservesMultiValueParams`
   - `TestMergeURLUsesNonDefaultParamSemantics`

## Why

`CloneWithFilter()` and `MergeURL()` are used in registry, directory, configurator, and invoker update flows.

The previous implementation performed extra params map copies and repeated locking through public helper methods. This PR keeps public `GetParams()` / `CopyParams()` semantics unchanged while reducing internal copy/lock overhead.

## Benchmark

Benchmarks were measured on the same machine with Go 1.25.

Environment:

```text
goos: darwin
goarch: arm64
cpu: Apple M5
pkg: dubbo.apache.org/dubbo-go/v3/common
```

Command:

```bash
go test ./common -bench 'BenchmarkURL(CloneWithFilter|MergeURL)' -benchmem -run '^$' -count=5
```

Summary of key results:

| Benchmark                                        | before ns/op | after ns/op | before B/op | after B/op | before allocs/op | after allocs/op |
| ------------------------------------------------ | ------------ | ----------- | ----------- | ---------- | ---------------- | --------------- |
| `CloneWithFilter/params_32`                      | 3309         | 2082        | 6232        | 3752       | 49               | 45              |
| `CloneWithFilter/params_256`                     | 32489        | 11701       | 47928       | 26408      | 279              | 269             |
| `CloneWithFilter/params_1024`                    | 122685       | 49558       | 207785      | 115280     | 1054             | 1039            |
| `CloneWithFilter/params_1024_exclude_20_percent` | 101994       | 62952       | 106120      | 62808      | 844              | 832             |
| `CloneWithFilter/params_1024_reserve_20_percent` | 378304       | 235029      | 25240       | 14632      | 221              | 213             |
| `MergeURL/params_1_with_method_params`           | 6196         | 3916        | 6360        | 4016       | 103              | 69              |
| `MergeURL/params_32_with_method_params`          | 13318        | 6487        | 19888       | 10416      | 218              | 116             |
| `MergeURL/params_256_with_method_params`         | 65596        | 23168       | 103280      | 29456      | 1006             | 450             |
| `MergeURL/params_1024_with_method_params`        | 284256       | 96447       | 447026      | 124472     | 3705             | 1604            |

Notable improvements:

```text
BenchmarkURLMergeURL/params_1024_with_method_params

ns/op:     284256 -> 96447   (~66.1% reduction)
B/op:      447026 -> 124472  (~72.2% reduction)
allocs/op: 3705   -> 1604    (~56.7% reduction)
BenchmarkURLCloneWithFilter/params_1024

ns/op:     122685 -> 49558   (~59.6% reduction)
B/op:      207785 -> 115280  (~44.5% reduction)
allocs/op: 1054   -> 1039    (~1.4% reduction)
```

## Test

```bash
go test ./common
```

Passed.

## Related issue

Fixes #3392
