### PR TITLE
ci: add race test for core packages

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -77,6 +77,39 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true # optional (default = false)
 
+  Race-Test:
+    name: Race Test (${{ matrix.os }} - Go ${{ matrix.go_version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        go_version:
+          - '1.23'
+        os:
+          - ubuntu-latest
+
+    steps:
+    - name: Setup Go ${{ matrix.go_version }}
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go_version }}
+
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Cache dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-race-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-race-
+          ${{ runner.os }}-go-
+
+    - name: Race Test
+      run: make test-race-core
+
   Integration-Test:
     name: Integration Test (${{ matrix.os }} - Go ${{ matrix.go_version }})
     runs-on: ${{ matrix.os }}

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,12 @@ MAKEFLAGS += --no-print-directory
 CLI_DIR = tools/dubbogo-cli
 IMPORTS_FORMATTER_DIR = tools/imports-formatter
 
-.PHONY: help test fmt clean lint check-fmt rpc-contract-check
+.PHONY: help test test-race-core fmt clean lint check-fmt rpc-contract-check
 
 help:
 	@echo "Available commands:"
 	@echo "  test       - Run unit tests"
+	@echo "  test-race-core - Run race detector tests for core packages"
 	@echo "  clean      - Clean test generate files"
 	@echo "  fmt        - Format code"
 	@echo "  lint       - Run golangci-lint"
@@ -40,6 +41,10 @@ help:
 test: clean
 	GOTOOLCHAIN=go1.25.0+auto go test ./... -coverprofile=coverage.txt -covermode=atomic
 	cd $(CLI_DIR) && GOTOOLCHAIN=go1.25.0+auto go test ./...
+
+# Run race detector tests for packages that guard shared framework state.
+test-race-core: clean
+	GOTOOLCHAIN=go1.25.0+auto go test -race ./common/... ./cluster/router/chain ./protocol/base ./registry/directory
 
 fmt: install-imports-formatter
 	# replace interface{} with any

--- a/cluster/router/chain/chain_test.go
+++ b/cluster/router/chain/chain_test.go
@@ -376,14 +376,19 @@ func TestSetInvokersIncrementsAndPublishesGeneration(t *testing.T) {
 // asserts the invoker snapshot it received from the cache belongs to the same generation the
 // chain published, catching any snapshot/generation skew under concurrency.
 type genCheckRouter struct {
+	mu         sync.RWMutex
 	cache      router.Cache
 	violations int64
 	fastPaths  int64
 }
 
-func (r *genCheckRouter) Name() string            { return "gen-check" }
-func (r *genCheckRouter) ShouldPool() bool        { return true }
-func (r *genCheckRouter) SetCache(c router.Cache) { r.cache = c }
+func (r *genCheckRouter) Name() string     { return "gen-check" }
+func (r *genCheckRouter) ShouldPool() bool { return true }
+func (r *genCheckRouter) SetCache(c router.Cache) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cache = c
+}
 func (r *genCheckRouter) URL() *common.URL        { return nil }
 func (r *genCheckRouter) Priority() int64         { return 0 }
 func (r *genCheckRouter) Notify(_ []base.Invoker) {}
@@ -398,10 +403,13 @@ func (r *genCheckRouter) Pool(invokers []base.Invoker) (router.AddrPool, router.
 }
 
 func (r *genCheckRouter) Route(invokers []base.Invoker, _ *common.URL, inv base.Invocation) []base.Invoker {
-	if r.cache == nil {
+	r.mu.RLock()
+	cache := r.cache
+	r.mu.RUnlock()
+	if cache == nil {
 		return invokers
 	}
-	pool, full, cacheGen := r.cache.FindAddrPool(r)
+	pool, full, cacheGen := cache.FindAddrPool(r)
 	snapGen := inv.GetAttributeWithDefaultValue(constant.RouterChainCacheGeneration, uint64(0)).(uint64)
 	if pool == nil || cacheGen != snapGen {
 		return invokers // fall back, exactly like TagRouter


### PR DESCRIPTION
## What
- Add a `test-race-core` Makefile target for shared-state core packages.
- Add a dedicated GitHub Actions race-test job.
- Make the router-chain race regression test helper protect its cache pointer so the new race gate can pass.

## Why
Issue #3248 lists enabling `go test -race` in CI, at least for core packages, as a P0 process improvement. This keeps the gate scoped to packages that guard shared framework state instead of enabling full-repo race detection in one large step.

## Verification
- `make test-race-core`
- `gofmt -w cluster/router/chain/chain_test.go`
- `git diff --check`

Refs #3248