### PR TITLE
fix(loadbalance): fix data race in RoundRobin setWeight and increaseCurrent

### DIFF
--- a/cluster/loadbalance/roundrobin/loadbalance.go
+++ b/cluster/loadbalance/roundrobin/loadbalance.go
@@ -144,8 +144,8 @@ func (robin *weightedRoundRobin) Weight() int64 {
 }
 
 func (robin *weightedRoundRobin) setWeight(weight int64) {
-	robin.weight = weight
-	robin.current = 0
+	atomic.StoreInt64(&robin.weight, weight)
+	atomic.StoreInt64(&robin.current, 0)
 }
 
 func (robin *weightedRoundRobin) LastUpdate() *time.Time {
@@ -157,7 +157,7 @@ func (robin *weightedRoundRobin) setLastUpdate(time *time.Time) {
 }
 
 func (robin *weightedRoundRobin) increaseCurrent() int64 {
-	return atomic.AddInt64(&robin.current, robin.weight)
+	return atomic.AddInt64(&robin.current, atomic.LoadInt64(&robin.weight))
 }
 
 func (robin *weightedRoundRobin) Current(delta int64) {


### PR DESCRIPTION
## Problem

`weightedRoundRobin` 的 `weight` 和 `current` 字段存在数据竞争：同一个字段混用了原子和非原子操作。

### 具体问题

| 方法 | 字段 | 操作 | 问题 |
|------|------|------|------|
| `setWeight()` | `weight` | `robin.weight = weight` | 非原子写，与 `Weight()` 的 `atomic.LoadInt64` 竞争 |
| `setWeight()` | `current` | `robin.current = 0` | 非原子写，与 `increaseCurrent()`/`Current()` 的 `atomic.AddInt64` 竞争 |
| `increaseCurrent()` | `weight` | `robin.weight` | 非原子读，与 `setWeight()` 的写操作竞争 |

## Fix

将所有非原子访问替换为对应的原子操作：

- `setWeight()`: `robin.weight = weight` → `atomic.StoreInt64(&robin.weight, weight)`
- `setWeight()`: `robin.current = 0` → `atomic.StoreInt64(&robin.current, 0)`
- `increaseCurrent()`: `robin.weight` → `atomic.LoadInt64(&robin.weight)`

## Verification

`go test ./cluster/loadbalance/roundrobin/ -race -count=5` 通过，无数据竞争报告。

🤖 Generated with [Claude Code](https://claude.com/claude-code)