### PR TITLE
refactor: remove legacy config handling from variadicrpccheck

### DIFF
--- a/tools/variadicrpccheck/helpers_test.go
+++ b/tools/variadicrpccheck/helpers_test.go
@@ -363,12 +363,12 @@ func TestAstAndTypeHelpers(t *testing.T) {
 
 		_, ok = analyzer.wrapperParamIndexFromCall(ref.pkg, params, &ast.CallExpr{Fun: &ast.BasicLit{}})
 		assert.False(t, ok)
-		configPkg := types.NewPackage("dubbo.apache.org/dubbo-go/v3/config", "config")
-		helperSel := &ast.SelectorExpr{X: &ast.Ident{Name: "config"}, Sel: &ast.Ident{Name: "SetProviderService"}}
+		dubboPkg := types.NewPackage("dubbo.apache.org/dubbo-go/v3", "dubbo")
+		helperSel := &ast.SelectorExpr{X: &ast.Ident{Name: "dubbo"}, Sel: &ast.Ident{Name: "SetProviderService"}}
 		helperPkg := &packages.Package{
 			TypesInfo: &types.Info{
 				Uses: map[*ast.Ident]types.Object{
-					helperSel.Sel: types.NewFunc(token.NoPos, configPkg, "SetProviderService", testSignature(false, nil, nil)),
+					helperSel.Sel: types.NewFunc(token.NoPos, dubboPkg, "SetProviderService", testSignature(false, nil, nil)),
 				},
 			},
 		}
@@ -389,10 +389,6 @@ func TestAstAndTypeHelpers(t *testing.T) {
 		proxyType := types.NewNamed(types.NewTypeName(token.NoPos, serverPkg, "Proxy", nil), types.NewStruct(nil, nil), nil)
 		proxyType.AddMethod(types.NewFunc(token.NoPos, serverPkg, "Implement", testSignature(false, []types.Type{types.NewInterfaceType(nil, nil)}, nil)))
 
-		configPkg := types.NewPackage("dubbo.apache.org/dubbo-go/v3/config", "config")
-		serviceConfigType := types.NewNamed(types.NewTypeName(token.NoPos, configPkg, "ServiceConfig", nil), types.NewStruct(nil, nil), nil)
-		serviceConfigType.AddMethod(types.NewFunc(token.NoPos, configPkg, "Implement", testSignature(false, []types.Type{types.NewInterfaceType(nil, nil)}, nil)))
-
 		commonPkg := types.NewPackage("dubbo.apache.org/dubbo-go/v3/common", "common")
 		serviceMapType := types.NewNamed(types.NewTypeName(token.NoPos, commonPkg, "serviceMap", nil), types.NewStruct(nil, nil), nil)
 		serviceMapType.AddMethod(types.NewFunc(token.NoPos, commonPkg, "Register", testSignature(false, []types.Type{types.NewInterfaceType(nil, nil), types.NewInterfaceType(nil, nil), types.NewInterfaceType(nil, nil), types.NewInterfaceType(nil, nil), types.NewInterfaceType(nil, nil)}, []types.Type{types.Universe.Lookup("error").Type()})))
@@ -406,10 +402,6 @@ func TestAstAndTypeHelpers(t *testing.T) {
 		assert.Equal(t, 0, idx)
 
 		idx, ok = selectedMethodHandlerArgumentIndex(types.NewMethodSet(types.NewPointer(serviceOptionsType)).Lookup(serverPkg, "Implement"))
-		require.True(t, ok)
-		assert.Equal(t, 0, idx)
-
-		idx, ok = selectedMethodHandlerArgumentIndex(types.NewMethodSet(types.NewPointer(serviceConfigType)).Lookup(configPkg, "Implement"))
 		require.True(t, ok)
 		assert.Equal(t, 0, idx)
 
@@ -427,21 +419,12 @@ func TestAstAndTypeHelpers(t *testing.T) {
 		assert.False(t, ok)
 	})
 
-	// Package-level helpers cover config registration, root dubbo helpers, and generated Register* entry points.
-	t.Run("calledObjectHandlerArgumentIndex matches config helpers and generated handlers", func(t *testing.T) {
+	// Package-level helpers cover root dubbo helpers and generated Register* entry points.
+	t.Run("calledObjectHandlerArgumentIndex matches root helpers and generated handlers", func(t *testing.T) {
 		analyzer := newRegistrationAnalyzer(nil)
-		configPkg := types.NewPackage("dubbo.apache.org/dubbo-go/v3/config", "config")
 		dubboPkg := types.NewPackage("dubbo.apache.org/dubbo-go/v3", "dubbo")
 
-		idx, ok := analyzer.calledObjectHandlerArgumentIndex(types.NewFunc(token.NoPos, configPkg, "SetProviderService", testSignature(false, []types.Type{types.NewInterfaceType(nil, nil)}, nil)))
-		require.True(t, ok)
-		assert.Equal(t, 0, idx)
-
-		idx, ok = analyzer.calledObjectHandlerArgumentIndex(types.NewFunc(token.NoPos, configPkg, "SetProviderServiceWithInfo", testSignature(false, []types.Type{types.NewInterfaceType(nil, nil), types.NewInterfaceType(nil, nil)}, nil)))
-		require.True(t, ok)
-		assert.Equal(t, 0, idx)
-
-		idx, ok = analyzer.calledObjectHandlerArgumentIndex(types.NewFunc(token.NoPos, dubboPkg, "SetProviderService", testSignature(false, []types.Type{types.NewInterfaceType(nil, nil)}, nil)))
+		idx, ok := analyzer.calledObjectHandlerArgumentIndex(types.NewFunc(token.NoPos, dubboPkg, "SetProviderService", testSignature(false, []types.Type{types.NewInterfaceType(nil, nil)}, nil)))
 		require.True(t, ok)
 		assert.Equal(t, 0, idx)
 
@@ -466,16 +449,16 @@ func TestAstAndTypeHelpers(t *testing.T) {
 		serverType := types.NewNamed(types.NewTypeName(token.NoPos, serverPkg, "Server", nil), types.NewStruct(nil, nil), nil)
 		serverType.AddMethod(types.NewFunc(token.NoPos, serverPkg, "RegisterService", testSignature(false, []types.Type{types.NewInterfaceType(nil, nil)}, []types.Type{types.Universe.Lookup("error").Type()})))
 		selection := types.NewMethodSet(types.NewPointer(serverType)).Lookup(serverPkg, "RegisterService")
-		configPkg := types.NewPackage("dubbo.apache.org/dubbo-go/v3/config", "config")
+		dubboPkg := types.NewPackage("dubbo.apache.org/dubbo-go/v3", "dubbo")
 
 		selector := &ast.SelectorExpr{X: &ast.Ident{Name: "srv"}, Sel: &ast.Ident{Name: "RegisterService"}}
-		packageSelector := &ast.SelectorExpr{X: &ast.Ident{Name: "config"}, Sel: &ast.Ident{Name: "SetProviderService"}}
+		packageSelector := &ast.SelectorExpr{X: &ast.Ident{Name: "dubbo"}, Sel: &ast.Ident{Name: "SetProviderService"}}
 		ident := &ast.Ident{Name: "RegisterGreeterHandler"}
 		pkg := &packages.Package{
 			TypesInfo: &types.Info{
 				Selections: map[*ast.SelectorExpr]*types.Selection{selector: selection},
 				Uses: map[*ast.Ident]types.Object{
-					packageSelector.Sel: types.NewFunc(token.NoPos, configPkg, "SetProviderService", testSignature(false, nil, nil)),
+					packageSelector.Sel: types.NewFunc(token.NoPos, dubboPkg, "SetProviderService", testSignature(false, nil, nil)),
 					ident:               types.NewFunc(token.NoPos, types.NewPackage("example.com/test", "test"), "RegisterGreeterHandler", testSignature(false, nil, nil)),
 				},
 			},

--- a/tools/variadicrpccheck/scan.go
+++ b/tools/variadicrpccheck/scan.go
@@ -35,13 +35,10 @@ import (
 var packagesLoad = packages.Load
 
 const (
-	dubboRootPkgPath   = "dubbo.apache.org/dubbo-go/v3"
-	dubboCommonPkgPath = dubboRootPkgPath + "/common"
-	dubboConfigPkgPath = dubboRootPkgPath + "/config"
-	dubboServerPkgPath = dubboRootPkgPath + "/server"
-
+	dubboRootPkgPath         = "dubbo.apache.org/dubbo-go/v3"
+	dubboCommonPkgPath       = dubboRootPkgPath + "/common"
+	dubboServerPkgPath       = dubboRootPkgPath + "/server"
 	serverServiceOptionsType = "*" + dubboServerPkgPath + ".ServiceOptions"
-	configServiceConfigType  = "*" + dubboConfigPkgPath + ".ServiceConfig"
 )
 
 type registeredTypeKey struct {
@@ -454,8 +451,6 @@ func selectedMethodHandlerArgumentIndex(selection *types.Selection) (int, bool) 
 		return 0, true
 	case path == dubboServerPkgPath && name == "Implement":
 		return 0, types.TypeString(selection.Recv(), nil) == serverServiceOptionsType
-	case path == dubboConfigPkgPath && name == "Implement":
-		return 0, types.TypeString(selection.Recv(), nil) == configServiceConfigType
 	case path == dubboCommonPkgPath && name == "Register":
 		return 4, strings.HasSuffix(types.TypeString(selection.Recv(), nil), ".serviceMap")
 	default:
@@ -471,7 +466,7 @@ func (a *registrationAnalyzer) calledObjectHandlerArgumentIndex(obj types.Object
 	}
 	if obj.Pkg() != nil {
 		switch obj.Pkg().Path() {
-		case dubboConfigPkgPath, dubboRootPkgPath:
+		case dubboRootPkgPath:
 			switch obj.Name() {
 			case "SetProviderService":
 				return 0, true

--- a/tools/variadicrpccheck/scan_test.go
+++ b/tools/variadicrpccheck/scan_test.go
@@ -220,46 +220,6 @@ func register() {
 	assert.Equal(t, filepath.Join(dir, "service", "service.go"), findings[0].Position.Filename)
 }
 
-func TestScanFindsVariadicImplementationRegisteredViaSetProviderServiceWithInfo(t *testing.T) {
-	dir := t.TempDir()
-	writeTempFile(t, dir, goModFileName, goModuleContentWithDubboGoReplace("example.com/providerinfo", repoRoot(t)))
-	writeTempFile(t, filepath.Join(dir, "service"), serviceFileName, `package service
-
-import "context"
-
-type VariadicService struct{}
-
-func (s *VariadicService) MultiArgs(ctx context.Context, args ...string) error {
-	return nil
-}
-
-type Helper struct{}
-
-func (h *Helper) Merge(ctx context.Context, values ...string) error {
-	return nil
-}
-`)
-	writeTempFile(t, filepath.Join(dir, "provider"), "provider.go", `package provider
-
-import (
-	"dubbo.apache.org/dubbo-go/v3/config"
-	"example.com/providerinfo/service"
-)
-
-func init() {
-	config.SetProviderServiceWithInfo(&service.VariadicService{}, nil)
-}
-`)
-
-	findings, err := Scan(dir, []string{"./..."})
-	require.NoError(t, err)
-	require.Len(t, findings, 1)
-	assert.Equal(t, "implementation", findings[0].Kind)
-	assert.Equal(t, "VariadicService", findings[0].TypeName)
-	assert.Equal(t, "MultiArgs", findings[0].MethodName)
-	assert.Equal(t, filepath.Join(dir, "service", "service.go"), findings[0].Position.Filename)
-}
-
 func TestScanFindsVariadicImplementationRegisteredViaRootSetProviderService(t *testing.T) {
 	dir := t.TempDir()
 	writeTempFile(t, dir, goModFileName, goModuleContentWithDubboGoReplace("example.com/rootprovider", repoRoot(t)))
@@ -310,12 +270,12 @@ func (s *VariadicService) MultiArgs(ctx context.Context, args ...string) error {
 	writeTempFile(t, filepath.Join(dir, "generated"), "generated.go", `package generated
 
 import (
+	dubbo "dubbo.apache.org/dubbo-go/v3"
 	"dubbo.apache.org/dubbo-go/v3/common"
-	"dubbo.apache.org/dubbo-go/v3/config"
 )
 
 func SetProviderService(srv common.RPCService) {
-	config.SetProviderServiceWithInfo(srv, nil)
+	dubbo.SetProviderServiceWithInfo(srv, nil)
 }
 `)
 	writeTempFile(t, filepath.Join(dir, "provider"), "provider.go", `package provider
@@ -400,14 +360,14 @@ func (s *VariadicService) MultiArgs(ctx context.Context, args ...string) error {
 	writeTempFile(t, filepath.Join(dir, "provider"), "provider.go", `package provider
 
 import (
+	dubbo "dubbo.apache.org/dubbo-go/v3"
 	"dubbo.apache.org/dubbo-go/v3/common"
-	"dubbo.apache.org/dubbo-go/v3/config"
 	"example.com/interfacevar/service"
 )
 
 func init() {
 	var svc common.RPCService = &service.VariadicService{}
-	config.SetProviderServiceWithInfo(svc, nil)
+	dubbo.SetProviderServiceWithInfo(svc, nil)
 }
 `)
 
@@ -442,14 +402,14 @@ func (s *SecondService) MultiArgs(ctx context.Context, args ...string) error {
 	writeTempFile(t, filepath.Join(dir, "provider"), "provider.go", `package provider
 
 import (
+	dubbo "dubbo.apache.org/dubbo-go/v3"
 	"dubbo.apache.org/dubbo-go/v3/common"
-	"dubbo.apache.org/dubbo-go/v3/config"
 	"example.com/interfacevarreassign/service"
 )
 
 func init() {
 	var svc common.RPCService = &service.FirstService{}
-	config.SetProviderServiceWithInfo(svc, nil)
+	dubbo.SetProviderServiceWithInfo(svc, nil)
 	svc = &service.SecondService{}
 }
 `)


### PR DESCRIPTION
### Why

Before making changes, I scanned `tools/variadicrpccheck` for remaining legacy `config` references. The tool itself does not directly import `dubbo.apache.org/dubbo-go/v3/config`, but its scanner rules and test fixtures still kept legacy config-based registration handling, including:

- `(*config.ServiceConfig).Implement(...)`
- `config.SetProviderService(...)`
- `config.SetProviderServiceWithInfo(...)`

These references were mainly in:

- `tools/variadicrpccheck/scan.go`
- `tools/variadicrpccheck/helpers_test.go`
- `tools/variadicrpccheck/scan_test.go`

Although these were not runtime imports, they kept `variadicrpccheck` aware of the legacy `config` package and would become stale anchors when the `config` package is removed later.

### What changed

This PR removes legacy `config` registration handling and related fixtures from `tools/variadicrpccheck`.

Changes include:

1. Remove legacy config-based registration matching from `scan.go`:
   - Remove `dubboConfigPkgPath`
   - Remove `configServiceConfigType`
   - Stop matching `(*config.ServiceConfig).Implement(...)`
   - Stop matching `config.SetProviderService(...)`
   - Stop matching `config.SetProviderServiceWithInfo(...)`
2. Keep the currently relevant registration paths:
   - `server.Register(...)`
   - `server.RegisterService(...)`
   - `(*server.ServiceOptions).Implement(...)`
   - root package `dubbo.SetProviderService(...)`
   - root package `dubbo.SetProviderServiceWithInfo(...)`
   - generated `Register*Handler(...)`
   - wrapper forwarding tracing
3. Clean up legacy `config` fixtures in `scan_test.go`:
   - Remove the test dedicated to `config.SetProviderServiceWithInfo(...)`
   - Update wrapper and interface-variable fixtures from `config.SetProviderServiceWithInfo(...)` to root `dubbo.SetProviderServiceWithInfo(...)`
4. Clean up synthetic `config` objects in `helpers_test.go`:
   - Remove `types.NewPackage("dubbo.apache.org/dubbo-go/v3/config", "config")`
   - Remove `ServiceConfig.Implement` coverage
   - Update related selector/object tests to use root `dubbo.SetProviderService(...)`

### Scope

This PR only changes `tools/variadicrpccheck` scanner rules and tests.

It does not change runtime business logic, and it does not modify `go.mod` or `go.sum`.

The scanner can still detect variadic RPC contracts registered through the currently retained registration paths, but it no longer keeps compatibility logic for the legacy `config` registration APIs.

This PR intentionally does not touch `compat.go`, `dubbo_test.go`, `compat_test.go`, or graceful-shutdown related files, since those are separate cleanup targets under #3396.

### Verification

Passed:

```bash
go test ./tools/variadicrpccheck
make rpc-contract-check
git diff --check
```

Also verified that no legacy `config` package path or legacy config registration API remains under `tools/variadicrpccheck`:

```bash
rg -n "dubbo\.apache\.org/dubbo-go/v3/config|dubboConfigPkgPath|configServiceConfigType|configPkg|legacyconfig" tools/variadicrpccheck

rg -n "config\.SetProviderService|config\.SetProviderServiceWithInfo|config\.ServiceConfig|ServiceConfig\.Implement" tools/variadicrpccheck
```

Both `rg` checks returned no matches.



### Related issue

Part of #3396