### PR TITLE
fix(loadbalance): prevent panic in consistent hash toKey for non-string args

### DIFF
--- a/cluster/loadbalance/consistenthashing/selector.go
+++ b/cluster/loadbalance/consistenthashing/selector.go
@@ -85,7 +85,7 @@ func (c *selector) toKey(args []any) string {
 	var sb strings.Builder
 	for i := range c.argumentIndex {
 		if i >= 0 && i < len(args) {
-			_, _ = fmt.Fprint(&sb, args[i].(string))
+			_, _ = fmt.Fprint(&sb, args[i])
 		}
 	}
 	return sb.String()


### PR DESCRIPTION
## Problem

`cluster/loadbalance/consistenthashing/selector.go:88` 中 `toKey` 方法使用了硬类型断言：

```go
_, _ = fmt.Fprint(&sb, args[i].(string))
```

当 `args[i]` 不是 `string` 类型（如 `int`、`struct` 等）时，该断言必定 panic。

## Fix

移除 `.(string)` 断言，改为直接传递 `args[i]` 给 `fmt.Fprint`：

```go
_, _ = fmt.Fprint(&sb, args[i])
```

`fmt.Fprint` 会自动将任意类型转为字符串表示，行为与 Java Dubbo 的 `toString()` 一致，不会 panic。

## Impact

- 修复前：非字符串参数必定 panic
- 修复后：任意类型参数均可安全转为字符串

🤖 Generated with [Claude Code](https://claude.com/claude-code)