### PR TITLE
feat(config): expose the method to get `CustomConfig` and `InstanceOptions`

### DIFF
--- a/dubbo.go
+++ b/dubbo.go
@@ -29,6 +29,7 @@ import (
 import (
 	"dubbo.apache.org/dubbo-go/v3/client"
 	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/server"
 )
 
@@ -40,7 +41,7 @@ var (
 	startOnce        sync.Once
 )
 
-// Instance is the highest layer conception that user could touch. It is mapped from RootConfig.
+// Instance is the highest layer conception that user could touch.
 // When users want to inject global configurations and configure common modules for client layer
 // and server layer, user-side code would be like this:
 //
@@ -59,6 +60,39 @@ func NewInstance(opts ...InstanceOption) (*Instance, error) {
 	}
 
 	return &Instance{insOpts: newInsOpts}, nil
+}
+
+// GetOptionsSnapshot returns a detached snapshot of this instance's options.
+func (ins *Instance) GetInstanceOptionsSnapshot() *InstanceOptions {
+	if ins == nil || ins.insOpts == nil {
+		return nil
+	}
+	return ins.insOpts.Clone()
+}
+
+// GetCustomConfig returns a detached snapshot of this instance's custom config.
+func (ins *Instance) GetCustomConfigSnapshot() *global.CustomConfig {
+	if ins == nil || ins.insOpts == nil {
+		return nil
+	}
+	return ins.insOpts.CloneCustom()
+}
+
+// GetInstanceOptionsSnapshot returns a detached snapshot of the options loaded by Load.
+func GetInstanceOptionsSnapshot() *InstanceOptions {
+	instanceOptionsMutex.Lock()
+	defer instanceOptionsMutex.Unlock()
+	return instanceOptions.Clone()
+}
+
+// GetCustomConfig returns a detached snapshot of the custom config loaded by Load.
+func GetCustomConfigSnapshot() *global.CustomConfig {
+	instanceOptionsMutex.Lock()
+	defer instanceOptionsMutex.Unlock()
+	if instanceOptions == nil {
+		return nil
+	}
+	return instanceOptions.CloneCustom()
 }
 
 // NewClient is like client.NewClient, but inject configurations from RootConfig and

--- a/dubbo_test.go
+++ b/dubbo_test.go
@@ -119,6 +119,91 @@ func TestIndependentConfig(t *testing.T) {
 	}
 }
 
+func TestInstanceOptionsSnapshotIsDetached(t *testing.T) {
+	useAgent := false
+	ins, err := NewInstance(func(opts *InstanceOptions) {
+		opts.Application.Name = "snapshot-app"
+		opts.Registries = map[string]*global.RegistryConfig{
+			"zk": {
+				Protocol:        constant.ZookeeperKey,
+				Address:         "127.0.0.1:2181",
+				UseAsMetaReport: "false",
+			},
+		}
+		opts.Tracing = map[string]*global.TracingConfig{
+			"jaeger": {
+				Name:     "jaeger",
+				Address:  "127.0.0.1:6831",
+				UseAgent: &useAgent,
+			},
+		}
+		opts.Custom = &global.CustomConfig{
+			ConfigMap: map[string]any{"k": "v"},
+		}
+	})
+	require.NoError(t, err)
+
+	snapshot := ins.GetInstanceOptionsSnapshot()
+	require.NotNil(t, snapshot)
+	require.NotNil(t, snapshot.Application)
+	require.NotNil(t, snapshot.Registries["zk"])
+	require.NotNil(t, snapshot.Tracing["jaeger"])
+	require.NotNil(t, snapshot.Tracing["jaeger"].UseAgent)
+	require.NotNil(t, snapshot.Custom)
+
+	snapshot.Application.Name = "changed-app"
+	snapshot.Registries["zk"].Address = "127.0.0.1:2182"
+	*snapshot.Tracing["jaeger"].UseAgent = true
+	snapshot.Custom.ConfigMap["k"] = "changed"
+
+	assert.Equal(t, "snapshot-app", ins.insOpts.Application.Name)
+	assert.Equal(t, "127.0.0.1:2181", ins.insOpts.Registries["zk"].Address)
+	assert.False(t, *ins.insOpts.Tracing["jaeger"].UseAgent)
+	assert.Equal(t, "v", ins.insOpts.Custom.ConfigMap["k"])
+}
+
+func TestWithCustom(t *testing.T) {
+	configMap := map[string]any{"k": "v"}
+	ins, err := NewInstance(WithCustom(configMap))
+	require.NoError(t, err)
+
+	configMap["k"] = "changed"
+
+	custom := ins.GetCustomConfigSnapshot()
+	require.NotNil(t, custom)
+	assert.Equal(t, "v", custom.ConfigMap["k"])
+
+	custom.ConfigMap["k"] = "changed-again"
+	assert.Equal(t, "v", ins.insOpts.Custom.ConfigMap["k"])
+}
+
+func TestGlobalInstanceOptionsSnapshotIsDetached(t *testing.T) {
+	prevIns := instanceOptions
+	defer func() { instanceOptions = prevIns }()
+
+	instanceOptions = defaultInstanceOptions()
+	instanceOptions.Application.Name = "global-snapshot-app"
+	instanceOptions.Custom = &global.CustomConfig{
+		ConfigMap: map[string]any{"k": "v"},
+	}
+
+	snapshot := GetInstanceOptionsSnapshot()
+	require.NotNil(t, snapshot)
+	require.NotNil(t, snapshot.Application)
+	require.NotNil(t, snapshot.Custom)
+
+	snapshot.Application.Name = "changed-app"
+	snapshot.Custom.ConfigMap["k"] = "changed"
+
+	assert.Equal(t, "global-snapshot-app", instanceOptions.Application.Name)
+	assert.Equal(t, "v", instanceOptions.Custom.ConfigMap["k"])
+
+	custom := GetCustomConfigSnapshot()
+	require.NotNil(t, custom)
+	custom.ConfigMap["k"] = "changed-again"
+	assert.Equal(t, "v", instanceOptions.Custom.ConfigMap["k"])
+}
+
 func TestInstanceInitKeepsGlobalOnlyConfigWithConfigCenter(t *testing.T) {
 	resetDynamicConfiguration(t)
 

--- a/global/config_test.go
+++ b/global/config_test.go
@@ -1751,8 +1751,10 @@ func TestDefaultCustomConfig(t *testing.T) {
 	t.Run("default_custom_config", func(t *testing.T) {
 		custom := DefaultCustomConfig()
 		assert.NotNil(t, custom)
+		assert.NotNil(t, custom.ConfigMap)
 	})
 }
+
 func TestMethodConfigClone(t *testing.T) {
 	t.Run("clone_full_method_config", func(t *testing.T) {
 		method := &MethodConfig{

--- a/global/tracing_config.go
+++ b/global/tracing_config.go
@@ -25,3 +25,23 @@ type TracingConfig struct {
 	Address     string `yaml:"address" json:"address,omitempty" property:"address"`
 	UseAgent    *bool  `default:"false" yaml:"use-agent" json:"use-agent,omitempty" property:"use-agent"`
 }
+
+// Clone a new TracingConfig
+func (c *TracingConfig) Clone() *TracingConfig {
+	if c == nil {
+		return nil
+	}
+
+	var useAgent *bool
+	if c.UseAgent != nil {
+		v := *c.UseAgent
+		useAgent = &v
+	}
+
+	return &TracingConfig{
+		Name:        c.Name,
+		ServiceName: c.ServiceName,
+		Address:     c.Address,
+		UseAgent:    useAgent,
+	}
+}

--- a/loader.go
+++ b/loader.go
@@ -68,22 +68,26 @@ var watcher = &fileWatcher{
 
 func Load(opts ...LoaderConfOption) error {
 	conf := NewLoaderConf(opts...)
+	newOpts := conf.opts
 	if conf.opts == nil {
+		newOpts = defaultInstanceOptions()
 		koan := GetConfigResolver(conf)
 		koan = conf.MergeConfig(koan)
-		if err := koan.UnmarshalWithConf(instanceOptions.Prefix(),
-			instanceOptions, koanf.UnmarshalConf{Tag: "yaml"}); err != nil {
+		if err := koan.UnmarshalWithConf(newOpts.Prefix(),
+			newOpts, koanf.UnmarshalConf{Tag: "yaml"}); err != nil {
 			return err
 		}
-	} else {
-		instanceOptions = conf.opts
 	}
 
-	if err := instanceOptions.init(); err != nil {
+	if err := newOpts.init(); err != nil {
 		return err
 	}
 
-	instance := &Instance{insOpts: instanceOptions}
+	instanceOptionsMutex.Lock()
+	instanceOptions = newOpts
+	instanceOptionsMutex.Unlock()
+
+	instance := &Instance{insOpts: newOpts}
 	// start the file watcher
 	once.Do(func() {
 		watcher.watcherWg.Add(1)

--- a/options.go
+++ b/options.go
@@ -18,6 +18,7 @@
 package dubbo
 
 import (
+	"maps"
 	"strconv"
 	"time"
 )
@@ -218,6 +219,17 @@ func (rc *InstanceOptions) CloneMetrics() *global.MetricsConfig {
 	return rc.Metrics.Clone()
 }
 
+func (rc *InstanceOptions) CloneTracing() map[string]*global.TracingConfig {
+	if rc.Tracing == nil {
+		return nil
+	}
+	tracing := make(map[string]*global.TracingConfig, len(rc.Tracing))
+	for k, v := range rc.Tracing {
+		tracing[k] = v.Clone()
+	}
+	return tracing
+}
+
 func (rc *InstanceOptions) CloneOtel() *global.OtelConfig {
 	if rc.Otel == nil {
 		return nil
@@ -269,6 +281,36 @@ func (rc *InstanceOptions) CloneTLSConfig() *global.TLSConfig {
 		return nil
 	}
 	return rc.TLSConfig.Clone()
+}
+
+// Clone returns a snapshot of InstanceOptions. The returned value is detached
+// from the running instance, so callers can inspect or modify it without
+// changing live framework configuration.
+func (rc *InstanceOptions) Clone() *InstanceOptions {
+	if rc == nil {
+		return nil
+	}
+
+	return &InstanceOptions{
+		Application:         rc.CloneApplication(),
+		Protocols:           rc.CloneProtocols(),
+		Registries:          rc.CloneRegistries(),
+		ConfigCenter:        rc.CloneConfigCenter(),
+		MetadataReport:      rc.CloneMetadataReport(),
+		Provider:            rc.CloneProvider(),
+		Consumer:            rc.CloneConsumer(),
+		Metrics:             rc.CloneMetrics(),
+		Tracing:             rc.CloneTracing(),
+		Otel:                rc.CloneOtel(),
+		Logger:              rc.CloneLogger(),
+		Shutdown:            rc.CloneShutdown(),
+		Router:              rc.CloneRouter(),
+		EventDispatcherType: rc.EventDispatcherType,
+		CacheFile:           rc.CacheFile,
+		Custom:              rc.CloneCustom(),
+		Profiles:            rc.CloneProfiles(),
+		TLSConfig:           rc.CloneTLSConfig(),
+	}
 }
 
 type InstanceOption func(*InstanceOptions)
@@ -453,16 +495,13 @@ func WithRouter(opts ...router.Option) InstanceOption {
 //	}
 //}
 
-//func WithCustom(opts ...global.CustomOption) InstanceOption {
-//	cusCfg := new(global.CustomConfig)
-//	for _, opt := range opts {
-//		opt(cusCfg)
-//	}
-//
-//	return func(cfg *InstanceOptions) {
-//		cfg.Custom = cusCfg
-//	}
-//}
+func WithCustom(configMap map[string]any) InstanceOption {
+	return func(cfg *InstanceOptions) {
+		custom := global.DefaultCustomConfig()
+		maps.Copy(custom.ConfigMap, configMap)
+		cfg.Custom = custom
+	}
+}
 
 //func WithProfiles(opts ...global.ProfilesOption) InstanceOption {
 //	proCfg := new(global.ProfilesConfig)


### PR DESCRIPTION
### Description

1. Users can't get `CustomConfig`, I expose it
2. Expose the snapshot method for users to get `InstanceOptions`

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
