### PR TITLE
fix(script-router): clear all script globals on runtime pool return

### DIFF
--- a/cluster/router/script/instance/js_instance.go
+++ b/cluster/router/script/instance/js_instance.go
@@ -46,6 +46,10 @@ type jsInstances struct {
 
 type jsInstance struct {
 	rt *goja.Runtime
+	// baseGlobals is the set of global names present in a freshly created
+	// runtime (built-ins). Any global outside this set is treated as
+	// request/script state and removed on reset.
+	baseGlobals map[string]struct{}
 }
 
 type program struct {
@@ -82,6 +86,10 @@ func (i *jsInstances) Run(rawScript string, invokers []base.Invoker, invocation 
 		return invokers, nil
 	}
 	matcher := i.insPool.Get().(*jsInstance)
+	defer func() {
+		matcher.reset()
+		i.insPool.Put(matcher)
+	}()
 
 	packInvokers := make([]base.Invoker, 0, len(invokers))
 	for _, invoker := range invokers {
@@ -179,9 +187,30 @@ func (j jsInstance) initReplyVar() {
 	}
 }
 
+// reset removes every global added since the runtime was created — the request
+// bindings (invokers/invocation/context/result) as well as any globals defined
+// by the executed user script — before returning the instance to the pool. This
+// prevents cross-request state leakage via pooled goja.Runtime globals. Built-in
+// globals captured at construction time are preserved.
+func (j jsInstance) reset() {
+	global := j.rt.GlobalObject()
+	for _, key := range global.Keys() {
+		if _, isBase := j.baseGlobals[key]; isBase {
+			continue
+		}
+		_ = global.Delete(key)
+	}
+}
+
 func newJsInstance() *jsInstance {
+	rt := goja.New()
+	base := make(map[string]struct{})
+	for _, key := range rt.GlobalObject().Keys() {
+		base[key] = struct{}{}
+	}
 	return &jsInstance{
-		rt: goja.New(),
+		rt:          rt,
+		baseGlobals: base,
 	}
 }
 

--- a/cluster/router/script/instance/js_instance_test.go
+++ b/cluster/router/script/instance/js_instance_test.go
@@ -716,3 +716,37 @@ func TestRunScriptInPanic(t *testing.T) {
 `
 	wontPanic(scriptCallWrongArgs3)
 }
+
+func TestJsInstanceResetClearsBindings(t *testing.T) {
+	inst := newJsInstance()
+
+	testify_require.NoError(t, inst.rt.Set("invokers", []string{"test"}))
+	testify_require.NoError(t, inst.rt.Set("invocation", "test-inv"))
+	testify_require.NoError(t, inst.rt.Set("context", "test-ctx"))
+	testify_require.NoError(t, inst.rt.Set(jsScriptResultName, "test-result"))
+	// Global defined by a user script must also be cleared on reset.
+	_, err := inst.rt.RunString("userDefinedGlobal = 42;")
+	testify_require.NoError(t, err)
+	assert.NotNil(t, inst.rt.Get("userDefinedGlobal"))
+
+	inst.reset()
+
+	// Get returns nil for undefined globals after reset.
+	assert.Nil(t, inst.rt.Get("invokers"))
+	assert.Nil(t, inst.rt.Get("invocation"))
+	assert.Nil(t, inst.rt.Get("context"))
+	assert.Nil(t, inst.rt.Get(jsScriptResultName))
+	assert.Nil(t, inst.rt.Get("userDefinedGlobal"))
+}
+
+func TestJsInstanceRunReturnsRuntimeToPool(t *testing.T) {
+	instances := newJsInstances()
+	testify_require.NoError(t, instances.Compile(Func_Script))
+
+	invokers, inv, _ := getRouteArgs()
+	for i := 0; i < 5; i++ {
+		result, err := instances.Run(Func_Script, invokers, inv)
+		testify_require.NoError(t, err)
+		assert.NotEmpty(t, result)
+	}
+}


### PR DESCRIPTION
Fixes #3453

### Description

  #### 5. Script-router JS runtime no longer leaks cross-request state
  `cluster/router/script/instance/js_instance.go`
  Pooled `goja.Runtime` instances were never returned to the pool, and request/script globals
  survived reuse. Added `defer reset()+Put()` in `Run()`. `reset()` snapshots the built-in
  global keys at construction and deletes every global outside that set — clearing both request
  bindings and user-script-defined globals while preserving built-ins.

### Tests
  - `TestJsInstanceResetClearsBindings` (incl. user-defined global), `TestJsInstanceRunReturnsRuntimeToPool`

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
