### PR TITLE
fix(shutdown): guard shutdownResult reads/writes with explicit mutex

### DIFF
--- a/graceful_shutdown/shutdown.go
+++ b/graceful_shutdown/shutdown.go
@@ -64,10 +64,11 @@ var (
 	shutdownConfigMu sync.RWMutex
 	shutdownConfig   *global.ShutdownConfig
 
-	shutdownOnce    sync.Once
-	shutdownStarted atomic.Bool
-	shutdownDone    = make(chan struct{})
-	shutdownResult  error
+	shutdownOnce     sync.Once
+	shutdownStarted  atomic.Bool
+	shutdownDone     = make(chan struct{})
+	shutdownResultMu sync.Mutex
+	shutdownResult   error
 
 	signalNotify = signal.Notify
 )
@@ -152,7 +153,10 @@ func Shutdown(ctx context.Context) error {
 
 	select {
 	case <-shutdownDone:
-		return shutdownResult
+		shutdownResultMu.Lock()
+		err := shutdownResult
+		shutdownResultMu.Unlock()
+		return err
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -214,14 +218,18 @@ func startShutdownOnce() {
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					logger.Warnf("[GracefulShutdown] shutdown panicked, err=%v", recovered)
+					shutdownResultMu.Lock()
 					shutdownResult = fmt.Errorf("graceful shutdown panic: %v", recovered)
+					shutdownResultMu.Unlock()
 				}
 				close(shutdownDone)
 			}()
 
 			cfg := loadShutdownConfig()
 			beforeShutdown(cfg)
+			shutdownResultMu.Lock()
 			shutdownResult = nil
+			shutdownResultMu.Unlock()
 		}()
 	})
 }

--- a/graceful_shutdown/shutdown_test.go
+++ b/graceful_shutdown/shutdown_test.go
@@ -113,6 +113,7 @@ func resetShutdownTestState() {
 	shutdownOnce = sync.Once{}
 	shutdownStarted = atomic.Bool{}
 	shutdownDone = make(chan struct{})
+	shutdownResultMu = sync.Mutex{}
 	shutdownResult = nil
 	signalNotify = signal.Notify
 }
@@ -629,4 +630,59 @@ func TestInvokeCustomShutdownCallbackDoesNotBlockForever(t *testing.T) {
 	elapsed := time.Since(start)
 
 	assert.Less(t, elapsed, time.Second)
+}
+
+func TestShutdownResultConsistentUnderConcurrentReaders(t *testing.T) {
+	resetShutdownTestState()
+
+	cfg := global.DefaultShutdownConfig()
+	internalSignal := false
+	cfg.InternalSignal = &internalSignal
+	cfg.ConsumerUpdateWaitTime = "0s"
+	cfg.StepTimeout = "0s"
+	cfg.NotifyTimeout = "10ms"
+	cfg.OfflineRequestWindowTimeout = "0s"
+	Init(SetShutdownConfig(cfg))
+
+	const readers = 50
+	var wg sync.WaitGroup
+	wg.Add(readers)
+	errs := make([]error, readers)
+	for i := 0; i < readers; i++ {
+		idx := i
+		go func() {
+			defer wg.Done()
+			errs[idx] = Shutdown(context.Background())
+		}()
+	}
+	wg.Wait()
+	for _, err := range errs {
+		assert.NoError(t, err)
+	}
+}
+
+func TestShutdownPanicSetsResultError(t *testing.T) {
+	resetShutdownTestState()
+
+	testProtocolName := "shutdown-panic-protocol"
+	extension.SetProtocol(testProtocolName, func() base.Protocol {
+		return &testProtocol{destroy: func() { panic("simulated shutdown panic") }}
+	})
+	t.Cleanup(func() { extension.UnregisterProtocol(testProtocolName) })
+
+	cfg := global.DefaultShutdownConfig()
+	internalSignal := false
+	cfg.InternalSignal = &internalSignal
+	cfg.ConsumerUpdateWaitTime = "0s"
+	cfg.StepTimeout = "0s"
+	cfg.NotifyTimeout = "10ms"
+	cfg.OfflineRequestWindowTimeout = "0s"
+	Init(SetShutdownConfig(cfg))
+
+	// RegisterProtocol must come after Init — Init resets protocols on first call.
+	RegisterProtocol(testProtocolName)
+
+	err := Shutdown(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "panic")
 }


### PR DESCRIPTION
### Description

  #### 3. Graceful shutdown result publication hardened
  `graceful_shutdown/shutdown.go`
  Added `shutdownResultMu` guarding all reads/writes of the package-level `shutdownResult`,
  removing reliance on subtle ordering assumptions between the background shutdown goroutine
  and concurrent `Shutdown()` readers.

Fixes #3453

### Tests
  - `TestShutdownResultConsistentUnderConcurrentReaders`, `TestShutdownPanicSetsResultError`

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
