### PR TITLE
feat(registry): support etcdv3 unsubscribe recovery

### DIFF
--- a/registry/etcdv3/listener.go
+++ b/registry/etcdv3/listener.go
@@ -31,66 +31,120 @@ import (
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/config_center"
 	"dubbo.apache.org/dubbo-go/v3/registry"
 	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
 
 type dataListener struct {
-	interestedURL []*common.URL
-	listener      config_center.ConfigurationListener
+	subscribed map[string]config_center.ConfigurationListener
+	mutex      sync.Mutex
+	closed     bool
 }
 
 // NewRegistryDataListener creates a data listener for etcd
-func NewRegistryDataListener(listener config_center.ConfigurationListener) *dataListener {
-	return &dataListener{listener: listener}
+func NewRegistryDataListener() *dataListener {
+	return &dataListener{
+		subscribed: make(map[string]config_center.ConfigurationListener),
+	}
 }
 
-// AddInterestedURL adds a registration @url to listen
-func (l *dataListener) AddInterestedURL(url *common.URL) {
-	l.interestedURL = append(l.interestedURL, url)
+// SubscribeURL registers a listener for url updates.
+func (l *dataListener) SubscribeURL(url *common.URL, listener config_center.ConfigurationListener) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	if l.closed {
+		return
+	}
+	l.subscribed[url.ServiceKey()] = listener
+}
+
+// UnSubscribeURL removes and closes the listener for url updates.
+func (l *dataListener) UnSubscribeURL(url *common.URL) config_center.ConfigurationListener {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	if l.closed {
+		return nil
+	}
+	listener := l.subscribed[url.ServiceKey()]
+	if listener == nil {
+		return nil
+	}
+	if regListener, ok := listener.(*configurationListener); ok {
+		regListener.Close()
+	}
+	delete(l.subscribed, url.ServiceKey())
+	return listener
 }
 
 // DataChange processes the data change event from registry center of etcd
 func (l *dataListener) DataChange(eventType remoting.Event) bool {
-	index := strings.Index(eventType.Path, "/providers/")
+	providersPath := constant.PathSeparator + constant.ProviderCategory + constant.PathSeparator
+	index := strings.Index(eventType.Path, providersPath)
 	if index == -1 {
 		logger.Warnf("[Registry][Etcdv3] listen with no url, event.path=%v", eventType.Path)
 		return false
 	}
-	url := eventType.Path[index+len("/providers/"):]
+	url := eventType.Path[index+len(providersPath):]
 	serviceURL, err := common.NewURL(url)
 	if err != nil {
 		logger.Warnf("[Registry][Etcdv3] listen NewURL, path=%s err=%v", eventType.Path, err)
 		return false
 	}
 
-	for _, v := range l.interestedURL {
-		if serviceURL.URLEqual(v) {
-			l.listener.Process(
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	if l.closed {
+		return false
+	}
+	match := false
+	for serviceKey, listener := range l.subscribed {
+		intf, group, version := common.ParseServiceKey(serviceKey)
+		if serviceURL.ServiceKey() == serviceKey || common.IsAnyCondition(intf, group, version, serviceURL) {
+			listener.Process(
 				&config_center.ConfigChangeEvent{
 					Key:        eventType.Path,
-					Value:      serviceURL,
+					Value:      serviceURL.Clone(),
 					ConfigType: eventType.Action,
 				},
 			)
-			return true
+			match = true
 		}
 	}
-	return false
+	return match
+}
+
+// Close closes all subscribed configuration listeners.
+func (l *dataListener) Close() {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	l.closed = true
+	for _, listener := range l.subscribed {
+		if regListener, ok := listener.(*configurationListener); ok {
+			regListener.Close()
+		}
+	}
 }
 
 type configurationListener struct {
-	registry  *etcdV3Registry
-	events    *gxchan.UnboundedChan
-	closeOnce sync.Once
+	registry     *etcdV3Registry
+	events       *gxchan.UnboundedChan
+	close        chan struct{}
+	closeOnce    sync.Once
+	subscribeURL *common.URL
 }
 
 // NewConfigurationListener for listening the event of etcdv3.
-func NewConfigurationListener(reg *etcdV3Registry) *configurationListener {
+func NewConfigurationListener(reg *etcdV3Registry, conf *common.URL) *configurationListener {
 	// add a new waiter
 	reg.WaitGroup().Add(1)
-	return &configurationListener{registry: reg, events: gxchan.NewUnboundedChan(32)}
+	return &configurationListener{
+		registry:     reg,
+		events:       gxchan.NewUnboundedChan(32),
+		close:        make(chan struct{}, 1),
+		subscribeURL: conf,
+	}
 }
 
 // Process data change event from config center of etcd
@@ -102,6 +156,8 @@ func (l *configurationListener) Process(configType *config_center.ConfigChangeEv
 func (l *configurationListener) Next() (*registry.ServiceEvent, error) {
 	for {
 		select {
+		case <-l.close:
+			return nil, perrors.New("listener has been closed")
 		case <-l.registry.Done():
 			logger.Warn("[Registry][Etcdv3] listener's etcd client connection is broken, so etcd event listener exit now")
 			return nil, perrors.New("listener stopped")
@@ -125,6 +181,7 @@ func (l *configurationListener) Next() (*registry.ServiceEvent, error) {
 // Close etcd registry center
 func (l *configurationListener) Close() {
 	l.closeOnce.Do(func() {
+		l.close <- struct{}{}
 		l.registry.WaitGroup().Done()
 	})
 }

--- a/registry/etcdv3/listener_test.go
+++ b/registry/etcdv3/listener_test.go
@@ -18,12 +18,111 @@
 package etcdv3
 
 import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/config_center"
+	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
 
-type MockDataListener struct{}
+type MockDataListener struct {
+	events []*config_center.ConfigChangeEvent
+}
 
-func (*MockDataListener) Process(configType *config_center.ConfigChangeEvent) {}
+func (m *MockDataListener) Process(configType *config_center.ConfigChangeEvent) {
+	m.events = append(m.events, configType)
+}
+
+func TestDataListenerDataChangeDispatchesMatchingService(t *testing.T) {
+	subscribeURL, err := common.NewURL("consumer://127.0.0.1:20000/org.apache.DemoService?group=g&version=1.0.0")
+	require.NoError(t, err)
+	providerURL, err := common.NewURL("dubbo://127.0.0.1:20001/org.apache.DemoService?group=g&version=1.0.0")
+	require.NoError(t, err)
+	listener := &MockDataListener{}
+	dataListener := NewRegistryDataListener()
+	dataListener.SubscribeURL(subscribeURL, listener)
+
+	matched := dataListener.DataChange(remoting.Event{
+		Path:   "/dubbo/org.apache.DemoService/providers/" + providerURL.String(),
+		Action: remoting.EventTypeAdd,
+	})
+
+	require.True(t, matched)
+	require.Len(t, listener.events, 1)
+	assert.Equal(t, remoting.EventTypeAdd, listener.events[0].ConfigType)
+	assert.Equal(t, providerURL.String(), listener.events[0].Value.(*common.URL).String())
+}
+
+func TestDataListenerDataChangeIgnoresUnmatchedService(t *testing.T) {
+	subscribeURL, err := common.NewURL("consumer://127.0.0.1:20000/org.apache.OtherService")
+	require.NoError(t, err)
+	providerURL, err := common.NewURL("dubbo://127.0.0.1:20001/org.apache.DemoService")
+	require.NoError(t, err)
+	listener := &MockDataListener{}
+	dataListener := NewRegistryDataListener()
+	dataListener.SubscribeURL(subscribeURL, listener)
+
+	matched := dataListener.DataChange(remoting.Event{
+		Path:   "/dubbo/org.apache.DemoService/providers/" + providerURL.String(),
+		Action: remoting.EventTypeAdd,
+	})
+
+	assert.False(t, matched)
+	assert.Empty(t, listener.events)
+}
+
+func TestDataListenerUnSubscribeStopsDispatch(t *testing.T) {
+	serviceURL, err := common.NewURL("consumer://127.0.0.1:20000/org.apache.DemoService")
+	require.NoError(t, err)
+	listener := &MockDataListener{}
+	dataListener := NewRegistryDataListener()
+	dataListener.SubscribeURL(serviceURL, listener)
+
+	removed := dataListener.UnSubscribeURL(serviceURL)
+	require.Same(t, listener, removed)
+	assert.Empty(t, dataListener.subscribed)
+}
+
+func TestDataListenerCloseStopsDispatch(t *testing.T) {
+	serviceURL, err := common.NewURL("consumer://127.0.0.1:20000/org.apache.DemoService")
+	require.NoError(t, err)
+	listener := &MockDataListener{}
+	dataListener := NewRegistryDataListener()
+	dataListener.SubscribeURL(serviceURL, listener)
+
+	dataListener.Close()
+	dataListener.SubscribeURL(serviceURL, listener)
+	removed := dataListener.UnSubscribeURL(serviceURL)
+
+	assert.Nil(t, removed)
+	assert.False(t, dataListener.DataChange(remoting.Event{
+		Path:   "/dubbo/org.apache.DemoService/providers/" + serviceURL.String(),
+		Action: remoting.EventTypeAdd,
+	}))
+	assert.Empty(t, listener.events)
+}
+
+func TestConfigurationListenerProcessAndNext(t *testing.T) {
+	reg := newTestRegistry(t)
+	serviceURL, err := common.NewURL("dubbo://127.0.0.1:20000/org.apache.DemoService")
+	require.NoError(t, err)
+	listener := NewConfigurationListener(reg, serviceURL)
+	defer listener.Close()
+
+	listener.Process(&config_center.ConfigChangeEvent{
+		Key:        "key",
+		Value:      serviceURL,
+		ConfigType: remoting.EventTypeAdd,
+	})
+
+	event, err := listener.Next()
+	require.NoError(t, err)
+	assert.Equal(t, remoting.EventTypeAdd, event.Action)
+	assert.Same(t, serviceURL, event.Service)
+}
 
 /*
 func Test_dataListener_DataChange(t *testing.T) {

--- a/registry/etcdv3/registry.go
+++ b/registry/etcdv3/registry.go
@@ -43,18 +43,29 @@ const (
 	Name = "etcdv3"
 )
 
+var (
+	etcdClientValid = func(client *gxetcd.Client) bool {
+		return client.Valid()
+	}
+	etcdClientDelete = func(client *gxetcd.Client, key string) error {
+		return client.Delete(key)
+	}
+	listenEtcdServiceEvent = func(listener *etcdv3.EventListener, key string, dataListener *dataListener) {
+		listener.ListenServiceEvent(key, dataListener)
+	}
+)
+
 func init() {
 	extension.SetRegistry(Name, newETCDV3Registry)
 }
 
 type etcdV3Registry struct {
 	registry.BaseRegistry
-	cltLock        sync.Mutex
-	client         *gxetcd.Client
-	listenerLock   sync.RWMutex
-	listener       *etcdv3.EventListener
-	dataListener   *dataListener
-	configListener *configurationListener
+	cltLock      sync.Mutex
+	client       *gxetcd.Client
+	listenerLock sync.RWMutex
+	listener     *etcdv3.EventListener
+	dataListener *dataListener
 }
 
 // Client gets the etcdv3 client
@@ -99,8 +110,24 @@ func newETCDV3Registry(url *common.URL) (registry.Registry, error) {
 // InitListeners init listeners of etcd registry center
 func (r *etcdV3Registry) InitListeners() {
 	r.listener = etcdv3.NewEventListener(r.client)
-	r.configListener = NewConfigurationListener(r)
-	r.dataListener = NewRegistryDataListener(r.configListener)
+	newDataListener := NewRegistryDataListener()
+	if r.dataListener != nil {
+		oldDataListener := r.dataListener
+		oldDataListener.mutex.Lock()
+		defer oldDataListener.mutex.Unlock()
+		oldDataListener.closed = true
+		for _, oldListener := range oldDataListener.subscribed {
+			regConfigListener, ok := oldListener.(*configurationListener)
+			if !ok {
+				continue
+			}
+			regConfigListener.Close()
+			newConfigListener := NewConfigurationListener(r, regConfigListener.subscribeURL)
+			newDataListener.SubscribeURL(regConfigListener.subscribeURL, newConfigListener)
+			go listenEtcdServiceEvent(r.listener, fmt.Sprintf("/dubbo/%s/"+constant.DefaultCategory, regConfigListener.subscribeURL.Service()), newDataListener)
+		}
+	}
+	r.dataListener = newDataListener
 }
 
 // DoRegister actually do the register job in the registry center of etcd
@@ -109,9 +136,13 @@ func (r *etcdV3Registry) DoRegister(root string, node string) error {
 	return r.client.RegisterTemp(path.Join(root, node), "")
 }
 
-// DoUnregister is not supported in etcdV3Registry.
 func (r *etcdV3Registry) DoUnregister(root string, node string) error {
-	return perrors.New("DoUnregister is not support in etcdV3Registry")
+	r.cltLock.Lock()
+	defer r.cltLock.Unlock()
+	if r.client == nil || !etcdClientValid(r.client) {
+		return perrors.New("etcd client is not valid")
+	}
+	return etcdClientDelete(r.client, path.Join(root, node))
 }
 
 // CloseAndNilClient closes listeners and clear client
@@ -122,8 +153,8 @@ func (r *etcdV3Registry) CloseAndNilClient() {
 
 // CloseListener closes listeners
 func (r *etcdV3Registry) CloseListener() {
-	if r.configListener != nil {
-		r.configListener.Close()
+	if r.dataListener != nil {
+		r.dataListener.Close()
 	}
 }
 
@@ -142,9 +173,6 @@ func (r *etcdV3Registry) CreatePath(k string) error {
 
 // DoSubscribe actually subscribe the provider URL
 func (r *etcdV3Registry) DoSubscribe(svc *common.URL) (registry.Listener, error) {
-	r.listenerLock.RLock()
-	configListener := r.configListener
-	r.listenerLock.RUnlock()
 	if r.listener == nil {
 		r.cltLock.Lock()
 		client := r.client
@@ -157,15 +185,26 @@ func (r *etcdV3Registry) DoSubscribe(svc *common.URL) (registry.Listener, error)
 		r.listenerLock.Unlock()
 	}
 
-	// register the svc to dataListener
-	r.dataListener.AddInterestedURL(svc)
-	go r.listener.ListenServiceEvent(fmt.Sprintf("/dubbo/%s/"+constant.DefaultCategory, svc.Service()), r.dataListener)
+	configListener := NewConfigurationListener(r, svc)
+	r.dataListener.SubscribeURL(svc, configListener)
+	go listenEtcdServiceEvent(r.listener, fmt.Sprintf("/dubbo/%s/"+constant.DefaultCategory, svc.Service()), r.dataListener)
 
 	return configListener, nil
 }
 
 func (r *etcdV3Registry) DoUnsubscribe(conf *common.URL) (registry.Listener, error) {
-	return nil, perrors.New("DoUnsubscribe is not support in etcdV3Registry")
+	if r.dataListener == nil {
+		return nil, nil
+	}
+	listener := r.dataListener.UnSubscribeURL(conf)
+	if listener == nil {
+		return nil, nil
+	}
+	regListener, ok := listener.(*configurationListener)
+	if !ok {
+		return nil, nil
+	}
+	return regListener, nil
 }
 
 // LoadSubscribeInstances load subscribe instance

--- a/registry/etcdv3/registry_test.go
+++ b/registry/etcdv3/registry_test.go
@@ -18,105 +18,236 @@
 // Package etcdv3 contains tests for etcdv3 registry components.
 package etcdv3
 
-/*
 import (
-	"reflect"
-	"sync"
+	"errors"
+	"path"
 	"testing"
+	"time"
 )
 
 import (
-	"github.com/agiledragon/gomonkey"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	gxetcd "github.com/dubbogo/gost/database/kv/etcd/v3"
 )
 
 import (
-	"dubbo.apache.org/dubbo-go/v3/registry"
-	"dubbo.apache.org/dubbo-go/v3/remoting"
+	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/remoting/etcdv3"
 )
 
-type fields struct {
-	BaseRegistry   registry.BaseRegistry
-	cltLock        sync.Mutex
-	client         *gxetcd.Client
-	listenerLock   sync.RWMutex
-	listener       *etcdv3.EventListener
-	dataListener   *dataListener
-	configListener *configurationListener
-}
-type args struct {
-	root      string
-	node      string
-	eventType remoting.Event
+func newTestRegistry(t *testing.T) *etcdV3Registry {
+	t.Helper()
+	registryURL, err := common.NewURL("registry://127.0.0.1:2379")
+	require.NoError(t, err)
+	reg := &etcdV3Registry{}
+	reg.InitBaseRegistry(registryURL, reg)
+	reg.dataListener = NewRegistryDataListener()
+	reg.listener = etcdv3.NewEventListener(nil)
+	return reg
 }
 
-func newEtcdV3Registry(f fields) *etcdV3Registry {
-	return &etcdV3Registry{
-		client:         f.client,
-		listener:       f.listener,
-		dataListener:   f.dataListener,
-		configListener: f.configListener,
+func newTestServiceURL(t *testing.T, rawURL string) *common.URL {
+	t.Helper()
+	serviceURL, err := common.NewURL(rawURL)
+	require.NoError(t, err)
+	return serviceURL
+}
+
+func TestEtcdV3RegistryDoUnregisterDeletesNode(t *testing.T) {
+	client := &gxetcd.Client{}
+	reg := newTestRegistry(t)
+	reg.client = client
+
+	oldValid := etcdClientValid
+	oldDelete := etcdClientDelete
+	defer func() {
+		etcdClientValid = oldValid
+		etcdClientDelete = oldDelete
+	}()
+
+	var deletedKey string
+	etcdClientValid = func(got *gxetcd.Client) bool {
+		assert.Same(t, client, got)
+		return true
 	}
-}
-
-func Test_etcdV3Registry_DoRegister(t *testing.T) {
-	var client *gxetcd.Client
-	patches := gomonkey.NewPatches()
-	patches = patches.ApplyMethod(reflect.TypeOf(client), "RegisterTemp", func(_ *gxetcd.Client, k, v string) error {
+	etcdClientDelete = func(got *gxetcd.Client, key string) error {
+		assert.Same(t, client, got)
+		deletedKey = key
 		return nil
-	})
-	defer patches.Reset()
+	}
 
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-	}{
-		{
-			name: "test",
-			fields: fields{
-				client: client,
-			},
-			args: args{
-				root: "/dubbo",
-				node: "/go",
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r := newEtcdV3Registry(tt.fields)
-			if err := r.DoRegister(tt.args.root, tt.args.node); (err != nil) != tt.wantErr {
-				t.Errorf("DoRegister() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
+	err := reg.DoUnregister("/dubbo/org.apache.DemoService/providers", "dubbo://127.0.0.1:20000/org.apache.DemoService")
+	require.NoError(t, err)
+	assert.Equal(t, path.Join("/dubbo/org.apache.DemoService/providers", "dubbo://127.0.0.1:20000/org.apache.DemoService"), deletedKey)
 }
 
-func Test_etcdV3Registry_DoUnregister(t *testing.T) {
-	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-	}{
-		{
-			name:    "test",
-			wantErr: true,
-		},
+func TestEtcdV3RegistryDoUnregisterRequiresValidClient(t *testing.T) {
+	reg := newTestRegistry(t)
+	reg.client = &gxetcd.Client{}
+
+	oldValid := etcdClientValid
+	defer func() {
+		etcdClientValid = oldValid
+	}()
+	etcdClientValid = func(*gxetcd.Client) bool {
+		return false
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			r := newEtcdV3Registry(tt.fields)
-			if err := r.DoUnregister(tt.args.root, tt.args.node); (err != nil) != tt.wantErr {
-				t.Errorf("DoUnregister() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
+
+	err := reg.DoUnregister("/dubbo", "node")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "etcd client is not valid")
 }
 
-*/
+func TestEtcdV3RegistryDoUnregisterPropagatesDeleteError(t *testing.T) {
+	reg := newTestRegistry(t)
+	reg.client = &gxetcd.Client{}
+	deleteErr := errors.New("delete failed")
+
+	oldValid := etcdClientValid
+	oldDelete := etcdClientDelete
+	defer func() {
+		etcdClientValid = oldValid
+		etcdClientDelete = oldDelete
+	}()
+	etcdClientValid = func(*gxetcd.Client) bool {
+		return true
+	}
+	etcdClientDelete = func(*gxetcd.Client, string) error {
+		return deleteErr
+	}
+
+	err := reg.DoUnregister("/dubbo", "node")
+	require.ErrorIs(t, err, deleteErr)
+}
+
+func TestEtcdV3RegistryDoUnsubscribeRemovesListener(t *testing.T) {
+	reg := newTestRegistry(t)
+	serviceURL := newTestServiceURL(t, "dubbo://127.0.0.1:20000/org.apache.DemoService?group=g&version=1.0.0")
+	configListener := NewConfigurationListener(reg, serviceURL)
+	reg.dataListener.SubscribeURL(serviceURL, configListener)
+
+	listener, err := reg.DoUnsubscribe(serviceURL)
+	require.NoError(t, err)
+	assert.Same(t, configListener, listener)
+	assert.Empty(t, reg.dataListener.subscribed)
+
+	_, err = configListener.Next()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listener has been closed")
+}
+
+func TestEtcdV3RegistryDoUnsubscribeMissingListener(t *testing.T) {
+	reg := newTestRegistry(t)
+	serviceURL := newTestServiceURL(t, "dubbo://127.0.0.1:20000/org.apache.DemoService")
+
+	listener, err := reg.DoUnsubscribe(serviceURL)
+	require.NoError(t, err)
+	assert.Nil(t, listener)
+}
+
+func TestEtcdV3RegistryDoSubscribeRegistersListener(t *testing.T) {
+	reg := newTestRegistry(t)
+	serviceURL := newTestServiceURL(t, "dubbo://127.0.0.1:20000/org.apache.DemoService?group=g&version=1.0.0")
+
+	oldListen := listenEtcdServiceEvent
+	defer func() {
+		listenEtcdServiceEvent = oldListen
+	}()
+
+	listened := make(chan string, 1)
+	listenEtcdServiceEvent = func(_ *etcdv3.EventListener, key string, _ *dataListener) {
+		listened <- key
+	}
+
+	listener, err := reg.DoSubscribe(serviceURL)
+	require.NoError(t, err)
+	require.NotNil(t, listener)
+
+	select {
+	case key := <-listened:
+		assert.Equal(t, "/dubbo/org.apache.DemoService/providers", key)
+	case <-time.After(time.Second):
+		t.Fatal("expected subscription to start listening")
+	}
+	assert.Same(t, listener, reg.dataListener.subscribed[serviceURL.ServiceKey()])
+	listener.Close()
+}
+
+func TestEtcdV3RegistryDoSubscribeRebuildsMissingEventListener(t *testing.T) {
+	reg := newTestRegistry(t)
+	reg.listener = nil
+	reg.client = &gxetcd.Client{}
+	serviceURL := newTestServiceURL(t, "dubbo://127.0.0.1:20000/org.apache.DemoService")
+
+	oldListen := listenEtcdServiceEvent
+	defer func() {
+		listenEtcdServiceEvent = oldListen
+	}()
+	listenEtcdServiceEvent = func(_ *etcdv3.EventListener, _ string, _ *dataListener) {}
+
+	listener, err := reg.DoSubscribe(serviceURL)
+	require.NoError(t, err)
+	require.NotNil(t, listener)
+	assert.NotNil(t, reg.listener)
+	listener.Close()
+}
+
+func TestEtcdV3RegistryDoSubscribeFailsWithMissingClient(t *testing.T) {
+	reg := newTestRegistry(t)
+	reg.listener = nil
+	reg.client = nil
+	serviceURL := newTestServiceURL(t, "dubbo://127.0.0.1:20000/org.apache.DemoService")
+
+	listener, err := reg.DoSubscribe(serviceURL)
+	require.Error(t, err)
+	assert.Nil(t, listener)
+	assert.Contains(t, err.Error(), "etcd client broken")
+}
+
+func TestEtcdV3RegistryCloseListenerClosesDataListener(t *testing.T) {
+	reg := newTestRegistry(t)
+	serviceURL := newTestServiceURL(t, "dubbo://127.0.0.1:20000/org.apache.DemoService")
+	configListener := NewConfigurationListener(reg, serviceURL)
+	reg.dataListener.SubscribeURL(serviceURL, configListener)
+
+	reg.CloseListener()
+
+	assert.True(t, reg.dataListener.closed)
+	_, err := configListener.Next()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listener has been closed")
+}
+
+func TestEtcdV3RegistryInitListenersRecoversSubscriptions(t *testing.T) {
+	reg := newTestRegistry(t)
+	serviceURL := newTestServiceURL(t, "dubbo://127.0.0.1:20000/org.apache.DemoService?group=g&version=1.0.0")
+	oldConfigListener := NewConfigurationListener(reg, serviceURL)
+	reg.dataListener.SubscribeURL(serviceURL, oldConfigListener)
+
+	oldListen := listenEtcdServiceEvent
+	defer func() {
+		listenEtcdServiceEvent = oldListen
+	}()
+
+	listened := make(chan string, 1)
+	listenEtcdServiceEvent = func(_ *etcdv3.EventListener, key string, _ *dataListener) {
+		listened <- key
+	}
+
+	reg.InitListeners()
+
+	select {
+	case key := <-listened:
+		assert.Equal(t, "/dubbo/org.apache.DemoService/providers", key)
+	case <-time.After(time.Second):
+		t.Fatal("expected recovered subscription to restart listening")
+	}
+	assert.NotNil(t, reg.dataListener.subscribed[serviceURL.ServiceKey()])
+	assert.False(t, reg.dataListener.closed)
+
+	_, err := oldConfigListener.Next()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "listener has been closed")
+}


### PR DESCRIPTION
## Summary
- implement etcdv3 DoUnregister by deleting the registered etcd key after client validation
- track etcdv3 subscriptions per service key so DoUnsubscribe can remove and close the matching listener
- recover active etcdv3 subscriptions when InitListeners rebuilds listeners after reconnect
- restore and extend etcdv3 registry/listener unit tests

Fixes #3366

## Tests
- go test ./registry/etcdv3
- go test ./registry/etcdv3 ./registry/...
- golangci-lint run ./registry/etcdv3 --timeout=5m
- git diff --check