### PR TITLE
feat(triple): expose unary response metadata via call options

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -277,6 +277,12 @@ func generateInvocation(ctx context.Context, methodName string, reqs []any, resp
 		invocation.WithAttachments(attachments),
 	)
 	inv.SetAttribute(constant.CallTypeKey, callType)
+	if opts.ResponseHeader != nil {
+		inv.SetAttribute(constant.ResponseHeaderKey, opts.ResponseHeader)
+	}
+	if opts.ResponseTrailer != nil {
+		inv.SetAttribute(constant.ResponseTrailerKey, opts.ResponseTrailer)
+	}
 
 	return inv, nil
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -20,6 +20,7 @@ package client
 import (
 	"context"
 	"errors"
+	"net/http"
 	"testing"
 	"time"
 )
@@ -146,7 +147,19 @@ func TestConnectionCallPassesOptions(t *testing.T) {
 	conn := &Connection{refOpts: &ReferenceOptions{invoker: invoker}}
 
 	var resp string
-	res, err := conn.call(context.Background(), []any{"req"}, &resp, "Ping", constant.CallUnary, WithCallRequestTimeout(1500*time.Millisecond), WithCallRetries(3))
+	var responseHeader http.Header
+	var responseTrailer http.Header
+	res, err := conn.call(
+		context.Background(),
+		[]any{"req"},
+		&resp,
+		"Ping",
+		constant.CallUnary,
+		WithCallRequestTimeout(1500*time.Millisecond),
+		WithCallRetries(3),
+		WithResponseHeader(&responseHeader),
+		WithResponseTrailer(&responseTrailer),
+	)
 	require.NoError(t, err)
 	require.Equal(t, invRes, res)
 
@@ -158,6 +171,14 @@ func TestConnectionCallPassesOptions(t *testing.T) {
 
 	requireCallType(t, inv, constant.CallUnary)
 	require.Equal(t, []any{"req", &resp}, inv.ParameterRawValues())
+
+	headerTarget, ok := inv.GetAttribute(constant.ResponseHeaderKey)
+	require.True(t, ok)
+	require.Same(t, &responseHeader, headerTarget)
+
+	trailerTarget, ok := inv.GetAttribute(constant.ResponseTrailerKey)
+	require.True(t, ok)
+	require.Same(t, &responseTrailer, trailerTarget)
 }
 
 func TestCallUnary(t *testing.T) {

--- a/client/options.go
+++ b/client/options.go
@@ -1026,22 +1026,18 @@ func WithCallRetries(retries int) CallOption {
 	}
 }
 
-// WithResponseHeader configures a target to receive response headers when the
-// protocol supports it.
-//
-// For Triple unary calls, the header is captured from both successful responses
-// and error responses when response metadata is available.
+// WithResponseHeader configures a target to receive response headers.
+// Currently, only Triple unary calls populate this option (including error
+// responses when metadata is available).
 func WithResponseHeader(header *http.Header) CallOption {
 	return func(opts *CallOptions) {
 		opts.ResponseHeader = header
 	}
 }
 
-// WithResponseTrailer configures a target to receive response trailers when the
-// protocol supports it.
-//
-// For Triple unary calls, the trailer is captured from both successful responses
-// and error responses when response metadata is available.
+// WithResponseTrailer configures a target to receive response trailers.
+// Currently, only Triple unary calls populate this option (including error
+// responses when metadata is available).
 func WithResponseTrailer(trailer *http.Header) CallOption {
 	return func(opts *CallOptions) {
 		opts.ResponseTrailer = trailer

--- a/client/options.go
+++ b/client/options.go
@@ -18,6 +18,7 @@
 package client
 
 import (
+	"net/http"
 	"strconv"
 	"time"
 )
@@ -999,8 +1000,10 @@ func SetClientRouters(routers []*global.RouterConfig) ClientOption {
 
 // todo: need to be consistent with MethodConfig
 type CallOptions struct {
-	RequestTimeout string
-	Retries        string
+	RequestTimeout  string
+	Retries         string
+	ResponseHeader  *http.Header
+	ResponseTrailer *http.Header
 }
 
 type CallOption func(*CallOptions)
@@ -1020,5 +1023,19 @@ func WithCallRequestTimeout(timeout time.Duration) CallOption {
 func WithCallRetries(retries int) CallOption {
 	return func(opts *CallOptions) {
 		opts.Retries = strconv.Itoa(retries)
+	}
+}
+
+// WithResponseHeader captures response headers for one specific call, only works for 'tri' protocol.
+func WithResponseHeader(header *http.Header) CallOption {
+	return func(opts *CallOptions) {
+		opts.ResponseHeader = header
+	}
+}
+
+// WithResponseTrailer captures response trailers for one specific call, only works for 'tri' protocol.
+func WithResponseTrailer(trailer *http.Header) CallOption {
+	return func(opts *CallOptions) {
+		opts.ResponseTrailer = trailer
 	}
 }

--- a/client/options.go
+++ b/client/options.go
@@ -1026,14 +1026,22 @@ func WithCallRetries(retries int) CallOption {
 	}
 }
 
-// WithResponseHeader captures response headers for one specific call, only works for 'tri' protocol.
+// WithResponseHeader configures a target to receive response headers when the
+// protocol supports it.
+//
+// For Triple unary calls, the header is captured from both successful responses
+// and error responses when response metadata is available.
 func WithResponseHeader(header *http.Header) CallOption {
 	return func(opts *CallOptions) {
 		opts.ResponseHeader = header
 	}
 }
 
-// WithResponseTrailer captures response trailers for one specific call, only works for 'tri' protocol.
+// WithResponseTrailer configures a target to receive response trailers when the
+// protocol supports it.
+//
+// For Triple unary calls, the trailer is captured from both successful responses
+// and error responses when response metadata is available.
 func WithResponseTrailer(trailer *http.Header) CallOption {
 	return func(opts *CallOptions) {
 		opts.ResponseTrailer = trailer

--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -157,6 +157,8 @@ const (
 	CycleReportKey                     = "cycle.report"
 	DefaultBlackListRecoverBlock       = 16
 	CallTypeKey                        = "call-type"
+	ResponseHeaderKey                  = "response-header"
+	ResponseTrailerKey                 = "response-trailer"
 	CallUnary                          = "unary"
 	CallClientStream                   = "client-stream"
 	CallServerStream                   = "server-stream"

--- a/protocol/triple/client.go
+++ b/protocol/triple/client.go
@@ -66,11 +66,17 @@ type clientManager struct {
 // TODO: code a triple client between clientManager and triple_protocol client
 // TODO: write a NewClient for triple client
 
-func (cm *clientManager) callUnary(ctx context.Context, method string, req, resp any) error {
+func (cm *clientManager) callUnary(ctx context.Context, method string, req, resp any, responseHeader, responseTrailer *http.Header) error {
 	triReq := tri.NewRequest(req)
 	triResp := tri.NewResponse(resp)
 	if err := cm.triClient.CallUnary(ctx, triReq, method, triResp); err != nil {
 		return err
+	}
+	if responseHeader != nil {
+		*responseHeader = triResp.Header().Clone()
+	}
+	if responseTrailer != nil {
+		*responseTrailer = triResp.Trailer().Clone()
 	}
 	return nil
 }

--- a/protocol/triple/client.go
+++ b/protocol/triple/client.go
@@ -69,16 +69,14 @@ type clientManager struct {
 func (cm *clientManager) callUnary(ctx context.Context, method string, req, resp any, responseHeader, responseTrailer *http.Header) error {
 	triReq := tri.NewRequest(req)
 	triResp := tri.NewResponse(resp)
-	if err := cm.triClient.CallUnary(ctx, triReq, method, triResp); err != nil {
-		return err
-	}
+	err := cm.triClient.CallUnary(ctx, triReq, method, triResp)
 	if responseHeader != nil {
 		*responseHeader = triResp.Header().Clone()
 	}
 	if responseTrailer != nil {
 		*responseTrailer = triResp.Trailer().Clone()
 	}
-	return nil
+	return err
 }
 
 func (cm *clientManager) callClientStream(ctx context.Context, method string) (any, error) {

--- a/protocol/triple/client_test.go
+++ b/protocol/triple/client_test.go
@@ -28,7 +28,6 @@ import (
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 

--- a/protocol/triple/client_test.go
+++ b/protocol/triple/client_test.go
@@ -150,6 +150,48 @@ func TestClientManagerCallUnaryCopiesResponseMetadata(t *testing.T) {
 	require.Equal(t, responseTrailerVal, responseTrailer.Get(responseTrailerKey))
 }
 
+func TestClientManagerCallUnaryCopiesErrorResponseMetadata(t *testing.T) {
+	const (
+		responseHeaderKey  = "x-test-error-header"
+		responseHeaderVal  = "error-header-value"
+		responseTrailerKey = "x-test-error-trailer"
+		responseTrailerVal = "error-trailer-value"
+	)
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/grpc")
+		w.Header().Set(responseHeaderKey, responseHeaderVal)
+		w.Header().Set("Trailer", "Grpc-Status, Grpc-Message, "+responseTrailerKey)
+		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Grpc-Status", "3")
+		w.Header().Set("Grpc-Message", "invalid%20test%20request")
+		w.Header().Set(responseTrailerKey, responseTrailerVal)
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	cm := &clientManager{
+		isIDL:     true,
+		triClient: tri.NewClient(server.Client(), server.URL+"/test.Service"),
+	}
+
+	var resp emptypb.Empty
+	var responseHeader http.Header
+	var responseTrailer http.Header
+	err := cm.callUnary(
+		context.Background(),
+		"Check",
+		&emptypb.Empty{},
+		&resp,
+		&responseHeader,
+		&responseTrailer,
+	)
+	require.Error(t, err)
+	require.Equal(t, tri.CodeInvalidArgument, tri.CodeOf(err))
+	require.Equal(t, responseHeaderVal, responseHeader.Get(responseHeaderKey))
+	require.Equal(t, responseTrailerVal, responseTrailer.Get(responseTrailerKey))
+}
+
 // TestClientManager_CallMethods_MissingClient removed - no longer applicable
 // in the service-level client architecture where all methods share a single triClient.
 

--- a/protocol/triple/client_test.go
+++ b/protocol/triple/client_test.go
@@ -28,6 +28,7 @@ import (
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 

--- a/protocol/triple/client_test.go
+++ b/protocol/triple/client_test.go
@@ -20,6 +20,7 @@ package triple
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -27,6 +28,8 @@ import (
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 import (
@@ -101,6 +104,50 @@ func TestClientManager_Close(t *testing.T) {
 
 	err := cm.close()
 	require.NoError(t, err)
+}
+
+func TestClientManagerCallUnaryCopiesResponseMetadata(t *testing.T) {
+	const (
+		responseHeaderKey  = "x-test-response-header"
+		responseHeaderVal  = "response-header-value"
+		responseTrailerKey = "x-test-response-trailer"
+		responseTrailerVal = "response-trailer-value"
+	)
+
+	handler := tri.NewUnaryHandler(
+		"/test.Service/Check",
+		func() any {
+			return new(emptypb.Empty)
+		},
+		func(ctx context.Context, req *tri.Request) (*tri.Response, error) {
+			resp := tri.NewResponse(new(emptypb.Empty))
+			resp.Header().Set(responseHeaderKey, responseHeaderVal)
+			resp.Trailer().Set(responseTrailerKey, responseTrailerVal)
+			return resp, nil
+		},
+	)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	cm := &clientManager{
+		isIDL:     true,
+		triClient: tri.NewClient(server.Client(), server.URL+"/test.Service", tri.WithTriple()),
+	}
+
+	var resp emptypb.Empty
+	var responseHeader http.Header
+	var responseTrailer http.Header
+	err := cm.callUnary(
+		context.Background(),
+		"Check",
+		&emptypb.Empty{},
+		&resp,
+		&responseHeader,
+		&responseTrailer,
+	)
+	require.NoError(t, err)
+	require.Equal(t, responseHeaderVal, responseHeader.Get(responseHeaderKey))
+	require.Equal(t, responseTrailerVal, responseTrailer.Get(responseTrailerKey))
 }
 
 // TestClientManager_CallMethods_MissingClient removed - no longer applicable

--- a/protocol/triple/triple_invoker.go
+++ b/protocol/triple/triple_invoker.go
@@ -101,11 +101,13 @@ func (ti *TripleInvoker) Invoke(ctx context.Context, invocation base.Invocation)
 
 	inRawLen := len(inRaw)
 
+	responseHeader, responseTrailer := responseMetadataTargets(invocation)
+
 	if !ti.clientManager.isIDL {
 		switch callType {
 		case constant.CallUnary:
 			// todo(DMwangnima): consider inRawLen == 0
-			if err := ti.clientManager.callUnary(ctx, method, inRaw[0:inRawLen-1], inRaw[inRawLen-1]); err != nil {
+			if err := ti.clientManager.callUnary(ctx, method, inRaw[0:inRawLen-1], inRaw[inRawLen-1], responseHeader, responseTrailer); err != nil {
 				result.SetError(err)
 			}
 		default:
@@ -118,7 +120,7 @@ func (ti *TripleInvoker) Invoke(ctx context.Context, invocation base.Invocation)
 		if len(inRaw) != 2 {
 			panic(fmt.Sprintf("Wrong parameter Values number for CallUnary, want 2, but got %d", inRawLen))
 		}
-		if err := ti.clientManager.callUnary(ctx, method, inRaw[0], inRaw[1]); err != nil {
+		if err := ti.clientManager.callUnary(ctx, method, inRaw[0], inRaw[1], responseHeader, responseTrailer); err != nil {
 			result.SetError(err)
 		}
 	case constant.CallClientStream:
@@ -156,6 +158,20 @@ func (ti *TripleInvoker) Invoke(ctx context.Context, invocation base.Invocation)
 	}
 
 	return &result
+}
+
+func responseMetadataTargets(invocation base.Invocation) (*http.Header, *http.Header) {
+	var responseHeader *http.Header
+	if headerRaw, ok := invocation.GetAttribute(constant.ResponseHeaderKey); ok {
+		responseHeader, _ = headerRaw.(*http.Header)
+	}
+
+	var responseTrailer *http.Header
+	if trailerRaw, ok := invocation.GetAttribute(constant.ResponseTrailerKey); ok {
+		responseTrailer, _ = trailerRaw.(*http.Header)
+	}
+
+	return responseHeader, responseTrailer
 }
 
 func mergeAttachmentToOutgoing(ctx context.Context, inv base.Invocation) (context.Context, error) {

--- a/protocol/triple/triple_invoker.go
+++ b/protocol/triple/triple_invoker.go
@@ -163,12 +163,20 @@ func (ti *TripleInvoker) Invoke(ctx context.Context, invocation base.Invocation)
 func responseMetadataTargets(invocation base.Invocation) (*http.Header, *http.Header) {
 	var responseHeader *http.Header
 	if headerRaw, ok := invocation.GetAttribute(constant.ResponseHeaderKey); ok {
-		responseHeader, _ = headerRaw.(*http.Header)
+		if header, ok := headerRaw.(*http.Header); ok {
+			responseHeader = header
+		} else if headerRaw != nil {
+			logger.Warnf("[Triple][Invoker] invocation attribute %s should be *http.Header, got %T", constant.ResponseHeaderKey, headerRaw)
+		}
 	}
 
 	var responseTrailer *http.Header
 	if trailerRaw, ok := invocation.GetAttribute(constant.ResponseTrailerKey); ok {
-		responseTrailer, _ = trailerRaw.(*http.Header)
+		if trailer, ok := trailerRaw.(*http.Header); ok {
+			responseTrailer = trailer
+		} else if trailerRaw != nil {
+			logger.Warnf("[Triple][Invoker] invocation attribute %s should be *http.Header, got %T", constant.ResponseTrailerKey, trailerRaw)
+		}
 	}
 
 	return responseHeader, responseTrailer

--- a/protocol/triple/triple_protocol/triple.go
+++ b/protocol/triple/triple_protocol/triple.go
@@ -346,6 +346,10 @@ func receiveUnaryResponse(conn StreamingClientConn, response AnyResponse) error 
 	if !ok {
 		panic(fmt.Sprintf("response %T is not of Response type", response))
 	}
+	defer func() {
+		resp.header = conn.ResponseHeader()
+		resp.trailer = conn.ResponseTrailer()
+	}()
 	if err := conn.Receive(resp.Msg); err != nil {
 		return err
 	}
@@ -357,8 +361,6 @@ func receiveUnaryResponse(conn StreamingClientConn, response AnyResponse) error 
 	} else if !errors.Is(err, io.EOF) {
 		return NewError(CodeUnknown, err)
 	}
-	resp.header = conn.ResponseHeader()
-	resp.trailer = conn.ResponseTrailer()
 	return nil
 }
 


### PR DESCRIPTION
## What is changed

Fixes #3429.

This PR exposes unary response headers and trailers for Triple generated clients through existing `client.CallOption`.

Generated unary methods already accept `opts ...client.CallOption`, so users can now capture response metadata without changing generated method signatures:

```go
var header, trailer http.Header

resp, err := cli.Greet(
    ctx,
    req,
    client.WithResponseHeader(&header),
    client.WithResponseTrailer(&trailer),
)
```

Main changes:

1. Add response metadata capture targets to `client.CallOptions`:

   - `ResponseHeader`
   - `ResponseTrailer`

2. Add new call options:

   - `client.WithResponseHeader`
   - `client.WithResponseTrailer`

3. Store response metadata capture targets in invocation attributes instead of attachments.

   These values are local client-side capture targets and should not be treated as RPC metadata to be transmitted.

4. Pass the capture targets through the Triple unary invocation path.

5. After the underlying Triple unary response is received, clone `triResp.Header()` and `triResp.Trailer()` into the user-provided targets.

## Why

Dubbo-Go Triple runtime already supports unary response metadata through `triple_protocol.Response.Header()` and `triple_protocol.Response.Trailer()`.

However, generated unary clients only return the business response message, so users could not access the underlying response headers and trailers from generated unary calls.

Streaming generated clients already expose response metadata through `ResponseHeader()` and `ResponseTrailer()`. This PR closes the unary gap and helps complete the header/trailer usage pattern discussed in #2422.

## Compatibility

Existing generated unary method signatures are unchanged.

Users who do not need response metadata can continue using the existing API:

```go
resp, err := cli.Greet(ctx, req)
```

Users who need response metadata can opt in through call options:

```go
var header, trailer http.Header

resp, err := cli.Greet(
    ctx,
    req,
    client.WithResponseHeader(&header),
    client.WithResponseTrailer(&trailer),
)
```

This avoids adding extra generated methods such as `GreetWithResponse` and keeps the generated client API backward-compatible.

## Tests

```bash
go test ./client
go test ./protocol/triple
```

The tests cover:

- response header/trailer capture options being propagated through invocation attributes
- Triple unary calls copying response headers/trailers back to user-provided variables
- existing unary calls without response metadata options continuing to work

 