### PR TITLE
perf(common): optimize URL.String() locking and string building

### DIFF
--- a/common/url.go
+++ b/common/url.go
@@ -395,17 +395,36 @@ func isMatchCategory(category1 string, category2 string) bool {
 }
 
 func (c *URL) String() string {
-	c.paramsLock.Lock()
-	defer c.paramsLock.Unlock()
+	c.paramsLock.RLock()
+	defer c.paramsLock.RUnlock()
+
+	encodedParams := c.params.Encode()
 	var buf strings.Builder
-	if len(c.Username) == 0 && len(c.Password) == 0 {
-		buf.WriteString(fmt.Sprintf("%s://%s:%s%s", c.Protocol, c.Ip, c.Port, c.Path))
-	} else {
-		buf.WriteString(fmt.Sprintf("%s://%s:%s@%s:%s%s", c.Protocol, c.Username, c.Password, c.Ip, c.Port, c.Path))
+
+	size := len(c.Protocol) + len("://") + len(c.Ip) + len(":") + len(c.Port) + len(c.Path)
+	if len(c.Username) != 0 || len(c.Password) != 0 {
+		size += len(c.Username) + len(":") + len(c.Password) + len("@")
 	}
-	if encoded := c.params.Encode(); encoded != "" {
+	if encodedParams != "" {
+		size += len("?") + len(encodedParams)
+	}
+
+	buf.Grow(size)
+	buf.WriteString(c.Protocol)
+	buf.WriteString("://")
+	if len(c.Username) != 0 || len(c.Password) != 0 {
+		buf.WriteString(c.Username)
+		buf.WriteString(":")
+		buf.WriteString(c.Password)
+		buf.WriteString("@")
+	}
+	buf.WriteString(c.Ip)
+	buf.WriteString(":")
+	buf.WriteString(c.Port)
+	buf.WriteString(c.Path)
+	if encodedParams != "" {
 		buf.WriteByte('?')
-		buf.WriteString(encoded)
+		buf.WriteString(encodedParams)
 	}
 	return buf.String()
 }


### PR DESCRIPTION
**What this PR does**:

Optimizes lock usage and string construction in `common.URL.String()`, making it lighter-weight and less blocking while keeping the existing output exactly unchanged.

This change includes:

- **Locking**: changes `paramsLock.Lock()` to `paramsLock.RLock()`, because this method only reads params. A read lock allows multiple concurrent `String()` calls while still remaining mutually exclusive with writes.
- **String construction**: replaces `fmt.Sprintf` with `strings.Builder` + `Grow` + `WriteString`. By precomputing the required capacity and allocating once, this removes intermediate strings and repeated growth.

**Which issue(s) this PR fixes**:

Fixes #3393

**Special notes for your reviewer**:

- The benchmark reuses the existing `BenchmarkURLString` on develop (`common/url_benchmark_test.go`, from #3399). Comparison results from `go test ./common/ -bench BenchmarkURLString -benchmem` on Apple M5:

  | Case        | Before                                | After                                     |
  | ----------- | ------------------------------------- | ----------------------------------------- |
  | params_1    | 383.2 ns/op, 728 B/op, 13 allocs/op   | 309.7 ns/op, 536 B/op, **7 allocs/op**    |
  | params_32   | 1651 ns/op, 3385 B/op, 16 allocs/op   | 1804 ns/op, 3192 B/op, **10 allocs/op**   |
  | params_256  | 18138 ns/op, 21698 B/op, 20 allocs/op | 18499 ns/op, 21496 B/op, **14 allocs/op** |
  | params_1024 | 95501 ns/op, 98025 B/op, 25 allocs/op | 91318 ns/op, 97784 B/op, **19 allocs/op** |

  Latency drops noticeably for small URLs. For large params cases, runtime is mostly dominated by `params.Encode()`, so latency is roughly unchanged, but the allocation count still decreases.

- `go test ./common/` passes.

**Does this PR introduce a user-facing change?**

```release-note
NONE