### PR TITLE
fix(graceful): strip internal count attachments

### DIFF
--- a/filter/graceful_shutdown/consumer_filter.go
+++ b/filter/graceful_shutdown/consumer_filter.go
@@ -100,6 +100,7 @@ func (f *consumerGracefulShutdownFilter) Invoke(ctx context.Context, invoker bas
 func (f *consumerGracefulShutdownFilter) OnResponse(ctx context.Context, result result.Result, invoker base.Invoker, invocation base.Invocation) result.Result {
 	if f.shutdownConfig != nil && shouldDecrementConsumerActive(result) {
 		f.shutdownConfig.ConsumerActiveCount.Dec()
+		removeCountMarkedAttachment(result, consumerCountMarkedKey)
 	}
 
 	// check closing flag in response

--- a/filter/graceful_shutdown/consumer_filter_test.go
+++ b/filter/graceful_shutdown/consumer_filter_test.go
@@ -128,6 +128,23 @@ func TestConsumerFilterDoesNotDecrementWithoutIncrement(t *testing.T) {
 	assert.Equal(t, int32(0), filter.shutdownConfig.ConsumerActiveCount.Load())
 }
 
+func TestConsumerFilterOnResponseRemovesInternalCountMarker(t *testing.T) {
+	filter := &consumerGracefulShutdownFilter{
+		shutdownConfig: graceful_shutdown.NewOptions().Shutdown,
+	}
+	filter.shutdownConfig.ConsumerActiveCount.Store(1)
+	invoker := newTestEmbeddedInvoker(common.NewURLWithOptions(common.WithParams(url.Values{})))
+	res := &result.RPCResult{}
+	res.AddAttachment(consumerCountMarkedKey, true)
+	res.AddAttachment("user-key", "user-value")
+
+	filter.OnResponse(context.Background(), res, invoker, invocation.NewRPCInvocation("GetUser", []any{"OK"}, make(map[string]any)))
+
+	assert.Equal(t, int32(0), filter.shutdownConfig.ConsumerActiveCount.Load())
+	assert.NotContains(t, res.Attachments(), consumerCountMarkedKey)
+	assert.Equal(t, "user-value", res.Attachment("user-key", nil))
+}
+
 func TestClosingInvokerExpiryRestoresAvailability(t *testing.T) {
 	opt := graceful_shutdown.NewOptions()
 	opt.Shutdown.ClosingInvokerExpireTime = "20ms"

--- a/filter/graceful_shutdown/provider_filter.go
+++ b/filter/graceful_shutdown/provider_filter.go
@@ -95,6 +95,7 @@ func (f *providerGracefulShutdownFilter) OnResponse(ctx context.Context, res res
 
 	if shouldDecrementProviderActive(res) {
 		f.shutdownConfig.ProviderActiveCount.Dec()
+		removeCountMarkedAttachment(res, providerCountMarkedKey)
 	}
 
 	// add closing flag to response
@@ -154,4 +155,11 @@ func shouldDecrementProviderActive(res result.Result) bool {
 	}
 	marked, ok := res.Attachment(providerCountMarkedKey, false).(bool)
 	return ok && marked
+}
+
+func removeCountMarkedAttachment(res result.Result, key string) {
+	if res == nil {
+		return
+	}
+	delete(res.Attachments(), key)
 }

--- a/filter/graceful_shutdown/provider_filter_test.go
+++ b/filter/graceful_shutdown/provider_filter_test.go
@@ -88,6 +88,34 @@ func TestProviderFilterOnResponseDoesNotDecrementRejectedRequest(t *testing.T) {
 	assert.Equal(t, int32(0), opt.Shutdown.ProviderActiveCount.Load())
 }
 
+func TestProviderFilterOnResponseRemovesInternalCountMarker(t *testing.T) {
+	opt := graceful_shutdown.NewOptions()
+	providerFilter := newProviderGracefulShutdownFilter().(*providerGracefulShutdownFilter)
+	providerFilter.Set(constant.GracefulShutdownFilterShutdownConfig, opt.Shutdown)
+	opt.Shutdown.ProviderActiveCount.Store(1)
+
+	res := &result.RPCResult{}
+	res.AddAttachment(providerCountMarkedKey, true)
+	res.AddAttachment("user-key", "user-value")
+
+	providerFilter.OnResponse(
+		context.Background(),
+		res,
+		base.NewBaseInvoker(common.NewURLWithOptions(common.WithParams(url.Values{}))),
+		invocation.NewRPCInvocation("GetUser", []any{"OK"}, make(map[string]any)),
+	)
+
+	assert.Equal(t, int32(0), opt.Shutdown.ProviderActiveCount.Load())
+	assert.NotContains(t, res.Attachments(), providerCountMarkedKey)
+	assert.Equal(t, "user-value", res.Attachment("user-key", nil))
+}
+
+func TestRemoveCountMarkedAttachmentAllowsNilResult(t *testing.T) {
+	assert.NotPanics(t, func() {
+		removeCountMarkedAttachment(nil, providerCountMarkedKey)
+	})
+}
+
 type TestRejectedExecutionHandler struct{}
 
 // RejectedExecution will do nothing, it only log the invocation.


### PR DESCRIPTION
## What
- Remove graceful shutdown internal count marker attachments after active request counts are decremented.
- Keep user response attachments unchanged.
- Cover both provider and consumer graceful shutdown filters.

## Why
Issue #3093 notes that old triple compat cannot serialize internal bool attachments. #3418 makes the protocol layer skip unsupported trailer values; this PR also cleans the graceful shutdown filter source so internal bookkeeping markers do not leak into protocol response attachments.

## Verification
- `go test ./filter/graceful_shutdown`
- `gofmt -w filter/graceful_shutdown/provider_filter.go filter/graceful_shutdown/consumer_filter.go filter/graceful_shutdown/provider_filter_test.go filter/graceful_shutdown/consumer_filter_test.go`
- `git diff --check`

Refs #3093