### PR TITLE
fix(triple): skip unsupported compat trailer attachments

### DIFF
--- a/protocol/triple/triple_protocol/handler_compat.go
+++ b/protocol/triple/triple_protocol/handler_compat.go
@@ -20,7 +20,6 @@ package triple_protocol
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 )
 
@@ -88,7 +87,7 @@ func (t *tripleCompatInterceptor) compatUnaryServerInterceptor(ctx context.Conte
 			case []string:
 				trailer[key] = valRaw
 			default:
-				panic(fmt.Sprintf("unsupported attachment value type %T", valRaw))
+				logger.Warnf("[Triple][Handler] procedure %s skips unsupported trailer attachment %s with value type %T", t.procedure, key, valRaw)
 			}
 		}
 		resp.trailer = trailer

--- a/protocol/triple/triple_protocol/handler_compat_test.go
+++ b/protocol/triple/triple_protocol/handler_compat_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/dubbogo/grpc-go/status"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 import (
@@ -53,17 +54,17 @@ func TestCompatUnaryServerInterceptorSkipsUnsupportedAttachmentValue(t *testing.
 		func(context.Context, any) (any, error) {
 			rpcResult := &result.RPCResult{Rest: "response"}
 			rpcResult.SetAttachments(map[string]any{
-				"string-value": "ok",
-				"list-value":   []string{"a", "b"},
-				"bool-value":   true,
+				"String-Value": "ok",
+				"List-Value":   []string{"a", "b"},
+				"Bool-Value":   true,
 			})
 			return rpcResult, nil
 		},
 	)
 
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	resp := respRaw.(*Response)
-	assert.Equal(t, []string{"ok"}, resp.Trailer()["string-value"])
-	assert.Equal(t, []string{"a", "b"}, resp.Trailer()["list-value"])
-	assert.Nil(t, resp.Trailer()["bool-value"])
+	assert.Equal(t, []string{"ok"}, resp.Trailer().Values("String-Value"))
+	assert.Equal(t, []string{"a", "b"}, resp.Trailer().Values("List-Value"))
+	assert.Empty(t, resp.Trailer().Values("Bool-Value"))
 }

--- a/protocol/triple/triple_protocol/handler_compat_test.go
+++ b/protocol/triple/triple_protocol/handler_compat_test.go
@@ -18,6 +18,7 @@
 package triple_protocol
 
 import (
+	"context"
 	"testing"
 )
 
@@ -26,6 +27,8 @@ import (
 	"github.com/dubbogo/grpc-go/status"
 
 	"github.com/stretchr/testify/assert"
+
+	"dubbo.apache.org/dubbo-go/v3/protocol/result"
 )
 
 func TestCompatError(t *testing.T) {
@@ -35,4 +38,30 @@ func TestCompatError(t *testing.T) {
 	assert.Equal(t, Code(1234), triErr.Code())
 	assert.Equal(t, "user defined", triErr.Message())
 	assert.Len(t, triErr.Details(), 1)
+}
+
+func TestCompatUnaryServerInterceptorSkipsUnsupportedAttachmentValue(t *testing.T) {
+	t.Parallel()
+
+	interceptor := &tripleCompatInterceptor{procedure: "test.Service/Method"}
+	respRaw, err := interceptor.compatUnaryServerInterceptor(
+		context.Background(),
+		"request",
+		nil,
+		func(context.Context, any) (any, error) {
+			rpcResult := &result.RPCResult{Rest: "response"}
+			rpcResult.SetAttachments(map[string]any{
+				"string-value": "ok",
+				"list-value":   []string{"a", "b"},
+				"bool-value":   true,
+			})
+			return rpcResult, nil
+		},
+	)
+
+	assert.Nil(t, err)
+	resp := respRaw.(*Response)
+	assert.Equal(t, []string{"ok"}, resp.Trailer()["string-value"])
+	assert.Equal(t, []string{"a", "b"}, resp.Trailer()["list-value"])
+	assert.Nil(t, resp.Trailer()["bool-value"])
 }

--- a/protocol/triple/triple_protocol/handler_compat_test.go
+++ b/protocol/triple/triple_protocol/handler_compat_test.go
@@ -27,7 +27,9 @@ import (
 	"github.com/dubbogo/grpc-go/status"
 
 	"github.com/stretchr/testify/assert"
+)
 
+import (
 	"dubbo.apache.org/dubbo-go/v3/protocol/result"
 )
 


### PR DESCRIPTION
## What
- Skip old triple compat response attachments that cannot be represented as HTTP trailer values.
- Keep string and []string attachments unchanged.
- Add a regression test for bool attachment values.

## Why
Issue #3093 reported that the old triple compat unary handler can panic when provider filters add internal attachments such as bool values. Those values should not fail the RPC response path just because they cannot be written as HTTP trailers.

## Validation
- go test ./protocol/triple/triple_protocol
- go test ./protocol/triple/...
- git diff --check

Refs #3093
