### PR TITLE
fix(getty): replace panic with error propagation in server config handling

### DIFF
--- a/remoting/getty/getty_server.go
+++ b/remoting/getty/getty_server.go
@@ -97,19 +97,33 @@ func initServer(url *common.URL) {
 			return
 		}
 
-		gettyServerConfigBytes, err := yaml.Marshal(gettyServerConfig)
+		gettyServerConfigBytes, err := safeYAMLMarshal(gettyServerConfig)
 		if err != nil {
-			panic(err)
+			logger.Errorf("[Remoting][Getty] failed to marshal getty server config, err=%v", err)
+			return
 		}
 		err = yaml.Unmarshal(gettyServerConfigBytes, srvConf)
 		if err != nil {
-			panic(err)
+			logger.Errorf("[Remoting][Getty] failed to unmarshal getty server config, err=%v", err)
+			return
 		}
 	}
 
 	if err := srvConf.CheckValidity(); err != nil {
-		panic(err)
+		logger.Errorf("[Remoting][Getty] server config is invalid, err=%v", err)
+		return
 	}
+}
+
+// safeYAMLMarshal wraps yaml.Marshal with a recover so that types unsupported by
+// the yaml encoder (e.g. channels, funcs) return an error instead of panicking.
+func safeYAMLMarshal(v any) (out []byte, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("yaml marshal panic: %v", r)
+		}
+	}()
+	return yaml.Marshal(v)
 }
 
 // SetServerConfig set dubbo server config.
@@ -177,7 +191,7 @@ func (s *Server) newSession(session getty.Session) error {
 		return nil
 	}
 	if _, ok = session.Conn().(*net.TCPConn); !ok {
-		panic(fmt.Sprintf("%s, session.conn{%#v} is not tcp connection\n", session.Stat(), session.Conn()))
+		return perrors.New(fmt.Sprintf("%s, session.conn{%#v} is not tcp connection", session.Stat(), session.Conn()))
 	}
 
 	if _, ok = session.Conn().(*tls.Conn); !ok {

--- a/remoting/getty/getty_server_test.go
+++ b/remoting/getty/getty_server_test.go
@@ -93,3 +93,20 @@ func TestInitServerTLS(t *testing.T) {
 		assert.False(t, srvConf.SSLEnabled)
 	})
 }
+
+func TestInitServerDoesNotPanicOnUnmarshalableParams(t *testing.T) {
+	url, err := common.NewURL("dubbo://127.0.0.1:20003/test")
+	require.NoError(t, err)
+	url.SetAttribute(constant.ProtocolConfigKey, map[string]*global.ProtocolConfig{
+		"dubbo": {
+			Name:   "dubbo",
+			Ip:     "127.0.0.1",
+			Port:   "20003",
+			Params: map[string]any{"conn-pool-size": make(chan int)}, // channel is not YAML-serializable
+		},
+	})
+	url.SetAttribute(constant.ApplicationKey, global.ApplicationConfig{})
+	assert.NotPanics(t, func() {
+		initServer(url)
+	})
+}


### PR DESCRIPTION
Fixes #3453

### Description

#### 2. Getty server no longer panics on config errors
  `remoting/getty/getty_server.go`
  Replaced `panic(err)` in config marshal/unmarshal, `CheckValidity()`, and `newSession()`
  with structured error logging / error returns. Added `safeYAMLMarshal` to recover the
  panic `yaml.v3` raises on unmarshalable types (channels, funcs) and surface it as an error.
  Malformed protocol config no longer escalates to process-level failure.

 ### Tests
  - `TestInitServerDoesNotPanicOnUnmarshalableParams` — channel in Params no longer panics

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
