### PR TITLE
fix(router): avoid script process panic on invalid config

### DIFF
--- a/cluster/router/script/router.go
+++ b/cluster/router/script/router.go
@@ -70,6 +70,18 @@ func (s *ScriptRouter) Process(event *config_center.ConfigChangeEvent) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
+	if event.ConfigType == remoting.EventTypeDel {
+		in, _ := ins.GetInstances(s.scriptType)
+
+		if in != nil && s.enabled {
+			in.Destroy(s.rawScript)
+		}
+		s.enabled = false
+		s.rawScript = ""
+		s.scriptType = ""
+		return
+	}
+
 	rawConf, ok := event.Value.(string)
 	if !ok {
 		logger.Errorf("[Router][Script] route config value must be string, actualType=%T", event.Value)
@@ -129,15 +141,6 @@ func (s *ScriptRouter) Process(event *config_center.ConfigChangeEvent) {
 			}
 		}
 
-	case remoting.EventTypeDel:
-		in, _ := ins.GetInstances(s.scriptType)
-
-		if in != nil && s.enabled {
-			in.Destroy(s.rawScript)
-		}
-		s.enabled = false
-		s.rawScript = ""
-		s.scriptType = ""
 	}
 }
 

--- a/cluster/router/script/router.go
+++ b/cluster/router/script/router.go
@@ -72,7 +72,8 @@ func (s *ScriptRouter) Process(event *config_center.ConfigChangeEvent) {
 
 	rawConf, ok := event.Value.(string)
 	if !ok {
-		panic(ok)
+		logger.Errorf("[Router][Script] route config value must be string, actualType=%T", event.Value)
+		return
 	}
 	cfg, err := parseRoute(rawConf)
 	if err != nil {

--- a/cluster/router/script/router_test.go
+++ b/cluster/router/script/router_test.go
@@ -244,6 +244,7 @@ func TestScriptRouterProcessSkipsNonStringConfig(t *testing.T) {
 
 func TestScriptRouterProcessDelSkipsConfigBody(t *testing.T) {
 	s := &ScriptRouter{
+		enabled:    true,
 		scriptType: "javascript",
 		rawScript:  "old script",
 	}

--- a/cluster/router/script/router_test.go
+++ b/cluster/router/script/router_test.go
@@ -228,10 +228,28 @@ script: |
 }
 
 func TestScriptRouterProcessSkipsNonStringConfig(t *testing.T) {
-	s := &ScriptRouter{}
+	s := &ScriptRouter{
+		enabled:    true,
+		scriptType: "javascript",
+		rawScript:  "old script",
+	}
 
 	assert.NotPanics(t, func() {
 		s.Process(&config_center.ConfigChangeEvent{Key: "", Value: 123, ConfigType: remoting.EventTypeUpdate})
+	})
+	assert.True(t, s.enabled)
+	assert.Equal(t, "javascript", s.scriptType)
+	assert.Equal(t, "old script", s.rawScript)
+}
+
+func TestScriptRouterProcessDelSkipsConfigBody(t *testing.T) {
+	s := &ScriptRouter{
+		scriptType: "javascript",
+		rawScript:  "old script",
+	}
+
+	assert.NotPanics(t, func() {
+		s.Process(&config_center.ConfigChangeEvent{Key: "", Value: nil, ConfigType: remoting.EventTypeDel})
 	})
 	assert.False(t, s.enabled)
 	assert.Empty(t, s.scriptType)

--- a/cluster/router/script/router_test.go
+++ b/cluster/router/script/router_test.go
@@ -227,6 +227,17 @@ script: |
 	}
 }
 
+func TestScriptRouterProcessSkipsNonStringConfig(t *testing.T) {
+	s := &ScriptRouter{}
+
+	assert.NotPanics(t, func() {
+		s.Process(&config_center.ConfigChangeEvent{Key: "", Value: 123, ConfigType: remoting.EventTypeUpdate})
+	})
+	assert.False(t, s.enabled)
+	assert.Empty(t, s.scriptType)
+	assert.Empty(t, s.rawScript)
+}
+
 func checkInvokersSame(invokers []base.Invoker, otherInvokers []base.Invoker) bool {
 	k := map[string]struct{}{}
 	for _, invoker := range otherInvokers {


### PR DESCRIPTION
## What changed

- Make `ScriptRouter.Process` ignore non-string config-center payloads instead of panicking.
- Add a regression test for non-string config updates to keep the router disabled and unchanged.

## Why

Issue #3203 lists a router cleanup item to fix `ScriptRouter.Process()` panicking on failed type assertions. Config-center events should not crash the process when they carry an unexpected value type; the router can log and skip the invalid update instead.

## Validation

- `go test ./cluster/router/script`
- `go test ./cluster/router/...`
- `git diff --check`

Refs #3203.
