### PR TITLE
perf(registry): pre-size service-discovery maps and slices on instanc…

### DIFF
--- a/registry/servicediscovery/service_instances_changed_listener_impl.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl.go
@@ -93,12 +93,11 @@ func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error
 	defer lstn.mutex.Unlock()
 
 	lstn.allInstances[ce.ServiceName] = ce.Instances
-	revisionToInstances := make(map[string][]registry.ServiceInstance)
-	newRevisionToMetadata := make(map[string]*info.MetadataInfo)
+	revisionToInstances := make(map[string][]registry.ServiceInstance, len(lstn.revisionToMetadata))
+	newRevisionToMetadata := make(map[string]*info.MetadataInfo, len(lstn.revisionToMetadata))
 	// The same service match key can be exported by several revisions.
 	// Keep each revision's ServiceInfo so provider-specific params are not collapsed.
-	serviceToRevisionServices := make(map[string]map[string]*info.ServiceInfo)
-	newServiceURLs := make(map[string][]*common.URL)
+	serviceToRevisionServices := make(map[string]map[string]*info.ServiceInfo, len(lstn.serviceUrls))
 
 	logger.Infof("[Registry][ServiceDiscovery] received instance notification event, service=%s size=%d", ce.ServiceName, len(ce.Instances))
 
@@ -153,6 +152,7 @@ func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error
 		metaCache.Set(cacheKey, metadataInfo)
 	}
 
+	newServiceURLs := make(map[string][]*common.URL, len(serviceToRevisionServices))
 	for serviceKey, revisionServices := range serviceToRevisionServices {
 		urls := make([]*common.URL, 0, 8)
 		for revision, serviceInfo := range revisionServices {


### PR DESCRIPTION
**What this PR does**

Adds conservative capacity preallocation for temporary maps in `ServiceInstancesChangedListenerImpl.OnEvent` to reduce dynamic map growth while processing service instance change events.

Specifically:

- `revisionToInstances` and `newRevisionToMetadata` are preallocated with `len(lstn.revisionToMetadata)`.
- `serviceToRevisionServices` is preallocated with `len(lstn.serviceUrls)`.
- `newServiceURLs` is moved closer to where it is built and preallocated with `len(serviceToRevisionServices)`, since their keys correspond one-to-one.

These changes only affect the initial capacity of temporary collections. They do not change the refresh algorithm, metadata loading behavior, or listener notification semantics.

**Which issue(s) this PR fixes**:
Fixes #3409