### PR TITLE
refactor(graceful): move shutdown setter interface

### DIFF
--- a/config/graceful_shutdown.go
+++ b/config/graceful_shutdown.go
@@ -32,6 +32,7 @@ import (
 import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
+	gracefulshutdown "dubbo.apache.org/dubbo-go/v3/graceful_shutdown"
 )
 
 /*
@@ -64,11 +65,11 @@ func gracefulShutdownInit() {
 		return
 	}
 	rc := GetRootConfig()
-	if filter, ok := gracefulShutdownConsumerFilter.(Setter); ok && rc != nil && rc.Shutdown != nil {
+	if filter, ok := gracefulShutdownConsumerFilter.(gracefulshutdown.Setter); ok && rc != nil && rc.Shutdown != nil {
 		filter.Set(constant.GracefulShutdownFilterShutdownConfig, GetShutDown())
 	}
 
-	if filter, ok := gracefulShutdownProviderFilter.(Setter); ok && rc != nil && rc.Shutdown != nil {
+	if filter, ok := gracefulShutdownProviderFilter.(gracefulshutdown.Setter); ok && rc != nil && rc.Shutdown != nil {
 		filter.Set(constant.GracefulShutdownFilterShutdownConfig, GetShutDown())
 	}
 

--- a/config/graceful_shutdown_test.go
+++ b/config/graceful_shutdown_test.go
@@ -17,6 +17,77 @@
 
 package config
 
+import (
+	"context"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/common/extension"
+	"dubbo.apache.org/dubbo-go/v3/filter"
+	"dubbo.apache.org/dubbo-go/v3/protocol/base"
+	"dubbo.apache.org/dubbo-go/v3/protocol/result"
+)
+
+type mockGracefulShutdownSetterFilter struct {
+	settings map[string]any
+}
+
+func newMockGracefulShutdownSetterFilter() *mockGracefulShutdownSetterFilter {
+	return &mockGracefulShutdownSetterFilter{
+		settings: make(map[string]any),
+	}
+}
+
+func (m *mockGracefulShutdownSetterFilter) Invoke(context.Context, base.Invoker, base.Invocation) result.Result {
+	return nil
+}
+
+func (m *mockGracefulShutdownSetterFilter) OnResponse(context.Context, result.Result, base.Invoker, base.Invocation) result.Result {
+	return nil
+}
+
+func (m *mockGracefulShutdownSetterFilter) Set(name string, conf any) {
+	m.settings[name] = conf
+}
+
+func TestGracefulShutdownInitSetsShutdownConfigOnFilters(t *testing.T) {
+	consumerFilter := newMockGracefulShutdownSetterFilter()
+	providerFilter := newMockGracefulShutdownSetterFilter()
+	extension.SetFilter(constant.GracefulShutdownConsumerFilterKey, func() filter.Filter {
+		return consumerFilter
+	})
+	extension.SetFilter(constant.GracefulShutdownProviderFilterKey, func() filter.Filter {
+		return providerFilter
+	})
+	t.Cleanup(func() {
+		extension.UnregisterFilter(constant.GracefulShutdownConsumerFilterKey)
+		extension.UnregisterFilter(constant.GracefulShutdownProviderFilterKey)
+	})
+
+	shutdownConfig := NewShutDownConfigBuilder().
+		SetInternalSignal(false).
+		Build()
+	SetRootConfig(*NewRootConfigBuilder().
+		SetShutdown(shutdownConfig).
+		Build())
+
+	gracefulShutdownInit()
+
+	consumerShutdownConfig, ok := consumerFilter.settings[constant.GracefulShutdownFilterShutdownConfig]
+	require.True(t, ok)
+	assert.Same(t, shutdownConfig, consumerShutdownConfig)
+	providerShutdownConfig, ok := providerFilter.settings[constant.GracefulShutdownFilterShutdownConfig]
+	require.True(t, ok)
+	assert.Same(t, shutdownConfig, providerShutdownConfig)
+}
+
 //
 //import (
 //	"dubbo.apache.org/dubbo-go/v3/config"

--- a/graceful_shutdown/setter.go
+++ b/graceful_shutdown/setter.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package config
+package graceful_shutdown
 
 type Setter interface {
 	Set(name string, config any)

--- a/graceful_shutdown/shutdown.go
+++ b/graceful_shutdown/shutdown.go
@@ -37,7 +37,6 @@ import (
 import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
-	"dubbo.apache.org/dubbo-go/v3/config"
 	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/metrics/probe"
 	protocolbase "dubbo.apache.org/dubbo-go/v3/protocol/base"
@@ -100,10 +99,10 @@ func Init(opts ...Option) {
 
 		storeShutdownConfig(newOpts.Shutdown)
 
-		if filter, ok := gracefulShutdownConsumerFilter.(config.Setter); ok {
+		if filter, ok := gracefulShutdownConsumerFilter.(Setter); ok {
 			filter.Set(constant.GracefulShutdownFilterShutdownConfig, newOpts.Shutdown)
 		}
-		if filter, ok := gracefulShutdownProviderFilter.(config.Setter); ok {
+		if filter, ok := gracefulShutdownProviderFilter.(Setter); ok {
 			filter.Set(constant.GracefulShutdownFilterShutdownConfig, newOpts.Shutdown)
 		}
 

--- a/graceful_shutdown/shutdown_test.go
+++ b/graceful_shutdown/shutdown_test.go
@@ -45,7 +45,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/protocol/result"
 )
 
-// MockFilter implements filter.Filter and config.Setter for testing
+// MockFilter implements filter.Filter and Setter for testing
 type MockFilter struct {
 	mock.Mock
 }


### PR DESCRIPTION
## What
- Move the graceful shutdown `Setter` interface out of the legacy `config` package into `graceful_shutdown`.
- Update both the new graceful shutdown runtime init and the legacy compat init to use the moved interface.
- Keep the existing legacy `*config.ShutdownConfig` filter compatibility branch for the later cleanup step.

## Why
Part of #3329 PR 3: shrink graceful shutdown dependencies on the legacy `config` package before the final config package removal.

## Verification
- `go test ./graceful_shutdown ./filter/graceful_shutdown ./config`
- `gofmt -w graceful_shutdown/setter.go graceful_shutdown/shutdown.go config/graceful_shutdown.go graceful_shutdown/shutdown_test.go`
- `git diff --check`

Note: I installed the repository-pinned `golangci-lint` version and started targeted lint for these packages, but the local run did not return diagnostics after more than a minute, so I stopped that local process and will rely on PR CI for the full lint gate.