### PR TITLE
perf(common): optimize URL key string construction

### DIFF
--- a/common/url.go
+++ b/common/url.go
@@ -20,7 +20,6 @@ package common
 import (
 	"bytes"
 	"encoding/base64"
-	"fmt"
 	"math"
 	"net"
 	"net/url"
@@ -431,22 +430,77 @@ func (c *URL) String() string {
 
 // Key gets key
 func (c *URL) Key() string {
-	buildString := fmt.Sprintf(
-		"%s://%s:%s@%s:%s/?interface=%s&group=%s&version=%s",
-		c.Protocol, c.Username, c.Password, c.Ip, c.Port, c.Service(), c.GetParam(constant.GroupKey, ""), c.GetParam(constant.VersionKey, ""),
-	)
-	return buildString
+	var buf strings.Builder
+	service := c.Service()
+	group := c.GetParam(constant.GroupKey, "")
+	version := c.GetParam(constant.VersionKey, "")
+
+	size := len(c.Protocol) + len("://") + len(c.Username) +
+		len(":") + len(c.Password) + len("@") +
+		len(c.Ip) + len(":") + len(c.Port) +
+		len("/?interface=") + len(service) +
+		len("&group=") + len(group) +
+		len("&version=") + len(version)
+
+	buf.Grow(size)
+	buf.WriteString(c.Protocol)
+	buf.WriteString("://")
+	buf.WriteString(c.Username)
+	buf.WriteString(":")
+	buf.WriteString(c.Password)
+	buf.WriteString("@")
+	buf.WriteString(c.Ip)
+	buf.WriteString(":")
+	buf.WriteString(c.Port)
+	buf.WriteString("/?interface=")
+	buf.WriteString(service)
+	buf.WriteString("&group=")
+	buf.WriteString(group)
+	buf.WriteString("&version=")
+	buf.WriteString(version)
+
+	return buf.String()
 }
 
 // GetCacheInvokerMapKey get directory cacheInvokerMap key
 func (c *URL) GetCacheInvokerMapKey() string {
-	buildString := fmt.Sprintf(
-		"%s://%s:%s@%s:%s/?interface=%s&group=%s&version=%s&timestamp=%s&"+constant.MeshClusterIDKey+"=%s",
-		c.Protocol, c.Username, c.Password, c.Ip, c.Port, c.Service(), c.GetParam(constant.GroupKey, ""),
-		c.GetParam(constant.VersionKey, ""), c.primitiveTS,
-		c.GetParam(constant.MeshClusterIDKey, ""),
-	)
-	return buildString
+	var buf strings.Builder
+	service := c.Service()
+	group := c.GetParam(constant.GroupKey, "")
+	version := c.GetParam(constant.VersionKey, "")
+	meshClusterID := c.GetParam(constant.MeshClusterIDKey, "")
+
+	size := len(c.Protocol) + len("://") + len(c.Username) +
+		len(":") + len(c.Password) + len("@") +
+		len(c.Ip) + len(":") + len(c.Port) +
+		len("/?interface=") + len(service) +
+		len("&group=") + len(group) +
+		len("&version=") + len(version) +
+		len("&timestamp=") + len(c.primitiveTS) +
+		len("&meshClusterID=") + len(meshClusterID)
+
+	buf.Grow(size)
+	buf.WriteString(c.Protocol)
+	buf.WriteString("://")
+	buf.WriteString(c.Username)
+	buf.WriteString(":")
+	buf.WriteString(c.Password)
+	buf.WriteString("@")
+	buf.WriteString(c.Ip)
+	buf.WriteString(":")
+	buf.WriteString(c.Port)
+	buf.WriteString("/?interface=")
+	buf.WriteString(service)
+	buf.WriteString("&group=")
+	buf.WriteString(group)
+	buf.WriteString("&version=")
+	buf.WriteString(version)
+	buf.WriteString("&timestamp=")
+	buf.WriteString(c.primitiveTS)
+	buf.WriteString("&meshClusterID=")
+	buf.WriteString(meshClusterID)
+
+	return buf.String()
 }
 
 // ServiceKey gets a unique key of a service.
@@ -461,7 +515,7 @@ func ServiceKey(intf string, group string, version string) string {
 	if intf == "" {
 		return ""
 	}
-	buf := &bytes.Buffer{}
+	var buf strings.Builder
 	if group != "" {
 		buf.WriteString(group)
 		buf.WriteString("/")


### PR DESCRIPTION
**What this PR does**:

Following the approach from #3404, this PR updates the remaining URL key-building helpers in `common/url.go` from `fmt.Sprintf` / `bytes.Buffer` to `strings.Builder` with preallocated capacity, reducing allocations and formatting overhead:

- `Key()`: replaces `fmt.Sprintf` while preserving the output format `protocol://username:password@ip:port/?interface=...&group=...&version=...`.
- `GetCacheInvokerMapKey()`: replaces `fmt.Sprintf` while preserving the `timestamp` parameter (still using `primitiveTS`) and the `meshClusterID` parameter.
- `ServiceKey()`: replaces `bytes.Buffer` with `strings.Builder` while preserving edge-case behavior for empty `intf`, non-empty `group`, and `version=0.0.0`.

**Which issue(s) this PR fixes**:

Fixes #3406

**Special notes for your reviewer**

- This benchmark reuses the existing URL benchmarks in `common/url_benchmark_test.go`. The following comparison results were collected on Apple M5 with `go test ./common -bench 'BenchmarkURL(Key|GetCacheInvokerMapKey|ServiceKey)' -benchmem`:

`BenchmarkURLKey`

| Case        | Before                             | After                             |
| ----------- | ---------------------------------- | --------------------------------- |
| params_1    | 185.7 ns/op, 192 B/op, 7 allocs/op | 84.00 ns/op, 96 B/op, 1 allocs/op |
| params_32   | 193.3 ns/op, 192 B/op, 7 allocs/op | 64.81 ns/op, 96 B/op, 1 allocs/op |
| params_256  | 182.5 ns/op, 192 B/op, 7 allocs/op | 66.46 ns/op, 96 B/op, 1 allocs/op |
| params_1024 | 182.7 ns/op, 192 B/op, 7 allocs/op | 59.02 ns/op, 96 B/op, 1 allocs/op |

`BenchmarkURLGetCacheInvokerMapKey`

| Case        | Before                             | After                              |
| ----------- | ---------------------------------- | ---------------------------------- |
| params_1    | 233.0 ns/op, 272 B/op, 9 allocs/op | 76.95 ns/op, 144 B/op, 1 allocs/op |
| params_32   | 258.9 ns/op, 272 B/op, 9 allocs/op | 74.57 ns/op, 144 B/op, 1 allocs/op |
| params_256  | 237.1 ns/op, 272 B/op, 9 allocs/op | 88.17 ns/op, 144 B/op, 1 allocs/op |
| params_1024 | 237.3 ns/op, 272 B/op, 9 allocs/op | 74.62 ns/op, 144 B/op, 1 allocs/op |

`BenchmarkURLServiceKey`

| Case        | Before                             | After                             |
| ----------- | ---------------------------------- | --------------------------------- |
| params_1    | 63.51 ns/op, 112 B/op, 2 allocs/op | 43.85 ns/op, 64 B/op, 2 allocs/op |
| params_32   | 54.99 ns/op, 112 B/op, 2 allocs/op | 48.87 ns/op, 64 B/op, 2 allocs/op |
| params_256  | 56.49 ns/op, 112 B/op, 2 allocs/op | 48.69 ns/op, 64 B/op, 2 allocs/op |
| params_1024 | 60.97 ns/op, 112 B/op, 2 allocs/op | 49.20 ns/op, 64 B/op, 2 allocs/op |

The benchmark comparison shows lower latency and memory usage across the three URL key-building helpers.

- `go test ./common` passes.

**Does this PR introduce a user-facing change?**:

```release-note
NONE