### PR TITLE
fix(forking): cancel losing parallel branches when first result wins

### DIFF
--- a/cluster/cluster/forking/cluster_invoker.go
+++ b/cluster/cluster/forking/cluster_invoker.go
@@ -71,10 +71,15 @@ func (invoker *forkingClusterInvoker) Invoke(ctx context.Context, invocation pro
 		}
 	}
 
+	// forkCtx is canceled when Invoke returns, signaling losing parallel
+	// goroutines to stop rather than running to completion.
+	forkCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	resultQ := queue.New(1)
 	for _, ivk := range selected {
 		go func(k protocolbase.Invoker) {
-			result := k.Invoke(ctx, invocation)
+			result := k.Invoke(forkCtx, invocation)
 			if err := resultQ.Put(result); err != nil {
 				logger.Errorf("[Cluster][Forking] resultQ put failed with exception err=%v", err)
 			}

--- a/cluster/cluster/forking/cluster_test.go
+++ b/cluster/cluster/forking/cluster_test.go
@@ -163,3 +163,38 @@ func TestForkingInvokeHalfTimeout(t *testing.T) {
 	assert.Equal(t, mockResult, result)
 	wg.Wait()
 }
+
+func TestForkingInvokeCancelsLosingBranches(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	forkingUrl.AddParam(constant.ForksKey, strconv.Itoa(2))
+
+	loserCtxCanceled := make(chan struct{})
+
+	winner := mock.NewMockInvoker(ctrl)
+	winner.EXPECT().IsAvailable().Return(true).AnyTimes()
+	winner.EXPECT().Invoke(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ base.Invocation) result.Result {
+			return &result.RPCResult{}
+		})
+
+	loser := mock.NewMockInvoker(ctrl)
+	loser.EXPECT().IsAvailable().Return(true).AnyTimes()
+	loser.EXPECT().Invoke(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, _ base.Invocation) result.Result {
+			<-ctx.Done()
+			close(loserCtxCanceled)
+			return &result.RPCResult{}
+		})
+
+	clusterInvoker := registerForking(winner, loser)
+	res := clusterInvoker.Invoke(context.Background(), &invocation.RPCInvocation{})
+	require.NoError(t, res.Error())
+
+	select {
+	case <-loserCtxCanceled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("loser branch context was not canceled after winner succeeded")
+	}
+}


### PR DESCRIPTION
Fixes #3453

### Description

  #### 6. Forking cluster cancels losing parallel branches
  `cluster/cluster/forking/cluster_invoker.go`
  Losing parallel invocations ran to completion after the winner returned, wasting downstream
  work. Derived a cancelable `forkCtx`; `defer cancel()` stops sibling requests as soon as the
  first accepted result wins.

### Tests
  - `TestForkingInvokeCancelsLosingBranches` — loser branch ctx canceled after winner succeeds

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
