### PR TITLE
perf(loadbalance): reduce temporary selection allocations

### DIFF
--- a/cluster/loadbalance/aliasmethod/alias_method.go
+++ b/cluster/loadbalance/aliasmethod/alias_method.go
@@ -28,6 +28,8 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 )
 
+const smallInvokerThreshold = 32
+
 type aliasMethodPicker struct {
 	invokers []base.Invoker // Instance
 
@@ -47,15 +49,30 @@ func NewAliasMethodPicker(invokers []base.Invoker, invocation base.Invocation) *
 // Alias Method: https://en.wikipedia.org/wiki/Alias_method
 func (am *aliasMethodPicker) init(invocation base.Invocation) {
 	n := len(am.invokers)
-	weights := make([]int64, n)
 	am.alias = make([]int, n)
 	am.prob = make([]float64, n)
 
 	totalWeight := int64(0)
 
-	scaledProb := make([]float64, n)
-	small := make([]int, 0, n)
-	large := make([]int, 0, n)
+	var (
+		weightStack     [smallInvokerThreshold]int64
+		scaledProbStack [smallInvokerThreshold]float64
+		smallStack      [smallInvokerThreshold]int
+		largeStack      [smallInvokerThreshold]int
+	)
+	weights := weightStack[:]
+	scaledProb := scaledProbStack[:]
+	small := smallStack[:0]
+	large := largeStack[:0]
+	if n > smallInvokerThreshold {
+		weights = make([]int64, n)
+		scaledProb = make([]float64, n)
+		small = make([]int, 0, n)
+		large = make([]int, 0, n)
+	} else {
+		weights = weights[:n]
+		scaledProb = scaledProb[:n]
+	}
 
 	now := time.Now().Unix()
 	for i, invoker := range am.invokers {

--- a/cluster/loadbalance/leastactive/loadbalance.go
+++ b/cluster/loadbalance/leastactive/loadbalance.go
@@ -32,6 +32,9 @@ import (
 const (
 	// Key is used to set the load balance extension
 	Key = "leastactive"
+
+	minStackInvokerCount = 8
+	maxStackInvokerCount = 32
 )
 
 func init() {
@@ -58,14 +61,25 @@ func (lb *leastActiveLoadBalance) Select(invokers []base.Invoker, invocation bas
 	}
 
 	var (
-		leastActive  int32                  = -1 // The least active value of all invokers
-		totalWeight  int64                       // The number of invokers having the same least active value (LEAST_ACTIVE)
-		firstWeight  int64                       // Initial value, used for comparison
-		leastCount   int                         // The number of invokers having the same least active value (LEAST_ACTIVE)
-		leastIndexes = make([]int, count)        // The index of invokers having the same least active value (LEAST_ACTIVE)
-		sameWeight   = true                      // Every invoker has the same weight value?
-		weights      = make([]int64, count)      // The weight of every invokers
+		leastActive  int32   = -1 // The least active value of all invokers
+		totalWeight  int64        // Sum of weights of invokers having the same least active value (LEAST_ACTIVE)
+		firstWeight  int64        // Initial value, used for comparison
+		leastCount   int          // The number of invokers having the same least active value (LEAST_ACTIVE)
+		leastIndexes []int        // The index of invokers having the same least active value (LEAST_ACTIVE)
+		sameWeight   = true       // Every invoker has the same weight value?
+		weights      []int64      // The weight of every invokers
 	)
+	var (
+		leastIndexStack [maxStackInvokerCount]int
+		weightStack     [maxStackInvokerCount]int64
+	)
+	if count >= minStackInvokerCount && count <= maxStackInvokerCount {
+		leastIndexes = leastIndexStack[:count]
+		weights = weightStack[:count]
+	} else {
+		leastIndexes = make([]int, count)
+		weights = make([]int64, count)
+	}
 
 	now := time.Now().Unix()
 	for i := 0; i < count; i++ {

--- a/cluster/loadbalance/loadbalance_benchmarks_test.go
+++ b/cluster/loadbalance/loadbalance_benchmarks_test.go
@@ -48,6 +48,19 @@ func Generate() []base.Invoker {
 	return invokers
 }
 
+func generateInvokers(count int, weighted bool) []base.Invoker {
+	invokers := make([]base.Invoker, 0, count)
+	for i := 1; i <= count; i++ {
+		rawURL := fmt.Sprintf("dubbo://192.168.1.%v:20000/org.apache.demo.HelloService", i)
+		if weighted {
+			rawURL = fmt.Sprintf("%s?weight=%d", rawURL, i)
+		}
+		url, _ := common.NewURL(rawURL)
+		invokers = append(invokers, base.NewBaseInvoker(url))
+	}
+	return invokers
+}
+
 func Benchloadbalance(b *testing.B, lb loadbalance.LoadBalance) {
 	b.Helper()
 	invokers := Generate()
@@ -105,4 +118,39 @@ func BenchmarkGetWeightAt(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		loadbalance.GetWeightAt(invokers[i%len(invokers)], inv, now)
 	}
+}
+
+func benchmarkLoadBalanceSmallMedium(b *testing.B, lb loadbalance.LoadBalance) {
+	b.Helper()
+	for _, count := range []int{2, 4, 8, 16, 32, 33} {
+		for _, weighted := range []bool{false, true} {
+			name := fmt.Sprintf("invokers=%d", count)
+			if weighted {
+				name += "/weighted"
+			} else {
+				name += "/uniform"
+			}
+			b.Run(name, func(b *testing.B) {
+				invokers := generateInvokers(count, weighted)
+				rpcInvocation := &invocation.RPCInvocation{}
+				b.ReportAllocs()
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					lb.Select(invokers, rpcInvocation)
+				}
+			})
+		}
+	}
+}
+
+func BenchmarkRandomLoadbalanceSmallMedium(b *testing.B) {
+	benchmarkLoadBalanceSmallMedium(b, extension.GetLoadbalance(constant.LoadBalanceKeyRandom))
+}
+
+func BenchmarkLeastactiveLoadbalanceSmallMedium(b *testing.B) {
+	benchmarkLoadBalanceSmallMedium(b, extension.GetLoadbalance(constant.LoadBalanceKeyLeastActive))
+}
+
+func BenchmarkAliasMethodLoadbalanceSmallMedium(b *testing.B) {
+	benchmarkLoadBalanceSmallMedium(b, extension.GetLoadbalance(constant.LoadBalanceKeyAliasMethod))
 }

--- a/cluster/loadbalance/random/loadbalance.go
+++ b/cluster/loadbalance/random/loadbalance.go
@@ -53,7 +53,21 @@ func (lb *randomLoadBalance) Select(invokers []base.Invoker, invocation base.Inv
 	// Every invoker has the same weight?
 	sameWeight := true
 	// the maxWeight of every invokers, the minWeight = 0 or the maxWeight of the last invoker
-	weights := make([]int64, length)
+	// Use stack buffers for common small invoker lists to avoid the temporary weights slice allocation.
+	var weights []int64
+	switch {
+	case length <= 8:
+		var weightStack [8]int64
+		weights = weightStack[:length:length]
+	case length <= 16:
+		var weightStack [16]int64
+		weights = weightStack[:length:length]
+	case length <= 32:
+		var weightStack [32]int64
+		weights = weightStack[:length:length]
+	default:
+		weights = make([]int64, length)
+	}
 	// The sum of weights
 	var totalWeight int64 = 0
 


### PR DESCRIPTION
<!DOCTYPE html><h2 cid="n2" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; white-space: pre-wrap; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.75em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.225; cursor: text; border-bottom: 1px solid rgb(238, 238, 238); caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-style: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain md-expand" style="box-sizing: border-box;">What is changed</span></h2><p cid="n3" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">This PR reduces request-time temporary slice allocations in several load balance selection paths for common small and medium invoker lists.</span></p><p cid="n4" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Changes are limited to:</span></p><ul class="ul-list" cid="n5" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0.8em 0px; padding-left: 30px; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li class="md-list-item" cid="n6" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n7" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">cluster/loadbalance/random/loadbalance.go</code></span></p></li><li class="md-list-item" cid="n8" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n9" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">cluster/loadbalance/leastactive/loadbalance.go</code></span></p></li><li class="md-list-item" cid="n10" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n11" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">cluster/loadbalance/aliasmethod/alias_method.go</code></span></p></li><li class="md-list-item" cid="n12" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n13" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">cluster/loadbalance/loadbalance_benchmarks_test.go</code></span></p></li></ul><p cid="n14" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Main changes:</span></p><ol class="ol-list" cid="n15" mdtype="list" style="box-sizing: border-box; margin: 0.8em 0px; padding-left: 30px; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li class="md-list-item" cid="n16" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n17" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Optimize random load balance temporary weights storage</span></p><ul class="ul-list" cid="n18" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0px; padding-left: 30px; position: relative;"><li class="md-list-item" cid="n19" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n20" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Keeps the existing prefix-sum weighted random selection algorithm.</span></p></li><li class="md-list-item" cid="n21" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n22" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Uses stack-backed weight buffers for common small and medium invoker counts:</span></p><ul class="ul-list" cid="n23" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0px; padding-left: 30px; position: relative;"><li class="md-list-item md-focus-container" cid="n24" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n25" mdtype="paragraph" class="md-end-block md-p md-focus" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s md-expand" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">length &lt;= 8</code></span></p></li><li class="md-list-item" cid="n26" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n27" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">length &lt;= 16</code></span></p></li><li class="md-list-item" cid="n28" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n29" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">length &lt;= 32</code></span></p></li></ul></li><li class="md-list-item" cid="n30" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n31" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Falls back to heap slices for larger invoker lists.</span></p></li><li class="md-list-item" cid="n32" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n33" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Preserves the existing weighted and uniform selection semantics.</span></p></li></ul></li><li class="md-list-item" cid="n34" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n35" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Optimize least-active temporary candidate storage</span></p><ul class="ul-list" cid="n36" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0px; padding-left: 30px; position: relative;"><li class="md-list-item" cid="n37" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n38" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Avoids request-time heap slices for </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">leastIndexes</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> and </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">weights</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> when </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">8 &lt;= count &lt;= 32</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">.</span></p></li><li class="md-list-item" cid="n39" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n40" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Keeps the original heap-slice path for very small lists where the benchmark did not show allocation benefits.</span></p></li><li class="md-list-item" cid="n41" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n42" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Falls back to heap slices for larger invoker lists.</span></p></li><li class="md-list-item" cid="n43" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n44" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Preserves the existing least-active filtering and weighted random selection semantics.</span></p></li></ul></li><li class="md-list-item" cid="n45" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n46" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Optimize alias-method picker construction</span></p><ul class="ul-list" cid="n47" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0px; padding-left: 30px; position: relative;"><li class="md-list-item" cid="n48" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n49" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Keeps </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">alias</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> and </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">prob</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> as picker-owned result storage.</span></p></li><li class="md-list-item" cid="n50" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n51" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Uses stack-backed temporary buffers for picker construction on common small and medium invoker counts:</span></p><ul class="ul-list" cid="n52" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0px; padding-left: 30px; position: relative;"><li class="md-list-item" cid="n53" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n54" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">weights</code></span></p></li><li class="md-list-item" cid="n55" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n56" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">scaledProb</code></span></p></li><li class="md-list-item" cid="n57" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n58" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">small</code></span></p></li><li class="md-list-item" cid="n59" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n60" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">large</code></span></p></li></ul></li><li class="md-list-item" cid="n61" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n62" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Falls back to heap slices for larger invoker lists.</span></p></li><li class="md-list-item" cid="n63" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n64" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Does not introduce long-lived picker caches.</span></p></li></ul></li><li class="md-list-item" cid="n65" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n66" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Add focused small/medium load balance benchmarks</span></p><ul class="ul-list" cid="n67" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0px; padding-left: 30px; position: relative;"><li class="md-list-item" cid="n68" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n69" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Covers random, least-active, and alias-method load balance implementations.</span></p></li><li class="md-list-item" cid="n70" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n71" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Covers invoker counts: </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">2</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">, </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">4</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">, </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">8</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">, </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">16</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">, </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">32</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">, and </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">33</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">.</span></p></li><li class="md-list-item" cid="n72" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n73" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Covers both uniform and weighted cases.</span></p></li><li class="md-list-item" cid="n74" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n75" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Includes </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">33</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> to verify the heap fallback path above the stack-buffer threshold.</span></p></li></ul></li></ol><h2 cid="n76" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; white-space: pre-wrap; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.75em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.225; cursor: text; border-bottom: 1px solid rgb(238, 238, 238); caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-style: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Why</span></h2><p cid="n77" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Some load balance implementations allocate temporary slices during each </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">Select</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> call. These paths are used during request-time selection, so avoiding short-lived temporary allocations for common small and medium invoker lists reduces allocation pressure without changing load balance semantics.</span></p><p cid="n78" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">This PR keeps the change local and conservative:</span></p><ul class="ul-list" cid="n79" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0.8em 0px; padding-left: 30px; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li class="md-list-item" cid="n80" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n81" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">No long-lived caches are introduced.</span></p></li><li class="md-list-item" cid="n82" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n83" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Existing selection algorithms are preserved.</span></p></li><li class="md-list-item" cid="n84" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n85" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Larger invoker lists continue to use heap-slice fallback paths.</span></p></li></ul><h2 cid="n86" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; white-space: pre-wrap; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.75em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.225; cursor: text; border-bottom: 1px solid rgb(238, 238, 238); caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-style: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Benchmark</span></h2><p cid="n87" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Benchmarks were measured on the same machine with Go 1.25.</span></p><p cid="n88" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Environment:</span></p><pre class="md-fences md-end-block ty-contain-cm modeLoaded" spellcheck="false" lang="text" cid="n89" mdtype="fences" style="box-sizing: border-box; overflow: visible; font-family: var(--monospace); font-size: 0.9em; display: block; break-inside: avoid; text-align: left; white-space: pre; background-image: inherit; background-position: inherit; background-size: inherit; background-repeat: inherit; background-attachment: inherit; background-origin: inherit; background-clip: inherit; background-color: rgb(248, 248, 248); position: relative; border: 1px solid rgb(231, 234, 237); border-radius: 3px; padding: 8px 4px 6px; margin-bottom: 15px; margin-top: 15px; width: inherit; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;">goos: darwin</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;">goarch: arm64</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;">cpu: Apple M5</span><br><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;">pkg: dubbo.apache.org/dubbo-go/v3/cluster/loadbalance</span></pre><p cid="n90" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Command:</span></p><pre class="md-fences md-end-block ty-contain-cm modeLoaded" spellcheck="false" lang="bash" cid="n91" mdtype="fences" style="box-sizing: border-box; overflow: visible; font-family: var(--monospace); font-size: 0.9em; display: block; break-inside: avoid; text-align: left; white-space: pre; background-image: inherit; background-position: inherit; background-size: inherit; background-repeat: inherit; background-attachment: inherit; background-origin: inherit; background-clip: inherit; background-color: rgb(248, 248, 248); position: relative; border: 1px solid rgb(231, 234, 237); border-radius: 3px; padding: 8px 4px 6px; margin-bottom: 15px; margin-top: 15px; width: inherit; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;">go test ./cluster/loadbalance <span class="cm-attribute" style="box-sizing: border-box; color: rgb(0, 0, 204);">-run</span> <span class="cm-string" style="box-sizing: border-box; color: rgb(170, 17, 17);">'^$'</span> <span class="cm-attribute" style="box-sizing: border-box; color: rgb(0, 0, 204);">-bench</span> <span class="cm-string" style="box-sizing: border-box; color: rgb(170, 17, 17);">'Benchmark(Random|Leastactive|AliasMethod)LoadbalanceSmallMedium'</span> <span class="cm-attribute" style="box-sizing: border-box; color: rgb(0, 0, 204);">-benchmem</span> <span class="cm-attribute" style="box-sizing: border-box; color: rgb(0, 0, 204);">-count</span><span class="cm-operator" style="box-sizing: border-box; color: rgb(152, 26, 26);">=</span><span class="cm-number" style="box-sizing: border-box; color: rgb(17, 102, 68);">10</span></span></pre><p cid="n92" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Summary of key allocation results:</span></p><figure class="md-table-fig table-figure" cid="n167" mdtype="table" style="box-sizing: border-box; margin: 1.2em 0px; overflow-x: auto; max-width: calc(100% + 16px); padding: 0px; cursor: default; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;">
Benchmark | B/op | Change | allocs/op | Change
-- | -- | -- | -- | --
Random/invokers=8/weighted | 832 -> 768 | -7.69% | 17 -> 16 | -5.88%
Random/invokers=16/weighted | 1.625Ki -> 1.500Ki | -7.69% | 33 -> 32 | -3.03%
Random/invokers=32/weighted | 3.250Ki -> 3.000Ki | -7.69% | 65 -> 64 | -1.54%
LeastActive/invokers=8/weighted | 1.625Ki -> 1.500Ki | -7.69% | 26 -> 24 | -7.69%
LeastActive/invokers=16/weighted | 3.250Ki -> 3.000Ki | -7.69% | 50 -> 48 | -4.00%
LeastActive/invokers=32/weighted | 6.500Ki -> 6.000Ki | -7.69% | 98 -> 96 | -2.04%
AliasMethod/invokers=8/weighted | 1152 -> 896 | -22.22% | 22 -> 18 | -18.18%
AliasMethod/invokers=16/weighted | 2.250Ki -> 1.750Ki | -22.22% | 38 -> 34 | -10.53%
AliasMethod/invokers=32/weighted | 4.500Ki -> 3.500Ki | -22.22% | 70 -> 66 | -5.71%

</figure><p cid="n228" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"></p><p cid="n240" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">The full benchmark matrix also covers </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">2</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">, </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">4</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">, and </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">33</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> invokers.</span></p><ul class="ul-list" cid="n233" mdtype="list" data-mark="-" style="box-sizing: border-box; margin: 0.8em 0px; padding-left: 30px; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><li class="md-list-item" cid="n234" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n235" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">2</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> and </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">4</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> are included to verify very small invoker lists; their allocation counts stay unchanged.</span></p></li><li class="md-list-item" cid="n236" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n237" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">33</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;"> is included to verify the heap fallback path above the stack-buffer threshold; its allocation counts also stay unchanged.</span></p></li><li class="md-list-item" cid="n238" mdtype="list_item" style="box-sizing: border-box; margin: 0px; position: relative;"><p cid="n239" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 1; margin: 0px 0px 0.5rem; white-space: pre-wrap; position: relative;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">The summary table focuses on </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">8</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">, </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">16</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">, and </span><span md-inline="code" spellcheck="false" class="md-pair-s" style="box-sizing: border-box;"><code style="box-sizing: border-box; font-family: var(--monospace); text-align: left; vertical-align: initial; border: 1px solid rgb(231, 234, 237); background-color: rgb(243, 244, 244); border-radius: 3px; padding: 0px 2px; font-size: 0.9em;">32</code></span><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">, where the stack-backed temporary buffers are used.</span></p></li></ul><p cid="n230" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"></p><h2 cid="n155" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; white-space: pre-wrap; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.75em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.225; cursor: text; border-bottom: 1px solid rgb(238, 238, 238); caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-style: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Test</span></h2><pre class="md-fences md-end-block ty-contain-cm modeLoaded" spellcheck="false" lang="bash" cid="n156" mdtype="fences" style="box-sizing: border-box; overflow: visible; font-family: var(--monospace); font-size: 0.9em; display: block; break-inside: avoid; text-align: left; white-space: pre; background-image: inherit; background-position: inherit; background-size: inherit; background-repeat: inherit; background-attachment: inherit; background-origin: inherit; background-clip: inherit; background-color: rgb(248, 248, 248); position: relative; border: 1px solid rgb(231, 234, 237); border-radius: 3px; padding: 8px 4px 6px; margin-bottom: 15px; margin-top: 15px; width: inherit; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span role="presentation" style="box-sizing: border-box; padding-right: 0.1px;"><span class="cm-def" style="box-sizing: border-box; color: rgb(0, 0, 255);">GOTOOLCHAIN</span><span class="cm-operator" style="box-sizing: border-box; color: rgb(152, 26, 26);">=</span>auto go test ./cluster/loadbalance/...</span></pre><p cid="n157" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Passed.</span></p><h2 cid="n158" mdtype="heading" class="md-end-block md-heading" style="box-sizing: border-box; white-space: pre-wrap; break-after: avoid-page; break-inside: avoid; orphans: 4; font-size: 1.75em; margin-top: 1rem; margin-bottom: 1rem; position: relative; font-weight: bold; line-height: 1.225; cursor: text; border-bottom: 1px solid rgb(238, 238, 238); caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-style: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Related issue</span></h2><p cid="n159" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><span md-inline="plain" class="md-plain" style="box-sizing: border-box;">Fixes #3407</span></p><p cid="n161" mdtype="paragraph" class="md-end-block md-p" style="box-sizing: border-box; line-height: inherit; orphans: 4; margin: 0.8em 0px; white-space: pre-wrap; position: relative; caret-color: rgb(0, 122, 255); color: rgb(51, 51, 51); font-family: &quot;Open Sans&quot;, &quot;Clear Sans&quot;, &quot;Helvetica Neue&quot;, Helvetica, Arial, &quot;Segoe UI Emoji&quot;, &quot;SF Pro&quot;, sans-serif; font-size: 16px; font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; background-color: rgb(255, 255, 255); text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"></p><br class="Apple-interchange-newline">