### PR TITLE
perf(triple): add fast paths for common content-type canonicalization

### DIFF
--- a/protocol/triple/triple_protocol/protocol.go
+++ b/protocol/triple/triple_protocol/protocol.go
@@ -335,19 +335,31 @@ func canonicalizeContentType(contentType string) string {
 	//
 	// See https://www.rfc-editor.org/rfc/rfc2045.html#section-5.1 for a full
 	// grammar.
-	var slashes int
-	for _, r := range contentType {
-		switch {
-		case r >= 'a' && r <= 'z':
-		case r == '.' || r == '+' || r == '-':
-		case r == '/':
-			slashes++
-		default:
-			return canonicalizeContentTypeSlow(contentType)
+	semi := strings.IndexByte(contentType, ';')
+	if semi < 0 {
+		if isSimpleMediaType(contentType) {
+			return contentType
 		}
+		return canonicalizeContentTypeSlow(contentType)
 	}
-	if slashes == 1 {
-		return contentType
+
+	// Fast path for a single "; charset=<token>" parameter, avoiding
+	// mime.ParseMediaType + mime.FormatMediaType for the common case of
+	// "application/json; charset=utf-8" and its uppercase variants.
+	base := contentType[:semi]
+	rest := contentType[semi+1:]
+	if isSimpleMediaType(base) && strings.IndexByte(rest, ';') < 0 {
+		const charsetParam = " charset="
+		if strings.HasPrefix(rest, charsetParam) {
+			val := rest[len(charsetParam):]
+			if isSimpleToken(val) {
+				lower := strings.ToLower(val)
+				if lower == val {
+					return contentType
+				}
+				return base + "; charset=" + lower
+			}
+		}
 	}
 	return canonicalizeContentTypeSlow(contentType)
 }
@@ -366,4 +378,42 @@ func canonicalizeContentTypeSlow(contentType string) string {
 		params["charset"] = strings.ToLower(charset)
 	}
 	return mime.FormatMediaType(base, params)
+}
+
+// isSimpleMediaType reports whether s is a well-formed, already-lowercase media
+// type without parameters: letters a-z, '.', '+', '-', exactly one '/'.
+func isSimpleMediaType(s string) bool {
+	slashes := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c == '.' || c == '+' || c == '-':
+		case c == '/':
+			slashes++
+		default:
+			return false
+		}
+	}
+	return slashes == 1
+}
+
+// isSimpleToken reports whether s is a non-empty MIME token composed of
+// letters, digits, '-', '_', and '.'.
+func isSimpleToken(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '-' || c == '_' || c == '.':
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/protocol/triple/triple_protocol/protocol.go
+++ b/protocol/triple/triple_protocol/protocol.go
@@ -329,39 +329,49 @@ func flushResponseWriter(w http.ResponseWriter) {
 }
 
 func canonicalizeContentType(contentType string) string {
-	// Typically, clients send Content-Type in canonical form, without
-	// parameters. In those cases, we'd like to avoid parsing and
-	// canonicalization overhead.
-	//
-	// See https://www.rfc-editor.org/rfc/rfc2045.html#section-5.1 for a full
-	// grammar.
-	semi := strings.IndexByte(contentType, ';')
-	if semi < 0 {
-		if isSimpleMediaType(contentType) {
-			return contentType
-		}
-		return canonicalizeContentTypeSlow(contentType)
-	}
-
-	// Fast path for a single "; charset=<token>" parameter, avoiding
-	// mime.ParseMediaType + mime.FormatMediaType for the common case of
-	// "application/json; charset=utf-8" and its uppercase variants.
-	base := contentType[:semi]
-	rest := contentType[semi+1:]
-	if isSimpleMediaType(base) && strings.IndexByte(rest, ';') < 0 {
-		const charsetParam = " charset="
-		if strings.HasPrefix(rest, charsetParam) {
-			val := rest[len(charsetParam):]
-			if isSimpleToken(val) {
-				lower := strings.ToLower(val)
-				if lower == val {
-					return contentType
-				}
-				return base + "; charset=" + lower
-			}
-		}
+	if canonical, ok := canonicalizeContentTypeFast(contentType); ok {
+		return canonical
 	}
 	return canonicalizeContentTypeSlow(contentType)
+}
+
+// canonicalizeContentTypeFast handles parameter-free types and the common
+// "; charset=<token>" case without invoking mime.ParseMediaType.
+// See https://www.rfc-editor.org/rfc/rfc2045.html#section-5.1 for a full grammar.
+func canonicalizeContentTypeFast(contentType string) (string, bool) {
+	semi := strings.IndexByte(contentType, ';')
+	if semi < 0 {
+		if isLowercaseMediaType(contentType) {
+			return contentType, true
+		}
+		return "", false
+	}
+
+	base := contentType[:semi]
+	param := contentType[semi+1:]
+
+	if !isLowercaseMediaType(base) {
+		return "", false
+	}
+	if strings.Contains(param, ";") {
+		return "", false
+	}
+
+	const prefix = " charset="
+	if !strings.HasPrefix(param, prefix) {
+		return "", false
+	}
+
+	charset := param[len(prefix):]
+	if !isSimpleCharsetToken(charset) {
+		return "", false
+	}
+
+	lower := strings.ToLower(charset)
+	if lower == charset {
+		return contentType, true
+	}
+	return base + "; charset=" + lower, true
 }
 
 func canonicalizeContentTypeSlow(contentType string) string {
@@ -380,28 +390,42 @@ func canonicalizeContentTypeSlow(contentType string) string {
 	return mime.FormatMediaType(base, params)
 }
 
-// isSimpleMediaType reports whether s is a well-formed, already-lowercase media
-// type without parameters: letters a-z, '.', '+', '-', exactly one '/'.
-func isSimpleMediaType(s string) bool {
-	slashes := 0
+// isLowercaseMediaType reports whether s is a well-formed, already-lowercase
+// media type: both type and subtype non-empty, separated by exactly one '/'.
+func isLowercaseMediaType(s string) bool {
+	slash := strings.IndexByte(s, '/')
+	if slash <= 0 || slash == len(s)-1 {
+		return false
+	}
+	if strings.IndexByte(s[slash+1:], '/') >= 0 {
+		return false
+	}
+	return isLowercaseToken(s[:slash]) && isLowercaseToken(s[slash+1:])
+}
+
+// isLowercaseToken reports whether s is a non-empty token of lowercase letters,
+// digits, '.', '+', and '-'.
+func isLowercaseToken(s string) bool {
+	if s == "" {
+		return false
+	}
 	for i := 0; i < len(s); i++ {
 		c := s[i]
 		switch {
 		case c >= 'a' && c <= 'z':
+		case c >= '0' && c <= '9':
 		case c == '.' || c == '+' || c == '-':
-		case c == '/':
-			slashes++
 		default:
 			return false
 		}
 	}
-	return slashes == 1
+	return true
 }
 
-// isSimpleToken reports whether s is a non-empty MIME token composed of
+// isSimpleCharsetToken reports whether s is a non-empty token composed of
 // letters, digits, '-', '_', and '.'.
-func isSimpleToken(s string) bool {
-	if len(s) == 0 {
+func isSimpleCharsetToken(s string) bool {
+	if s == "" {
 		return false
 	}
 	for i := 0; i < len(s); i++ {

--- a/protocol/triple/triple_protocol/protocol_test.go
+++ b/protocol/triple/triple_protocol/protocol_test.go
@@ -29,10 +29,14 @@ func TestCanonicalizeContentType(t *testing.T) {
 		arg  string
 		want string
 	}{
+		// slow path: base type needs case normalization
 		{name: "uppercase should be normalized", arg: "APPLICATION/json", want: "application/json"},
-		{name: "charset param should be treated as lowercase", arg: "application/json; charset=UTF-8", want: "application/json; charset=utf-8"},
-		{name: "non charset param should not be changed", arg: "multipart/form-data; boundary=fooBar", want: "multipart/form-data; boundary=fooBar"},
 		{name: "no parameters should be normalized", arg: "APPLICATION/json;  ", want: "application/json"},
+		// slow path: non-charset parameter
+		{name: "non charset param should not be changed", arg: "multipart/form-data; boundary=fooBar", want: "multipart/form-data; boundary=fooBar"},
+		// fast path: charset parameter normalization
+		{name: "charset param uppercase normalized via fast path", arg: "application/json; charset=UTF-8", want: "application/json; charset=utf-8"},
+		{name: "charset param already lowercase returned as-is", arg: "application/json; charset=utf-8", want: "application/json; charset=utf-8"},
 	}
 	for _, tt := range tests {
 		tt := tt
@@ -45,23 +49,30 @@ func TestCanonicalizeContentType(t *testing.T) {
 
 func BenchmarkCanonicalizeContentType(b *testing.B) {
 	b.Run("simple", func(b *testing.B) {
+		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			_ = canonicalizeContentType("application/json")
 		}
-		b.ReportAllocs()
 	})
 
-	b.Run("with charset", func(b *testing.B) {
+	b.Run("charset canonical", func(b *testing.B) {
+		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			_ = canonicalizeContentType("application/json; charset=utf-8")
 		}
-		b.ReportAllocs()
 	})
 
-	b.Run("with other param", func(b *testing.B) {
+	b.Run("charset uppercase", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = canonicalizeContentType("application/json; charset=UTF-8")
+		}
+	})
+
+	b.Run("non-charset param", func(b *testing.B) {
+		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
 			_ = canonicalizeContentType("application/json; foo=utf-8")
 		}
-		b.ReportAllocs()
 	})
 }

--- a/protocol/triple/triple_protocol/protocol_test.go
+++ b/protocol/triple/triple_protocol/protocol_test.go
@@ -37,6 +37,9 @@ func TestCanonicalizeContentType(t *testing.T) {
 		// fast path: charset parameter normalization
 		{name: "charset param uppercase normalized via fast path", arg: "application/json; charset=UTF-8", want: "application/json; charset=utf-8"},
 		{name: "charset param already lowercase returned as-is", arg: "application/json; charset=utf-8", want: "application/json; charset=utf-8"},
+		// malformed: must fall through to slow path unchanged (not rewritten by fast path)
+		{name: "malformed missing type", arg: "/json; charset=UTF-8", want: "/json; charset=UTF-8"},
+		{name: "malformed missing subtype", arg: "application/; charset=UTF-8", want: "application/; charset=UTF-8"},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
### Description
Fixes #3405 

Summary

  `canonicalizeContentType` already had a fast path for parameter-free types like `application/json`, but content types with ; `charset=utf-8` fell through to `mime.ParseMediaType + mime.FormatMediaType` on every
  request — allocating even when the value was already canonical.

  This PR adds a second fast path that handles the common case of a single ; `charset=<token>` parameter without invoking the MIME parser:
  - If the charset value is already lowercase, returns the original string unchanged (zero allocs).
  - If the charset value needs lowercasing (e.g. `UTF-8`), builds the result with a single string concat instead of going through the full parse/format cycle.
  - All other cases (non-charset params, multiple params, quoted values, malformed input) fall through to `canonicalizeContentTypeSlow` unchanged.
  
  Two helpers extracted from the inline logic: `isSimpleMediaType` (byte-loop, no allocs) and `isSimpleToken` (same).

  Changes

  - `protocol/triple/triple_protocol/protocol.go`: refactored fast path, added charset fast path, added isSimpleMediaType / isSimpleToken
  - `protocol/triple/triple_protocol/protocol_test.go`: added fast-path test cases; moved b.ReportAllocs() before loop; added charset canonical, charset uppercase, non-charset param sub-benchmarks


### Checklist
  - [x] go test ./protocol/triple/triple_protocol/ passes (528 tests)
  - [x] TestCanonicalizeContentType covers both fast-path and slow-path cases
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
