### PR TITLE
fix(otel): fix metadataSupplier Get/Set type mismatch breaking trace propagation

### DIFF
--- a/filter/otel/trace/attachment.go
+++ b/filter/otel/trace/attachment.go
@@ -39,21 +39,28 @@ func (s *metadataSupplier) Get(key string) string {
 	if s.metadata == nil {
 		return ""
 	}
-	item, ok := s.metadata[key].([]string)
-	if !ok {
+	val, ok := s.metadata[key]
+	if !ok || val == nil {
 		return ""
 	}
-	if len(item) == 0 {
+	switch v := val.(type) {
+	case []string:
+		if len(v) > 0 {
+			return v[0]
+		}
+		return ""
+	case string:
+		return v
+	default:
 		return ""
 	}
-	return item[0]
 }
 
 func (s *metadataSupplier) Set(key string, value string) {
 	if s.metadata == nil {
 		s.metadata = map[string]any{}
 	}
-	s.metadata[key] = value
+	s.metadata[key] = []string{value}
 }
 
 func (s *metadataSupplier) Keys() []string {

--- a/filter/otel/trace/attachment_test.go
+++ b/filter/otel/trace/attachment_test.go
@@ -110,12 +110,28 @@ func Test_metadataSupplier_Get(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "test",
+			name: "slice value",
 			metadata: map[string]any{
 				"key": []string{"test"},
 			},
 			key:  "key",
 			want: "test",
+		},
+		{
+			name: "string value (defensive read)",
+			metadata: map[string]any{
+				"key": "test",
+			},
+			key:  "key",
+			want: "test",
+		},
+		{
+			name: "non-string non-slice value",
+			metadata: map[string]any{
+				"key": 123,
+			},
+			key:  "key",
+			want: "",
 		},
 	}
 	for _, tt := range tests {
@@ -127,5 +143,27 @@ func Test_metadataSupplier_Get(t *testing.T) {
 				t.Errorf("Get() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func Test_metadataSupplier_SetGetRoundTrip(t *testing.T) {
+	// This is the core bug scenario: Set stores a value, Get must be able to read it back.
+	s := &metadataSupplier{
+		metadata: map[string]any{},
+	}
+	s.Set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01")
+
+	got := s.Get("traceparent")
+	if got != "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" {
+		t.Errorf("round-trip Get() = %q, want traceparent value", got)
+	}
+
+	// Verify the stored type is []string, consistent with triple's generateAttachments
+	stored, ok := s.metadata["traceparent"].([]string)
+	if !ok {
+		t.Errorf("Set stored type %T, want []string", s.metadata["traceparent"])
+	}
+	if len(stored) != 1 || stored[0] != "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" {
+		t.Errorf("stored value = %v, want [traceparent]", stored)
 	}
 }


### PR DESCRIPTION
## Problem

`metadataSupplier` in `filter/otel/trace/attachment.go` has a type mismatch between `Get` and `Set`:

- **`Set`** stores values as `string`: `s.metadata[key] = value`
- **`Get`** reads values as `[]string`: `s.metadata[key].([]string)`

When the OTel propagator calls `Inject` (which uses `Set`) followed by `Extract` (which uses `Get`), the type assertion in `Get` fails and returns an empty string. This breaks trace context propagation — `traceparent` and other W3C trace headers are silently lost.

This is also a partial root cause of #3240 (traceparent being broken by triple_invoker).

## Fix

### `Set` — store `[]string{value}` instead of `string`

This aligns with how triple's `generateAttachments` stores `http.Header` values (as `[]string`), which is the data source on the Extract (server) side.

### `Get` — add defensive `string` type handling

In addition to `[]string`, `Get` now also handles plain `string` values. This matches the pattern used by `RPCInvocation.GetAttachment` and provides robustness against externally-set string values.

## Test Coverage

- Added `string value (defensive read)` test case — verifies Get reads string type
- Added `non-string non-slice value` test case — verifies safe fallback
- Added `Test_metadataSupplier_SetGetRoundTrip` — the core bug scenario: Set then Get must succeed, and stored type must be `[]string`

🤖 Generated with [Claude Code](https://claude.com/claude-code)