### PR TITLE
fix(loadbalance): serialize weighted round-robin select under concurrency

### DIFF
--- a/cluster/loadbalance/roundrobin/loadbalance.go
+++ b/cluster/loadbalance/roundrobin/loadbalance.go
@@ -69,6 +69,12 @@ func (lb *rrLoadBalance) Select(invokers []base.Invoker, invocation base.Invocat
 	cache, _ := methodWeightMap.LoadOrStore(key, &cachedInvokers{})
 	cachedInvokers := cache.(*cachedInvokers)
 
+	// Serialize the full select+update sequence per service+method key so that
+	// concurrent callers cannot observe each other's intermediate currentWeight
+	// state and skew the weighted distribution.
+	cachedInvokers.mu.Lock()
+	defer cachedInvokers.mu.Unlock()
+
 	var (
 		clean               = false
 		totalWeight         = int64(0)
@@ -166,5 +172,6 @@ func (robin *weightedRoundRobin) Current(delta int64) {
 }
 
 type cachedInvokers struct {
+	mu       sync.Mutex
 	sync.Map /*[string]weightedRoundRobin*/
 }

--- a/cluster/loadbalance/roundrobin/loadbalance_test.go
+++ b/cluster/loadbalance/roundrobin/loadbalance_test.go
@@ -20,6 +20,7 @@ package roundrobin
 import (
 	"fmt"
 	"strconv"
+	"sync"
 	"testing"
 )
 
@@ -74,4 +75,28 @@ func TestRoundRobinByWeight(t *testing.T) {
 		w, _ := strconv.Atoi(i.GetURL().GetParam("weight", "-1"))
 		assert.Equal(t, w, selected[i])
 	}
+}
+
+func TestRoundRobinByWeightConcurrent(t *testing.T) {
+	loadBalance := NewRRLoadBalance()
+
+	var invokers []base.Invoker
+	for i := 1; i <= 5; i++ {
+		url, _ := common.NewURL(fmt.Sprintf("dubbo://192.168.1.%v:20000/org.apache.demo.HelloService?weight=%v", i, i))
+		invokers = append(invokers, base.NewBaseInvoker(url))
+	}
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 30; j++ {
+				invoker := loadBalance.Select(invokers, &invocation.RPCInvocation{})
+				assert.NotNil(t, invoker)
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
### Description
Fixes https://github.com/apache/dubbo-go/issues/3453

  #### 1. RoundRobin selection now atomic under concurrency
  `cluster/loadbalance/roundrobin/loadbalance.go`
  The weighted-round-robin select+update sequence was only per-field atomic, so concurrent
  callers could observe each other's intermediate `currentWeight` and skew distribution.
  Added a per-key `sync.Mutex` on `cachedInvokers` so the full select+update transaction is
  serialized per service+method (contention bounded to the same key).

### Tests
  - `TestRoundRobinByWeightConcurrent` — 50 goroutines × 30 selections, race-clean

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
