### PR TITLE
refactor(config): move config reader interface

### DIFF
--- a/common/config/config_reader.go
+++ b/common/config/config_reader.go
@@ -15,13 +15,13 @@
  * limitations under the License.
  */
 
-package interfaces
+package config
 
 import (
 	"bytes"
 )
 
-// ConfigReader is used to read config from consumer or provider
+// ConfigReader is used to read config from consumer or provider.
 type ConfigReader interface {
 	ReadConsumerConfig(reader *bytes.Buffer) error
 	ReadProviderConfig(reader *bytes.Buffer) error

--- a/common/extension/config_reader.go
+++ b/common/extension/config_reader.go
@@ -18,21 +18,21 @@
 package extension
 
 import (
-	"dubbo.apache.org/dubbo-go/v3/config/interfaces"
+	commonCfg "dubbo.apache.org/dubbo-go/v3/common/config"
 )
 
 var (
-	configReaders = NewRegistry[func() interfaces.ConfigReader]("config reader")
+	configReaders = NewRegistry[func() commonCfg.ConfigReader]("config reader")
 	defaults      = NewRegistry[string]("default config reader")
 )
 
 // SetConfigReaders sets a creator of config reader with @name
-func SetConfigReaders(name string, v func() interfaces.ConfigReader) {
+func SetConfigReaders(name string, v func() commonCfg.ConfigReader) {
 	configReaders.Register(name, v)
 }
 
 // GetConfigReaders gets a config reader with @name
-func GetConfigReaders(name string) interfaces.ConfigReader {
+func GetConfigReaders(name string) commonCfg.ConfigReader {
 	return configReaders.MustGet(name)()
 }
 

--- a/common/extension/config_reader_test.go
+++ b/common/extension/config_reader_test.go
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package extension
+
+import (
+	"bytes"
+	"testing"
+)
+
+import (
+	commonCfg "dubbo.apache.org/dubbo-go/v3/common/config"
+)
+
+type testConfigReader struct{}
+
+func (*testConfigReader) ReadConsumerConfig(*bytes.Buffer) error {
+	return nil
+}
+
+func (*testConfigReader) ReadProviderConfig(*bytes.Buffer) error {
+	return nil
+}
+
+func TestConfigReaderRegistry(t *testing.T) {
+	t.Cleanup(func() {
+		configReaders.Unregister("config-reader-test")
+		defaults.Unregister("config-reader-module")
+	})
+
+	SetConfigReaders("config-reader-test", func() commonCfg.ConfigReader {
+		return &testConfigReader{}
+	})
+	SetDefaultConfigReader("config-reader-module", "config-reader-test")
+
+	if _, ok := GetConfigReaders("config-reader-test").(*testConfigReader); !ok {
+		t.Fatal("expected registered config reader")
+	}
+	if got := GetDefaultConfigReader()["config-reader-module"]; got != "config-reader-test" {
+		t.Fatalf("expected default config reader, got %q", got)
+	}
+}

--- a/protocol/rest/config/reader/rest_config_reader.go
+++ b/protocol/rest/config/reader/rest_config_reader.go
@@ -32,9 +32,9 @@ import (
 )
 
 import (
+	commonCfg "dubbo.apache.org/dubbo-go/v3/common/config"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
-	"dubbo.apache.org/dubbo-go/v3/config/interfaces"
 	"dubbo.apache.org/dubbo-go/v3/protocol/rest/config"
 )
 
@@ -45,7 +45,7 @@ func init() {
 
 type RestConfigReader struct{}
 
-func NewRestConfigReader() interfaces.ConfigReader {
+func NewRestConfigReader() commonCfg.ConfigReader {
 	return &RestConfigReader{}
 }
 


### PR DESCRIPTION
## Summary
- move the remaining ConfigReader interface from legacy config/interfaces to common/config
- update config reader registry APIs to use common/config.ConfigReader
- update the REST config reader to implement the migrated interface

Part of #3329

## Tests
- go test ./common/config ./common/extension ./protocol/rest/config/reader ./protocol/rest/...
- golangci-lint run ./common/config ./common/extension ./protocol/rest/config/reader --timeout=5m
- git diff --check