### PR TITLE
fix(polaris): reconcile initial subscribe snapshot

### DIFF
--- a/registry/polaris/core.go
+++ b/registry/polaris/core.go
@@ -36,11 +36,15 @@ import (
 type item func(remoting.EventType, []model.Instance)
 
 type PolarisServiceWatcher struct {
-	consumer       api.ConsumerAPI
-	subscribeParam *api.WatchServiceRequest
-	lock           *sync.RWMutex
-	subscribers    []item
-	execOnce       *sync.Once
+	consumer                api.ConsumerAPI
+	subscribeParam          *api.WatchServiceRequest
+	lock                    *sync.RWMutex
+	subscribers             []item
+	execOnce                *sync.Once
+	initialSnapshotLock     sync.Mutex
+	initialSnapshot         []model.Instance
+	hasInitialSnapshot      bool
+	initialSnapshotConsumed bool
 }
 
 // newPolarisWatcher create PolarisServiceWatcher to do watch service action
@@ -72,6 +76,68 @@ func (watcher *PolarisServiceWatcher) lazyRun() {
 	})
 }
 
+func (watcher *PolarisServiceWatcher) setInitialSnapshot(instances []model.Instance) {
+	watcher.initialSnapshotLock.Lock()
+	defer watcher.initialSnapshotLock.Unlock()
+
+	// A watcher is reused per service. Never re-arm reconciliation after its first successful snapshot.
+	if watcher.initialSnapshotConsumed {
+		return
+	}
+	watcher.initialSnapshot = append([]model.Instance(nil), instances...)
+	watcher.hasInitialSnapshot = true
+}
+
+func (watcher *PolarisServiceWatcher) takeInitialSnapshot() ([]model.Instance, bool) {
+	watcher.initialSnapshotLock.Lock()
+	defer watcher.initialSnapshotLock.Unlock()
+
+	if watcher.initialSnapshotConsumed {
+		return nil, false
+	}
+	watcher.initialSnapshotConsumed = true
+	if !watcher.hasInitialSnapshot {
+		return nil, false
+	}
+
+	instances := append([]model.Instance(nil), watcher.initialSnapshot...)
+	watcher.initialSnapshot = nil
+	watcher.hasInitialSnapshot = false
+	return instances, true
+}
+
+func missingInitialInstances(initial []model.Instance, current []model.Instance) []model.Instance {
+	currentInstances := make(map[model.InstanceKey]struct{}, len(current))
+	for _, instance := range current {
+		currentInstances[instance.GetInstanceKey()] = struct{}{}
+	}
+
+	missing := make([]model.Instance, 0, len(initial))
+	for _, instance := range initial {
+		if _, ok := currentInstances[instance.GetInstanceKey()]; !ok {
+			missing = append(missing, instance)
+		}
+	}
+	return missing
+}
+
+func (watcher *PolarisServiceWatcher) handleInitialWatchSnapshot(current []model.Instance) {
+	if initial, ok := watcher.takeInitialSnapshot(); ok {
+		missing := missingInitialInstances(initial, current)
+		if len(missing) > 0 {
+			watcher.notifyAllSubscriber(&config_center.ConfigChangeEvent{
+				Value:      missing,
+				ConfigType: remoting.EventTypeDel,
+			})
+		}
+	}
+
+	watcher.notifyAllSubscriber(&config_center.ConfigChangeEvent{
+		Value:      current,
+		ConfigType: remoting.EventTypeAdd,
+	})
+}
+
 // startWatch start run work to watch target service by polaris
 func (watcher *PolarisServiceWatcher) startWatch() {
 	for {
@@ -80,10 +146,7 @@ func (watcher *PolarisServiceWatcher) startWatch() {
 			time.Sleep(time.Duration(500 * time.Millisecond))
 			continue
 		}
-		watcher.notifyAllSubscriber(&config_center.ConfigChangeEvent{
-			Value:      resp.GetAllInstancesResp.Instances,
-			ConfigType: remoting.EventTypeAdd,
-		})
+		watcher.handleInitialWatchSnapshot(resp.GetAllInstancesResp.Instances)
 
 		for event := range resp.EventChannel {
 			eType := event.GetSubScribeEventType()

--- a/registry/polaris/core.go
+++ b/registry/polaris/core.go
@@ -29,22 +29,25 @@ import (
 )
 
 import (
-	"dubbo.apache.org/dubbo-go/v3/config_center"
 	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
 
 type item func(remoting.EventType, []model.Instance)
 
+type subscriberState struct {
+	notify          item
+	initialSnapshot []model.Instance
+	reconciled      bool
+}
+
 type PolarisServiceWatcher struct {
-	consumer                api.ConsumerAPI
-	subscribeParam          *api.WatchServiceRequest
-	lock                    *sync.RWMutex
-	subscribers             []item
-	execOnce                *sync.Once
-	initialSnapshotLock     sync.Mutex
-	initialSnapshot         []model.Instance
-	hasInitialSnapshot      bool
-	initialSnapshotConsumed bool
+	consumer         api.ConsumerAPI
+	subscribeParam   *api.WatchServiceRequest
+	lock             *sync.Mutex
+	subscribers      []*subscriberState
+	execOnce         *sync.Once
+	currentInstances []model.Instance
+	snapshotReady    bool
 }
 
 // newPolarisWatcher create PolarisServiceWatcher to do watch service action
@@ -52,21 +55,28 @@ func newPolarisWatcher(param *api.WatchServiceRequest, consumer api.ConsumerAPI)
 	watcher := &PolarisServiceWatcher{
 		subscribeParam: param,
 		consumer:       consumer,
-		lock:           &sync.RWMutex{},
-		subscribers:    make([]item, 0),
+		lock:           &sync.Mutex{},
+		subscribers:    make([]*subscriberState, 0),
 		execOnce:       &sync.Once{},
 	}
 	return watcher, nil
 }
 
 // AddSubscriber add subscriber into watcher's subscribers
-func (watcher *PolarisServiceWatcher) AddSubscriber(subscriber func(remoting.EventType, []model.Instance)) {
+func (watcher *PolarisServiceWatcher) AddSubscriber(subscriber item) {
+	state := &subscriberState{
+		notify:     subscriber,
+		reconciled: true,
+	}
 
-	watcher.lock.Lock()
+	func() {
+		watcher.lock.Lock()
+		defer watcher.lock.Unlock()
+
+		watcher.subscribers = append(watcher.subscribers, state)
+	}()
+
 	watcher.lazyRun()
-	defer watcher.lock.Unlock()
-
-	watcher.subscribers = append(watcher.subscribers, subscriber)
 }
 
 // lazyRun Delayed execution, only triggered when AddSubscriber is called, and will only be executed once
@@ -76,38 +86,28 @@ func (watcher *PolarisServiceWatcher) lazyRun() {
 	})
 }
 
-// setInitialSnapshot stores synchronously loaded instances as the baseline for
-// reconciling the first successful watcher full snapshot.
-func (watcher *PolarisServiceWatcher) setInitialSnapshot(instances []model.Instance) {
-	watcher.initialSnapshotLock.Lock()
-	defer watcher.initialSnapshotLock.Unlock()
-
-	// A watcher is reused per service. Never re-arm reconciliation after its first successful snapshot.
-	if watcher.initialSnapshotConsumed {
-		return
-	}
-	watcher.initialSnapshot = append([]model.Instance(nil), instances...)
-	watcher.hasInitialSnapshot = true
-}
-
-// takeInitialSnapshot returns and consumes the baseline for the first successful watcher full snapshot.
-// Failed WatchService attempts do not call it, and a consumed watcher cannot be armed again.
-func (watcher *PolarisServiceWatcher) takeInitialSnapshot() ([]model.Instance, bool) {
-	watcher.initialSnapshotLock.Lock()
-	defer watcher.initialSnapshotLock.Unlock()
-
-	if watcher.initialSnapshotConsumed {
-		return nil, false
-	}
-	watcher.initialSnapshotConsumed = true
-	if !watcher.hasInitialSnapshot {
-		return nil, false
+func (watcher *PolarisServiceWatcher) addSubscriberWithInitialSnapshot(
+	initialSnapshot []model.Instance,
+	subscriber item,
+) {
+	state := &subscriberState{
+		notify:          subscriber,
+		initialSnapshot: copyInstances(initialSnapshot),
 	}
 
-	instances := append([]model.Instance(nil), watcher.initialSnapshot...)
-	watcher.initialSnapshot = nil
-	watcher.hasInitialSnapshot = false
-	return instances, true
+	func() {
+		watcher.lock.Lock()
+		defer watcher.lock.Unlock()
+
+		watcher.subscribers = append(watcher.subscribers, state)
+		if watcher.snapshotReady {
+			watcher.reconcileSubscriberLocked(state)
+		}
+	}()
+
+	// Start only after the subscriber is registered and any available current
+	// snapshot has been replayed.
+	watcher.lazyRun()
 }
 
 // missingInitialInstances returns initial - current by model.InstanceKey while
@@ -127,23 +127,31 @@ func missingInitialInstances(initial []model.Instance, current []model.Instance)
 	return missing
 }
 
-// handleInitialWatchSnapshot reconciles the first successful watcher full snapshot
-// with the synchronous baseline before publishing the current instances.
-func (watcher *PolarisServiceWatcher) handleInitialWatchSnapshot(current []model.Instance) {
-	if initial, ok := watcher.takeInitialSnapshot(); ok {
-		missing := missingInitialInstances(initial, current)
-		if len(missing) > 0 {
-			watcher.notifyAllSubscriber(&config_center.ConfigChangeEvent{
-				Value:      missing,
-				ConfigType: remoting.EventTypeDel,
-			})
-		}
-	}
+// handleWatchSnapshot replaces the watcher's current state and reconciles each
+// subscriber's own synchronous-load baseline exactly once.
+func (watcher *PolarisServiceWatcher) handleWatchSnapshot(current []model.Instance) {
+	watcher.lock.Lock()
+	defer watcher.lock.Unlock()
 
-	watcher.notifyAllSubscriber(&config_center.ConfigChangeEvent{
-		Value:      current,
-		ConfigType: remoting.EventTypeAdd,
-	})
+	watcher.currentInstances = copyInstances(current)
+	watcher.snapshotReady = true
+	for _, subscriber := range watcher.subscribers {
+		if subscriber.reconciled {
+			watcher.notifySubscriberLocked(subscriber, remoting.EventTypeAdd, watcher.currentInstances)
+			continue
+		}
+		watcher.reconcileSubscriberLocked(subscriber)
+	}
+}
+
+func (watcher *PolarisServiceWatcher) reconcileSubscriberLocked(subscriber *subscriberState) {
+	missing := missingInitialInstances(subscriber.initialSnapshot, watcher.currentInstances)
+	if len(missing) > 0 {
+		watcher.notifySubscriberLocked(subscriber, remoting.EventTypeDel, missing)
+	}
+	watcher.notifySubscriberLocked(subscriber, remoting.EventTypeAdd, watcher.currentInstances)
+	subscriber.reconciled = true
+	subscriber.initialSnapshot = nil
 }
 
 // startWatch start run work to watch target service by polaris
@@ -154,49 +162,93 @@ func (watcher *PolarisServiceWatcher) startWatch() {
 			time.Sleep(time.Duration(500 * time.Millisecond))
 			continue
 		}
-		watcher.handleInitialWatchSnapshot(resp.GetAllInstancesResp.Instances)
+		watcher.handleWatchSnapshot(resp.GetAllInstancesResp.Instances)
 
 		for event := range resp.EventChannel {
 			eType := event.GetSubScribeEventType()
 			if eType == internalapi.EventInstance {
-				insEvent := event.(*model.InstanceEvent)
-
-				if insEvent.AddEvent != nil {
-					watcher.notifyAllSubscriber(&config_center.ConfigChangeEvent{
-						Value:      insEvent.AddEvent.Instances,
-						ConfigType: remoting.EventTypeAdd,
-					})
-				}
-				if insEvent.UpdateEvent != nil {
-					instances := make([]model.Instance, len(insEvent.UpdateEvent.UpdateList))
-					for i := range insEvent.UpdateEvent.UpdateList {
-						instances[i] = insEvent.UpdateEvent.UpdateList[i].After
-					}
-					watcher.notifyAllSubscriber(&config_center.ConfigChangeEvent{
-						Value:      instances,
-						ConfigType: remoting.EventTypeUpdate,
-					})
-				}
-				if insEvent.DeleteEvent != nil {
-					watcher.notifyAllSubscriber(&config_center.ConfigChangeEvent{
-						Value:      insEvent.DeleteEvent.Instances,
-						ConfigType: remoting.EventTypeDel,
-					})
-				}
+				watcher.handleInstanceEvent(event.(*model.InstanceEvent))
 			}
 		}
 
 	}
 }
 
-// notifyAllSubscriber notify config_center.ConfigChangeEvent to all subscriber
-func (watcher *PolarisServiceWatcher) notifyAllSubscriber(event *config_center.ConfigChangeEvent) {
-	watcher.lock.RLock()
-	defer watcher.lock.RUnlock()
-
-	for i := 0; i < len(watcher.subscribers); i++ {
-		subscriber := watcher.subscribers[i]
-		subscriber(event.ConfigType, event.Value.([]model.Instance))
+func (watcher *PolarisServiceWatcher) handleInstanceEvent(event *model.InstanceEvent) {
+	if event == nil {
+		return
 	}
 
+	watcher.lock.Lock()
+	defer watcher.lock.Unlock()
+
+	if event.AddEvent != nil {
+		instances := copyInstances(event.AddEvent.Instances)
+		for _, instance := range instances {
+			watcher.upsertCurrentInstanceLocked(instance)
+		}
+		watcher.notifyReconciledSubscribersLocked(remoting.EventTypeAdd, instances)
+	}
+	if event.UpdateEvent != nil {
+		instances := make([]model.Instance, 0, len(event.UpdateEvent.UpdateList))
+		for _, update := range event.UpdateEvent.UpdateList {
+			if update.Before.GetInstanceKey() != update.After.GetInstanceKey() {
+				watcher.removeCurrentInstancesLocked([]model.Instance{update.Before})
+			}
+			watcher.upsertCurrentInstanceLocked(update.After)
+			instances = append(instances, update.After)
+		}
+		watcher.notifyReconciledSubscribersLocked(remoting.EventTypeUpdate, instances)
+	}
+	if event.DeleteEvent != nil {
+		instances := copyInstances(event.DeleteEvent.Instances)
+		watcher.removeCurrentInstancesLocked(instances)
+		watcher.notifyReconciledSubscribersLocked(remoting.EventTypeDel, instances)
+	}
+}
+
+func (watcher *PolarisServiceWatcher) upsertCurrentInstanceLocked(instance model.Instance) {
+	key := instance.GetInstanceKey()
+	for i := range watcher.currentInstances {
+		if watcher.currentInstances[i].GetInstanceKey() == key {
+			watcher.currentInstances[i] = instance
+			return
+		}
+	}
+	watcher.currentInstances = append(watcher.currentInstances, instance)
+}
+
+func (watcher *PolarisServiceWatcher) removeCurrentInstancesLocked(instances []model.Instance) {
+	keys := make(map[model.InstanceKey]struct{}, len(instances))
+	for _, instance := range instances {
+		keys[instance.GetInstanceKey()] = struct{}{}
+	}
+
+	current := watcher.currentInstances[:0]
+	for _, instance := range watcher.currentInstances {
+		if _, remove := keys[instance.GetInstanceKey()]; !remove {
+			current = append(current, instance)
+		}
+	}
+	watcher.currentInstances = current
+}
+
+func (watcher *PolarisServiceWatcher) notifyReconciledSubscribersLocked(eventType remoting.EventType, instances []model.Instance) {
+	for _, subscriber := range watcher.subscribers {
+		if subscriber.reconciled {
+			watcher.notifySubscriberLocked(subscriber, eventType, instances)
+		}
+	}
+}
+
+func (watcher *PolarisServiceWatcher) notifySubscriberLocked(
+	subscriber *subscriberState,
+	eventType remoting.EventType,
+	instances []model.Instance,
+) {
+	subscriber.notify(eventType, copyInstances(instances))
+}
+
+func copyInstances(instances []model.Instance) []model.Instance {
+	return append([]model.Instance(nil), instances...)
 }

--- a/registry/polaris/core.go
+++ b/registry/polaris/core.go
@@ -173,10 +173,10 @@ func (watcher *PolarisServiceWatcher) handleWatchSnapshot(current []model.Instan
 	watcher.lock.Lock()
 	defer watcher.lock.Unlock()
 
-	registryCurrent := notifiableInstances(current, watcher.hasRegistrySubscriberLocked())
+	next := copyInstances(current)
+	registryCurrent := notifiableInstances(next, watcher.hasRegistrySubscriberLocked())
 	previous := watcher.currentInstances
 	hadPreviousSnapshot := watcher.snapshotReady
-	next := copyInstances(current)
 	var removedSincePrevious []model.Instance
 	if hadPreviousSnapshot {
 		registryPrevious := notifiableInstances(previous, false)
@@ -262,13 +262,17 @@ func (watcher *PolarisServiceWatcher) handleInstanceEvent(event *model.InstanceE
 		registryUpdates := make([]model.Instance, 0, len(event.UpdateEvent.UpdateList))
 		registryDeletes := make([]model.Instance, 0, len(event.UpdateEvent.UpdateList))
 		changedKeyBefore := make([]model.Instance, 0, len(event.UpdateEvent.UpdateList))
+		updates := make([]model.OneInstanceUpdate, 0, len(event.UpdateEvent.UpdateList))
 		for _, update := range event.UpdateEvent.UpdateList {
-			if update.Before.GetInstanceKey() != update.After.GetInstanceKey() {
-				changedKeyBefore = append(changedKeyBefore, update.Before)
+			before := newPolarisInstanceSnapshot(update.Before)
+			after := newPolarisInstanceSnapshot(update.After)
+			updates = append(updates, model.OneInstanceUpdate{Before: before, After: after})
+			if before.GetInstanceKey() != after.GetInstanceKey() {
+				changedKeyBefore = append(changedKeyBefore, before)
 			}
 		}
 		watcher.removeCurrentInstancesLocked(changedKeyBefore)
-		for _, update := range event.UpdateEvent.UpdateList {
+		for _, update := range updates {
 			beforeValid := polarisInstanceURLValidationError(update.Before) == ""
 			afterValidationError := polarisInstanceURLValidationError(update.After)
 			afterValid := afterValidationError == ""
@@ -369,5 +373,167 @@ func (watcher *PolarisServiceWatcher) notifySubscriberLocked(
 }
 
 func copyInstances(instances []model.Instance) []model.Instance {
-	return append([]model.Instance(nil), instances...)
+	if len(instances) == 0 {
+		return nil
+	}
+
+	copied := make([]model.Instance, len(instances))
+	for i, instance := range instances {
+		copied[i] = newPolarisInstanceSnapshot(instance)
+	}
+	return copied
+}
+
+type polarisInstanceSnapshot struct {
+	instanceKey          model.InstanceKey
+	namespace            string
+	service              string
+	id                   string
+	host                 string
+	port                 uint32
+	vpcID                string
+	protocol             string
+	version              string
+	weight               int
+	priority             uint32
+	metadata             map[string]string
+	logicSet             string
+	circuitBreakerStatus model.CircuitBreakerStatus
+	healthy              bool
+	isolated             bool
+	enableHealthCheck    bool
+	region               string
+	zone                 string
+	idc                  string
+	campus               string
+	revision             string
+}
+
+func newPolarisInstanceSnapshot(instance model.Instance) model.Instance {
+	if instance == nil {
+		return nil
+	}
+	return &polarisInstanceSnapshot{
+		instanceKey:          instance.GetInstanceKey(),
+		namespace:            instance.GetNamespace(),
+		service:              instance.GetService(),
+		id:                   instance.GetId(),
+		host:                 instance.GetHost(),
+		port:                 instance.GetPort(),
+		vpcID:                instance.GetVpcId(),
+		protocol:             instance.GetProtocol(),
+		version:              instance.GetVersion(),
+		weight:               instance.GetWeight(),
+		priority:             instance.GetPriority(),
+		metadata:             copyStringMap(instance.GetMetadata()),
+		logicSet:             instance.GetLogicSet(),
+		circuitBreakerStatus: instance.GetCircuitBreakerStatus(),
+		healthy:              instance.IsHealthy(),
+		isolated:             instance.IsIsolated(),
+		enableHealthCheck:    instance.IsEnableHealthCheck(),
+		region:               instance.GetRegion(),
+		zone:                 instance.GetZone(),
+		idc:                  instance.GetIDC(),
+		campus:               instance.GetCampus(),
+		revision:             instance.GetRevision(),
+	}
+}
+
+func copyStringMap(source map[string]string) map[string]string {
+	if source == nil {
+		return nil
+	}
+	copied := make(map[string]string, len(source))
+	for key, value := range source {
+		copied[key] = value
+	}
+	return copied
+}
+
+func (instance *polarisInstanceSnapshot) GetInstanceKey() model.InstanceKey {
+	return instance.instanceKey
+}
+
+func (instance *polarisInstanceSnapshot) GetNamespace() string {
+	return instance.namespace
+}
+
+func (instance *polarisInstanceSnapshot) GetService() string {
+	return instance.service
+}
+
+func (instance *polarisInstanceSnapshot) GetId() string {
+	return instance.id
+}
+
+func (instance *polarisInstanceSnapshot) GetHost() string {
+	return instance.host
+}
+
+func (instance *polarisInstanceSnapshot) GetPort() uint32 {
+	return instance.port
+}
+
+func (instance *polarisInstanceSnapshot) GetVpcId() string {
+	return instance.vpcID
+}
+
+func (instance *polarisInstanceSnapshot) GetProtocol() string {
+	return instance.protocol
+}
+
+func (instance *polarisInstanceSnapshot) GetVersion() string {
+	return instance.version
+}
+
+func (instance *polarisInstanceSnapshot) GetWeight() int {
+	return instance.weight
+}
+
+func (instance *polarisInstanceSnapshot) GetPriority() uint32 {
+	return instance.priority
+}
+
+func (instance *polarisInstanceSnapshot) GetMetadata() map[string]string {
+	return instance.metadata
+}
+
+func (instance *polarisInstanceSnapshot) GetLogicSet() string {
+	return instance.logicSet
+}
+
+func (instance *polarisInstanceSnapshot) GetCircuitBreakerStatus() model.CircuitBreakerStatus {
+	return instance.circuitBreakerStatus
+}
+
+func (instance *polarisInstanceSnapshot) IsHealthy() bool {
+	return instance.healthy
+}
+
+func (instance *polarisInstanceSnapshot) IsIsolated() bool {
+	return instance.isolated
+}
+
+func (instance *polarisInstanceSnapshot) IsEnableHealthCheck() bool {
+	return instance.enableHealthCheck
+}
+
+func (instance *polarisInstanceSnapshot) GetRegion() string {
+	return instance.region
+}
+
+func (instance *polarisInstanceSnapshot) GetZone() string {
+	return instance.zone
+}
+
+func (instance *polarisInstanceSnapshot) GetIDC() string {
+	return instance.idc
+}
+
+func (instance *polarisInstanceSnapshot) GetCampus() string {
+	return instance.campus
+}
+
+func (instance *polarisInstanceSnapshot) GetRevision() string {
+	return instance.revision
 }

--- a/registry/polaris/core.go
+++ b/registry/polaris/core.go
@@ -63,9 +63,11 @@ func newPolarisWatcher(param *api.WatchServiceRequest, consumer api.ConsumerAPI)
 }
 
 // AddSubscriber add subscriber into watcher's subscribers
-func (watcher *PolarisServiceWatcher) AddSubscriber(subscriber item) {
+func (watcher *PolarisServiceWatcher) AddSubscriber(
+	subscriber func(remoting.EventType, []model.Instance),
+) {
 	state := &subscriberState{
-		notify:     subscriber,
+		notify:     item(subscriber),
 		reconciled: true,
 	}
 
@@ -157,21 +159,24 @@ func (watcher *PolarisServiceWatcher) reconcileSubscriberLocked(subscriber *subs
 // startWatch start run work to watch target service by polaris
 func (watcher *PolarisServiceWatcher) startWatch() {
 	for {
-		resp, err := watcher.consumer.WatchService(watcher.subscribeParam)
-		if err != nil {
+		if err := watcher.watchOnce(); err != nil {
 			time.Sleep(time.Duration(500 * time.Millisecond))
-			continue
 		}
-		watcher.handleWatchSnapshot(resp.GetAllInstancesResp.Instances)
-
-		for event := range resp.EventChannel {
-			eType := event.GetSubScribeEventType()
-			if eType == internalapi.EventInstance {
-				watcher.handleInstanceEvent(event.(*model.InstanceEvent))
-			}
-		}
-
 	}
+}
+
+func (watcher *PolarisServiceWatcher) watchOnce() error {
+	resp, err := watcher.consumer.WatchService(watcher.subscribeParam)
+	if err != nil {
+		return err
+	}
+	watcher.handleWatchSnapshot(resp.GetAllInstancesResp.Instances)
+	for event := range resp.EventChannel {
+		if event.GetSubScribeEventType() == internalapi.EventInstance {
+			watcher.handleInstanceEvent(event.(*model.InstanceEvent))
+		}
+	}
+	return nil
 }
 
 func (watcher *PolarisServiceWatcher) handleInstanceEvent(event *model.InstanceEvent) {

--- a/registry/polaris/core.go
+++ b/registry/polaris/core.go
@@ -23,6 +23,8 @@ import (
 )
 
 import (
+	"github.com/dubbogo/gost/log/logger"
+
 	api "github.com/polarismesh/polaris-go"
 	internalapi "github.com/polarismesh/polaris-go/api"
 	"github.com/polarismesh/polaris-go/pkg/model"
@@ -34,10 +36,27 @@ import (
 
 type item func(remoting.EventType, []model.Instance)
 
+type subscriberKind uint8
+
+const (
+	registrySubscriber subscriberKind = iota
+	applicationSubscriber
+)
+
+type initialReconcileMode uint8
+
+const (
+	reconcileWithBaseline initialReconcileMode = iota
+	reconcileWithFullSnapshot
+)
+
 type subscriberState struct {
-	notify          item
-	initialSnapshot []model.Instance
-	reconciled      bool
+	notify             item
+	notifyFullSnapshot func([]model.Instance)
+	initialSnapshot    []model.Instance
+	initialMode        initialReconcileMode
+	reconciled         bool
+	kind               subscriberKind
 }
 
 type PolarisServiceWatcher struct {
@@ -69,6 +88,7 @@ func (watcher *PolarisServiceWatcher) AddSubscriber(
 	state := &subscriberState{
 		notify:     item(subscriber),
 		reconciled: true,
+		kind:       applicationSubscriber,
 	}
 
 	func() {
@@ -88,13 +108,18 @@ func (watcher *PolarisServiceWatcher) lazyRun() {
 	})
 }
 
-func (watcher *PolarisServiceWatcher) addSubscriberWithInitialSnapshot(
+func (watcher *PolarisServiceWatcher) addRegistrySubscriber(
 	initialSnapshot []model.Instance,
+	mode initialReconcileMode,
 	subscriber item,
+	fullSnapshotSubscriber func([]model.Instance),
 ) {
 	state := &subscriberState{
-		notify:          subscriber,
-		initialSnapshot: copyInstances(initialSnapshot),
+		notify:             subscriber,
+		notifyFullSnapshot: fullSnapshotSubscriber,
+		initialSnapshot:    copyInstances(initialSnapshot),
+		initialMode:        mode,
+		kind:               registrySubscriber,
 	}
 
 	func() {
@@ -103,7 +128,7 @@ func (watcher *PolarisServiceWatcher) addSubscriberWithInitialSnapshot(
 
 		watcher.subscribers = append(watcher.subscribers, state)
 		if watcher.snapshotReady {
-			watcher.reconcileSubscriberLocked(state)
+			watcher.reconcileSubscriberLocked(state, notifiableInstances(watcher.currentInstances, true))
 		}
 	}()
 
@@ -112,21 +137,34 @@ func (watcher *PolarisServiceWatcher) addSubscriberWithInitialSnapshot(
 	watcher.lazyRun()
 }
 
-// missingInitialInstances returns initial - current by model.InstanceKey while
-// preserving the order of the initial snapshot.
-func missingInitialInstances(initial []model.Instance, current []model.Instance) []model.Instance {
+// missingInstances returns previous - current by model.InstanceKey while
+// preserving the order of the previous snapshot.
+func missingInstances(previous, current []model.Instance) []model.Instance {
 	currentInstances := make(map[model.InstanceKey]struct{}, len(current))
 	for _, instance := range current {
 		currentInstances[instance.GetInstanceKey()] = struct{}{}
 	}
 
-	missing := make([]model.Instance, 0, len(initial))
-	for _, instance := range initial {
+	missing := make([]model.Instance, 0, len(previous))
+	for _, instance := range previous {
 		if _, ok := currentInstances[instance.GetInstanceKey()]; !ok {
 			missing = append(missing, instance)
 		}
 	}
 	return missing
+}
+
+func notifiableInstances(instances []model.Instance, reportInvalid bool) []model.Instance {
+	valid := make([]model.Instance, 0, len(instances))
+	for _, instance := range instances {
+		validationError := polarisInstanceURLValidationError(instance)
+		if validationError == "" {
+			valid = append(valid, instance)
+		} else if reportInvalid {
+			logger.Errorf("[Registry][Polaris] %s, instance=%+v", validationError, instance)
+		}
+	}
+	return valid
 }
 
 // handleWatchSnapshot replaces the watcher's current state and reconciles each
@@ -135,23 +173,47 @@ func (watcher *PolarisServiceWatcher) handleWatchSnapshot(current []model.Instan
 	watcher.lock.Lock()
 	defer watcher.lock.Unlock()
 
-	watcher.currentInstances = copyInstances(current)
+	registryCurrent := notifiableInstances(current, watcher.hasRegistrySubscriberLocked())
+	previous := watcher.currentInstances
+	hadPreviousSnapshot := watcher.snapshotReady
+	next := copyInstances(current)
+	var removedSincePrevious []model.Instance
+	if hadPreviousSnapshot {
+		registryPrevious := notifiableInstances(previous, false)
+		removedSincePrevious = missingInstances(registryPrevious, registryCurrent)
+	}
+	watcher.currentInstances = next
 	watcher.snapshotReady = true
 	for _, subscriber := range watcher.subscribers {
-		if subscriber.reconciled {
+		if subscriber.kind == applicationSubscriber {
 			watcher.notifySubscriberLocked(subscriber, remoting.EventTypeAdd, watcher.currentInstances)
 			continue
 		}
-		watcher.reconcileSubscriberLocked(subscriber)
+		if subscriber.reconciled {
+			if len(removedSincePrevious) > 0 {
+				watcher.notifySubscriberLocked(subscriber, remoting.EventTypeDel, removedSincePrevious)
+			}
+			watcher.notifySubscriberLocked(subscriber, remoting.EventTypeAdd, registryCurrent)
+			continue
+		}
+		watcher.reconcileSubscriberLocked(subscriber, registryCurrent)
 	}
 }
 
-func (watcher *PolarisServiceWatcher) reconcileSubscriberLocked(subscriber *subscriberState) {
-	missing := missingInitialInstances(subscriber.initialSnapshot, watcher.currentInstances)
-	if len(missing) > 0 {
-		watcher.notifySubscriberLocked(subscriber, remoting.EventTypeDel, missing)
+func (watcher *PolarisServiceWatcher) reconcileSubscriberLocked(
+	subscriber *subscriberState,
+	current []model.Instance,
+) {
+	switch subscriber.initialMode {
+	case reconcileWithBaseline:
+		missing := missingInstances(subscriber.initialSnapshot, current)
+		if len(missing) > 0 {
+			watcher.notifySubscriberLocked(subscriber, remoting.EventTypeDel, missing)
+		}
+		watcher.notifySubscriberLocked(subscriber, remoting.EventTypeAdd, current)
+	case reconcileWithFullSnapshot:
+		subscriber.notifyFullSnapshot(copyInstances(current))
 	}
-	watcher.notifySubscriberLocked(subscriber, remoting.EventTypeAdd, watcher.currentInstances)
 	subscriber.reconciled = true
 	subscriber.initialSnapshot = nil
 }
@@ -195,15 +257,41 @@ func (watcher *PolarisServiceWatcher) handleInstanceEvent(event *model.InstanceE
 		watcher.notifyReconciledSubscribersLocked(remoting.EventTypeAdd, instances)
 	}
 	if event.UpdateEvent != nil {
-		instances := make([]model.Instance, 0, len(event.UpdateEvent.UpdateList))
+		reportInvalid := watcher.hasRegistrySubscriberLocked()
+		applicationUpdates := make([]model.Instance, 0, len(event.UpdateEvent.UpdateList))
+		registryUpdates := make([]model.Instance, 0, len(event.UpdateEvent.UpdateList))
+		registryDeletes := make([]model.Instance, 0, len(event.UpdateEvent.UpdateList))
+		changedKeyBefore := make([]model.Instance, 0, len(event.UpdateEvent.UpdateList))
 		for _, update := range event.UpdateEvent.UpdateList {
 			if update.Before.GetInstanceKey() != update.After.GetInstanceKey() {
-				watcher.removeCurrentInstancesLocked([]model.Instance{update.Before})
+				changedKeyBefore = append(changedKeyBefore, update.Before)
 			}
-			watcher.upsertCurrentInstanceLocked(update.After)
-			instances = append(instances, update.After)
 		}
-		watcher.notifyReconciledSubscribersLocked(remoting.EventTypeUpdate, instances)
+		watcher.removeCurrentInstancesLocked(changedKeyBefore)
+		for _, update := range event.UpdateEvent.UpdateList {
+			beforeValid := polarisInstanceURLValidationError(update.Before) == ""
+			afterValidationError := polarisInstanceURLValidationError(update.After)
+			afterValid := afterValidationError == ""
+			keyChanged := update.Before.GetInstanceKey() != update.After.GetInstanceKey()
+			watcher.upsertCurrentInstanceLocked(update.After)
+			applicationUpdates = append(applicationUpdates, update.After)
+			if keyChanged && beforeValid {
+				registryDeletes = append(registryDeletes, update.Before)
+			}
+			if afterValid {
+				registryUpdates = append(registryUpdates, update.After)
+				continue
+			}
+			if reportInvalid {
+				logger.Errorf("[Registry][Polaris] %s, instance=%+v", afterValidationError, update.After)
+			}
+			if !keyChanged && beforeValid {
+				registryDeletes = append(registryDeletes, update.Before)
+			}
+		}
+		watcher.notifyReconciledSubscribersByKindLocked(applicationSubscriber, remoting.EventTypeUpdate, applicationUpdates)
+		watcher.notifyReconciledSubscribersByKindLocked(registrySubscriber, remoting.EventTypeDel, registryDeletes)
+		watcher.notifyReconciledSubscribersByKindLocked(registrySubscriber, remoting.EventTypeUpdate, registryUpdates)
 	}
 	if event.DeleteEvent != nil {
 		instances := copyInstances(event.DeleteEvent.Instances)
@@ -243,6 +331,30 @@ func (watcher *PolarisServiceWatcher) removeCurrentInstancesLocked(instances []m
 func (watcher *PolarisServiceWatcher) notifyReconciledSubscribersLocked(eventType remoting.EventType, instances []model.Instance) {
 	for _, subscriber := range watcher.subscribers {
 		if subscriber.reconciled {
+			watcher.notifySubscriberLocked(subscriber, eventType, instances)
+		}
+	}
+}
+
+func (watcher *PolarisServiceWatcher) hasRegistrySubscriberLocked() bool {
+	for _, subscriber := range watcher.subscribers {
+		if subscriber.kind == registrySubscriber {
+			return true
+		}
+	}
+	return false
+}
+
+func (watcher *PolarisServiceWatcher) notifyReconciledSubscribersByKindLocked(
+	kind subscriberKind,
+	eventType remoting.EventType,
+	instances []model.Instance,
+) {
+	if len(instances) == 0 {
+		return
+	}
+	for _, subscriber := range watcher.subscribers {
+		if subscriber.reconciled && subscriber.kind == kind {
 			watcher.notifySubscriberLocked(subscriber, eventType, instances)
 		}
 	}

--- a/registry/polaris/core.go
+++ b/registry/polaris/core.go
@@ -76,6 +76,8 @@ func (watcher *PolarisServiceWatcher) lazyRun() {
 	})
 }
 
+// setInitialSnapshot stores synchronously loaded instances as the baseline for
+// reconciling the first successful watcher full snapshot.
 func (watcher *PolarisServiceWatcher) setInitialSnapshot(instances []model.Instance) {
 	watcher.initialSnapshotLock.Lock()
 	defer watcher.initialSnapshotLock.Unlock()
@@ -88,6 +90,8 @@ func (watcher *PolarisServiceWatcher) setInitialSnapshot(instances []model.Insta
 	watcher.hasInitialSnapshot = true
 }
 
+// takeInitialSnapshot returns and consumes the baseline for the first successful watcher full snapshot.
+// Failed WatchService attempts do not call it, and a consumed watcher cannot be armed again.
 func (watcher *PolarisServiceWatcher) takeInitialSnapshot() ([]model.Instance, bool) {
 	watcher.initialSnapshotLock.Lock()
 	defer watcher.initialSnapshotLock.Unlock()
@@ -106,6 +110,8 @@ func (watcher *PolarisServiceWatcher) takeInitialSnapshot() ([]model.Instance, b
 	return instances, true
 }
 
+// missingInitialInstances returns initial - current by model.InstanceKey while
+// preserving the order of the initial snapshot.
 func missingInitialInstances(initial []model.Instance, current []model.Instance) []model.Instance {
 	currentInstances := make(map[model.InstanceKey]struct{}, len(current))
 	for _, instance := range current {
@@ -121,6 +127,8 @@ func missingInitialInstances(initial []model.Instance, current []model.Instance)
 	return missing
 }
 
+// handleInitialWatchSnapshot reconciles the first successful watcher full snapshot
+// with the synchronous baseline before publishing the current instances.
 func (watcher *PolarisServiceWatcher) handleInitialWatchSnapshot(current []model.Instance) {
 	if initial, ok := watcher.takeInitialSnapshot(); ok {
 		missing := missingInitialInstances(initial, current)

--- a/registry/polaris/core.go
+++ b/registry/polaris/core.go
@@ -229,12 +229,14 @@ func (watcher *PolarisServiceWatcher) removeCurrentInstancesLocked(instances []m
 		keys[instance.GetInstanceKey()] = struct{}{}
 	}
 
-	current := watcher.currentInstances[:0]
-	for _, instance := range watcher.currentInstances {
+	old := watcher.currentInstances
+	current := old[:0]
+	for _, instance := range old {
 		if _, remove := keys[instance.GetInstanceKey()]; !remove {
 			current = append(current, instance)
 		}
 	}
+	clear(old[len(current):])
 	watcher.currentInstances = current
 }
 

--- a/registry/polaris/listener.go
+++ b/registry/polaris/listener.go
@@ -35,15 +35,28 @@ import (
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
-	"dubbo.apache.org/dubbo-go/v3/config_center"
 	"dubbo.apache.org/dubbo-go/v3/registry"
 	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
 
+type polarisNotificationKind uint8
+
+const (
+	incrementalNotification polarisNotificationKind = iota
+	fullSnapshotNotification
+)
+
+type polarisNotification struct {
+	kind      polarisNotificationKind
+	eventType remoting.EventType
+	instances []model.Instance
+}
+
 type polarisListener struct {
-	watcher *PolarisServiceWatcher
-	events  *gxchan.UnboundedChan
-	closeCh chan struct{}
+	watcher       *PolarisServiceWatcher
+	events        *gxchan.UnboundedChan
+	closeCh       chan struct{}
+	pendingEvents []*registry.ServiceEvent
 }
 
 // NewPolarisListener new polaris listener
@@ -53,9 +66,18 @@ func NewPolarisListener(watcher *PolarisServiceWatcher) (*polarisListener, error
 	return listener, nil
 }
 
-func newPolarisListener(watcher *PolarisServiceWatcher, initialSnapshot []model.Instance) (*polarisListener, error) {
+func newPolarisListener(
+	watcher *PolarisServiceWatcher,
+	initialSnapshot []model.Instance,
+	mode initialReconcileMode,
+) (*polarisListener, error) {
 	listener := newPolarisListenerState(watcher)
-	listener.watcher.addSubscriberWithInitialSnapshot(initialSnapshot, listener.notify)
+	listener.watcher.addRegistrySubscriber(
+		initialSnapshot,
+		mode,
+		listener.notify,
+		listener.notifyFullSnapshot,
+	)
 	return listener, nil
 }
 
@@ -68,8 +90,37 @@ func newPolarisListenerState(watcher *PolarisServiceWatcher) *polarisListener {
 }
 
 func (pl *polarisListener) notify(et remoting.EventType, ins []model.Instance) {
-	for i := range ins {
-		pl.events.In() <- &config_center.ConfigChangeEvent{Value: ins[i], ConfigType: et}
+	if len(ins) == 0 {
+		return
+	}
+	pl.events.In() <- &polarisNotification{
+		kind:      incrementalNotification,
+		eventType: et,
+		instances: copyInstances(ins),
+	}
+}
+
+func (pl *polarisListener) notifyFullSnapshot(ins []model.Instance) {
+	pl.events.In() <- &polarisNotification{
+		kind:      fullSnapshotNotification,
+		instances: copyInstances(ins),
+	}
+}
+
+// nextNotification returns the next tagged notification in FIFO order.
+func (pl *polarisListener) nextNotification() (*polarisNotification, error) {
+	for {
+		select {
+		case <-pl.closeCh:
+			logger.Warn("[Registry][Polaris] polaris listener is close")
+			return nil, perrors.New("listener stopped")
+		case val := <-pl.events.Out():
+			notification, ok := val.(*polarisNotification)
+			if !ok || notification == nil {
+				return nil, perrors.Errorf("invalid polaris notification type %T", val)
+			}
+			return notification, nil
+		}
 	}
 }
 
@@ -80,11 +131,33 @@ func (pl *polarisListener) Next() (*registry.ServiceEvent, error) {
 		case <-pl.closeCh:
 			logger.Warn("[Registry][Polaris] polaris listener is close")
 			return nil, perrors.New("listener stopped")
-		case val := <-pl.events.Out():
-			e, _ := val.(*config_center.ConfigChangeEvent)
-			logger.Debugf("[Registry][Polaris] got polaris event %s", e)
-			instance := e.Value.(model.Instance)
-			return &registry.ServiceEvent{Action: e.ConfigType, Service: generateUrl(instance)}, nil
+		default:
+		}
+
+		if len(pl.pendingEvents) > 0 {
+			event := pl.pendingEvents[0]
+			pl.pendingEvents[0] = nil
+			pl.pendingEvents = pl.pendingEvents[1:]
+			return event, nil
+		}
+
+		notification, err := pl.nextNotification()
+		if err != nil {
+			return nil, err
+		}
+		action := notification.eventType
+		if notification.kind == fullSnapshotNotification {
+			action = remoting.EventTypeUpdate
+		}
+		for _, instance := range notification.instances {
+			serviceURL := generateUrl(instance)
+			if serviceURL == nil {
+				continue
+			}
+			pl.pendingEvents = append(pl.pendingEvents, &registry.ServiceEvent{
+				Action:  action,
+				Service: serviceURL,
+			})
 		}
 	}
 }
@@ -96,24 +169,17 @@ func (pl *polarisListener) Close() {
 }
 
 func generateUrl(instance model.Instance) *common.URL {
-	if instance.GetMetadata() == nil {
-		logger.Errorf("[Registry][Polaris] polaris instance metadata is empty, instance=%+v", instance)
+	if validationError := polarisInstanceURLValidationError(instance); validationError != "" {
+		logger.Errorf("[Registry][Polaris] %s, instance=%+v", validationError, instance)
 		return nil
 	}
+
 	path := instance.GetMetadata()["path"]
 	myInterface := instance.GetMetadata()["interface"]
-	if len(path) == 0 && len(myInterface) == 0 {
-		logger.Errorf("[Registry][Polaris] polaris instance metadata does not have both path key and interface key, instance=%+v", instance)
-		return nil
-	}
 	if len(path) == 0 && len(myInterface) != 0 {
 		path = "/" + myInterface
 	}
 	protocol := instance.GetProtocol()
-	if len(protocol) == 0 {
-		logger.Errorf("[Registry][Polaris] polaris instance metadata does not have protocol key, instance=%+v", instance)
-		return nil
-	}
 	urlMap := url.Values{}
 	for k, v := range instance.GetMetadata() {
 		urlMap.Set(k, v)
@@ -129,4 +195,19 @@ func generateUrl(instance model.Instance) *common.URL {
 		common.WithParams(urlMap),
 		common.WithPath(path),
 	)
+}
+
+func polarisInstanceURLValidationError(instance model.Instance) string {
+	if instance.GetMetadata() == nil {
+		return "polaris instance metadata is empty"
+	}
+	path := instance.GetMetadata()["path"]
+	myInterface := instance.GetMetadata()["interface"]
+	if len(path) == 0 && len(myInterface) == 0 {
+		return "polaris instance metadata does not have both path key and interface key"
+	}
+	if len(instance.GetProtocol()) == 0 {
+		return "polaris instance metadata does not have protocol key"
+	}
+	return ""
 }

--- a/registry/polaris/listener.go
+++ b/registry/polaris/listener.go
@@ -89,6 +89,8 @@ func newPolarisListenerState(watcher *PolarisServiceWatcher) *polarisListener {
 	}
 }
 
+// The watcher already provides an isolated snapshot for this listener, so the
+// notification queue can take ownership without copying it again.
 func (pl *polarisListener) notify(et remoting.EventType, ins []model.Instance) {
 	if len(ins) == 0 {
 		return
@@ -96,14 +98,14 @@ func (pl *polarisListener) notify(et remoting.EventType, ins []model.Instance) {
 	pl.events.In() <- &polarisNotification{
 		kind:      incrementalNotification,
 		eventType: et,
-		instances: copyInstances(ins),
+		instances: ins,
 	}
 }
 
 func (pl *polarisListener) notifyFullSnapshot(ins []model.Instance) {
 	pl.events.In() <- &polarisNotification{
 		kind:      fullSnapshotNotification,
-		instances: copyInstances(ins),
+		instances: ins,
 	}
 }
 

--- a/registry/polaris/listener.go
+++ b/registry/polaris/listener.go
@@ -48,20 +48,29 @@ type polarisListener struct {
 
 // NewPolarisListener new polaris listener
 func NewPolarisListener(watcher *PolarisServiceWatcher) (*polarisListener, error) {
-	listener := &polarisListener{
+	listener := newPolarisListenerState(watcher)
+	listener.watcher.AddSubscriber(listener.notify)
+	return listener, nil
+}
+
+func newPolarisListener(watcher *PolarisServiceWatcher, initialSnapshot []model.Instance) (*polarisListener, error) {
+	listener := newPolarisListenerState(watcher)
+	listener.watcher.addSubscriberWithInitialSnapshot(initialSnapshot, listener.notify)
+	return listener, nil
+}
+
+func newPolarisListenerState(watcher *PolarisServiceWatcher) *polarisListener {
+	return &polarisListener{
 		watcher: watcher,
 		events:  gxchan.NewUnboundedChan(32),
 		closeCh: make(chan struct{}),
 	}
-	listener.startListen()
-	return listener, nil
 }
-func (pl *polarisListener) startListen() {
-	pl.watcher.AddSubscriber(func(et remoting.EventType, ins []model.Instance) {
-		for i := range ins {
-			pl.events.In() <- &config_center.ConfigChangeEvent{Value: ins[i], ConfigType: et}
-		}
-	})
+
+func (pl *polarisListener) notify(et remoting.EventType, ins []model.Instance) {
+	for i := range ins {
+		pl.events.In() <- &config_center.ConfigChangeEvent{Value: ins[i], ConfigType: et}
+	}
 }
 
 // Next returns next service event once received

--- a/registry/polaris/registry.go
+++ b/registry/polaris/registry.go
@@ -19,6 +19,7 @@ package polaris
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"sync"
 	"time"
@@ -68,16 +69,22 @@ func newPolarisRegistry(url *common.URL) (registry.Registry, error) {
 	}
 
 	pRegistry := &polarisRegistry{
-		url:              url,
-		namespace:        url.GetParam(constant.RegistryNamespaceKey, constant.PolarisDefaultNamespace),
-		provider:         providerApi,
-		consumer:         consumerApi,
-		registryUrls:     make([]*common.URL, 0, 4),
-		watchers:         map[string]*PolarisServiceWatcher{},
-		initialSnapshots: make(map[string][]model.Instance),
+		url:                       url,
+		namespace:                 url.GetParam(constant.RegistryNamespaceKey, constant.PolarisDefaultNamespace),
+		provider:                  providerApi,
+		consumer:                  consumerApi,
+		registryUrls:              make([]*common.URL, 0, 4),
+		watchers:                  map[string]*PolarisServiceWatcher{},
+		initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance),
+		initialSubscribeVersions:  make(map[initialSubscribeInstancesKey]uint64),
 	}
 
 	return pRegistry, nil
+}
+
+type initialSubscribeInstancesKey struct {
+	serviceName string
+	notify      registry.NotifyListener
 }
 
 type polarisRegistry struct {
@@ -89,9 +96,13 @@ type polarisRegistry struct {
 	registryUrls []*common.URL
 	listenerLock sync.RWMutex
 	watchers     map[string]*PolarisServiceWatcher
-	// initialSnapshots bridges the synchronous load with the first watcher snapshot so disappeared providers can be deleted.
-	initialSnapshotLock sync.Mutex
-	initialSnapshots    map[string][]model.Instance
+	// initialSubscribeInstances temporarily stores valid LoadSubscribeInstances
+	// results, keyed by service and supported NotifyListener identity. Subscribe
+	// clears the instances, version, and listener reference after a successful
+	// transfer. The watcher does not hold a global initial baseline.
+	initialSubscribeInstancesLock sync.Mutex
+	initialSubscribeInstances     map[initialSubscribeInstancesKey][]model.Instance
+	initialSubscribeVersions      map[initialSubscribeInstancesKey]uint64
 }
 
 // Register will register the service @url to its polaris registry center.
@@ -138,14 +149,14 @@ func (pr *polarisRegistry) Subscribe(url *common.URL, notifyListener registry.No
 	if role != common.CONSUMER {
 		return nil
 	}
+	serviceName := url.Interface()
 	timer := time.NewTimer(time.Duration(RegistryConnDelay) * time.Second)
 	defer timer.Stop()
 
 	for {
-		serviceName := url.Interface()
-		listener, err := pr.createPolarisListener(serviceName, NewPolarisListener)
+		listener, err := pr.createPolarisListener(serviceName, notifyListener, newPolarisListener)
 		if err != nil {
-			logger.Warnf("[Registry][Polaris] getListener() = err=%v", perrors.WithStack(err))
+			logger.Warnf("[Registry][Polaris] create listener failed, service=%s, err=%v", serviceName, perrors.WithStack(err))
 			<-timer.C
 			timer.Reset(time.Duration(RegistryConnDelay) * time.Second)
 			continue
@@ -165,20 +176,28 @@ func (pr *polarisRegistry) Subscribe(url *common.URL, notifyListener registry.No
 	}
 }
 
-// createPolarisListener creates or reuses the service watcher, transfers its pending baseline,
-// and only then invokes newListener so the watcher cannot start before snapshot injection.
+// createPolarisListener creates or reuses the watcher and binds the pending
+// synchronous-load instances to the newly created listener.
 func (pr *polarisRegistry) createPolarisListener(
 	serviceName string,
-	newListener func(*PolarisServiceWatcher) (*polarisListener, error),
+	notify registry.NotifyListener,
+	newListener func(*PolarisServiceWatcher, []model.Instance) (*polarisListener, error),
 ) (*polarisListener, error) {
+	key := newInitialSubscribeInstancesKey(serviceName, notify)
 	watcher, err := pr.createPolarisWatcher(serviceName)
 	if err != nil {
 		return nil, err
 	}
-	if initialSnapshot, ok := pr.takeInitialSnapshot(serviceName); ok {
-		watcher.setInitialSnapshot(initialSnapshot)
+	initialSubscribeInstances, found, initialSubscribeVersion := pr.takeInitialSubscribeInstancesWithVersion(key)
+	listener, err := newListener(watcher, initialSubscribeInstances)
+	if err != nil {
+		if found {
+			pr.restoreInitialSubscribeInstances(key, initialSubscribeInstances, initialSubscribeVersion)
+		}
+		return nil, err
 	}
-	return newListener(watcher)
+	pr.completeInitialSubscribeInstances(key, initialSubscribeVersion)
+	return listener, nil
 }
 
 // UnSubscribe returns nil if unsubscribing registry successfully. If not returns an error.
@@ -190,6 +209,7 @@ func (pr *polarisRegistry) UnSubscribe(url *common.URL, notifyListener registry.
 // LoadSubscribeInstances load subscribe instance
 func (pr *polarisRegistry) LoadSubscribeInstances(url *common.URL, notify registry.NotifyListener) error {
 	serviceName := url.Interface()
+	key := newInitialSubscribeInstancesKey(serviceName, notify)
 	resp, err := pr.consumer.GetInstances(&api.GetInstancesRequest{
 		GetInstancesRequest: model.GetInstancesRequest{
 			Service:   serviceName,
@@ -200,45 +220,101 @@ func (pr *polarisRegistry) LoadSubscribeInstances(url *common.URL, notify regist
 		return perrors.New(fmt.Sprintf("could not query the instances for serviceName=%s,namespace=%s,error=%v",
 			serviceName, pr.namespace, err))
 	}
-	initialSnapshot := make([]model.Instance, 0, len(resp.Instances))
+	initialSubscribeInstances := make([]model.Instance, 0, len(resp.Instances))
 	for i := range resp.Instances {
 		if newUrl := generateUrl(resp.Instances[i]); newUrl != nil {
 			notify.Notify(&registry.ServiceEvent{Action: remoting.EventTypeAdd, Service: newUrl})
-			initialSnapshot = append(initialSnapshot, resp.Instances[i])
+			initialSubscribeInstances = append(initialSubscribeInstances, resp.Instances[i])
 		}
 	}
-	pr.storeInitialSnapshot(serviceName, initialSnapshot)
+	pr.storeInitialSubscribeInstances(key, initialSubscribeInstances)
 	return nil
 }
 
-// storeInitialSnapshot keeps valid instances notified during synchronous loading
-// until Subscribe transfers the baseline to the service watcher.
-func (pr *polarisRegistry) storeInitialSnapshot(serviceName string, instances []model.Instance) {
-	pr.initialSnapshotLock.Lock()
-	defer pr.initialSnapshotLock.Unlock()
-
-	if len(instances) == 0 {
-		delete(pr.initialSnapshots, serviceName)
-		return
+func newInitialSubscribeInstancesKey(serviceName string, notify registry.NotifyListener) initialSubscribeInstancesKey {
+	value := reflect.ValueOf(notify)
+	if !value.IsValid() || value.Kind() != reflect.Pointer || value.IsNil() {
+		// This service-scoped fallback provides compatibility and panic safety for
+		// unsupported listener identities. It does not guarantee precise isolation
+		// between multiple unsupported listeners for the same service.
+		return initialSubscribeInstancesKey{serviceName: serviceName}
 	}
-	if pr.initialSnapshots == nil {
-		pr.initialSnapshots = make(map[string][]model.Instance)
-	}
-	pr.initialSnapshots[serviceName] = append([]model.Instance(nil), instances...)
+	return initialSubscribeInstancesKey{serviceName: serviceName, notify: notify}
 }
 
-// takeInitialSnapshot removes and returns the pending service baseline, transferring it
-// from synchronous LoadSubscribeInstances to the asynchronous watcher exactly once.
-func (pr *polarisRegistry) takeInitialSnapshot(serviceName string) ([]model.Instance, bool) {
-	pr.initialSnapshotLock.Lock()
-	defer pr.initialSnapshotLock.Unlock()
+// storeInitialSubscribeInstances keeps valid instances notified by
+// LoadSubscribeInstances until Subscribe transfers them to the same supported
+// notify-listener identity. A successful transfer clears the instances,
+// version, and listener reference. Watchers do not hold a global initial
+// baseline.
+func (pr *polarisRegistry) storeInitialSubscribeInstances(key initialSubscribeInstancesKey, instances []model.Instance) {
+	pr.initialSubscribeInstancesLock.Lock()
+	defer pr.initialSubscribeInstancesLock.Unlock()
 
-	instances, ok := pr.initialSnapshots[serviceName]
-	if !ok {
-		return nil, false
+	if pr.initialSubscribeVersions == nil {
+		pr.initialSubscribeVersions = make(map[initialSubscribeInstancesKey]uint64)
 	}
-	delete(pr.initialSnapshots, serviceName)
-	return append([]model.Instance(nil), instances...), true
+	pr.initialSubscribeVersions[key]++
+	if len(instances) == 0 {
+		delete(pr.initialSubscribeInstances, key)
+		return
+	}
+	if pr.initialSubscribeInstances == nil {
+		pr.initialSubscribeInstances = make(map[initialSubscribeInstancesKey][]model.Instance)
+	}
+	pr.initialSubscribeInstances[key] = append([]model.Instance(nil), instances...)
+}
+
+// takeInitialSubscribeInstances transfers synchronous LoadSubscribeInstances
+// state to the matching asynchronous listener exactly once.
+func (pr *polarisRegistry) takeInitialSubscribeInstances(serviceName string, notify registry.NotifyListener) ([]model.Instance, bool) {
+	key := newInitialSubscribeInstancesKey(serviceName, notify)
+	instances, ok, initialSubscribeVersion := pr.takeInitialSubscribeInstancesWithVersion(key)
+	pr.completeInitialSubscribeInstances(key, initialSubscribeVersion)
+	return instances, ok
+}
+
+func (pr *polarisRegistry) takeInitialSubscribeInstancesWithVersion(key initialSubscribeInstancesKey) ([]model.Instance, bool, uint64) {
+	pr.initialSubscribeInstancesLock.Lock()
+	defer pr.initialSubscribeInstancesLock.Unlock()
+
+	instances, ok := pr.initialSubscribeInstances[key]
+	if !ok {
+		return nil, false, pr.initialSubscribeVersions[key]
+	}
+	delete(pr.initialSubscribeInstances, key)
+	return copyInstances(instances), true, pr.initialSubscribeVersions[key]
+}
+
+func (pr *polarisRegistry) completeInitialSubscribeInstances(key initialSubscribeInstancesKey, initialSubscribeVersion uint64) {
+	pr.initialSubscribeInstancesLock.Lock()
+	defer pr.initialSubscribeInstancesLock.Unlock()
+
+	if pr.initialSubscribeVersions[key] != initialSubscribeVersion {
+		return
+	}
+	if _, pending := pr.initialSubscribeInstances[key]; pending {
+		return
+	}
+	delete(pr.initialSubscribeVersions, key)
+}
+
+// restoreInitialSubscribeInstances puts back instances when listener creation
+// fails. A newer synchronous load wins if it already stored another version.
+func (pr *polarisRegistry) restoreInitialSubscribeInstances(key initialSubscribeInstancesKey, instances []model.Instance, initialSubscribeVersion uint64) {
+	pr.initialSubscribeInstancesLock.Lock()
+	defer pr.initialSubscribeInstancesLock.Unlock()
+
+	if pr.initialSubscribeVersions[key] != initialSubscribeVersion {
+		return
+	}
+	if _, exists := pr.initialSubscribeInstances[key]; exists {
+		return
+	}
+	if pr.initialSubscribeInstances == nil {
+		pr.initialSubscribeInstances = make(map[initialSubscribeInstancesKey][]model.Instance)
+	}
+	pr.initialSubscribeInstances[key] = copyInstances(instances)
 }
 
 // GetURL returns polaris registry's url.

--- a/registry/polaris/registry.go
+++ b/registry/polaris/registry.go
@@ -68,12 +68,13 @@ func newPolarisRegistry(url *common.URL) (registry.Registry, error) {
 	}
 
 	pRegistry := &polarisRegistry{
-		url:          url,
-		namespace:    url.GetParam(constant.RegistryNamespaceKey, constant.PolarisDefaultNamespace),
-		provider:     providerApi,
-		consumer:     consumerApi,
-		registryUrls: make([]*common.URL, 0, 4),
-		watchers:     map[string]*PolarisServiceWatcher{},
+		url:              url,
+		namespace:        url.GetParam(constant.RegistryNamespaceKey, constant.PolarisDefaultNamespace),
+		provider:         providerApi,
+		consumer:         consumerApi,
+		registryUrls:     make([]*common.URL, 0, 4),
+		watchers:         map[string]*PolarisServiceWatcher{},
+		initialSnapshots: make(map[string][]model.Instance),
 	}
 
 	return pRegistry, nil
@@ -88,6 +89,9 @@ type polarisRegistry struct {
 	registryUrls []*common.URL
 	listenerLock sync.RWMutex
 	watchers     map[string]*PolarisServiceWatcher
+	// initialSnapshots bridges the synchronous load with the first watcher snapshot so disappeared providers can be deleted.
+	initialSnapshotLock sync.Mutex
+	initialSnapshots    map[string][]model.Instance
 }
 
 // Register will register the service @url to its polaris registry center.
@@ -146,6 +150,9 @@ func (pr *polarisRegistry) Subscribe(url *common.URL, notifyListener registry.No
 			timer.Reset(time.Duration(RegistryConnDelay) * time.Second)
 			continue
 		}
+		if initialSnapshot, ok := pr.takeInitialSnapshot(serviceName); ok {
+			watcher.setInitialSnapshot(initialSnapshot)
+		}
 
 		listener, err := NewPolarisListener(watcher)
 		if err != nil {
@@ -188,12 +195,41 @@ func (pr *polarisRegistry) LoadSubscribeInstances(url *common.URL, notify regist
 		return perrors.New(fmt.Sprintf("could not query the instances for serviceName=%s,namespace=%s,error=%v",
 			serviceName, pr.namespace, err))
 	}
+	initialSnapshot := make([]model.Instance, 0, len(resp.Instances))
 	for i := range resp.Instances {
 		if newUrl := generateUrl(resp.Instances[i]); newUrl != nil {
 			notify.Notify(&registry.ServiceEvent{Action: remoting.EventTypeAdd, Service: newUrl})
+			initialSnapshot = append(initialSnapshot, resp.Instances[i])
 		}
 	}
+	pr.storeInitialSnapshot(serviceName, initialSnapshot)
 	return nil
+}
+
+func (pr *polarisRegistry) storeInitialSnapshot(serviceName string, instances []model.Instance) {
+	pr.initialSnapshotLock.Lock()
+	defer pr.initialSnapshotLock.Unlock()
+
+	if len(instances) == 0 {
+		delete(pr.initialSnapshots, serviceName)
+		return
+	}
+	if pr.initialSnapshots == nil {
+		pr.initialSnapshots = make(map[string][]model.Instance)
+	}
+	pr.initialSnapshots[serviceName] = append([]model.Instance(nil), instances...)
+}
+
+func (pr *polarisRegistry) takeInitialSnapshot(serviceName string) ([]model.Instance, bool) {
+	pr.initialSnapshotLock.Lock()
+	defer pr.initialSnapshotLock.Unlock()
+
+	instances, ok := pr.initialSnapshots[serviceName]
+	if !ok {
+		return nil, false
+	}
+	delete(pr.initialSnapshots, serviceName)
+	return append([]model.Instance(nil), instances...), true
 }
 
 // GetURL returns polaris registry's url.

--- a/registry/polaris/registry.go
+++ b/registry/polaris/registry.go
@@ -185,7 +185,10 @@ func (pr *polarisRegistry) createPolarisListener(
 	serviceName string,
 	notify registry.NotifyListener,
 ) (*polarisListener, error) {
-	key := newInitialSubscribeInstancesKey(serviceName, notify)
+	key, err := newInitialSubscribeInstancesKey(serviceName, notify)
+	if err != nil {
+		return nil, err
+	}
 	watcher, err := pr.createPolarisWatcher(serviceName)
 	if err != nil {
 		return nil, err
@@ -208,7 +211,10 @@ func (pr *polarisRegistry) UnSubscribe(url *common.URL, notifyListener registry.
 // LoadSubscribeInstances load subscribe instance
 func (pr *polarisRegistry) LoadSubscribeInstances(url *common.URL, notify registry.NotifyListener) error {
 	serviceName := url.Interface()
-	key := newInitialSubscribeInstancesKey(serviceName, notify)
+	key, err := newInitialSubscribeInstancesKey(serviceName, notify)
+	if err != nil {
+		return err
+	}
 	resp, err := pr.consumer.GetInstances(&api.GetInstancesRequest{
 		GetInstancesRequest: model.GetInstancesRequest{
 			Service:   serviceName,
@@ -230,15 +236,33 @@ func (pr *polarisRegistry) LoadSubscribeInstances(url *common.URL, notify regist
 	return nil
 }
 
-func newInitialSubscribeInstancesKey(serviceName string, notify registry.NotifyListener) initialSubscribeInstancesKey {
-	value := reflect.ValueOf(notify)
-	if !value.IsValid() || value.Kind() != reflect.Pointer || value.IsNil() {
-		// This service-scoped fallback provides compatibility and panic safety for
-		// unsupported listener identities. It does not guarantee precise isolation
-		// between multiple unsupported listeners for the same service.
-		return initialSubscribeInstancesKey{serviceName: serviceName}
+func newInitialSubscribeInstancesKey(
+	serviceName string,
+	notify registry.NotifyListener,
+) (initialSubscribeInstancesKey, error) {
+	if isNilNotifyListener(notify) {
+		return initialSubscribeInstancesKey{}, fmt.Errorf("notify listener type %T is nil", notify)
 	}
-	return initialSubscribeInstancesKey{serviceName: serviceName, notify: notify}
+	if !reflect.TypeOf(notify).Comparable() {
+		return initialSubscribeInstancesKey{}, fmt.Errorf("notify listener type %T is not comparable", notify)
+	}
+	if !reflect.ValueOf(notify).Comparable() {
+		return initialSubscribeInstancesKey{}, fmt.Errorf("notify listener type %T is not comparable", notify)
+	}
+	return initialSubscribeInstancesKey{serviceName: serviceName, notify: notify}, nil
+}
+
+func isNilNotifyListener(notify registry.NotifyListener) bool {
+	if notify == nil {
+		return true
+	}
+	value := reflect.ValueOf(notify)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 // storeInitialSubscribeInstances keeps a defensive copy of the valid instances

--- a/registry/polaris/registry.go
+++ b/registry/polaris/registry.go
@@ -75,8 +75,7 @@ func newPolarisRegistry(url *common.URL) (registry.Registry, error) {
 		consumer:                  consumerApi,
 		registryUrls:              make([]*common.URL, 0, 4),
 		watchers:                  map[string]*PolarisServiceWatcher{},
-		initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance),
-		initialSubscribeVersions:  make(map[initialSubscribeInstancesKey]uint64),
+		initialSubscribeInstances: make(map[initialSubscribeInstancesKey]*initialSubscribeInstancesEntry),
 	}
 
 	return pRegistry, nil
@@ -85,6 +84,10 @@ func newPolarisRegistry(url *common.URL) (registry.Registry, error) {
 type initialSubscribeInstancesKey struct {
 	serviceName string
 	notify      registry.NotifyListener
+}
+
+type initialSubscribeInstancesEntry struct {
+	instances []model.Instance
 }
 
 type polarisRegistry struct {
@@ -98,11 +101,11 @@ type polarisRegistry struct {
 	watchers     map[string]*PolarisServiceWatcher
 	// initialSubscribeInstances temporarily stores valid LoadSubscribeInstances
 	// results, keyed by service and supported NotifyListener identity. Subscribe
-	// clears the instances, version, and listener reference after a successful
-	// transfer. The watcher does not hold a global initial baseline.
+	// binds them to the corresponding listener/subscriber and clears the entry
+	// after listener creation succeeds. Watchers do not hold a global initial
+	// baseline.
 	initialSubscribeInstancesLock sync.Mutex
-	initialSubscribeInstances     map[initialSubscribeInstancesKey][]model.Instance
-	initialSubscribeVersions      map[initialSubscribeInstancesKey]uint64
+	initialSubscribeInstances     map[initialSubscribeInstancesKey]*initialSubscribeInstancesEntry
 }
 
 // Register will register the service @url to its polaris registry center.
@@ -154,7 +157,7 @@ func (pr *polarisRegistry) Subscribe(url *common.URL, notifyListener registry.No
 	defer timer.Stop()
 
 	for {
-		listener, err := pr.createPolarisListener(serviceName, notifyListener, newPolarisListener)
+		listener, err := pr.createPolarisListener(serviceName, notifyListener)
 		if err != nil {
 			logger.Warnf("[Registry][Polaris] create listener failed, service=%s, err=%v", serviceName, perrors.WithStack(err))
 			<-timer.C
@@ -181,22 +184,18 @@ func (pr *polarisRegistry) Subscribe(url *common.URL, notifyListener registry.No
 func (pr *polarisRegistry) createPolarisListener(
 	serviceName string,
 	notify registry.NotifyListener,
-	newListener func(*PolarisServiceWatcher, []model.Instance) (*polarisListener, error),
 ) (*polarisListener, error) {
 	key := newInitialSubscribeInstancesKey(serviceName, notify)
 	watcher, err := pr.createPolarisWatcher(serviceName)
 	if err != nil {
 		return nil, err
 	}
-	initialSubscribeInstances, found, initialSubscribeVersion := pr.takeInitialSubscribeInstancesWithVersion(key)
-	listener, err := newListener(watcher, initialSubscribeInstances)
+	entry, instances := pr.loadInitialSubscribeInstances(key)
+	listener, err := newPolarisListener(watcher, instances)
 	if err != nil {
-		if found {
-			pr.restoreInitialSubscribeInstances(key, initialSubscribeInstances, initialSubscribeVersion)
-		}
 		return nil, err
 	}
-	pr.completeInitialSubscribeInstances(key, initialSubscribeVersion)
+	pr.completeInitialSubscribeInstances(key, entry)
 	return listener, nil
 }
 
@@ -242,79 +241,49 @@ func newInitialSubscribeInstancesKey(serviceName string, notify registry.NotifyL
 	return initialSubscribeInstancesKey{serviceName: serviceName, notify: notify}
 }
 
-// storeInitialSubscribeInstances keeps valid instances notified by
-// LoadSubscribeInstances until Subscribe transfers them to the same supported
-// notify-listener identity. A successful transfer clears the instances,
-// version, and listener reference. Watchers do not hold a global initial
-// baseline.
+// storeInitialSubscribeInstances keeps a defensive copy of the valid instances
+// loaded synchronously by LoadSubscribeInstances. Subscribe binds the entry to
+// the corresponding listener/subscriber. Watchers do not hold a global initial
+// baseline, and successful listener creation clears the bound entry.
 func (pr *polarisRegistry) storeInitialSubscribeInstances(key initialSubscribeInstancesKey, instances []model.Instance) {
 	pr.initialSubscribeInstancesLock.Lock()
 	defer pr.initialSubscribeInstancesLock.Unlock()
 
-	if pr.initialSubscribeVersions == nil {
-		pr.initialSubscribeVersions = make(map[initialSubscribeInstancesKey]uint64)
-	}
-	pr.initialSubscribeVersions[key]++
 	if len(instances) == 0 {
 		delete(pr.initialSubscribeInstances, key)
 		return
 	}
 	if pr.initialSubscribeInstances == nil {
-		pr.initialSubscribeInstances = make(map[initialSubscribeInstancesKey][]model.Instance)
+		pr.initialSubscribeInstances = make(map[initialSubscribeInstancesKey]*initialSubscribeInstancesEntry)
 	}
-	pr.initialSubscribeInstances[key] = append([]model.Instance(nil), instances...)
+	pr.initialSubscribeInstances[key] = &initialSubscribeInstancesEntry{
+		instances: copyInstances(instances),
+	}
 }
 
-// takeInitialSubscribeInstances transfers synchronous LoadSubscribeInstances
-// state to the matching asynchronous listener exactly once.
-func (pr *polarisRegistry) takeInitialSubscribeInstances(serviceName string, notify registry.NotifyListener) ([]model.Instance, bool) {
-	key := newInitialSubscribeInstancesKey(serviceName, notify)
-	instances, ok, initialSubscribeVersion := pr.takeInitialSubscribeInstancesWithVersion(key)
-	pr.completeInitialSubscribeInstances(key, initialSubscribeVersion)
-	return instances, ok
-}
-
-func (pr *polarisRegistry) takeInitialSubscribeInstancesWithVersion(key initialSubscribeInstancesKey) ([]model.Instance, bool, uint64) {
+func (pr *polarisRegistry) loadInitialSubscribeInstances(
+	key initialSubscribeInstancesKey,
+) (*initialSubscribeInstancesEntry, []model.Instance) {
 	pr.initialSubscribeInstancesLock.Lock()
 	defer pr.initialSubscribeInstancesLock.Unlock()
 
-	instances, ok := pr.initialSubscribeInstances[key]
-	if !ok {
-		return nil, false, pr.initialSubscribeVersions[key]
+	entry := pr.initialSubscribeInstances[key]
+	if entry == nil {
+		return nil, nil
 	}
-	delete(pr.initialSubscribeInstances, key)
-	return copyInstances(instances), true, pr.initialSubscribeVersions[key]
+	return entry, copyInstances(entry.instances)
 }
 
-func (pr *polarisRegistry) completeInitialSubscribeInstances(key initialSubscribeInstancesKey, initialSubscribeVersion uint64) {
+func (pr *polarisRegistry) completeInitialSubscribeInstances(
+	key initialSubscribeInstancesKey,
+	entry *initialSubscribeInstancesEntry,
+) {
 	pr.initialSubscribeInstancesLock.Lock()
 	defer pr.initialSubscribeInstancesLock.Unlock()
 
-	if pr.initialSubscribeVersions[key] != initialSubscribeVersion {
-		return
+	if pr.initialSubscribeInstances[key] == entry {
+		delete(pr.initialSubscribeInstances, key)
 	}
-	if _, pending := pr.initialSubscribeInstances[key]; pending {
-		return
-	}
-	delete(pr.initialSubscribeVersions, key)
-}
-
-// restoreInitialSubscribeInstances puts back instances when listener creation
-// fails. A newer synchronous load wins if it already stored another version.
-func (pr *polarisRegistry) restoreInitialSubscribeInstances(key initialSubscribeInstancesKey, instances []model.Instance, initialSubscribeVersion uint64) {
-	pr.initialSubscribeInstancesLock.Lock()
-	defer pr.initialSubscribeInstancesLock.Unlock()
-
-	if pr.initialSubscribeVersions[key] != initialSubscribeVersion {
-		return
-	}
-	if _, exists := pr.initialSubscribeInstances[key]; exists {
-		return
-	}
-	if pr.initialSubscribeInstances == nil {
-		pr.initialSubscribeInstances = make(map[initialSubscribeInstancesKey][]model.Instance)
-	}
-	pr.initialSubscribeInstances[key] = copyInstances(instances)
 }
 
 // GetURL returns polaris registry's url.

--- a/registry/polaris/registry.go
+++ b/registry/polaris/registry.go
@@ -323,6 +323,7 @@ func isNilNotifyListener(notify registry.NotifyListener) bool {
 // instance that successful LoadSubscribeInstances calls may have notified for
 // this listener. Subscribe consumes the merged listener-scoped baseline once.
 func (pr *polarisRegistry) storeInitialSubscribeInstances(key initialSubscribeInstancesKey, instances []model.Instance) {
+	currentSnapshot := copyInstances(instances)
 	pr.initialSubscribeInstancesLock.Lock()
 	defer pr.initialSubscribeInstancesLock.Unlock()
 
@@ -330,7 +331,7 @@ func (pr *polarisRegistry) storeInitialSubscribeInstances(key initialSubscribeIn
 	if entry := pr.initialSubscribeInstances[key]; entry != nil {
 		previous = entry.instances
 	}
-	merged := mergeInitialSubscribeInstances(previous, instances)
+	merged := mergeInitialSubscribeInstances(previous, currentSnapshot)
 	if len(merged) == 0 {
 		return
 	}

--- a/registry/polaris/registry.go
+++ b/registry/polaris/registry.go
@@ -153,11 +153,15 @@ func (pr *polarisRegistry) Subscribe(url *common.URL, notifyListener registry.No
 		return nil
 	}
 	serviceName := url.Interface()
+	key, cacheable, err := initialSubscribeInstancesKeyFor(serviceName, notifyListener)
+	if err != nil {
+		return err
+	}
 	timer := time.NewTimer(time.Duration(RegistryConnDelay) * time.Second)
 	defer timer.Stop()
 
 	for {
-		listener, err := pr.createPolarisListener(serviceName, notifyListener)
+		listener, err := pr.createPolarisListenerWithIdentity(serviceName, key, cacheable)
 		if err != nil {
 			logger.Warnf("[Registry][Polaris] create listener failed, service=%s, err=%v", serviceName, perrors.WithStack(err))
 			<-timer.C
@@ -166,16 +170,47 @@ func (pr *polarisRegistry) Subscribe(url *common.URL, notifyListener registry.No
 		}
 
 		for {
-			serviceEvent, err := listener.Next()
+			notification, err := listener.nextNotification()
 
 			if err != nil {
 				logger.Warnf("[Registry][Polaris] Selector.watch() = err=%v", perrors.WithStack(err))
 				listener.Close()
 				return err
 			}
-			logger.Infof("[Registry][Polaris] update begin, event=%v", serviceEvent.String())
-			notifyListener.Notify(serviceEvent)
+			notifyPolarisNotification(notification, notifyListener)
 		}
+	}
+}
+
+func notifyPolarisNotification(
+	notification *polarisNotification,
+	notify registry.NotifyListener,
+) {
+	switch notification.kind {
+	case incrementalNotification:
+		for _, instance := range notification.instances {
+			serviceURL := generateUrl(instance)
+			if serviceURL == nil {
+				continue
+			}
+			notify.Notify(&registry.ServiceEvent{
+				Action:  notification.eventType,
+				Service: serviceURL,
+			})
+		}
+	case fullSnapshotNotification:
+		events := make([]*registry.ServiceEvent, 0, len(notification.instances))
+		for _, instance := range notification.instances {
+			serviceURL := generateUrl(instance)
+			if serviceURL == nil {
+				continue
+			}
+			events = append(events, &registry.ServiceEvent{
+				Action:  remoting.EventTypeUpdate,
+				Service: serviceURL,
+			})
+		}
+		notify.NotifyAll(events, func() {})
 	}
 }
 
@@ -185,20 +220,36 @@ func (pr *polarisRegistry) createPolarisListener(
 	serviceName string,
 	notify registry.NotifyListener,
 ) (*polarisListener, error) {
-	key, err := newInitialSubscribeInstancesKey(serviceName, notify)
+	key, cacheable, err := initialSubscribeInstancesKeyFor(serviceName, notify)
 	if err != nil {
 		return nil, err
 	}
+	return pr.createPolarisListenerWithIdentity(serviceName, key, cacheable)
+}
+
+func (pr *polarisRegistry) createPolarisListenerWithIdentity(
+	serviceName string,
+	key initialSubscribeInstancesKey,
+	cacheable bool,
+) (*polarisListener, error) {
 	watcher, err := pr.createPolarisWatcher(serviceName)
 	if err != nil {
 		return nil, err
 	}
-	entry, instances := pr.loadInitialSubscribeInstances(key)
-	listener, err := newPolarisListener(watcher, instances)
+	var entry *initialSubscribeInstancesEntry
+	var instances []model.Instance
+	mode := reconcileWithFullSnapshot
+	if cacheable {
+		entry, instances = pr.loadInitialSubscribeInstances(key)
+		mode = reconcileWithBaseline
+	}
+	listener, err := newPolarisListener(watcher, instances, mode)
 	if err != nil {
 		return nil, err
 	}
-	pr.completeInitialSubscribeInstances(key, entry)
+	if cacheable {
+		pr.completeInitialSubscribeInstances(key, entry)
+	}
 	return listener, nil
 }
 
@@ -211,7 +262,7 @@ func (pr *polarisRegistry) UnSubscribe(url *common.URL, notifyListener registry.
 // LoadSubscribeInstances load subscribe instance
 func (pr *polarisRegistry) LoadSubscribeInstances(url *common.URL, notify registry.NotifyListener) error {
 	serviceName := url.Interface()
-	key, err := newInitialSubscribeInstancesKey(serviceName, notify)
+	key, cacheable, err := initialSubscribeInstancesKeyFor(serviceName, notify)
 	if err != nil {
 		return err
 	}
@@ -225,31 +276,34 @@ func (pr *polarisRegistry) LoadSubscribeInstances(url *common.URL, notify regist
 		return perrors.New(fmt.Sprintf("could not query the instances for serviceName=%s,namespace=%s,error=%v",
 			serviceName, pr.namespace, err))
 	}
-	initialSubscribeInstances := make([]model.Instance, 0, len(resp.Instances))
+	validInstances := make([]model.Instance, 0, len(resp.Instances))
+	initialEvents := make([]*registry.ServiceEvent, 0, len(resp.Instances))
 	for i := range resp.Instances {
 		if newUrl := generateUrl(resp.Instances[i]); newUrl != nil {
-			notify.Notify(&registry.ServiceEvent{Action: remoting.EventTypeAdd, Service: newUrl})
-			initialSubscribeInstances = append(initialSubscribeInstances, resp.Instances[i])
+			validInstances = append(validInstances, resp.Instances[i])
+			initialEvents = append(initialEvents, &registry.ServiceEvent{Action: remoting.EventTypeAdd, Service: newUrl})
 		}
 	}
-	pr.storeInitialSubscribeInstances(key, initialSubscribeInstances)
+	if cacheable {
+		pr.storeInitialSubscribeInstances(key, validInstances)
+	}
+	for _, event := range initialEvents {
+		notify.Notify(event)
+	}
 	return nil
 }
 
-func newInitialSubscribeInstancesKey(
+func initialSubscribeInstancesKeyFor(
 	serviceName string,
 	notify registry.NotifyListener,
-) (initialSubscribeInstancesKey, error) {
+) (initialSubscribeInstancesKey, bool, error) {
 	if isNilNotifyListener(notify) {
-		return initialSubscribeInstancesKey{}, fmt.Errorf("notify listener type %T is nil", notify)
-	}
-	if !reflect.TypeOf(notify).Comparable() {
-		return initialSubscribeInstancesKey{}, fmt.Errorf("notify listener type %T is not comparable", notify)
+		return initialSubscribeInstancesKey{}, false, fmt.Errorf("notify listener type %T is nil", notify)
 	}
 	if !reflect.ValueOf(notify).Comparable() {
-		return initialSubscribeInstancesKey{}, fmt.Errorf("notify listener type %T is not comparable", notify)
+		return initialSubscribeInstancesKey{}, false, nil
 	}
-	return initialSubscribeInstancesKey{serviceName: serviceName, notify: notify}, nil
+	return initialSubscribeInstancesKey{serviceName: serviceName, notify: notify}, true, nil
 }
 
 func isNilNotifyListener(notify registry.NotifyListener) bool {
@@ -265,24 +319,61 @@ func isNilNotifyListener(notify registry.NotifyListener) bool {
 	}
 }
 
-// storeInitialSubscribeInstances keeps a defensive copy of the valid instances
-// loaded synchronously by LoadSubscribeInstances. Subscribe binds the entry to
-// the corresponding listener/subscriber. Watchers do not hold a global initial
-// baseline, and successful listener creation clears the bound entry.
+// storeInitialSubscribeInstances accumulates a defensive copy of every valid
+// instance that successful LoadSubscribeInstances calls may have notified for
+// this listener. Subscribe consumes the merged listener-scoped baseline once.
 func (pr *polarisRegistry) storeInitialSubscribeInstances(key initialSubscribeInstancesKey, instances []model.Instance) {
 	pr.initialSubscribeInstancesLock.Lock()
 	defer pr.initialSubscribeInstancesLock.Unlock()
 
-	if len(instances) == 0 {
-		delete(pr.initialSubscribeInstances, key)
+	var previous []model.Instance
+	if entry := pr.initialSubscribeInstances[key]; entry != nil {
+		previous = entry.instances
+	}
+	merged := mergeInitialSubscribeInstances(previous, instances)
+	if len(merged) == 0 {
 		return
 	}
 	if pr.initialSubscribeInstances == nil {
 		pr.initialSubscribeInstances = make(map[initialSubscribeInstancesKey]*initialSubscribeInstancesEntry)
 	}
 	pr.initialSubscribeInstances[key] = &initialSubscribeInstancesEntry{
-		instances: copyInstances(instances),
+		instances: merged,
 	}
+}
+
+func mergeInitialSubscribeInstances(previous, current []model.Instance) []model.Instance {
+	currentByKey := make(map[model.InstanceKey]model.Instance, len(current))
+	currentOrder := make([]model.InstanceKey, 0, len(current))
+	for _, instance := range current {
+		key := instance.GetInstanceKey()
+		if _, exists := currentByKey[key]; !exists {
+			currentOrder = append(currentOrder, key)
+		}
+		currentByKey[key] = instance
+	}
+
+	merged := make([]model.Instance, 0, len(previous)+len(currentOrder))
+	seen := make(map[model.InstanceKey]struct{}, len(previous)+len(currentOrder))
+	for _, instance := range previous {
+		key := instance.GetInstanceKey()
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		if newer, exists := currentByKey[key]; exists {
+			instance = newer
+		}
+		merged = append(merged, instance)
+		seen[key] = struct{}{}
+	}
+	for _, key := range currentOrder {
+		if _, exists := seen[key]; exists {
+			continue
+		}
+		merged = append(merged, currentByKey[key])
+		seen[key] = struct{}{}
+	}
+	return merged
 }
 
 func (pr *polarisRegistry) loadInitialSubscribeInstances(
@@ -350,6 +441,10 @@ func (pr *polarisRegistry) Destroy() {
 			logger.Errorf("[Registry][Polaris] deRegister URL=%+v err=%v", url, err)
 		}
 	}
+	pr.initialSubscribeInstancesLock.Lock()
+	clear(pr.initialSubscribeInstances)
+	pr.initialSubscribeInstances = nil
+	pr.initialSubscribeInstancesLock.Unlock()
 }
 
 // IsAvailable always return true when use polaris

--- a/registry/polaris/registry.go
+++ b/registry/polaris/registry.go
@@ -143,18 +143,7 @@ func (pr *polarisRegistry) Subscribe(url *common.URL, notifyListener registry.No
 
 	for {
 		serviceName := url.Interface()
-		watcher, err := pr.createPolarisWatcher(serviceName)
-		if err != nil {
-			logger.Warnf("[Registry][Polaris] getwatcher() = err=%v", perrors.WithStack(err))
-			<-timer.C
-			timer.Reset(time.Duration(RegistryConnDelay) * time.Second)
-			continue
-		}
-		if initialSnapshot, ok := pr.takeInitialSnapshot(serviceName); ok {
-			watcher.setInitialSnapshot(initialSnapshot)
-		}
-
-		listener, err := NewPolarisListener(watcher)
+		listener, err := pr.createPolarisListener(serviceName, NewPolarisListener)
 		if err != nil {
 			logger.Warnf("[Registry][Polaris] getListener() = err=%v", perrors.WithStack(err))
 			<-timer.C
@@ -174,6 +163,22 @@ func (pr *polarisRegistry) Subscribe(url *common.URL, notifyListener registry.No
 			notifyListener.Notify(serviceEvent)
 		}
 	}
+}
+
+// createPolarisListener creates or reuses the service watcher, transfers its pending baseline,
+// and only then invokes newListener so the watcher cannot start before snapshot injection.
+func (pr *polarisRegistry) createPolarisListener(
+	serviceName string,
+	newListener func(*PolarisServiceWatcher) (*polarisListener, error),
+) (*polarisListener, error) {
+	watcher, err := pr.createPolarisWatcher(serviceName)
+	if err != nil {
+		return nil, err
+	}
+	if initialSnapshot, ok := pr.takeInitialSnapshot(serviceName); ok {
+		watcher.setInitialSnapshot(initialSnapshot)
+	}
+	return newListener(watcher)
 }
 
 // UnSubscribe returns nil if unsubscribing registry successfully. If not returns an error.
@@ -206,6 +211,8 @@ func (pr *polarisRegistry) LoadSubscribeInstances(url *common.URL, notify regist
 	return nil
 }
 
+// storeInitialSnapshot keeps valid instances notified during synchronous loading
+// until Subscribe transfers the baseline to the service watcher.
 func (pr *polarisRegistry) storeInitialSnapshot(serviceName string, instances []model.Instance) {
 	pr.initialSnapshotLock.Lock()
 	defer pr.initialSnapshotLock.Unlock()
@@ -220,6 +227,8 @@ func (pr *polarisRegistry) storeInitialSnapshot(serviceName string, instances []
 	pr.initialSnapshots[serviceName] = append([]model.Instance(nil), instances...)
 }
 
+// takeInitialSnapshot removes and returns the pending service baseline, transferring it
+// from synchronous LoadSubscribeInstances to the asynchronous watcher exactly once.
 func (pr *polarisRegistry) takeInitialSnapshot(serviceName string) ([]model.Instance, bool) {
 	pr.initialSnapshotLock.Lock()
 	defer pr.initialSnapshotLock.Unlock()

--- a/registry/polaris/registry_test.go
+++ b/registry/polaris/registry_test.go
@@ -18,8 +18,10 @@
 package polaris
 
 import (
+	"context"
 	"errors"
-	"fmt"
+	"os"
+	"os/exec"
 	"reflect"
 	"strconv"
 	"strings"
@@ -40,7 +42,6 @@ import (
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
-	"dubbo.apache.org/dubbo-go/v3/config_center"
 	"dubbo.apache.org/dubbo-go/v3/registry"
 	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
@@ -59,6 +60,31 @@ type fakePolarisConsumer struct {
 	watchErr          error
 	watchCalls        int
 	watchRequest      *api.WatchServiceRequest
+}
+
+type gatedPolarisWatchResult struct {
+	response *model.WatchServiceResponse
+	err      error
+}
+
+type gatedPolarisConsumer struct {
+	*fakePolarisConsumer
+	watchRequests chan *api.WatchServiceRequest
+	watchResults  chan gatedPolarisWatchResult
+}
+
+func newGatedPolarisConsumer(instanceResponses ...[]model.Instance) *gatedPolarisConsumer {
+	return &gatedPolarisConsumer{
+		fakePolarisConsumer: &fakePolarisConsumer{instanceResponses: instanceResponses},
+		watchRequests:       make(chan *api.WatchServiceRequest),
+		watchResults:        make(chan gatedPolarisWatchResult),
+	}
+}
+
+func (f *gatedPolarisConsumer) WatchService(request *api.WatchServiceRequest) (*model.WatchServiceResponse, error) {
+	f.watchRequests <- request
+	result := <-f.watchResults
+	return result.response, result.err
 }
 
 func (f *fakePolarisConsumer) GetInstances(_ *api.GetInstancesRequest) (*model.InstancesResponse, error) {
@@ -97,24 +123,31 @@ type recordedPolarisEvent struct {
 	revision string
 }
 
-type recordingPolarisNotifyListener struct {
-	events []recordedPolarisEvent
+type recordedNotification struct {
+	kind        polarisNotificationKind
+	events      []recordedPolarisEvent
+	callbackNil bool
 }
 
-type unsupportedPolarisNotifyListener []recordedPolarisEvent
+type recordingPolarisNotifyListener struct {
+	notifications []recordedNotification
+	onNotify      func(*registry.ServiceEvent)
+}
 
-type unsupportedMapPolarisNotifyListener map[string]int
+type nonComparablePolarisNotifyListener []*recordingPolarisNotifyListener
 
-type unsupportedFuncPolarisNotifyListener func()
+type nonComparableMapPolarisNotifyListener map[string]*recordingPolarisNotifyListener
 
-type unsupportedChanPolarisNotifyListener chan struct{}
+type nonComparableFuncPolarisNotifyListener func(*registry.ServiceEvent, []*registry.ServiceEvent, func())
 
-type unsupportedStructPolarisNotifyListener struct {
-	_ []recordedPolarisEvent
+type nonComparableStructPolarisNotifyListener struct {
+	recorder *recordingPolarisNotifyListener
+	_        []recordedPolarisEvent
 }
 
 type runtimeUnhashablePolarisNotifyListener struct {
-	state any
+	state    any
+	recorder *recordingPolarisNotifyListener
 }
 
 type comparableValuePolarisNotifyListener struct {
@@ -124,29 +157,69 @@ type comparableValuePolarisNotifyListener struct {
 
 type nilablePolarisNotifyListener struct{}
 
-func (unsupportedPolarisNotifyListener) Notify(*registry.ServiceEvent) {}
+type nilableChannelPolarisNotifyListener chan struct{}
 
-func (unsupportedPolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
+type stopSubscribePump struct{}
 
-func (unsupportedMapPolarisNotifyListener) Notify(*registry.ServiceEvent) {}
+func (l nonComparablePolarisNotifyListener) Notify(event *registry.ServiceEvent) {
+	if len(l) > 0 && l[0] != nil {
+		l[0].Notify(event)
+	}
+}
 
-func (unsupportedMapPolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
+func (l nonComparablePolarisNotifyListener) NotifyAll(events []*registry.ServiceEvent, callback func()) {
+	if len(l) > 0 && l[0] != nil {
+		l[0].NotifyAll(events, callback)
+	}
+}
 
-func (unsupportedFuncPolarisNotifyListener) Notify(*registry.ServiceEvent) {}
+func (l nonComparableMapPolarisNotifyListener) Notify(event *registry.ServiceEvent) {
+	if recorder := l["recorder"]; recorder != nil {
+		recorder.Notify(event)
+	}
+}
 
-func (unsupportedFuncPolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
+func (l nonComparableMapPolarisNotifyListener) NotifyAll(events []*registry.ServiceEvent, callback func()) {
+	if recorder := l["recorder"]; recorder != nil {
+		recorder.NotifyAll(events, callback)
+	}
+}
 
-func (unsupportedChanPolarisNotifyListener) Notify(*registry.ServiceEvent) {}
+func (l nonComparableFuncPolarisNotifyListener) Notify(event *registry.ServiceEvent) {
+	if l != nil {
+		l(event, nil, nil)
+	}
+}
 
-func (unsupportedChanPolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
+func (l nonComparableFuncPolarisNotifyListener) NotifyAll(events []*registry.ServiceEvent, callback func()) {
+	if l != nil {
+		l(nil, events, callback)
+	}
+}
 
-func (unsupportedStructPolarisNotifyListener) Notify(*registry.ServiceEvent) {}
+func (l nonComparableStructPolarisNotifyListener) Notify(event *registry.ServiceEvent) {
+	if l.recorder != nil {
+		l.recorder.Notify(event)
+	}
+}
 
-func (unsupportedStructPolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
+func (l nonComparableStructPolarisNotifyListener) NotifyAll(events []*registry.ServiceEvent, callback func()) {
+	if l.recorder != nil {
+		l.recorder.NotifyAll(events, callback)
+	}
+}
 
-func (runtimeUnhashablePolarisNotifyListener) Notify(*registry.ServiceEvent) {}
+func (l runtimeUnhashablePolarisNotifyListener) Notify(event *registry.ServiceEvent) {
+	if l.recorder != nil {
+		l.recorder.Notify(event)
+	}
+}
 
-func (runtimeUnhashablePolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
+func (l runtimeUnhashablePolarisNotifyListener) NotifyAll(events []*registry.ServiceEvent, callback func()) {
+	if l.recorder != nil {
+		l.recorder.NotifyAll(events, callback)
+	}
+}
 
 func (l comparableValuePolarisNotifyListener) Notify(event *registry.ServiceEvent) {
 	l.recorder.Notify(event)
@@ -160,41 +233,48 @@ func (*nilablePolarisNotifyListener) Notify(*registry.ServiceEvent) {}
 
 func (*nilablePolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
 
+func (nilableChannelPolarisNotifyListener) Notify(*registry.ServiceEvent) {}
+
+func (nilableChannelPolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
+
 func (r *recordingPolarisNotifyListener) Notify(event *registry.ServiceEvent) {
-	r.record(
-		event.Action,
-		event.Service.Ip,
-		event.Service.Port,
-		event.Service.GetParam(constant.PolarisInstanceID, ""),
-		event.Service.GetParam(testPolarisRevisionKey, ""),
-	)
+	r.notifications = append(r.notifications, recordedNotification{
+		kind:   incrementalNotification,
+		events: []recordedPolarisEvent{recordedPolarisEventFromServiceEvent(event)},
+	})
+	if r.onNotify != nil {
+		r.onNotify(event)
+	}
 }
 
 func (r *recordingPolarisNotifyListener) NotifyAll(events []*registry.ServiceEvent, callback func()) {
-	for _, event := range events {
-		r.Notify(event)
-	}
+	r.notifications = append(r.notifications, recordedNotification{
+		kind:        fullSnapshotNotification,
+		events:      recordedPolarisEventsFromServiceEvents(events),
+		callbackNil: callback == nil,
+	})
 	if callback != nil {
 		callback()
 	}
 }
 
 func (r *recordingPolarisNotifyListener) recordInstances(action remoting.EventType, instances []model.Instance) {
-	for _, instance := range instances {
-		r.events = append(r.events, recordedPolarisEventFromInstance(action, instance))
+	if len(instances) == 0 {
+		return
 	}
+	events := make([]recordedPolarisEvent, 0, len(instances))
+	for _, instance := range instances {
+		events = append(events, recordedPolarisEventFromInstance(action, instance))
+	}
+	r.notifications = append(r.notifications, recordedNotification{kind: incrementalNotification, events: events})
 }
 
-func (r *recordingPolarisNotifyListener) record(
-	action remoting.EventType,
-	host string,
-	port string,
-	id string,
-	revision string,
-) {
-	r.events = append(r.events, recordedPolarisEvent{
-		action: action, host: host, port: port, id: id, revision: revision,
-	})
+func (r *recordingPolarisNotifyListener) recordedEvents() []recordedPolarisEvent {
+	var events []recordedPolarisEvent
+	for _, notification := range r.notifications {
+		events = append(events, notification.events...)
+	}
+	return events
 }
 
 func TestPolarisInitialSnapshotReconciliation(t *testing.T) {
@@ -203,99 +283,34 @@ func TestPolarisInitialSnapshotReconciliation(t *testing.T) {
 	sameKeyA := newPolarisTestInstance("new-polaris-id", "10.0.0.1", 20001, serviceName, true)
 	instanceA.GetMetadata()[testPolarisRevisionKey] = "before"
 	sameKeyA.GetMetadata()[testPolarisRevisionKey] = "after"
-	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
-	instanceC := newPolarisTestInstance("instance-c", "10.0.0.3", 20003, serviceName, true)
 	invalid := newPolarisTestInstance("invalid", "10.0.0.9", 20009, serviceName, false)
-
-	tests := []struct {
-		name           string
-		loaded         []model.Instance
-		current        []model.Instance
-		watchEvents    []model.SubScribeEvent
-		wantLoad       []recordedPolarisEvent
-		wantListener   []recordedPolarisEvent
-		wantInstance   model.Instance
-		wantWatchCalls int
-	}{
-		{
-			name:    "A replaced by B and incremental event is wired",
-			loaded:  []model.Instance{instanceA, invalid},
-			current: []model.Instance{instanceB},
-			watchEvents: []model.SubScribeEvent{&model.InstanceEvent{
-				AddEvent: &model.InstanceAddEvent{Instances: []model.Instance{instanceC}},
-			}},
-			wantLoad: []recordedPolarisEvent{
-				{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
-			},
-			wantListener: []recordedPolarisEvent{
-				{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
-				{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
-				{action: remoting.EventTypeAdd, host: "10.0.0.3", port: "20003"},
-			},
-			wantWatchCalls: 1,
-		},
-		{
-			name:     "first snapshot empty",
-			loaded:   []model.Instance{instanceA},
-			wantLoad: []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"}},
-			wantListener: []recordedPolarisEvent{
-				{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
-			},
-			wantWatchCalls: 1,
-		},
-		{
-			name:     "same InstanceKey with different Polaris ID",
-			loaded:   []model.Instance{instanceA},
-			current:  []model.Instance{sameKeyA},
-			wantLoad: []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"}},
-			wantListener: []recordedPolarisEvent{
-				{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
-			},
-			wantInstance:   sameKeyA,
-			wantWatchCalls: 1,
-		},
-		{
-			name:           "invalid instance is excluded from baseline",
-			loaded:         []model.Instance{invalid},
-			wantWatchCalls: 1,
-		},
+	consumer := &fakePolarisConsumer{
+		instanceResponses: [][]model.Instance{{instanceA, invalid}},
+		watchInstances:    []model.Instance{sameKeyA},
+	}
+	pr := newTestPolarisRegistry(consumer)
+	notify := &recordingPolarisNotifyListener{}
+	if err := pr.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
+		t.Fatalf("LoadSubscribeInstances() error = %v", err)
+	}
+	watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
+	listener, err := pr.createPolarisListener(serviceName, notify)
+	if err != nil {
+		t.Fatalf("createPolarisListener() error = %v", err)
+	}
+	defer closeTestPolarisListener(listener)
+	if err := watcher.watchOnce(); err != nil {
+		t.Fatalf("watchOnce() error = %v", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			consumer := &fakePolarisConsumer{
-				instanceResponses: [][]model.Instance{tt.loaded},
-				watchInstances:    tt.current,
-				watchEvents:       tt.watchEvents,
-			}
-			pr := newTestPolarisRegistry(consumer)
-			notify := &recordingPolarisNotifyListener{}
-			url := newPolarisConsumerURL(serviceName)
-
-			if err := pr.LoadSubscribeInstances(url, notify); err != nil {
-				t.Fatalf("LoadSubscribeInstances() error = %v", err)
-			}
-			watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
-			listener, err := pr.createPolarisListener(serviceName, notify)
-			if err != nil {
-				t.Fatalf("createPolarisListener() error = %v", err)
-			}
-			defer closeTestPolarisListener(listener)
-			if watchErr := watcher.watchOnce(); watchErr != nil {
-				t.Fatalf("watchOnce() error = %v", watchErr)
-			}
-
-			assertPolarisEventsAddress(t, notify.events, tt.wantLoad)
-			listenerEvents := assertPolarisListenerEvents(t, listener, tt.wantListener)
-			if tt.wantInstance != nil {
-				assertPolarisEventInstance(t, listenerEvents[0], remoting.EventTypeAdd, tt.wantInstance)
-			}
-			assertPolarisWatchRequest(t, consumer.watchRequest, watcher.subscribeParam, serviceName)
-			if consumer.watchCalls != tt.wantWatchCalls {
-				t.Fatalf("WatchService() calls = %d, want %d", consumer.watchCalls, tt.wantWatchCalls)
-			}
-		})
-	}
+	assertPolarisEventsAddress(t, notify.recordedEvents(), []recordedPolarisEvent{{
+		action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001",
+	}})
+	events := assertPolarisListenerEvents(t, listener, []recordedPolarisEvent{{
+		action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001",
+	}})
+	assertPolarisEventInstance(t, events[0], remoting.EventTypeAdd, sameKeyA)
+	assertPolarisWatchRequest(t, consumer.watchRequest, watcher.subscribeParam, serviceName)
 
 	t.Run("WatchService error is returned", func(t *testing.T) {
 		wantErr := errors.New("watch failed")
@@ -306,6 +321,280 @@ func TestPolarisInitialSnapshotReconciliation(t *testing.T) {
 		if watcher.snapshotReady {
 			t.Fatal("watcher snapshot is ready after WatchService error")
 		}
+	})
+}
+
+func TestPolarisWatchServiceReconnectLifecycle(t *testing.T) {
+	serviceName := "com.test.ReconnectSnapshotService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	consumer := newGatedPolarisConsumer()
+	pr := newTestPolarisRegistry(consumer)
+	watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
+	listener, err := newPolarisListener(watcher, nil, reconcileWithBaseline)
+	if err != nil {
+		t.Fatalf("newPolarisListener() error = %v", err)
+	}
+	defer closeTestPolarisListener(listener)
+
+	firstRequest := runGatedPolarisWatchOnce(t, watcher, consumer, []model.Instance{instanceA, instanceB})
+	assertPolarisListenerEvents(t, listener, []recordedPolarisEvent{
+		{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
+		{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
+	})
+	secondRequest := runGatedPolarisWatchOnce(t, watcher, consumer, []model.Instance{instanceB})
+	assertPolarisListenerEvents(t, listener, []recordedPolarisEvent{
+		{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+		{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
+	})
+	assertPolarisWatchRequest(t, firstRequest, watcher.subscribeParam, serviceName)
+	assertPolarisWatchRequest(t, secondRequest, watcher.subscribeParam, serviceName)
+
+	t.Run("single instance to empty snapshot", func(t *testing.T) {
+		pr := newTestPolarisRegistry(nil)
+		watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
+		listener, err := newPolarisListener(watcher, nil, reconcileWithBaseline)
+		if err != nil {
+			t.Fatalf("newPolarisListener() error = %v", err)
+		}
+		defer closeTestPolarisListener(listener)
+
+		watcher.handleWatchSnapshot([]model.Instance{instanceA})
+		assertPolarisListenerEvents(t, listener, []recordedPolarisEvent{{
+			action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001",
+		}})
+
+		watcher.handleWatchSnapshot(nil)
+		assertPolarisListenerEvents(t, listener, []recordedPolarisEvent{{
+			action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001",
+		}})
+		if len(watcher.currentInstances) != 0 {
+			t.Fatalf("current instance count = %d, want 0", len(watcher.currentInstances))
+		}
+	})
+}
+
+func TestPolarisComparableSubscriberDeletesInstanceThatBecomesInvalid(t *testing.T) {
+	serviceName := "com.test.ValidToInvalidSnapshotService"
+	validA := newPolarisTestInstance("valid-a", "10.0.0.1", 20001, serviceName, true)
+	invalidA := newPolarisTestInstance("invalid-a", "10.0.0.1", 20001, serviceName, false)
+
+	t.Run("first reconciliation compares baseline with notifiable current set", func(t *testing.T) {
+		pr := newTestPolarisRegistry(&fakePolarisConsumer{
+			instanceResponses: [][]model.Instance{{validA}},
+		})
+		notify := &recordingPolarisNotifyListener{}
+		if err := pr.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
+			t.Fatalf("LoadSubscribeInstances() error = %v", err)
+		}
+		watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
+		listener, err := pr.createPolarisListener(serviceName, notify)
+		if err != nil {
+			t.Fatalf("createPolarisListener() error = %v", err)
+		}
+		defer closeTestPolarisListener(listener)
+
+		watcher.handleWatchSnapshot([]model.Instance{invalidA})
+		assertPolarisListenerEvents(t, listener, []recordedPolarisEvent{
+			{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+		})
+	})
+
+	t.Run("reconnect deletes previously valid instance before skipping invalid current", func(t *testing.T) {
+		watcher := newStoppedPolarisWatcher(t, nil)
+		listener, err := newPolarisListener(watcher, nil, reconcileWithBaseline)
+		if err != nil {
+			t.Fatalf("newPolarisListener() error = %v", err)
+		}
+		defer closeTestPolarisListener(listener)
+		watcher.handleWatchSnapshot([]model.Instance{validA})
+		assertPolarisListenerEvent(t, listener, remoting.EventTypeAdd, validA)
+
+		watcher.handleWatchSnapshot([]model.Instance{invalidA})
+		assertPolarisListenerEvents(t, listener, []recordedPolarisEvent{
+			{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+		})
+	})
+}
+
+func TestPolarisRegistrySubscriberUpdateNotificationMatrix(t *testing.T) {
+	serviceName := "com.test.UpdateNotificationMatrixService"
+	validA := newPolarisTestInstance("valid-a", "10.0.0.1", 20001, serviceName, true)
+	updatedA := newPolarisTestInstance("updated-a", "10.0.0.1", 20001, serviceName, true)
+	validB := newPolarisTestInstance("valid-b", "10.0.0.2", 20002, serviceName, true)
+	invalidA := newPolarisTestInstance("invalid-a", "10.0.0.1", 20001, serviceName, false)
+	invalidB := newPolarisTestInstance("invalid-b", "10.0.0.2", 20002, serviceName, false)
+
+	tests := []struct {
+		name            string
+		before          model.Instance
+		after           model.Instance
+		wantRegistry    []recordedPolarisEvent
+		verifyReconnect bool
+		verifyNoRepeat  bool
+	}{
+		{
+			name:   "same key valid to valid updates after",
+			before: validA,
+			after:  updatedA,
+			wantRegistry: []recordedPolarisEvent{
+				{action: remoting.EventTypeUpdate, host: "10.0.0.1", port: "20001"},
+			},
+		},
+		{
+			name:   "changed key valid to valid deletes before updating",
+			before: validA,
+			after:  validB,
+			wantRegistry: []recordedPolarisEvent{
+				{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+				{action: remoting.EventTypeUpdate, host: "10.0.0.2", port: "20002"},
+			},
+			verifyReconnect: true,
+		},
+		{
+			name:   "same key valid to invalid deletes before",
+			before: validA,
+			after:  invalidA,
+			wantRegistry: []recordedPolarisEvent{
+				{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+			},
+			verifyNoRepeat: true,
+		},
+		{
+			name:   "changed key valid to invalid deletes before",
+			before: validA,
+			after:  invalidB,
+			wantRegistry: []recordedPolarisEvent{
+				{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+			},
+		},
+		{
+			name:   "invalid to valid only updates after",
+			before: invalidA,
+			after:  validB,
+			wantRegistry: []recordedPolarisEvent{
+				{action: remoting.EventTypeUpdate, host: "10.0.0.2", port: "20002"},
+			},
+		},
+		{
+			name:   "invalid to invalid has no registry notification",
+			before: invalidA,
+			after:  invalidB,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			watcher := newStoppedPolarisWatcher(t, nil)
+			listener, err := newPolarisListener(watcher, nil, reconcileWithBaseline)
+			if err != nil {
+				t.Fatalf("newPolarisListener() error = %v", err)
+			}
+			defer closeTestPolarisListener(listener)
+
+			watcher.handleWatchSnapshot([]model.Instance{tt.before})
+			if polarisInstanceURLValidationError(tt.before) == "" {
+				assertPolarisListenerEvent(t, listener, remoting.EventTypeAdd, tt.before)
+			} else {
+				assertNoPolarisListenerEvent(t, listener)
+			}
+			application := &recordingPolarisNotifyListener{}
+			watcher.AddSubscriber(application.recordInstances)
+
+			watcher.handleInstanceEvent(&model.InstanceEvent{
+				UpdateEvent: &model.InstanceUpdateEvent{UpdateList: []model.OneInstanceUpdate{{
+					Before: tt.before,
+					After:  tt.after,
+				}}},
+			})
+
+			var registryEvents []recordedPolarisEvent
+			if len(tt.wantRegistry) == 0 {
+				assertNoPolarisListenerEvent(t, listener)
+			} else {
+				registryEvents = assertPolarisIncrementalListenerEvents(t, listener, tt.wantRegistry)
+			}
+			for _, event := range registryEvents {
+				if event.action == remoting.EventTypeUpdate {
+					assertPolarisEventInstance(t, event, remoting.EventTypeUpdate, tt.after)
+				}
+			}
+			if len(application.recordedEvents()) != 1 {
+				t.Fatalf("application event count = %d, want 1", len(application.recordedEvents()))
+			}
+			assertPolarisEventInstance(t, application.recordedEvents()[0], remoting.EventTypeUpdate, tt.after)
+			if len(watcher.currentInstances) != 1 {
+				t.Fatalf("current instance count = %d, want 1", len(watcher.currentInstances))
+			}
+			assertPolarisInstanceIdentity(t, watcher.currentInstances[0], tt.after)
+
+			if tt.verifyReconnect {
+				watcher.handleWatchSnapshot([]model.Instance{tt.after})
+				assertPolarisListenerEvents(t, listener, []recordedPolarisEvent{{
+					action: remoting.EventTypeAdd,
+					host:   tt.after.GetHost(),
+					port:   strconv.Itoa(int(tt.after.GetPort())),
+				}})
+			}
+			if tt.verifyNoRepeat {
+				watcher.handleWatchSnapshot([]model.Instance{tt.after})
+				assertNoPolarisListenerEvent(t, listener)
+			}
+		})
+	}
+}
+
+func TestPolarisChangedKeyUpdateBatchPreservesEveryAfterInstance(t *testing.T) {
+	serviceName := "com.test.ChangedKeyUpdateBatchService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	movedA := newPolarisTestInstance("moved-a", "10.0.0.2", 20002, serviceName, true)
+	movedB := newPolarisTestInstance("moved-b", "10.0.0.3", 20003, serviceName, true)
+	watcher := newStoppedPolarisWatcher(t, nil)
+	listener, err := newPolarisListener(watcher, nil, reconcileWithBaseline)
+	if err != nil {
+		t.Fatalf("newPolarisListener() error = %v", err)
+	}
+	defer closeTestPolarisListener(listener)
+
+	watcher.handleWatchSnapshot([]model.Instance{instanceA, instanceB})
+	assertPolarisListenerEvents(t, listener, []recordedPolarisEvent{
+		{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
+		{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
+	})
+	application := &recordingPolarisNotifyListener{}
+	watcher.AddSubscriber(application.recordInstances)
+
+	watcher.handleInstanceEvent(&model.InstanceEvent{
+		UpdateEvent: &model.InstanceUpdateEvent{UpdateList: []model.OneInstanceUpdate{
+			{Before: instanceA, After: movedA},
+			{Before: instanceB, After: movedB},
+		}},
+	})
+
+	registryEvents := assertPolarisIncrementalListenerEvents(t, listener, []recordedPolarisEvent{
+		{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+		{action: remoting.EventTypeDel, host: "10.0.0.2", port: "20002"},
+		{action: remoting.EventTypeUpdate, host: "10.0.0.2", port: "20002"},
+		{action: remoting.EventTypeUpdate, host: "10.0.0.3", port: "20003"},
+	})
+	assertPolarisEventInstance(t, registryEvents[2], remoting.EventTypeUpdate, movedA)
+	assertPolarisEventInstance(t, registryEvents[3], remoting.EventTypeUpdate, movedB)
+	if len(application.recordedEvents()) != 2 {
+		t.Fatalf("application event count = %d, want 2", len(application.recordedEvents()))
+	}
+	assertPolarisEventInstance(t, application.recordedEvents()[0], remoting.EventTypeUpdate, movedA)
+	assertPolarisEventInstance(t, application.recordedEvents()[1], remoting.EventTypeUpdate, movedB)
+	if len(watcher.currentInstances) != 2 {
+		t.Fatalf("current instance count = %d, want 2", len(watcher.currentInstances))
+	}
+	assertPolarisInstanceIdentity(t, watcher.currentInstances[0], movedA)
+	assertPolarisInstanceIdentity(t, watcher.currentInstances[1], movedB)
+
+	watcher.handleWatchSnapshot([]model.Instance{movedB})
+	assertPolarisListenerEvents(t, listener, []recordedPolarisEvent{
+		{action: remoting.EventTypeDel, host: "10.0.0.2", port: "20002"},
+		{action: remoting.EventTypeAdd, host: "10.0.0.3", port: "20003"},
 	})
 }
 
@@ -360,53 +649,261 @@ func TestPolarisInitialSubscribeInstancesAreListenerScoped(t *testing.T) {
 	serviceName := "com.test.ListenerScopedBaselineService"
 	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
 	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
-	consumer := &fakePolarisConsumer{instanceResponses: [][]model.Instance{{instanceA}, {instanceB}, nil}}
-	pr := newTestPolarisRegistry(consumer)
-	firstNotify := &recordingPolarisNotifyListener{}
-	secondNotify := &recordingPolarisNotifyListener{}
-	url := newPolarisConsumerURL(serviceName)
+	newerA := newPolarisTestInstance("newer-a", "10.0.0.1", 20001, serviceName, true)
+	newerA.GetMetadata()[testPolarisRevisionKey] = "newer"
 
-	if err := pr.LoadSubscribeInstances(url, firstNotify); err != nil {
-		t.Fatalf("LoadSubscribeInstances(first) error = %v", err)
-	}
-	if err := pr.LoadSubscribeInstances(url, secondNotify); err != nil {
-		t.Fatalf("LoadSubscribeInstances(second) error = %v", err)
-	}
-	if err := pr.LoadSubscribeInstances(url, firstNotify); err != nil {
-		t.Fatalf("LoadSubscribeInstances(first empty) error = %v", err)
+	for _, tt := range []struct {
+		name        string
+		responses   [][]model.Instance
+		current     []model.Instance
+		wantPending int
+		want        []recordedPolarisEvent
+	}{
+		{
+			name:        "Load A then Load B keeps A for first Watch B",
+			responses:   [][]model.Instance{{instanceA}, {instanceB}},
+			current:     []model.Instance{instanceB},
+			wantPending: 2,
+			want: []recordedPolarisEvent{
+				{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+				{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
+			},
+		},
+		{
+			name:        "empty Load preserves prior pending baseline",
+			responses:   [][]model.Instance{{instanceA}, nil},
+			wantPending: 1,
+			want:        []recordedPolarisEvent{{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"}},
+		},
+		{
+			name:        "duplicate InstanceKey keeps latest instance once",
+			responses:   [][]model.Instance{{instanceA}, {newerA}},
+			wantPending: 1,
+			want:        []recordedPolarisEvent{{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"}},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			consumer := &fakePolarisConsumer{instanceResponses: tt.responses}
+			pr := newTestPolarisRegistry(consumer)
+			notify := &recordingPolarisNotifyListener{}
+			url := newPolarisConsumerURL(serviceName)
+			for range tt.responses {
+				if err := pr.LoadSubscribeInstances(url, notify); err != nil {
+					t.Fatalf("LoadSubscribeInstances() error = %v", err)
+				}
+			}
+
+			key := mustInitialSubscribeInstancesKey(t, serviceName, notify)
+			entry, pending := pr.loadInitialSubscribeInstances(key)
+			if entry == nil || len(pending) != tt.wantPending {
+				t.Fatalf("pending baseline = (%p, %v), want %d instances", entry, pending, tt.wantPending)
+			}
+			if tt.name == "duplicate InstanceKey keeps latest instance once" {
+				assertPolarisInstanceIdentity(t, pending[0], newerA)
+			}
+
+			watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
+			watcher.handleWatchSnapshot(tt.current)
+			listener, err := pr.createPolarisListener(serviceName, notify)
+			if err != nil {
+				t.Fatalf("createPolarisListener() error = %v", err)
+			}
+			defer closeTestPolarisListener(listener)
+			events := assertPolarisListenerEvents(t, listener, tt.want)
+			if tt.name == "duplicate InstanceKey keeps latest instance once" {
+				assertPolarisEventInstance(t, events[0], remoting.EventTypeDel, newerA)
+			}
+			if pendingEntry, _ := pr.loadInitialSubscribeInstances(key); pendingEntry != nil {
+				t.Fatalf("pending entry after listener success = %p, want nil", pendingEntry)
+			}
+		})
 	}
 
-	firstKey := mustInitialSubscribeInstancesKey(t, serviceName, firstNotify)
-	if entry, instances := pr.loadInitialSubscribeInstances(firstKey); entry != nil || len(instances) != 0 {
-		t.Fatalf("first pending entry = (%p, %v), want empty", entry, instances)
+	t.Run("baseline is stored before Notify", func(t *testing.T) {
+		pr := newTestPolarisRegistry(&fakePolarisConsumer{instanceResponses: [][]model.Instance{{instanceA}}})
+		baselineWasReady := false
+		notify := &recordingPolarisNotifyListener{}
+		notify.onNotify = func(*registry.ServiceEvent) {
+			key := mustInitialSubscribeInstancesKey(t, serviceName, notify)
+			entry, instances := pr.loadInitialSubscribeInstances(key)
+			baselineWasReady = entry != nil && len(instances) == 1
+		}
+		if err := pr.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
+			t.Fatalf("LoadSubscribeInstances() error = %v", err)
+		}
+		if !baselineWasReady {
+			t.Fatal("pending baseline was not stored before Notify(ADD)")
+		}
+	})
+
+	t.Run("Destroy clears pending baseline", func(t *testing.T) {
+		pr := newTestPolarisRegistry(nil)
+		notify := &recordingPolarisNotifyListener{}
+		key := mustInitialSubscribeInstancesKey(t, serviceName, notify)
+		pr.storeInitialSubscribeInstances(key, []model.Instance{instanceA})
+		pr.Destroy()
+		pr.Destroy()
+		if len(pr.initialSubscribeInstances) != 0 {
+			t.Fatalf("pending entry count after Destroy = %d, want 0", len(pr.initialSubscribeInstances))
+		}
+	})
+}
+
+func TestPolarisInitialSubscribeCompletionPreservesNewerEntry(t *testing.T) {
+	serviceName := "com.test.InitialSubscribeCompletionService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	pr := newTestPolarisRegistry(nil)
+	notify := &recordingPolarisNotifyListener{}
+	key := mustInitialSubscribeInstancesKey(t, serviceName, notify)
+
+	pr.storeInitialSubscribeInstances(key, []model.Instance{instanceA})
+	oldEntry, oldBaseline := pr.loadInitialSubscribeInstances(key)
+	if oldEntry == nil || len(oldBaseline) != 1 {
+		t.Fatalf("old pending entry = (%p, %v), want instance A", oldEntry, oldBaseline)
 	}
-	secondKey := mustInitialSubscribeInstancesKey(t, serviceName, secondNotify)
-	secondEntry, instances := pr.loadInitialSubscribeInstances(secondKey)
-	if secondEntry == nil || len(instances) != 1 || instances[0].GetInstanceKey() != instanceB.GetInstanceKey() {
-		t.Fatalf("second pending entry = (%p, %v), want instance B", secondEntry, instances)
+	assertPolarisInstanceIdentity(t, oldBaseline[0], instanceA)
+
+	pr.storeInitialSubscribeInstances(key, []model.Instance{instanceB})
+	newEntry, newBaseline := pr.loadInitialSubscribeInstances(key)
+	if newEntry == nil || newEntry == oldEntry {
+		t.Fatalf("new pending entry = %p, want non-nil entry distinct from %p", newEntry, oldEntry)
+	}
+	if len(newBaseline) != 2 {
+		t.Fatalf("new pending baseline = %v, want instances A and B", newBaseline)
+	}
+	assertPolarisInstanceIdentity(t, newBaseline[0], instanceA)
+	assertPolarisInstanceIdentity(t, newBaseline[1], instanceB)
+
+	pr.completeInitialSubscribeInstances(key, oldEntry)
+	remainingEntry, remainingBaseline := pr.loadInitialSubscribeInstances(key)
+	if remainingEntry != newEntry || len(remainingBaseline) != 2 {
+		t.Fatalf("pending entry after old completion = (%p, %v), want newer entry %p with A and B", remainingEntry, remainingBaseline, newEntry)
+	}
+	assertPolarisInstanceIdentity(t, remainingBaseline[0], instanceA)
+	assertPolarisInstanceIdentity(t, remainingBaseline[1], instanceB)
+
+	pr.completeInitialSubscribeInstances(key, newEntry)
+	entry, instances := pr.loadInitialSubscribeInstances(key)
+	if entry != nil || len(instances) != 0 {
+		t.Fatalf("pending entry after new completion = (%p, %v), want empty", entry, instances)
+	}
+}
+
+func TestPolarisSubscribeConsumesTaggedNotifications(t *testing.T) {
+	const childEnv = "DUBBO_GO_POLARIS_SUBSCRIBE_TEST_CHILD"
+	if os.Getenv(childEnv) == "" {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestPolarisSubscribeConsumesTaggedNotifications$", "-test.count=1")
+		cmd.Env = append(os.Environ(), childEnv+"=1")
+		if output, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("Subscribe child test failed: %v\n%s", err, output)
+		}
+		return
 	}
 
-	watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
-	watcher.handleWatchSnapshot(nil)
-	listener, err := pr.createPolarisListener(serviceName, secondNotify)
-	if err != nil {
-		t.Fatalf("createPolarisListener() error = %v", err)
-	}
-	defer closeTestPolarisListener(listener)
-	assertPolarisListenerEvent(t, listener, remoting.EventTypeDel, instanceB)
-	if entry, _ := pr.loadInitialSubscribeInstances(secondKey); entry != nil {
-		t.Fatalf("pending entry after listener success = %p, want nil", entry)
-	}
+	serviceName := "com.test.SubscribeNotificationPumpService"
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	instanceC := newPolarisTestInstance("instance-c", "10.0.0.3", 20003, serviceName, true)
 
-	pr.storeInitialSubscribeInstances(secondKey, []model.Instance{instanceA})
-	oldEntry, _ := pr.loadInitialSubscribeInstances(secondKey)
-	pr.storeInitialSubscribeInstances(secondKey, []model.Instance{instanceB})
-	newEntry, _ := pr.loadInitialSubscribeInstances(secondKey)
-	pr.completeInitialSubscribeInstances(secondKey, oldEntry)
-	remaining, remainingInstances := pr.loadInitialSubscribeInstances(secondKey)
-	if remaining != newEntry || len(remainingInstances) != 1 || remainingInstances[0].GetInstanceKey() != instanceB.GetInstanceKey() {
-		t.Fatalf("newer pending entry = (%p, %v), want preserved instance B", remaining, remainingInstances)
-	}
+	t.Run("nil listener is rejected before retry", func(t *testing.T) {
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- newTestPolarisRegistry(nil).Subscribe(newPolarisConsumerURL(serviceName), nil)
+		}()
+		select {
+		case err := <-errCh:
+			if err == nil {
+				t.Fatal("Subscribe() error = nil, want nil listener error")
+			}
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("Subscribe() did not reject nil listener before entering retry loop")
+		}
+	})
+
+	t.Run("comparable Load baseline reaches public Subscribe FIFO", func(t *testing.T) {
+		instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+		consumer := newGatedPolarisConsumer([]model.Instance{instanceA})
+		pr := newTestPolarisRegistry(consumer)
+		notify := &recordingPolarisNotifyListener{}
+		if err := pr.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
+			t.Fatalf("LoadSubscribeInstances() error = %v", err)
+		}
+		watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
+		delivered := 0
+		notify.onNotify = func(*registry.ServiceEvent) {
+			delivered++
+			if delivered == 2 {
+				panic(stopSubscribePump{})
+			}
+		}
+		stopped := startTestPolarisSubscribe(pr, serviceName, notify)
+		waitForPolarisSubscribers(t, watcher, 1)
+		request := runGatedPolarisWatchOnce(t, watcher, consumer, []model.Instance{instanceB})
+		assertSubscribePumpStopped(t, stopped)
+
+		assertPolarisWatchRequest(t, request, watcher.subscribeParam, serviceName)
+		assertPolarisEventsAddress(t, notify.recordedEvents(), []recordedPolarisEvent{
+			{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
+			{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+			{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
+		})
+		if consumer.getCalls != 1 {
+			t.Fatalf("GetInstances() calls = %d, want 1", consumer.getCalls)
+		}
+	})
+
+	t.Run("full snapshot is consumed before following incremental event", func(t *testing.T) {
+		pr := newTestPolarisRegistry(nil)
+		watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
+		calls := make(chan recordedNotification, 2)
+		notify := nonComparableFuncPolarisNotifyListener(func(
+			event *registry.ServiceEvent,
+			events []*registry.ServiceEvent,
+			callback func(),
+		) {
+			if event != nil {
+				calls <- recordedNotification{
+					kind:   incrementalNotification,
+					events: []recordedPolarisEvent{recordedPolarisEventFromServiceEvent(event)},
+				}
+				panic(stopSubscribePump{})
+			}
+			calls <- recordedNotification{
+				kind:        fullSnapshotNotification,
+				events:      recordedPolarisEventsFromServiceEvents(events),
+				callbackNil: callback == nil,
+			}
+			if callback != nil {
+				callback()
+			}
+		})
+		stopped := startTestPolarisSubscribe(pr, serviceName, notify)
+		waitForPolarisSubscribers(t, watcher, 1)
+
+		watcher.handleWatchSnapshot([]model.Instance{instanceB})
+		watcher.handleInstanceEvent(&model.InstanceEvent{
+			AddEvent: &model.InstanceAddEvent{Instances: []model.Instance{instanceC}},
+		})
+
+		full := receiveRecordedNotification(t, calls)
+		incremental := receiveRecordedNotification(t, calls)
+		if full.kind != fullSnapshotNotification || full.callbackNil {
+			t.Fatalf("first Subscribe call = %#v, want full with non-nil callback", full)
+		}
+		assertPolarisEventsAddress(t, full.events, []recordedPolarisEvent{
+			{action: remoting.EventTypeUpdate, host: "10.0.0.2", port: "20002"},
+		})
+		if incremental.kind != incrementalNotification {
+			t.Fatalf("second Subscribe call kind = %v, want incremental", incremental.kind)
+		}
+		assertPolarisEventsAddress(t, incremental.events, []recordedPolarisEvent{
+			{action: remoting.EventTypeAdd, host: "10.0.0.3", port: "20003"},
+		})
+		assertSubscribePumpStopped(t, stopped)
+	})
+
 }
 
 func TestPolarisComparableValueNotifyListenersKeepIndependentBaselines(t *testing.T) {
@@ -507,7 +1004,7 @@ func TestPolarisWatcherTracksCurrentState(t *testing.T) {
 			wantInstance: updatedA,
 		},
 		{
-			name:    "UPDATE changed key replaces internally and emits only UPDATE",
+			name:    "UPDATE changed key preserves raw application UPDATE",
 			initial: []model.Instance{instanceA},
 			event: &model.InstanceEvent{UpdateEvent: &model.InstanceUpdateEvent{
 				UpdateList: []model.OneInstanceUpdate{{Before: instanceA, After: instanceB}},
@@ -541,9 +1038,9 @@ func TestPolarisWatcherTracksCurrentState(t *testing.T) {
 			if !reflect.DeepEqual(actualIDs, tt.wantIDs) {
 				t.Fatalf("current instance IDs = %v, want %v", actualIDs, tt.wantIDs)
 			}
-			assertPolarisEventsAddress(t, notify.events, tt.wantEvents)
+			assertPolarisEventsAddress(t, notify.recordedEvents(), tt.wantEvents)
 			if tt.wantInstance != nil {
-				assertPolarisEventInstance(t, notify.events[0], remoting.EventTypeUpdate, tt.wantInstance)
+				assertPolarisEventInstance(t, notify.recordedEvents()[0], remoting.EventTypeUpdate, tt.wantInstance)
 				assertPolarisInstanceIdentity(t, watcher.currentInstances[0], tt.wantInstance)
 			}
 		})
@@ -555,97 +1052,31 @@ func TestPolarisWatcherClearsRemovedInstanceReferences(t *testing.T) {
 	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
 	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
 	instanceC := newPolarisTestInstance("instance-c", "10.0.0.3", 20003, serviceName, true)
-	missing := newPolarisTestInstance("missing", "10.0.0.9", 20009, serviceName, true)
-
-	t.Run("partial delete clears tail and preserves notification", func(t *testing.T) {
-		watcher := newStoppedPolarisWatcher(t, nil)
-		watcher.handleWatchSnapshot([]model.Instance{instanceA, instanceB, instanceC})
-		backing := watcher.currentInstances
-		notify := &recordingPolarisNotifyListener{}
-		watcher.AddSubscriber(notify.recordInstances)
-
-		watcher.handleInstanceEvent(&model.InstanceEvent{
-			DeleteEvent: &model.InstanceDeleteEvent{Instances: []model.Instance{instanceB, instanceC}},
-		})
-
-		if len(watcher.currentInstances) != 1 {
-			t.Fatalf("current instance count = %d, want 1", len(watcher.currentInstances))
-		}
-		assertPolarisInstanceIdentity(t, watcher.currentInstances[0], instanceA)
-		if &watcher.currentInstances[0] != &backing[0] {
-			t.Fatal("current instances did not reuse the original backing array")
-		}
-		for i, instance := range backing[len(watcher.currentInstances):] {
-			if instance != nil {
-				t.Errorf("removed backing slot %d = %v, want nil", i+len(watcher.currentInstances), instance)
-			}
-		}
-		assertPolarisEventsAddress(t, notify.events, []recordedPolarisEvent{
-			{action: remoting.EventTypeDel, host: "10.0.0.2", port: "20002"},
-			{action: remoting.EventTypeDel, host: "10.0.0.3", port: "20003"},
-		})
+	watcher := newStoppedPolarisWatcher(t, nil)
+	watcher.handleWatchSnapshot([]model.Instance{instanceA, instanceB, instanceC})
+	backing := watcher.currentInstances
+	watcher.handleInstanceEvent(&model.InstanceEvent{
+		DeleteEvent: &model.InstanceDeleteEvent{Instances: []model.Instance{instanceA, instanceB, instanceC}},
 	})
 
-	t.Run("delete all clears every slot", func(t *testing.T) {
-		watcher := newStoppedPolarisWatcher(t, nil)
-		watcher.handleWatchSnapshot([]model.Instance{instanceA, instanceB, instanceC})
-		backing := watcher.currentInstances
-
-		watcher.removeCurrentInstancesLocked([]model.Instance{instanceA, instanceB, instanceC})
-
-		if len(watcher.currentInstances) != 0 {
-			t.Fatalf("current instance count = %d, want 0", len(watcher.currentInstances))
+	if len(watcher.currentInstances) != 0 {
+		t.Fatalf("current instance count = %d, want 0", len(watcher.currentInstances))
+	}
+	for i, instance := range backing {
+		if instance != nil {
+			t.Errorf("removed backing slot %d = %v, want nil", i, instance)
 		}
-		for i, instance := range backing {
-			if instance != nil {
-				t.Errorf("removed backing slot %d = %v, want nil", i, instance)
-			}
+	}
+	watcher.currentInstances = append(watcher.currentInstances, instanceA)
+	if &watcher.currentInstances[0] != &backing[0] {
+		t.Fatal("append did not reuse the cleared backing array")
+	}
+	assertPolarisInstanceIdentity(t, watcher.currentInstances[0], instanceA)
+	for i, instance := range backing[1:] {
+		if instance != nil {
+			t.Errorf("backing slot %d exposed stale instance %v", i+1, instance)
 		}
-	})
-
-	t.Run("delete missing instance preserves order and storage", func(t *testing.T) {
-		watcher := newStoppedPolarisWatcher(t, nil)
-		watcher.handleWatchSnapshot([]model.Instance{instanceA, instanceB, instanceC})
-		backing := watcher.currentInstances
-
-		watcher.removeCurrentInstancesLocked([]model.Instance{missing})
-
-		if len(watcher.currentInstances) != 3 {
-			t.Fatalf("current instance count = %d, want 3", len(watcher.currentInstances))
-		}
-		for i, want := range []model.Instance{instanceA, instanceB, instanceC} {
-			assertPolarisInstanceIdentity(t, watcher.currentInstances[i], want)
-		}
-		if &watcher.currentInstances[0] != &backing[0] {
-			t.Fatal("current instances did not preserve the original backing array")
-		}
-	})
-
-	t.Run("empty removal preserves current instances", func(t *testing.T) {
-		watcher := newStoppedPolarisWatcher(t, nil)
-		watcher.handleWatchSnapshot([]model.Instance{instanceA, instanceB})
-		backing := watcher.currentInstances
-
-		watcher.removeCurrentInstancesLocked(nil)
-
-		if len(watcher.currentInstances) != 2 {
-			t.Fatalf("current instance count = %d, want 2", len(watcher.currentInstances))
-		}
-		assertPolarisInstanceIdentity(t, watcher.currentInstances[0], instanceA)
-		assertPolarisInstanceIdentity(t, watcher.currentInstances[1], instanceB)
-		if &watcher.currentInstances[0] != &backing[0] {
-			t.Fatal("current instances did not preserve the original backing array")
-		}
-	})
-
-	t.Run("empty current instances is safe", func(t *testing.T) {
-		watcher := newStoppedPolarisWatcher(t, nil)
-		watcher.removeCurrentInstancesLocked([]model.Instance{instanceA})
-		watcher.removeCurrentInstancesLocked(nil)
-		if len(watcher.currentInstances) != 0 {
-			t.Fatalf("current instance count = %d, want 0", len(watcher.currentInstances))
-		}
-	})
+	}
 }
 
 func TestPolarisApplicationSubscriberCompatibility(t *testing.T) {
@@ -660,19 +1091,23 @@ func TestPolarisApplicationSubscriberCompatibility(t *testing.T) {
 		watcher.AddSubscriber(notify.recordInstances)
 		watcher.handleWatchSnapshot([]model.Instance{instanceA})
 		want := []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"}}
-		assertPolarisEventsAddress(t, notify.events, want)
+		assertPolarisEventsAddress(t, notify.recordedEvents(), want)
 	})
 
-	t.Run("after-ready has no replay and receives increments", func(t *testing.T) {
+	t.Run("reconnect keeps full add behavior without synthetic deletes", func(t *testing.T) {
 		watcher := newStoppedPolarisWatcher(t, nil)
-		watcher.handleWatchSnapshot([]model.Instance{instanceA})
 		notify := &recordingPolarisNotifyListener{}
 		watcher.AddSubscriber(notify.recordInstances)
-		watcher.handleInstanceEvent(&model.InstanceEvent{
-			AddEvent: &model.InstanceAddEvent{Instances: []model.Instance{instanceB}},
-		})
-		want := []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"}}
-		assertPolarisEventsAddress(t, notify.events, want)
+
+		watcher.handleWatchSnapshot([]model.Instance{instanceA, instanceB})
+		watcher.handleWatchSnapshot([]model.Instance{instanceB})
+
+		want := []recordedPolarisEvent{
+			{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
+			{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
+			{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
+		}
+		assertPolarisEventsAddress(t, notify.recordedEvents(), want)
 	})
 
 	t.Run("NewPolarisListener wrapper", func(t *testing.T) {
@@ -691,159 +1126,309 @@ func TestPolarisApplicationSubscriberCompatibility(t *testing.T) {
 	})
 }
 
+func TestPolarisListenerNextCompatibility(t *testing.T) {
+	serviceName := "com.test.ListenerNextCompatibilityService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	invalid := newPolarisTestInstance("invalid", "10.0.0.9", 20009, serviceName, false)
+
+	t.Run("expands tagged notifications and skips invalid instances", func(t *testing.T) {
+		listener := newPolarisListenerState(newStoppedPolarisWatcher(t, nil))
+		defer closeTestPolarisListener(listener)
+		listener.notify(remoting.EventTypeAdd, []model.Instance{instanceA, invalid, instanceB})
+		for _, want := range []model.Instance{instanceA, instanceB} {
+			event, err := listener.Next()
+			if err != nil {
+				t.Fatalf("Next() error = %v", err)
+			}
+			if event.Action != remoting.EventTypeAdd || event.Service.Ip != want.GetHost() {
+				t.Fatalf("Next() event = %#v, want ADD %s", event, want.GetHost())
+			}
+		}
+
+		listener.notifyFullSnapshot([]model.Instance{invalid, instanceB})
+		event, err := listener.Next()
+		if err != nil {
+			t.Fatalf("Next() full snapshot error = %v", err)
+		}
+		if event.Action != remoting.EventTypeUpdate || event.Service.Ip != instanceB.GetHost() {
+			t.Fatalf("Next() full snapshot event = %#v, want UPDATE %s", event, instanceB.GetHost())
+		}
+
+		listener.notifyFullSnapshot(nil)
+		listener.notify(remoting.EventTypeUpdate, []model.Instance{instanceA})
+		event, err = listener.Next()
+		if err != nil {
+			t.Fatalf("Next() after empty full snapshot error = %v", err)
+		}
+		if event.Action != remoting.EventTypeUpdate || event.Service.Ip != instanceA.GetHost() {
+			t.Fatalf("Next() after empty full snapshot event = %#v, want UPDATE %s", event, instanceA.GetHost())
+		}
+	})
+
+	t.Run("Close after partial batch prevents pending drain", func(t *testing.T) {
+		listener := newPolarisListenerState(newStoppedPolarisWatcher(t, nil))
+		listener.notify(remoting.EventTypeAdd, []model.Instance{instanceA, instanceB})
+		event, err := listener.Next()
+		if err != nil {
+			t.Fatalf("first Next() error = %v", err)
+		}
+		if event == nil || event.Action != remoting.EventTypeAdd || event.Service.Ip != instanceA.GetHost() {
+			t.Fatalf("first Next() event = %#v, want ADD %s", event, instanceA.GetHost())
+		}
+
+		listener.Close()
+		event, err = listener.Next()
+		if event != nil {
+			t.Fatalf("Next() after Close event = %#v, want nil", event)
+		}
+		if err == nil || !strings.Contains(err.Error(), "listener stopped") {
+			t.Fatalf("Next() after Close error = %v, want listener stopped", err)
+		}
+	})
+}
+
 func TestPolarisSnapshotsUseDefensiveCopies(t *testing.T) {
 	serviceName := "com.test.DefensiveCopyService"
 	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
 	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
 
-	t.Run("subscriber initial snapshot", func(t *testing.T) {
-		watcher := newStoppedPolarisWatcher(t, nil)
-		notify := &recordingPolarisNotifyListener{}
-		initial := []model.Instance{instanceA}
-		watcher.addSubscriberWithInitialSnapshot(initial, notify.recordInstances)
-		initial[0] = instanceB
-		watcher.handleWatchSnapshot(nil)
-		want := []recordedPolarisEvent{{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"}}
-		assertPolarisEventsAddress(t, notify.events, want)
-	})
-
 	t.Run("watcher current state and callback slices", func(t *testing.T) {
 		watcher := newStoppedPolarisWatcher(t, nil)
-		watcher.addSubscriberWithInitialSnapshot(nil, func(_ remoting.EventType, instances []model.Instance) {
+		watcher.addRegistrySubscriber(nil, reconcileWithBaseline, func(_ remoting.EventType, instances []model.Instance) {
 			if len(instances) > 0 {
 				instances[0] = instanceB
 			}
-		})
+		}, func([]model.Instance) {})
 		current := []model.Instance{instanceA}
 		watcher.handleWatchSnapshot(current)
 		current[0] = instanceB
 
 		notify := &recordingPolarisNotifyListener{}
-		watcher.addSubscriberWithInitialSnapshot(nil, notify.recordInstances)
+		watcher.addRegistrySubscriber(nil, reconcileWithBaseline, notify.recordInstances, func([]model.Instance) {})
 		want := []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"}}
-		assertPolarisEventsAddress(t, notify.events, want)
-	})
-
-	t.Run("pending registry entry", func(t *testing.T) {
-		pr := newTestPolarisRegistry(nil)
-		key := mustInitialSubscribeInstancesKey(t, serviceName, &recordingPolarisNotifyListener{})
-		input := []model.Instance{instanceA}
-		pr.storeInitialSubscribeInstances(key, input)
-		input[0] = instanceB
-
-		entry, pending := pr.loadInitialSubscribeInstances(key)
-		if entry == nil || len(pending) != 1 {
-			t.Fatalf("pending entry = (%p, %v), want one instance", entry, pending)
-		}
-		assertPolarisInstanceIdentity(t, pending[0], instanceA)
+		assertPolarisEventsAddress(t, notify.recordedEvents(), want)
 	})
 }
 
-func TestPolarisRejectsInvalidNotifyListenerIdentities(t *testing.T) {
-	serviceName := "com.test.InvalidNotifyListenerService"
+func TestPolarisNonComparableListenerReconciliation(t *testing.T) {
+	serviceName := "com.test.NonComparableListenerService"
 	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	var typedNil *nilablePolarisNotifyListener
-	var nilSlice unsupportedPolarisNotifyListener
-	var nilMap unsupportedMapPolarisNotifyListener
-	var nilFunc unsupportedFuncPolarisNotifyListener
-	var nilChan unsupportedChanPolarisNotifyListener
-	tests := []struct {
-		name          string
-		notify        registry.NotifyListener
-		withInstances bool
+	invalid := newPolarisTestInstance("invalid", "10.0.0.9", 20009, serviceName, false)
+
+	t.Run("nil listeners are rejected before querying instances", func(t *testing.T) {
+		var pointer *nilablePolarisNotifyListener
+		var slice nonComparablePolarisNotifyListener
+		var mapped nonComparableMapPolarisNotifyListener
+		var function nonComparableFuncPolarisNotifyListener
+		var channel nilableChannelPolarisNotifyListener
+		for _, tt := range []struct {
+			name   string
+			notify registry.NotifyListener
+		}{
+			{name: "nil interface"},
+			{name: "pointer", notify: pointer},
+			{name: "slice", notify: slice},
+			{name: "map", notify: mapped},
+			{name: "func", notify: function},
+			{name: "channel", notify: channel},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				consumer := &fakePolarisConsumer{instanceResponses: [][]model.Instance{{instanceA}}}
+				pr := newTestPolarisRegistry(consumer)
+				err := callPolarisRegistryWithoutPanic(t, func() error {
+					return pr.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), tt.notify)
+				})
+				if err == nil {
+					t.Fatal("LoadSubscribeInstances() error = nil, want nil listener error")
+				}
+				if consumer.getCalls != 0 {
+					t.Fatalf("GetInstances() calls = %d, want 0", consumer.getCalls)
+				}
+			})
+		}
+	})
+
+	t.Run("listener shapes load without pending baseline", func(t *testing.T) {
+		for _, tt := range newNonComparablePolarisNotifyListenerCases() {
+			t.Run(tt.name, func(t *testing.T) {
+				consumer := &fakePolarisConsumer{instanceResponses: [][]model.Instance{{instanceA}}}
+				pr := newTestPolarisRegistry(consumer)
+				if err := pr.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), tt.notify); err != nil {
+					t.Fatalf("LoadSubscribeInstances() error = %v", err)
+				}
+				if consumer.getCalls != 1 {
+					t.Fatalf("GetInstances() calls = %d, want 1", consumer.getCalls)
+				}
+				if len(pr.initialSubscribeInstances) != 0 {
+					t.Fatalf("pending entry count = %d, want 0", len(pr.initialSubscribeInstances))
+				}
+				assertPolarisEventsAddress(t, tt.recorder.recordedEvents(), []recordedPolarisEvent{{
+					action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001",
+				}})
+			})
+		}
+	})
+
+	for _, tt := range []struct {
+		name    string
+		current []model.Instance
 	}{
-		{name: "nil interface", notify: nil},
-		{name: "typed nil pointer", notify: typedNil, withInstances: true},
-		{name: "typed nil slice", notify: nilSlice, withInstances: true},
-		{name: "typed nil map", notify: nilMap, withInstances: true},
-		{name: "typed nil func", notify: nilFunc, withInstances: true},
-		{name: "typed nil chan", notify: nilChan, withInstances: true},
-		{name: "non-comparable slice", notify: unsupportedPolarisNotifyListener{}, withInstances: true},
-		{name: "non-comparable map", notify: unsupportedMapPolarisNotifyListener{}, withInstances: true},
-		{name: "non-comparable func", notify: unsupportedFuncPolarisNotifyListener(func() {}), withInstances: true},
-		{name: "non-comparable struct", notify: unsupportedStructPolarisNotifyListener{}, withInstances: true},
+		{name: "empty snapshot calls NotifyAll", current: nil},
+		{name: "all invalid snapshot calls NotifyAll empty", current: []model.Instance{invalid}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			listenerCase := newNonComparablePolarisNotifyListenerCases()[2]
+			pr := newTestPolarisRegistry(nil)
+			watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
+			listener, err := pr.createPolarisListener(serviceName, listenerCase.notify)
+			if err != nil {
+				t.Fatalf("createPolarisListener() error = %v", err)
+			}
+			defer closeTestPolarisListener(listener)
+			watcher.handleWatchSnapshot(tt.current)
+			deliverNextPolarisNotification(t, listener, listenerCase.notify)
+			assertPolarisFullSnapshots(t, listenerCase.recorder, [][]recordedPolarisEvent{{}})
+		})
+	}
+
+}
+
+func TestPolarisNonComparableListenerReplacesSynchronousLoad(t *testing.T) {
+	const serviceName = "com.test.NonComparableListenerReplacementService"
+
+	run := func(t *testing.T, current []model.Instance, want []recordedPolarisEvent) {
+		t.Helper()
+		instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+		consumer := &fakePolarisConsumer{instanceResponses: [][]model.Instance{{instanceA}}}
+		pr := newTestPolarisRegistry(consumer)
+		recorder := &recordingPolarisNotifyListener{}
+		notify := nonComparablePolarisNotifyListener{recorder}
+
+		if err := pr.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
+			t.Fatalf("LoadSubscribeInstances() error = %v", err)
+		}
+		if len(recorder.notifications) != 1 || recorder.notifications[0].kind != incrementalNotification {
+			t.Fatalf("notifications after LoadSubscribeInstances() = %#v, want one incremental notification", recorder.notifications)
+		}
+		assertPolarisEventsAddress(t, recorder.notifications[0].events, []recordedPolarisEvent{{
+			action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001",
+		}})
+		if len(pr.initialSubscribeInstances) != 0 {
+			t.Fatalf("pending entry count = %d, want 0", len(pr.initialSubscribeInstances))
+		}
+
+		watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
+		listener, err := pr.createPolarisListener(serviceName, notify)
+		if err != nil {
+			t.Fatalf("createPolarisListener() error = %v", err)
+		}
+		defer closeTestPolarisListener(listener)
+
+		watcher.handleWatchSnapshot(current)
+		deliverNextPolarisNotification(t, listener, notify)
+		if len(recorder.notifications) != 2 || recorder.notifications[1].kind != fullSnapshotNotification {
+			t.Fatalf("notifications after Watch snapshot = %#v, want incremental load followed by full snapshot", recorder.notifications)
+		}
+		assertPolarisFullSnapshots(t, recorder, [][]recordedPolarisEvent{want})
+	}
+
+	t.Run("A to B", func(t *testing.T) {
+		instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+		run(t, []model.Instance{instanceB}, []recordedPolarisEvent{{
+			action: remoting.EventTypeUpdate, host: "10.0.0.2", port: "20002",
+		}})
+	})
+
+	t.Run("A to empty", func(t *testing.T) {
+		run(t, nil, []recordedPolarisEvent{})
+	})
+}
+
+type nonComparablePolarisNotifyListenerCase struct {
+	name     string
+	notify   registry.NotifyListener
+	recorder *recordingPolarisNotifyListener
+}
+
+func newNonComparablePolarisNotifyListenerCases() []nonComparablePolarisNotifyListenerCase {
+	newFuncListener := func(recorder *recordingPolarisNotifyListener) nonComparableFuncPolarisNotifyListener {
+		return func(event *registry.ServiceEvent, events []*registry.ServiceEvent, callback func()) {
+			if event != nil {
+				recorder.Notify(event)
+				return
+			}
+			recorder.NotifyAll(events, callback)
+		}
+	}
+
+	sliceRecorder := &recordingPolarisNotifyListener{}
+	mapRecorder := &recordingPolarisNotifyListener{}
+	funcRecorder := &recordingPolarisNotifyListener{}
+	structRecorder := &recordingPolarisNotifyListener{}
+	runtimeRecorder := &recordingPolarisNotifyListener{}
+	return []nonComparablePolarisNotifyListenerCase{
+		{name: "named slice", notify: nonComparablePolarisNotifyListener{sliceRecorder}, recorder: sliceRecorder},
+		{name: "named map", notify: nonComparableMapPolarisNotifyListener{"recorder": mapRecorder}, recorder: mapRecorder},
+		{name: "named func", notify: newFuncListener(funcRecorder), recorder: funcRecorder},
 		{
-			name:          "runtime-unhashable interface field",
-			notify:        runtimeUnhashablePolarisNotifyListener{state: []int{1}},
-			withInstances: true,
+			name:     "struct containing slice",
+			notify:   nonComparableStructPolarisNotifyListener{recorder: structRecorder},
+			recorder: structRecorder,
+		},
+		{
+			name:     "runtime-unhashable interface field",
+			notify:   runtimeUnhashablePolarisNotifyListener{state: []int{1}, recorder: runtimeRecorder},
+			recorder: runtimeRecorder,
 		},
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name+" load", func(t *testing.T) {
-			var responses [][]model.Instance
-			if tt.withInstances {
-				responses = [][]model.Instance{{instanceA}}
-			}
-			consumer := &fakePolarisConsumer{instanceResponses: responses}
-			pr := newTestPolarisRegistry(consumer)
-			err := callPolarisRegistryWithoutPanic(t, func() error {
-				return pr.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), tt.notify)
-			})
-			if err == nil {
-				t.Errorf("LoadSubscribeInstances() error = nil, want invalid listener error")
-			} else if listenerType := fmt.Sprintf("%T", tt.notify); !strings.Contains(err.Error(), listenerType) {
-				t.Errorf("LoadSubscribeInstances() error = %q, want listener type %q", err, listenerType)
-			}
-			if consumer.getCalls != 0 {
-				t.Errorf("GetInstances() calls = %d, want 0", consumer.getCalls)
-			}
-			if len(pr.initialSubscribeInstances) != 0 {
-				t.Errorf("pending entry count = %d, want 0", len(pr.initialSubscribeInstances))
-			}
-		})
-
-		t.Run(tt.name+" create listener", func(t *testing.T) {
-			pr := newTestPolarisRegistry(nil)
-			mustStoppedRegistryWatcher(t, pr, serviceName)
-			var listener *polarisListener
-			err := callPolarisRegistryWithoutPanic(t, func() error {
-				var createErr error
-				listener, createErr = pr.createPolarisListener(serviceName, tt.notify)
-				return createErr
-			})
-			if listener != nil {
-				closeTestPolarisListener(listener)
-			}
-			if err == nil {
-				t.Errorf("createPolarisListener() error = nil, want invalid listener error")
-			} else if listenerType := fmt.Sprintf("%T", tt.notify); !strings.Contains(err.Error(), listenerType) {
-				t.Errorf("createPolarisListener() error = %q, want listener type %q", err, listenerType)
-			}
-			if len(pr.initialSubscribeInstances) != 0 {
-				t.Errorf("pending entry count = %d, want 0", len(pr.initialSubscribeInstances))
-			}
-		})
-	}
 }
 
-func TestPolarisPointerNotifyListenerKeepsBaseline(t *testing.T) {
-	serviceName := "com.test.PointerNotifyListenerService"
+func TestPolarisNonComparableSubscribersAreIndependent(t *testing.T) {
+	serviceName := "com.test.IndependentFullSnapshotService"
 	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	consumer := &fakePolarisConsumer{instanceResponses: [][]model.Instance{{instanceA}}}
-	pr := newTestPolarisRegistry(consumer)
-	notify := &recordingPolarisNotifyListener{}
 
-	if err := pr.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
-		t.Fatalf("LoadSubscribeInstances() error = %v", err)
-	}
-	key := mustInitialSubscribeInstancesKey(t, serviceName, notify)
-	entry, instances := pr.loadInitialSubscribeInstances(key)
-	if entry == nil || len(instances) != 1 || instances[0].GetInstanceKey() != instanceA.GetInstanceKey() {
-		t.Fatalf("pointer listener pending entry = (%p, %v), want instance A", entry, instances)
-	}
+	t.Run("two subscribers receive independent full refresh", func(t *testing.T) {
+		pr := newTestPolarisRegistry(nil)
+		watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
+		first := newNonComparablePolarisNotifyListenerCases()[0]
+		second := newNonComparablePolarisNotifyListenerCases()[1]
+		firstListener, err := pr.createPolarisListener(serviceName, first.notify)
+		if err != nil {
+			t.Fatalf("createPolarisListener(first) error = %v", err)
+		}
+		defer closeTestPolarisListener(firstListener)
+		secondListener, err := pr.createPolarisListener(serviceName, second.notify)
+		if err != nil {
+			t.Fatalf("createPolarisListener(second) error = %v", err)
+		}
+		defer closeTestPolarisListener(secondListener)
 
-	watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
-	watcher.handleWatchSnapshot(nil)
-	listener, err := pr.createPolarisListener(serviceName, notify)
-	if err != nil {
-		t.Fatalf("createPolarisListener() error = %v", err)
-	}
-	defer closeTestPolarisListener(listener)
-	assertPolarisListenerEvent(t, listener, remoting.EventTypeDel, instanceA)
-	if pending, _ := pr.loadInitialSubscribeInstances(key); pending != nil {
-		t.Fatalf("pointer listener pending entry after listener success = %p, want nil", pending)
-	}
+		watcher.handleWatchSnapshot([]model.Instance{instanceA})
+		deliverNextPolarisNotification(t, firstListener, first.notify)
+		deliverNextPolarisNotification(t, secondListener, second.notify)
+		want := [][]recordedPolarisEvent{{{
+			action: remoting.EventTypeUpdate, host: "10.0.0.1", port: "20001",
+		}}}
+		assertPolarisFullSnapshots(t, first.recorder, want)
+		assertPolarisFullSnapshots(t, second.recorder, want)
+	})
+
+	t.Run("subscriber added after watcher ready immediately receives current snapshot", func(t *testing.T) {
+		pr := newTestPolarisRegistry(nil)
+		watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
+		watcher.handleWatchSnapshot([]model.Instance{instanceA})
+		tt := newNonComparablePolarisNotifyListenerCases()[0]
+		listener, err := pr.createPolarisListener(serviceName, tt.notify)
+		if err != nil {
+			t.Fatalf("createPolarisListener() error = %v", err)
+		}
+		defer closeTestPolarisListener(listener)
+		deliverNextPolarisNotification(t, listener, tt.notify)
+		assertPolarisFullSnapshots(t, tt.recorder, [][]recordedPolarisEvent{{{
+			action: remoting.EventTypeUpdate, host: "10.0.0.1", port: "20001",
+		}}})
+	})
 }
 
 func newTestPolarisRegistry(consumer api.ConsumerAPI) *polarisRegistry {
@@ -870,9 +1455,12 @@ func mustInitialSubscribeInstancesKey(
 	notify registry.NotifyListener,
 ) initialSubscribeInstancesKey {
 	t.Helper()
-	key, err := newInitialSubscribeInstancesKey(serviceName, notify)
+	key, cacheable, err := initialSubscribeInstancesKeyFor(serviceName, notify)
 	if err != nil {
-		t.Fatalf("newInitialSubscribeInstancesKey() error = %v", err)
+		t.Fatalf("initialSubscribeInstancesKeyFor() error = %v", err)
+	}
+	if !cacheable {
+		t.Fatalf("initialSubscribeInstancesKeyFor() cacheable = false, want true")
 	}
 	return key
 }
@@ -883,6 +1471,138 @@ func closeTestPolarisListener(listener *polarisListener) {
 	listener.Close()
 	close(listener.events.In())
 	for range listener.events.Out() {
+	}
+}
+
+func deliverNextPolarisNotification(
+	t *testing.T,
+	listener *polarisListener,
+	notify registry.NotifyListener,
+) {
+	t.Helper()
+	notification, err := listener.nextNotification()
+	if err != nil {
+		t.Fatalf("nextNotification() error = %v", err)
+	}
+	notifyPolarisNotification(notification, notify)
+}
+
+func startTestPolarisSubscribe(
+	pr *polarisRegistry,
+	serviceName string,
+	notify registry.NotifyListener,
+) <-chan any {
+	stopped := make(chan any, 1)
+	go func() {
+		defer func() {
+			stopped <- recover()
+		}()
+		_ = pr.Subscribe(newPolarisConsumerURL(serviceName), notify)
+	}()
+	return stopped
+}
+
+func waitForPolarisSubscribers(t *testing.T, watcher *PolarisServiceWatcher, want int) {
+	t.Helper()
+	deadline := time.NewTimer(time.Second)
+	defer deadline.Stop()
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		watcher.lock.Lock()
+		count := len(watcher.subscribers)
+		watcher.lock.Unlock()
+		if count == want {
+			return
+		}
+		select {
+		case <-deadline.C:
+			t.Fatalf("subscriber count = %d, want %d", count, want)
+		case <-ticker.C:
+		}
+	}
+}
+
+func runGatedPolarisWatchOnce(
+	t *testing.T,
+	watcher *PolarisServiceWatcher,
+	consumer *gatedPolarisConsumer,
+	instances []model.Instance,
+) *api.WatchServiceRequest {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() {
+		done <- watcher.watchOnce()
+	}()
+
+	var request *api.WatchServiceRequest
+	select {
+	case request = <-consumer.watchRequests:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for WatchService call")
+	}
+	events := make(chan model.SubScribeEvent)
+	consumer.watchResults <- gatedPolarisWatchResult{response: &model.WatchServiceResponse{
+		EventChannel: events,
+		GetAllInstancesResp: &model.InstancesResponse{
+			Instances: copyInstances(instances),
+		},
+	}}
+	close(events)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("watchOnce() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("watchOnce() did not stop after EventChannel closed")
+	}
+	return request
+}
+
+func receiveRecordedNotification(t *testing.T, calls <-chan recordedNotification) recordedNotification {
+	t.Helper()
+	select {
+	case call := <-calls:
+		return call
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for Subscribe notification")
+		return recordedNotification{}
+	}
+}
+
+func assertSubscribePumpStopped(t *testing.T, stopped <-chan any) {
+	t.Helper()
+	select {
+	case recovered := <-stopped:
+		if _, ok := recovered.(stopSubscribePump); !ok {
+			t.Fatalf("Subscribe stopped with %#v, want stopSubscribePump", recovered)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Subscribe notification pump did not stop")
+	}
+}
+
+func assertPolarisFullSnapshots(
+	t *testing.T,
+	recorder *recordingPolarisNotifyListener,
+	want [][]recordedPolarisEvent,
+) {
+	t.Helper()
+	var full []recordedNotification
+	for _, notification := range recorder.notifications {
+		if notification.kind == fullSnapshotNotification {
+			full = append(full, notification)
+		}
+	}
+	if len(full) != len(want) {
+		t.Fatalf("full snapshot count = %d, want %d", len(full), len(want))
+	}
+	for i := range want {
+		assertPolarisEventsAddress(t, full[i].events, want[i])
+		if full[i].callbackNil {
+			t.Fatalf("NotifyAll() callback %d was nil", i)
+		}
 	}
 }
 
@@ -913,26 +1633,61 @@ func assertPolarisListenerEvents(
 ) []recordedPolarisEvent {
 	t.Helper()
 	actualEvents := make([]recordedPolarisEvent, 0, len(events))
-	for _, expected := range events {
+	for len(actualEvents) < len(events) {
 		select {
 		case value := <-listener.events.Out():
-			event, ok := value.(*config_center.ConfigChangeEvent)
+			notification, ok := value.(*polarisNotification)
 			if !ok {
-				t.Fatalf("listener event type = %T, want *config_center.ConfigChangeEvent", value)
+				t.Fatalf("listener event type = %T, want *polarisNotification", value)
 			}
-			instance, ok := event.Value.(model.Instance)
-			if !ok {
-				t.Fatalf("listener event value type = %T, want model.Instance", event.Value)
+			action := notification.eventType
+			if notification.kind == fullSnapshotNotification {
+				action = remoting.EventTypeUpdate
 			}
-			actual := recordedPolarisEventFromInstance(event.ConfigType, instance)
-			assertPolarisEventAddress(t, actual, expected)
-			actualEvents = append(actualEvents, actual)
+			for _, instance := range notification.instances {
+				actualEvents = append(actualEvents, recordedPolarisEventFromInstance(action, instance))
+			}
 		case <-time.After(time.Second):
-			t.Fatalf("timed out waiting for listener event %#v", expected)
+			t.Fatalf("timed out waiting for listener events %#v", events)
 		}
 	}
+	assertPolarisEventsAddress(t, actualEvents, events)
 	assertNoPolarisListenerEvent(t, listener)
 	return actualEvents
+}
+
+func assertPolarisIncrementalListenerEvents(
+	t *testing.T,
+	listener *polarisListener,
+	want []recordedPolarisEvent,
+) []recordedPolarisEvent {
+	t.Helper()
+
+	actual := make([]recordedPolarisEvent, 0, len(want))
+	for len(actual) < len(want) {
+		select {
+		case value := <-listener.events.Out():
+			notification, ok := value.(*polarisNotification)
+			if !ok || notification == nil {
+				t.Fatalf("listener notification type = %T, want *polarisNotification", value)
+			}
+			if notification.kind != incrementalNotification {
+				t.Fatalf("notification kind = %v, want incrementalNotification", notification.kind)
+			}
+			for _, instance := range notification.instances {
+				actual = append(
+					actual,
+					recordedPolarisEventFromInstance(notification.eventType, instance),
+				)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for incremental listener events %#v", want)
+		}
+	}
+
+	assertPolarisEventsAddress(t, actual, want)
+	assertNoPolarisListenerEvent(t, listener)
+	return actual
 }
 
 func recordedPolarisEventFromInstance(action remoting.EventType, instance model.Instance) recordedPolarisEvent {
@@ -943,6 +1698,24 @@ func recordedPolarisEventFromInstance(action remoting.EventType, instance model.
 		id:       instance.GetId(),
 		revision: instance.GetMetadata()[testPolarisRevisionKey],
 	}
+}
+
+func recordedPolarisEventFromServiceEvent(event *registry.ServiceEvent) recordedPolarisEvent {
+	return recordedPolarisEvent{
+		action:   event.Action,
+		host:     event.Service.Ip,
+		port:     event.Service.Port,
+		id:       event.Service.GetParam(constant.PolarisInstanceID, ""),
+		revision: event.Service.GetParam(testPolarisRevisionKey, ""),
+	}
+}
+
+func recordedPolarisEventsFromServiceEvents(events []*registry.ServiceEvent) []recordedPolarisEvent {
+	recorded := make([]recordedPolarisEvent, 0, len(events))
+	for _, event := range events {
+		recorded = append(recorded, recordedPolarisEventFromServiceEvent(event))
+	}
+	return recorded
 }
 
 func assertPolarisEventsAddress(t *testing.T, actual, expected []recordedPolarisEvent) {
@@ -1028,13 +1801,13 @@ func assertPolarisListenerEvent(t *testing.T, listener *polarisListener, action 
 	t.Helper()
 	select {
 	case value := <-listener.events.Out():
-		event, ok := value.(*config_center.ConfigChangeEvent)
+		notification, ok := value.(*polarisNotification)
 		if !ok {
-			t.Fatalf("listener event type = %T, want *config_center.ConfigChangeEvent", value)
+			t.Fatalf("listener event type = %T, want *polarisNotification", value)
 		}
-		actual, ok := event.Value.(model.Instance)
-		if !ok || event.ConfigType != action || actual.GetInstanceKey() != instance.GetInstanceKey() {
-			t.Fatalf("listener event = %#v, want action=%v instance=%v", event, action, instance)
+		if len(notification.instances) != 1 || notification.eventType != action ||
+			notification.instances[0].GetInstanceKey() != instance.GetInstanceKey() {
+			t.Fatalf("listener event = %#v, want action=%v instance=%v", notification, action, instance)
 		}
 	case <-time.After(time.Second):
 		t.Fatalf("timed out waiting for action=%v instance=%v", action, instance)

--- a/registry/polaris/registry_test.go
+++ b/registry/polaris/registry_test.go
@@ -1,0 +1,284 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package polaris
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+import (
+	"github.com/golang/protobuf/ptypes/wrappers"
+
+	api "github.com/polarismesh/polaris-go"
+	"github.com/polarismesh/polaris-go/pkg/model"
+	"github.com/polarismesh/polaris-go/pkg/model/local"
+	"github.com/polarismesh/polaris-go/pkg/model/pb"
+	namingpb "github.com/polarismesh/polaris-go/pkg/model/pb/v1"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/registry"
+	"dubbo.apache.org/dubbo-go/v3/remoting"
+)
+
+const testPolarisNamespace = "test"
+
+type fakePolarisConsumer struct {
+	api.ConsumerAPI
+	instances []model.Instance
+}
+
+func (f *fakePolarisConsumer) GetInstances(_ *api.GetInstancesRequest) (*model.InstancesResponse, error) {
+	instances := append([]model.Instance(nil), f.instances...)
+	return &model.InstancesResponse{Instances: instances}, nil
+}
+
+type recordedPolarisEvent struct {
+	action remoting.EventType
+	host   string
+	port   string
+}
+
+type recordingPolarisNotifyListener struct {
+	events []recordedPolarisEvent
+}
+
+func (r *recordingPolarisNotifyListener) Notify(event *registry.ServiceEvent) {
+	r.events = append(r.events, recordedPolarisEvent{
+		action: event.Action,
+		host:   event.Service.Ip,
+		port:   event.Service.Port,
+	})
+}
+
+func (r *recordingPolarisNotifyListener) NotifyAll(events []*registry.ServiceEvent, callback func()) {
+	for _, event := range events {
+		r.Notify(event)
+	}
+	if callback != nil {
+		callback()
+	}
+}
+
+func (r *recordingPolarisNotifyListener) recordInstances(action remoting.EventType, instances []model.Instance) {
+	for _, instance := range instances {
+		r.events = append(r.events, recordedPolarisEvent{
+			action: action,
+			host:   instance.GetHost(),
+			port:   strconv.Itoa(int(instance.GetPort())),
+		})
+	}
+}
+
+func TestPolarisInitialSnapshotReconciliation(t *testing.T) {
+	serviceName := "com.test.InitialSnapshotService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	invalidInstance := newPolarisTestInstance("invalid", "10.0.0.9", 20009, serviceName, false)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+
+	tests := []struct {
+		name     string
+		current  []model.Instance
+		expected []recordedPolarisEvent
+	}{
+		{
+			name:    "A is replaced by B",
+			current: []model.Instance{instanceB},
+			expected: []recordedPolarisEvent{
+				{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
+				{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+				{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
+			},
+		},
+		{
+			name:    "first watcher snapshot is empty",
+			current: []model.Instance{},
+			expected: []recordedPolarisEvent{
+				{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
+				{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			notify := &recordingPolarisNotifyListener{}
+			consumer := &fakePolarisConsumer{instances: []model.Instance{instanceA, invalidInstance}}
+			polarisRegistry := &polarisRegistry{
+				namespace:        testPolarisNamespace,
+				consumer:         consumer,
+				initialSnapshots: make(map[string][]model.Instance),
+			}
+
+			if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
+				t.Fatalf("LoadSubscribeInstances() error = %v", err)
+			}
+
+			initial, ok := polarisRegistry.takeInitialSnapshot(serviceName)
+			if !ok {
+				t.Fatal("initial snapshot was not saved")
+			}
+			if len(initial) != 1 || initial[0].GetInstanceKey() != instanceA.GetInstanceKey() {
+				t.Fatalf("initial snapshot = %v, want only instance A", initial)
+			}
+
+			watcher, err := newPolarisWatcher(nil, consumer)
+			if err != nil {
+				t.Fatalf("newPolarisWatcher() error = %v", err)
+			}
+			watcher.setInitialSnapshot(initial)
+			watcher.subscribers = append(watcher.subscribers, notify.recordInstances)
+			watcher.handleInitialWatchSnapshot(tt.current)
+
+			if !reflect.DeepEqual(notify.events, tt.expected) {
+				t.Fatalf("events = %#v, want %#v", notify.events, tt.expected)
+			}
+		})
+	}
+}
+
+func TestMissingInitialInstancesSameInstance(t *testing.T) {
+	serviceName := "com.test.SameInstanceService"
+	initial := newPolarisTestInstance("old-id", "10.0.0.1", 20001, serviceName, true)
+	current := newPolarisTestInstance("new-id", "10.0.0.1", 20001, serviceName, true)
+
+	missing := missingInitialInstances([]model.Instance{initial}, []model.Instance{current})
+	if len(missing) != 0 {
+		t.Fatalf("missingInitialInstances() = %v, want empty", missing)
+	}
+}
+
+func TestMissingInitialInstancesPreservesInitialOrder(t *testing.T) {
+	serviceName := "com.test.InstanceOrderService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	instanceC := newPolarisTestInstance("instance-c", "10.0.0.3", 20003, serviceName, true)
+
+	missing := missingInitialInstances(
+		[]model.Instance{instanceA, instanceB, instanceC},
+		[]model.Instance{instanceB},
+	)
+	if len(missing) != 2 {
+		t.Fatalf("missingInitialInstances() length = %d, want 2", len(missing))
+	}
+	if missing[0].GetInstanceKey() != instanceA.GetInstanceKey() ||
+		missing[1].GetInstanceKey() != instanceC.GetInstanceKey() {
+		t.Fatalf("missingInitialInstances() = %v, want [instance A, instance C]", missing)
+	}
+}
+
+func TestPolarisWatcherInitialSnapshotConsumedOnce(t *testing.T) {
+	serviceName := "com.test.OneShotService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	watcher, err := newPolarisWatcher(nil, nil)
+	if err != nil {
+		t.Fatalf("newPolarisWatcher() error = %v", err)
+	}
+
+	snapshot := []model.Instance{instanceA}
+	watcher.setInitialSnapshot(snapshot)
+	snapshot[0] = instanceB
+
+	first, ok := watcher.takeInitialSnapshot()
+	if !ok {
+		t.Fatal("first takeInitialSnapshot() ok = false, want true")
+	}
+	if len(first) != 1 || first[0].GetInstanceKey() != instanceA.GetInstanceKey() {
+		t.Fatalf("first takeInitialSnapshot() = %v, want instance A", first)
+	}
+
+	watcher.setInitialSnapshot([]model.Instance{instanceB})
+	if second, ok := watcher.takeInitialSnapshot(); ok || len(second) != 0 {
+		t.Fatalf("second takeInitialSnapshot() = (%v, %v), want (empty, false)", second, ok)
+	}
+}
+
+func TestLoadSubscribeInstancesClearsStaleEmptySnapshot(t *testing.T) {
+	serviceName := "com.test.EmptyInitialSnapshotService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	polarisRegistry := &polarisRegistry{
+		namespace:        testPolarisNamespace,
+		consumer:         &fakePolarisConsumer{},
+		initialSnapshots: make(map[string][]model.Instance),
+	}
+	polarisRegistry.storeInitialSnapshot(serviceName, []model.Instance{instanceA})
+
+	if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), &recordingPolarisNotifyListener{}); err != nil {
+		t.Fatalf("LoadSubscribeInstances() error = %v", err)
+	}
+	if snapshot, ok := polarisRegistry.takeInitialSnapshot(serviceName); ok || len(snapshot) != 0 {
+		t.Fatalf("takeInitialSnapshot() = (%v, %v), want (empty, false)", snapshot, ok)
+	}
+}
+
+func TestPolarisRegistryInitialSnapshotUsesDefensiveCopy(t *testing.T) {
+	serviceName := "com.test.DefensiveCopyService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	polarisRegistry := &polarisRegistry{initialSnapshots: make(map[string][]model.Instance)}
+
+	snapshot := []model.Instance{instanceA}
+	polarisRegistry.storeInitialSnapshot(serviceName, snapshot)
+	snapshot[0] = instanceB
+
+	stored, ok := polarisRegistry.takeInitialSnapshot(serviceName)
+	if !ok {
+		t.Fatal("takeInitialSnapshot() ok = false, want true")
+	}
+	if len(stored) != 1 || stored[0].GetInstanceKey() != instanceA.GetInstanceKey() {
+		t.Fatalf("takeInitialSnapshot() = %v, want instance A", stored)
+	}
+}
+
+func newPolarisConsumerURL(serviceName string) *common.URL {
+	return common.NewURLWithOptions(
+		common.WithProtocol("consumer"),
+		common.WithInterface(serviceName),
+		common.WithParamsValue(constant.RegistryRoleKey, strconv.Itoa(common.CONSUMER)),
+	)
+}
+
+func newPolarisTestInstance(id string, host string, port uint32, serviceName string, valid bool) model.Instance {
+	metadata := map[string]string{
+		"interface": serviceName,
+		"path":      "/" + serviceName,
+	}
+	if !valid {
+		metadata = nil
+	}
+
+	instance := &namingpb.Instance{
+		Id:       &wrappers.StringValue{Value: id},
+		Host:     &wrappers.StringValue{Value: host},
+		Port:     &wrappers.UInt32Value{Value: port},
+		Protocol: &wrappers.StringValue{Value: "tri"},
+		Healthy:  &wrappers.BoolValue{Value: true},
+		Isolate:  &wrappers.BoolValue{Value: false},
+		Metadata: metadata,
+	}
+	return pb.NewInstanceInProto(
+		instance,
+		&model.ServiceKey{Namespace: testPolarisNamespace, Service: serviceName},
+		local.NewInstanceLocalValue(),
+	)
+}

--- a/registry/polaris/registry_test.go
+++ b/registry/polaris/registry_test.go
@@ -374,6 +374,117 @@ func TestPolarisWatchServiceReconnectLifecycle(t *testing.T) {
 	})
 }
 
+func TestPolarisWatchSnapshotIsolatedFromInputMutation(t *testing.T) {
+	serviceName := "com.test.InputMutationSnapshotService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	wantKey := instanceA.GetInstanceKey()
+	wantHost := instanceA.GetHost()
+	wantPort := instanceA.GetPort()
+	wantInterface := instanceA.GetMetadata()["interface"]
+	wantPath := instanceA.GetMetadata()["path"]
+	watcher := newStoppedPolarisWatcher(t, nil)
+	listener, err := newPolarisListener(watcher, nil, reconcileWithBaseline)
+	if err != nil {
+		t.Fatalf("newPolarisListener() error = %v", err)
+	}
+	defer closeTestPolarisListener(listener)
+
+	watcher.handleWatchSnapshot([]model.Instance{instanceA})
+	assertPolarisListenerEvent(t, listener, remoting.EventTypeAdd, instanceA)
+	if len(watcher.currentInstances) != 1 {
+		t.Fatalf("current instance count = %d, want 1", len(watcher.currentInstances))
+	}
+	current := watcher.currentInstances[0]
+	if current == instanceA {
+		t.Fatal("watcher current instance shares the input instance")
+	}
+
+	delete(instanceA.GetMetadata(), "interface")
+	delete(instanceA.GetMetadata(), "path")
+	if current.GetMetadata()["interface"] != wantInterface || current.GetMetadata()["path"] != wantPath {
+		t.Fatalf("watcher metadata = %v, want interface=%q path=%q", current.GetMetadata(), wantInterface, wantPath)
+	}
+
+	watcher.handleWatchSnapshot(nil)
+	select {
+	case value := <-listener.events.Out():
+		notification, ok := value.(*polarisNotification)
+		if !ok || notification == nil {
+			t.Fatalf("listener notification type = %T, want *polarisNotification", value)
+		}
+		if notification.eventType != remoting.EventTypeDel || len(notification.instances) != 1 {
+			t.Fatalf("listener notification = %#v, want one DEL instance", notification)
+		}
+		deleted := notification.instances[0]
+		if deleted.GetInstanceKey() != wantKey || deleted.GetHost() != wantHost || deleted.GetPort() != wantPort {
+			t.Fatalf(
+				"deleted instance = (key=%v host=%s port=%d), want (key=%v host=%s port=%d)",
+				deleted.GetInstanceKey(),
+				deleted.GetHost(),
+				deleted.GetPort(),
+				wantKey,
+				wantHost,
+				wantPort,
+			)
+		}
+		if deleted.GetMetadata()["interface"] != wantInterface || deleted.GetMetadata()["path"] != wantPath {
+			t.Fatalf("deleted instance metadata = %v, want interface=%q path=%q", deleted.GetMetadata(), wantInterface, wantPath)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for DEL after input mutation")
+	}
+	assertNoPolarisListenerEvent(t, listener)
+	if len(watcher.currentInstances) != 0 {
+		t.Fatalf("current instance count = %d, want 0", len(watcher.currentInstances))
+	}
+}
+
+func TestPolarisSubscriberMutationDoesNotAffectWatcherSnapshot(t *testing.T) {
+	serviceName := "com.test.SubscriberMutationSnapshotService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	wantInterface := instanceA.GetMetadata()["interface"]
+	wantPath := instanceA.GetMetadata()["path"]
+	watcher := newStoppedPolarisWatcher(t, nil)
+	listener, err := newPolarisListener(watcher, nil, reconcileWithBaseline)
+	if err != nil {
+		t.Fatalf("newPolarisListener() error = %v", err)
+	}
+	defer closeTestPolarisListener(listener)
+
+	watcher.AddSubscriber(func(_ remoting.EventType, instances []model.Instance) {
+		if len(instances) == 0 {
+			return
+		}
+		delete(instances[0].GetMetadata(), "interface")
+		delete(instances[0].GetMetadata(), "path")
+	})
+	var secondInterface string
+	var secondPath string
+	watcher.AddSubscriber(func(_ remoting.EventType, instances []model.Instance) {
+		if len(instances) == 0 {
+			return
+		}
+		secondInterface = instances[0].GetMetadata()["interface"]
+		secondPath = instances[0].GetMetadata()["path"]
+	})
+
+	watcher.handleWatchSnapshot([]model.Instance{instanceA})
+	assertPolarisListenerEvent(t, listener, remoting.EventTypeAdd, instanceA)
+	if secondInterface != wantInterface || secondPath != wantPath {
+		t.Fatalf("second subscriber metadata = (interface=%q path=%q), want (interface=%q path=%q)", secondInterface, secondPath, wantInterface, wantPath)
+	}
+	if len(watcher.currentInstances) != 1 {
+		t.Fatalf("current instance count = %d, want 1", len(watcher.currentInstances))
+	}
+	currentMetadata := watcher.currentInstances[0].GetMetadata()
+	if currentMetadata["interface"] != wantInterface || currentMetadata["path"] != wantPath {
+		t.Fatalf("watcher metadata = %v, want interface=%q path=%q", currentMetadata, wantInterface, wantPath)
+	}
+
+	watcher.handleWatchSnapshot(nil)
+	assertPolarisListenerEvent(t, listener, remoting.EventTypeDel, instanceA)
+}
+
 func TestPolarisComparableSubscriberDeletesInstanceThatBecomesInvalid(t *testing.T) {
 	serviceName := "com.test.ValidToInvalidSnapshotService"
 	validA := newPolarisTestInstance("valid-a", "10.0.0.1", 20001, serviceName, true)
@@ -733,6 +844,27 @@ func TestPolarisInitialSubscribeInstancesAreListenerScoped(t *testing.T) {
 		}
 		if !baselineWasReady {
 			t.Fatal("pending baseline was not stored before Notify(ADD)")
+		}
+	})
+
+	t.Run("stored baseline is isolated from input mutation", func(t *testing.T) {
+		baselineA := newPolarisTestInstance("baseline-a", "10.0.0.1", 20001, serviceName, true)
+		wantInterface := baselineA.GetMetadata()["interface"]
+		wantPath := baselineA.GetMetadata()["path"]
+		pr := newTestPolarisRegistry(nil)
+		notify := &recordingPolarisNotifyListener{}
+		key := mustInitialSubscribeInstancesKey(t, serviceName, notify)
+
+		pr.storeInitialSubscribeInstances(key, []model.Instance{baselineA})
+		delete(baselineA.GetMetadata(), "interface")
+		delete(baselineA.GetMetadata(), "path")
+		_, baseline := pr.loadInitialSubscribeInstances(key)
+		if len(baseline) != 1 {
+			t.Fatalf("pending baseline count = %d, want 1", len(baseline))
+		}
+		metadata := baseline[0].GetMetadata()
+		if metadata["interface"] != wantInterface || metadata["path"] != wantPath {
+			t.Fatalf("pending baseline metadata = %v, want interface=%q path=%q", metadata, wantInterface, wantPath)
 		}
 	})
 

--- a/registry/polaris/registry_test.go
+++ b/registry/polaris/registry_test.go
@@ -43,62 +43,76 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
 
-const testPolarisNamespace = "test"
+const (
+	testPolarisNamespace   = "test"
+	testPolarisRevisionKey = "revision"
+)
 
 type fakePolarisConsumer struct {
 	api.ConsumerAPI
-	instances         []model.Instance
 	instanceResponses [][]model.Instance
 	getCalls          int
 	watchInstances    []model.Instance
+	watchEvents       []model.SubScribeEvent
+	watchErr          error
 	watchCalls        int
+	watchRequest      *api.WatchServiceRequest
 }
 
 func (f *fakePolarisConsumer) GetInstances(_ *api.GetInstancesRequest) (*model.InstancesResponse, error) {
-	instances := f.instances
+	var instances []model.Instance
 	if f.getCalls < len(f.instanceResponses) {
 		instances = f.instanceResponses[f.getCalls]
 	}
 	f.getCalls++
-	instances = append([]model.Instance(nil), instances...)
-	return &model.InstancesResponse{Instances: instances}, nil
+	return &model.InstancesResponse{Instances: copyInstances(instances)}, nil
 }
 
-func (f *fakePolarisConsumer) WatchService(_ *api.WatchServiceRequest) (*model.WatchServiceResponse, error) {
+func (f *fakePolarisConsumer) WatchService(request *api.WatchServiceRequest) (*model.WatchServiceResponse, error) {
 	f.watchCalls++
-	eventChannel := make(chan model.SubScribeEvent)
-	close(eventChannel)
+	f.watchRequest = request
+	if f.watchErr != nil {
+		return nil, f.watchErr
+	}
+	events := make(chan model.SubScribeEvent, len(f.watchEvents))
+	for _, event := range f.watchEvents {
+		events <- event
+	}
+	close(events)
 	return &model.WatchServiceResponse{
-		EventChannel: eventChannel,
+		EventChannel: events,
 		GetAllInstancesResp: &model.InstancesResponse{
-			Instances: append([]model.Instance(nil), f.watchInstances...),
+			Instances: copyInstances(f.watchInstances),
 		},
 	}, nil
 }
 
 type recordedPolarisEvent struct {
-	action remoting.EventType
-	host   string
-	port   string
+	action   remoting.EventType
+	host     string
+	port     string
+	id       string
+	revision string
 }
 
 type recordingPolarisNotifyListener struct {
-	events  []recordedPolarisEvent
-	eventCh chan recordedPolarisEvent
+	events []recordedPolarisEvent
 }
 
-type nonComparablePolarisNotifyListener []recordedPolarisEvent
+type unsupportedPolarisNotifyListener []recordedPolarisEvent
 
-func (nonComparablePolarisNotifyListener) Notify(*registry.ServiceEvent) {}
+func (unsupportedPolarisNotifyListener) Notify(*registry.ServiceEvent) {}
 
-func (nonComparablePolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
+func (unsupportedPolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
 
 func (r *recordingPolarisNotifyListener) Notify(event *registry.ServiceEvent) {
-	r.record(recordedPolarisEvent{
-		action: event.Action,
-		host:   event.Service.Ip,
-		port:   event.Service.Port,
-	})
+	r.record(
+		event.Action,
+		event.Service.Ip,
+		event.Service.Port,
+		event.Service.GetParam(constant.PolarisInstanceID, ""),
+		event.Service.GetParam(testPolarisRevisionKey, ""),
+	)
 }
 
 func (r *recordingPolarisNotifyListener) NotifyAll(events []*registry.ServiceEvent, callback func()) {
@@ -112,645 +126,458 @@ func (r *recordingPolarisNotifyListener) NotifyAll(events []*registry.ServiceEve
 
 func (r *recordingPolarisNotifyListener) recordInstances(action remoting.EventType, instances []model.Instance) {
 	for _, instance := range instances {
-		r.record(recordedPolarisEvent{
-			action: action,
-			host:   instance.GetHost(),
-			port:   strconv.Itoa(int(instance.GetPort())),
-		})
+		r.events = append(r.events, recordedPolarisEventFromInstance(action, instance))
 	}
 }
 
-func (r *recordingPolarisNotifyListener) record(event recordedPolarisEvent) {
-	r.events = append(r.events, event)
-	if r.eventCh != nil {
-		r.eventCh <- event
-	}
-}
-
-func TestPolarisSubscribeInitialSnapshotTransfer(t *testing.T) {
-	serviceName := "com.test.SubscribeSnapshotTransferService"
-	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
-	consumer := &fakePolarisConsumer{
-		instances:      []model.Instance{instanceA},
-		watchInstances: []model.Instance{instanceB},
-	}
-	notify := &recordingPolarisNotifyListener{eventCh: make(chan recordedPolarisEvent, 3)}
-	polarisRegistry := &polarisRegistry{
-		namespace:                 testPolarisNamespace,
-		consumer:                  consumer,
-		watchers:                  make(map[string]*PolarisServiceWatcher),
-		initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance),
-	}
-
-	if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
-		t.Fatalf("LoadSubscribeInstances() error = %v", err)
-	}
-
-	_, err := polarisRegistry.createPolarisListener(serviceName, notify, func(watcher *PolarisServiceWatcher, initialSnapshot []model.Instance) (*polarisListener, error) {
-		resp, watchErr := watcher.consumer.WatchService(watcher.subscribeParam)
-		if watchErr != nil {
-			return nil, watchErr
-		}
-		watcher.execOnce.Do(func() {})
-		watcher.addSubscriberWithInitialSnapshot(initialSnapshot, notify.recordInstances)
-		watcher.handleWatchSnapshot(resp.GetAllInstancesResp.Instances)
-		return &polarisListener{}, nil
+func (r *recordingPolarisNotifyListener) record(
+	action remoting.EventType,
+	host string,
+	port string,
+	id string,
+	revision string,
+) {
+	r.events = append(r.events, recordedPolarisEvent{
+		action: action, host: host, port: port, id: id, revision: revision,
 	})
-	if err != nil {
-		t.Fatalf("createPolarisListener() error = %v", err)
-	}
-	if consumer.watchCalls != 1 {
-		t.Fatalf("WatchService() calls = %d, want 1", consumer.watchCalls)
-	}
-
-	expected := []recordedPolarisEvent{
-		{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
-		{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
-		{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
-	}
-	actual := make([]recordedPolarisEvent, 0, len(expected))
-	timer := time.NewTimer(time.Second)
-	defer timer.Stop()
-	for range expected {
-		select {
-		case event := <-notify.eventCh:
-			actual = append(actual, event)
-		case <-timer.C:
-			t.Fatalf("timed out waiting for events, got %#v", actual)
-		}
-	}
-	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("events = %#v, want %#v", actual, expected)
-	}
 }
 
 func TestPolarisInitialSnapshotReconciliation(t *testing.T) {
 	serviceName := "com.test.InitialSnapshotService"
-	instanceA := newPolarisTestInstance(
-		"instance-a",
-		"10.0.0.1",
-		20001,
-		serviceName,
-		true,
-	)
-	invalidInstance := newPolarisTestInstance(
-		"invalid",
-		"10.0.0.9",
-		20009,
-		serviceName,
-		false,
-	)
-	instanceB := newPolarisTestInstance(
-		"instance-b",
-		"10.0.0.2",
-		20002,
-		serviceName,
-		true,
-	)
-
-	t.Run("A is replaced by B", func(t *testing.T) {
-		testPolarisInitialSnapshotReconciliation(
-			t,
-			serviceName,
-			instanceA,
-			invalidInstance,
-			[]model.Instance{instanceB},
-			[]recordedPolarisEvent{
-				{
-					action: remoting.EventTypeAdd,
-					host:   "10.0.0.1",
-					port:   "20001",
-				},
-				{
-					action: remoting.EventTypeDel,
-					host:   "10.0.0.1",
-					port:   "20001",
-				},
-				{
-					action: remoting.EventTypeAdd,
-					host:   "10.0.0.2",
-					port:   "20002",
-				},
-			},
-		)
-	})
-
-	t.Run("first watcher snapshot is empty", func(t *testing.T) {
-		testPolarisInitialSnapshotReconciliation(
-			t,
-			serviceName,
-			instanceA,
-			invalidInstance,
-			nil,
-			[]recordedPolarisEvent{
-				{
-					action: remoting.EventTypeAdd,
-					host:   "10.0.0.1",
-					port:   "20001",
-				},
-				{
-					action: remoting.EventTypeDel,
-					host:   "10.0.0.1",
-					port:   "20001",
-				},
-			},
-		)
-	})
-}
-
-func testPolarisInitialSnapshotReconciliation(t *testing.T, serviceName string, instanceA model.Instance, invalidInstance model.Instance, current []model.Instance, expected []recordedPolarisEvent) {
-	t.Helper()
-
-	notify := &recordingPolarisNotifyListener{}
-	consumer := &fakePolarisConsumer{
-		instances: []model.Instance{instanceA, invalidInstance},
-	}
-
-	polarisRegistry := &polarisRegistry{
-		namespace:                 testPolarisNamespace,
-		consumer:                  consumer,
-		initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance),
-	}
-
-	if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
-		t.Fatalf("LoadSubscribeInstances() error = %v", err)
-	}
-
-	initial, ok := polarisRegistry.takeInitialSubscribeInstances(serviceName, notify)
-	if !ok {
-		t.Fatal("initial snapshot was not saved")
-	}
-
-	if len(initial) != 1 ||
-		initial[0].GetInstanceKey() != instanceA.GetInstanceKey() {
-		t.Fatalf("initial snapshot = %v, want only instance A", initial)
-	}
-
-	watcher := newStoppedPolarisWatcher(t, consumer)
-	watcher.addSubscriberWithInitialSnapshot(initial, notify.recordInstances)
-	watcher.handleWatchSnapshot(current)
-
-	if !reflect.DeepEqual(notify.events, expected) {
-		t.Fatalf("events = %#v, want %#v", notify.events, expected)
-	}
-}
-
-func TestMissingInitialInstancesSameInstance(t *testing.T) {
-	serviceName := "com.test.SameInstanceService"
-	initial := newPolarisTestInstance("old-id", "10.0.0.1", 20001, serviceName, true)
-	current := newPolarisTestInstance("new-id", "10.0.0.1", 20001, serviceName, true)
-
-	missing := missingInitialInstances([]model.Instance{initial}, []model.Instance{current})
-	if len(missing) != 0 {
-		t.Fatalf("missingInitialInstances() = %v, want empty", missing)
-	}
-}
-
-func TestMissingInitialInstancesPreservesInitialOrder(t *testing.T) {
-	serviceName := "com.test.InstanceOrderService"
 	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	sameKeyA := newPolarisTestInstance("new-polaris-id", "10.0.0.1", 20001, serviceName, true)
+	instanceA.GetMetadata()[testPolarisRevisionKey] = "before"
+	sameKeyA.GetMetadata()[testPolarisRevisionKey] = "after"
 	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
 	instanceC := newPolarisTestInstance("instance-c", "10.0.0.3", 20003, serviceName, true)
+	invalid := newPolarisTestInstance("invalid", "10.0.0.9", 20009, serviceName, false)
 
-	missing := missingInitialInstances(
-		[]model.Instance{instanceA, instanceB, instanceC},
-		[]model.Instance{instanceB},
-	)
-	if len(missing) != 2 {
-		t.Fatalf("missingInitialInstances() length = %d, want 2", len(missing))
+	tests := []struct {
+		name           string
+		loaded         []model.Instance
+		current        []model.Instance
+		watchEvents    []model.SubScribeEvent
+		wantLoad       []recordedPolarisEvent
+		wantListener   []recordedPolarisEvent
+		wantInstance   model.Instance
+		wantWatchCalls int
+	}{
+		{
+			name:    "A replaced by B and incremental event is wired",
+			loaded:  []model.Instance{instanceA, invalid},
+			current: []model.Instance{instanceB},
+			watchEvents: []model.SubScribeEvent{&model.InstanceEvent{
+				AddEvent: &model.InstanceAddEvent{Instances: []model.Instance{instanceC}},
+			}},
+			wantLoad: []recordedPolarisEvent{
+				{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
+			},
+			wantListener: []recordedPolarisEvent{
+				{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+				{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
+				{action: remoting.EventTypeAdd, host: "10.0.0.3", port: "20003"},
+			},
+			wantWatchCalls: 1,
+		},
+		{
+			name:     "first snapshot empty",
+			loaded:   []model.Instance{instanceA},
+			wantLoad: []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"}},
+			wantListener: []recordedPolarisEvent{
+				{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+			},
+			wantWatchCalls: 1,
+		},
+		{
+			name:     "same InstanceKey with different Polaris ID",
+			loaded:   []model.Instance{instanceA},
+			current:  []model.Instance{sameKeyA},
+			wantLoad: []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"}},
+			wantListener: []recordedPolarisEvent{
+				{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
+			},
+			wantInstance:   sameKeyA,
+			wantWatchCalls: 1,
+		},
+		{
+			name:           "invalid instance is excluded from baseline",
+			loaded:         []model.Instance{invalid},
+			wantWatchCalls: 1,
+		},
 	}
-	if missing[0].GetInstanceKey() != instanceA.GetInstanceKey() ||
-		missing[1].GetInstanceKey() != instanceC.GetInstanceKey() {
-		t.Fatalf("missingInitialInstances() = %v, want [instance A, instance C]", missing)
-	}
-}
 
-func TestPolarisSubscriberInitialSnapshotReconciledOnce(t *testing.T) {
-	serviceName := "com.test.OneShotService"
-	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
-	watcher := newStoppedPolarisWatcher(t, nil)
-	notify := &recordingPolarisNotifyListener{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			consumer := &fakePolarisConsumer{
+				instanceResponses: [][]model.Instance{tt.loaded},
+				watchInstances:    tt.current,
+				watchEvents:       tt.watchEvents,
+			}
+			pr := newTestPolarisRegistry(consumer)
+			notify := &recordingPolarisNotifyListener{}
+			url := newPolarisConsumerURL(serviceName)
 
-	snapshot := []model.Instance{instanceA}
-	watcher.addSubscriberWithInitialSnapshot(snapshot, notify.recordInstances)
-	snapshot[0] = instanceB
-	watcher.handleWatchSnapshot([]model.Instance{instanceB})
-	watcher.handleWatchSnapshot([]model.Instance{instanceB})
+			if err := pr.LoadSubscribeInstances(url, notify); err != nil {
+				t.Fatalf("LoadSubscribeInstances() error = %v", err)
+			}
+			watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
+			listener, err := pr.createPolarisListener(serviceName, notify)
+			if err != nil {
+				t.Fatalf("createPolarisListener() error = %v", err)
+			}
+			defer closeTestPolarisListener(listener)
+			if watchErr := watcher.watchOnce(); watchErr != nil {
+				t.Fatalf("watchOnce() error = %v", watchErr)
+			}
 
-	expected := []recordedPolarisEvent{
-		{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
-		{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
-		{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
+			assertPolarisEventsAddress(t, notify.events, tt.wantLoad)
+			listenerEvents := assertPolarisListenerEvents(t, listener, tt.wantListener)
+			if tt.wantInstance != nil {
+				assertPolarisEventInstance(t, listenerEvents[0], remoting.EventTypeAdd, tt.wantInstance)
+			}
+			assertPolarisWatchRequest(t, consumer.watchRequest, watcher.subscribeParam, serviceName)
+			if consumer.watchCalls != tt.wantWatchCalls {
+				t.Fatalf("WatchService() calls = %d, want %d", consumer.watchCalls, tt.wantWatchCalls)
+			}
+		})
 	}
-	if !reflect.DeepEqual(notify.events, expected) {
-		t.Fatalf("events = %#v, want %#v", notify.events, expected)
-	}
-	if len(watcher.subscribers) != 1 || !watcher.subscribers[0].reconciled || watcher.subscribers[0].initialSnapshot != nil {
-		t.Fatalf("subscriber state = %#v, want reconciled state with cleared baseline", watcher.subscribers)
-	}
+
+	t.Run("WatchService error is returned", func(t *testing.T) {
+		wantErr := errors.New("watch failed")
+		watcher := newStoppedPolarisWatcher(t, &fakePolarisConsumer{watchErr: wantErr})
+		if err := watcher.watchOnce(); !errors.Is(err, wantErr) {
+			t.Fatalf("watchOnce() error = %v, want %v", err, wantErr)
+		}
+		if watcher.snapshotReady {
+			t.Fatal("watcher snapshot is ready after WatchService error")
+		}
+	})
 }
 
 func TestPolarisReusedWatcherReconcilesSecondSubscriberAfterDelete(t *testing.T) {
 	serviceName := "com.test.ReusedWatcherService"
 	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	consumer := &fakePolarisConsumer{instances: []model.Instance{instanceA}}
-	polarisRegistry := &polarisRegistry{
-		namespace:                 testPolarisNamespace,
-		consumer:                  consumer,
-		watchers:                  make(map[string]*PolarisServiceWatcher),
-		initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance),
+	consumer := &fakePolarisConsumer{
+		instanceResponses: [][]model.Instance{{instanceA}},
+		watchInstances:    []model.Instance{instanceA},
+		watchEvents: []model.SubScribeEvent{&model.InstanceEvent{
+			DeleteEvent: &model.InstanceDeleteEvent{Instances: []model.Instance{instanceA}},
+		}},
 	}
-
-	watcher, err := polarisRegistry.createPolarisWatcher(serviceName)
-	if err != nil {
-		t.Fatalf("createPolarisWatcher() error = %v", err)
-	}
-	watcher.execOnce.Do(func() {})
+	pr := newTestPolarisRegistry(consumer)
+	watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
 
 	firstNotify := &recordingPolarisNotifyListener{}
-	firstListener, err := polarisRegistry.createPolarisListener(serviceName, firstNotify, newPolarisListener)
+	firstListener, err := pr.createPolarisListener(serviceName, firstNotify)
 	if err != nil {
 		t.Fatalf("createPolarisListener(first) error = %v", err)
 	}
-	defer firstListener.Close()
-	if firstListener.watcher != watcher {
-		t.Fatal("first listener did not use the shared watcher")
-	}
+	defer closeTestPolarisListener(firstListener)
 	watcher.handleWatchSnapshot([]model.Instance{instanceA})
 	assertPolarisListenerEvent(t, firstListener, remoting.EventTypeAdd, instanceA)
 
-	second := &recordingPolarisNotifyListener{}
-	if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), second); err != nil {
-		t.Fatalf("LoadSubscribeInstances() error = %v", err)
+	secondNotify := &recordingPolarisNotifyListener{}
+	if loadErr := pr.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), secondNotify); loadErr != nil {
+		t.Fatalf("LoadSubscribeInstances() error = %v", loadErr)
 	}
-	watcher.handleInstanceEvent(&model.InstanceEvent{
-		DeleteEvent: &model.InstanceDeleteEvent{Instances: []model.Instance{instanceA}},
-	})
+	if watchErr := watcher.watchOnce(); watchErr != nil {
+		t.Fatalf("watchOnce() error = %v", watchErr)
+	}
+	assertPolarisListenerEvent(t, firstListener, remoting.EventTypeAdd, instanceA)
 	assertPolarisListenerEvent(t, firstListener, remoting.EventTypeDel, instanceA)
 
-	if expected := []recordedPolarisEvent{
-		{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
-	}; !reflect.DeepEqual(second.events, expected) {
-		t.Fatalf("second subscriber events before joining = %#v, want %#v", second.events, expected)
-	}
-
-	secondListener, err := polarisRegistry.createPolarisListener(serviceName, second, newPolarisListener)
+	secondListener, err := pr.createPolarisListener(serviceName, secondNotify)
 	if err != nil {
 		t.Fatalf("createPolarisListener(second) error = %v", err)
 	}
-	defer secondListener.Close()
-	if secondListener.watcher != watcher {
-		t.Fatal("second listener did not reuse the shared watcher")
-	}
+	defer closeTestPolarisListener(secondListener)
 	assertPolarisListenerEvent(t, secondListener, remoting.EventTypeDel, instanceA)
-
 	assertNoPolarisListenerEvent(t, firstListener)
 
 	watcher.handleWatchSnapshot(nil)
 	assertNoPolarisListenerEvent(t, secondListener)
+	if len(watcher.subscribers) != 2 || !watcher.subscribers[1].reconciled || watcher.subscribers[1].initialSnapshot != nil {
+		t.Fatalf("second subscriber state = %#v, want reconciled with cleared baseline", watcher.subscribers[1])
+	}
 }
 
-func TestPolarisInitialSubscribeInstancesAreScopedToNotifyListener(t *testing.T) {
+func TestPolarisInitialSubscribeInstancesAreListenerScoped(t *testing.T) {
 	serviceName := "com.test.ListenerScopedBaselineService"
 	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
 	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
-	consumer := &fakePolarisConsumer{instanceResponses: [][]model.Instance{{instanceA}, {instanceB}}}
-	polarisRegistry := &polarisRegistry{
-		namespace: testPolarisNamespace,
-		consumer:  consumer,
-		watchers:  make(map[string]*PolarisServiceWatcher),
-	}
+	consumer := &fakePolarisConsumer{instanceResponses: [][]model.Instance{{instanceA}, {instanceB}, nil}}
+	pr := newTestPolarisRegistry(consumer)
 	firstNotify := &recordingPolarisNotifyListener{}
 	secondNotify := &recordingPolarisNotifyListener{}
 	url := newPolarisConsumerURL(serviceName)
 
-	if err := polarisRegistry.LoadSubscribeInstances(url, firstNotify); err != nil {
+	if err := pr.LoadSubscribeInstances(url, firstNotify); err != nil {
 		t.Fatalf("LoadSubscribeInstances(first) error = %v", err)
 	}
-	if err := polarisRegistry.LoadSubscribeInstances(url, secondNotify); err != nil {
+	if err := pr.LoadSubscribeInstances(url, secondNotify); err != nil {
 		t.Fatalf("LoadSubscribeInstances(second) error = %v", err)
 	}
-
-	watcher, err := polarisRegistry.createPolarisWatcher(serviceName)
-	if err != nil {
-		t.Fatalf("createPolarisWatcher() error = %v", err)
+	if err := pr.LoadSubscribeInstances(url, firstNotify); err != nil {
+		t.Fatalf("LoadSubscribeInstances(first empty) error = %v", err)
 	}
-	watcher.execOnce.Do(func() {})
+
+	firstKey := newInitialSubscribeInstancesKey(serviceName, firstNotify)
+	if entry, instances := pr.loadInitialSubscribeInstances(firstKey); entry != nil || len(instances) != 0 {
+		t.Fatalf("first pending entry = (%p, %v), want empty", entry, instances)
+	}
+	secondKey := newInitialSubscribeInstancesKey(serviceName, secondNotify)
+	secondEntry, instances := pr.loadInitialSubscribeInstances(secondKey)
+	if secondEntry == nil || len(instances) != 1 || instances[0].GetInstanceKey() != instanceB.GetInstanceKey() {
+		t.Fatalf("second pending entry = (%p, %v), want instance B", secondEntry, instances)
+	}
+
+	watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
 	watcher.handleWatchSnapshot(nil)
-
-	firstListener, err := polarisRegistry.createPolarisListener(serviceName, firstNotify, newPolarisListener)
-	if err != nil {
-		t.Fatalf("createPolarisListener(first) error = %v", err)
-	}
-	defer firstListener.Close()
-	assertPolarisListenerEvent(t, firstListener, remoting.EventTypeDel, instanceA)
-
-	secondListener, err := polarisRegistry.createPolarisListener(serviceName, secondNotify, newPolarisListener)
-	if err != nil {
-		t.Fatalf("createPolarisListener(second) error = %v", err)
-	}
-	defer secondListener.Close()
-	assertPolarisListenerEvent(t, secondListener, remoting.EventTypeDel, instanceB)
-}
-
-func TestPolarisEmptyLoadDoesNotClearAnotherListenerBaseline(t *testing.T) {
-	serviceName := "com.test.ListenerScopedEmptyBaselineService"
-	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	consumer := &fakePolarisConsumer{instanceResponses: [][]model.Instance{{instanceA}, nil}}
-	polarisRegistry := &polarisRegistry{
-		namespace: testPolarisNamespace,
-		consumer:  consumer,
-		watchers:  make(map[string]*PolarisServiceWatcher),
-	}
-	firstNotify := &recordingPolarisNotifyListener{}
-	secondNotify := &recordingPolarisNotifyListener{}
-	url := newPolarisConsumerURL(serviceName)
-
-	if err := polarisRegistry.LoadSubscribeInstances(url, firstNotify); err != nil {
-		t.Fatalf("LoadSubscribeInstances(first) error = %v", err)
-	}
-	if err := polarisRegistry.LoadSubscribeInstances(url, secondNotify); err != nil {
-		t.Fatalf("LoadSubscribeInstances(second) error = %v", err)
-	}
-
-	watcher, err := polarisRegistry.createPolarisWatcher(serviceName)
-	if err != nil {
-		t.Fatalf("createPolarisWatcher() error = %v", err)
-	}
-	watcher.execOnce.Do(func() {})
-	watcher.handleWatchSnapshot(nil)
-
-	firstListener, err := polarisRegistry.createPolarisListener(serviceName, firstNotify, newPolarisListener)
-	if err != nil {
-		t.Fatalf("createPolarisListener(first) error = %v", err)
-	}
-	defer firstListener.Close()
-	assertPolarisListenerEvent(t, firstListener, remoting.EventTypeDel, instanceA)
-
-	secondListener, err := polarisRegistry.createPolarisListener(serviceName, secondNotify, newPolarisListener)
-	if err != nil {
-		t.Fatalf("createPolarisListener(second) error = %v", err)
-	}
-	defer secondListener.Close()
-	assertNoPolarisListenerEvent(t, secondListener)
-}
-
-func TestPolarisLoadSupportsNonComparableNotifyListener(t *testing.T) {
-	serviceName := "com.test.NonComparableNotifyListenerService"
-	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	consumer := &fakePolarisConsumer{instances: []model.Instance{instanceA}}
-	polarisRegistry := &polarisRegistry{namespace: testPolarisNamespace, consumer: consumer}
-	notify := nonComparablePolarisNotifyListener{}
-
-	if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
-		t.Fatalf("LoadSubscribeInstances() error = %v", err)
-	}
-	if consumer.getCalls != 1 {
-		t.Fatalf("GetInstances() calls = %d, want 1", consumer.getCalls)
-	}
-	stored, ok := polarisRegistry.takeInitialSubscribeInstances(serviceName, notify)
-	if !ok || len(stored) != 1 || stored[0].GetInstanceKey() != instanceA.GetInstanceKey() {
-		t.Fatalf("initial subscribe instances = (%v, %v), want instance A", stored, ok)
-	}
-}
-
-func TestPolarisInitialSubscribeInstancesStateClearedAfterListenerCreation(t *testing.T) {
-	serviceName := "com.test.InitialSubscribeInstancesCleanupService"
-	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	notify := &recordingPolarisNotifyListener{}
-	polarisRegistry := &polarisRegistry{
-		namespace: testPolarisNamespace,
-		consumer:  &fakePolarisConsumer{instances: []model.Instance{instanceA}},
-		watchers:  make(map[string]*PolarisServiceWatcher),
-	}
-	if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
-		t.Fatalf("LoadSubscribeInstances() error = %v", err)
-	}
-	watcher, err := polarisRegistry.createPolarisWatcher(serviceName)
-	if err != nil {
-		t.Fatalf("createPolarisWatcher() error = %v", err)
-	}
-	watcher.execOnce.Do(func() {})
-
-	listener, err := polarisRegistry.createPolarisListener(serviceName, notify, newPolarisListener)
+	listener, err := pr.createPolarisListener(serviceName, secondNotify)
 	if err != nil {
 		t.Fatalf("createPolarisListener() error = %v", err)
 	}
-	defer listener.Close()
-	if len(polarisRegistry.initialSubscribeInstances) != 0 || len(polarisRegistry.initialSubscribeVersions) != 0 {
-		t.Fatalf("initial subscribe instances state = (%d snapshots, %d versions), want empty", len(polarisRegistry.initialSubscribeInstances), len(polarisRegistry.initialSubscribeVersions))
+	defer closeTestPolarisListener(listener)
+	assertPolarisListenerEvent(t, listener, remoting.EventTypeDel, instanceB)
+	if entry, _ := pr.loadInitialSubscribeInstances(secondKey); entry != nil {
+		t.Fatalf("pending entry after listener success = %p, want nil", entry)
+	}
+
+	pr.storeInitialSubscribeInstances(secondKey, []model.Instance{instanceA})
+	oldEntry, _ := pr.loadInitialSubscribeInstances(secondKey)
+	pr.storeInitialSubscribeInstances(secondKey, []model.Instance{instanceB})
+	newEntry, _ := pr.loadInitialSubscribeInstances(secondKey)
+	pr.completeInitialSubscribeInstances(secondKey, oldEntry)
+	remaining, remainingInstances := pr.loadInitialSubscribeInstances(secondKey)
+	if remaining != newEntry || len(remainingInstances) != 1 || remainingInstances[0].GetInstanceKey() != instanceB.GetInstanceKey() {
+		t.Fatalf("newer pending entry = (%p, %v), want preserved instance B", remaining, remainingInstances)
 	}
 }
 
-func TestPolarisWatcherTracksIncrementalCurrentInstances(t *testing.T) {
-	serviceName := "com.test.IncrementalStateService"
+func TestPolarisWatcherTracksCurrentState(t *testing.T) {
+	serviceName := "com.test.CurrentStateService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	updatedA := newPolarisTestInstance("updated-a", "10.0.0.1", 20001, serviceName, true)
+	instanceA.GetMetadata()[testPolarisRevisionKey] = "before"
+	updatedA.GetMetadata()[testPolarisRevisionKey] = "after"
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+
+	tests := []struct {
+		name         string
+		initial      []model.Instance
+		event        *model.InstanceEvent
+		wantIDs      []string
+		wantEvents   []recordedPolarisEvent
+		wantInstance model.Instance
+	}{
+		{
+			name:    "ADD",
+			initial: []model.Instance{instanceA},
+			event: &model.InstanceEvent{AddEvent: &model.InstanceAddEvent{
+				Instances: []model.Instance{instanceB},
+			}},
+			wantIDs:    []string{"instance-a", "instance-b"},
+			wantEvents: []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"}},
+		},
+		{
+			name:    "UPDATE same key",
+			initial: []model.Instance{instanceA},
+			event: &model.InstanceEvent{UpdateEvent: &model.InstanceUpdateEvent{
+				UpdateList: []model.OneInstanceUpdate{{Before: instanceA, After: updatedA}},
+			}},
+			wantIDs:      []string{"updated-a"},
+			wantEvents:   []recordedPolarisEvent{{action: remoting.EventTypeUpdate, host: "10.0.0.1", port: "20001"}},
+			wantInstance: updatedA,
+		},
+		{
+			name:    "UPDATE changed key replaces internally and emits only UPDATE",
+			initial: []model.Instance{instanceA},
+			event: &model.InstanceEvent{UpdateEvent: &model.InstanceUpdateEvent{
+				UpdateList: []model.OneInstanceUpdate{{Before: instanceA, After: instanceB}},
+			}},
+			wantIDs:    []string{"instance-b"},
+			wantEvents: []recordedPolarisEvent{{action: remoting.EventTypeUpdate, host: "10.0.0.2", port: "20002"}},
+		},
+		{
+			name:    "DELETE",
+			initial: []model.Instance{instanceA, instanceB},
+			event: &model.InstanceEvent{DeleteEvent: &model.InstanceDeleteEvent{
+				Instances: []model.Instance{instanceA},
+			}},
+			wantIDs:    []string{"instance-b"},
+			wantEvents: []recordedPolarisEvent{{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			watcher := newStoppedPolarisWatcher(t, nil)
+			watcher.handleWatchSnapshot(tt.initial)
+			notify := &recordingPolarisNotifyListener{}
+			watcher.AddSubscriber(notify.recordInstances)
+			watcher.handleInstanceEvent(tt.event)
+
+			actualIDs := make([]string, 0, len(watcher.currentInstances))
+			for _, instance := range watcher.currentInstances {
+				actualIDs = append(actualIDs, instance.GetId())
+			}
+			if !reflect.DeepEqual(actualIDs, tt.wantIDs) {
+				t.Fatalf("current instance IDs = %v, want %v", actualIDs, tt.wantIDs)
+			}
+			assertPolarisEventsAddress(t, notify.events, tt.wantEvents)
+			if tt.wantInstance != nil {
+				assertPolarisEventInstance(t, notify.events[0], remoting.EventTypeUpdate, tt.wantInstance)
+				assertPolarisInstanceIdentity(t, watcher.currentInstances[0], tt.wantInstance)
+			}
+		})
+	}
+}
+
+func TestPolarisApplicationSubscriberCompatibility(t *testing.T) {
+	serviceName := "com.test.ApplicationSubscriberService"
 	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
 	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
-	instanceC := newPolarisTestInstance("instance-c", "10.0.0.3", 20003, serviceName, true)
-	replacementB := newPolarisTestInstance("replacement-b", "10.0.0.2", 20002, serviceName, true)
-	watcher := newStoppedPolarisWatcher(t, nil)
-	notify := &recordingPolarisNotifyListener{}
-	watcher.addSubscriberWithInitialSnapshot(nil, notify.recordInstances)
-	watcher.handleWatchSnapshot([]model.Instance{instanceA})
 
-	watcher.handleInstanceEvent(&model.InstanceEvent{
-		AddEvent: &model.InstanceAddEvent{Instances: []model.Instance{instanceB}},
-	})
-	watcher.handleInstanceEvent(&model.InstanceEvent{
-		UpdateEvent: &model.InstanceUpdateEvent{UpdateList: []model.OneInstanceUpdate{
-			{Before: instanceA, After: instanceC},
-			{Before: instanceB, After: replacementB},
-		}},
-	})
-	watcher.handleInstanceEvent(&model.InstanceEvent{
-		DeleteEvent: &model.InstanceDeleteEvent{Instances: []model.Instance{instanceC}},
+	t.Run("public signature and before-ready snapshot", func(t *testing.T) {
+		watcher := newStoppedPolarisWatcher(t, nil)
+		notify := &recordingPolarisNotifyListener{}
+		assertPolarisAddSubscriberSignature(watcher.AddSubscriber)
+		watcher.AddSubscriber(notify.recordInstances)
+		watcher.handleWatchSnapshot([]model.Instance{instanceA})
+		want := []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"}}
+		assertPolarisEventsAddress(t, notify.events, want)
 	})
 
-	if len(watcher.currentInstances) != 1 || watcher.currentInstances[0].GetId() != replacementB.GetId() {
-		t.Fatalf("currentInstances = %v, want only replacement B", watcher.currentInstances)
-	}
-	expectedEvents := []recordedPolarisEvent{
-		{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
-		{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
-		{action: remoting.EventTypeUpdate, host: "10.0.0.3", port: "20003"},
-		{action: remoting.EventTypeUpdate, host: "10.0.0.2", port: "20002"},
-		{action: remoting.EventTypeDel, host: "10.0.0.3", port: "20003"},
-	}
-	if !reflect.DeepEqual(notify.events, expectedEvents) {
-		t.Fatalf("incremental events = %#v, want %#v", notify.events, expectedEvents)
-	}
-
-}
-
-func TestPolarisAddSubscriberBeforeInitialSnapshotReceivesCurrentInstances(t *testing.T) {
-	serviceName := "com.test.AddSubscriberBeforeSnapshotService"
-	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	watcher := newStoppedPolarisWatcher(t, nil)
-	notify := &recordingPolarisNotifyListener{}
-
-	watcher.AddSubscriber(notify.recordInstances)
-	watcher.handleWatchSnapshot([]model.Instance{instanceA})
-
-	expected := []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"}}
-	if !reflect.DeepEqual(notify.events, expected) {
-		t.Fatalf("events = %#v, want %#v", notify.events, expected)
-	}
-}
-
-func TestPolarisAddSubscriberAfterInitialSnapshotDoesNotReplayCurrentInstances(t *testing.T) {
-	serviceName := "com.test.AddSubscriberAfterSnapshotService"
-	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
-	watcher := newStoppedPolarisWatcher(t, nil)
-	watcher.handleWatchSnapshot([]model.Instance{instanceA})
-	notify := &recordingPolarisNotifyListener{}
-
-	watcher.AddSubscriber(notify.recordInstances)
-	if len(notify.events) != 0 {
-		t.Fatalf("events after AddSubscriber() = %#v, want no replay", notify.events)
-	}
-
-	watcher.handleInstanceEvent(&model.InstanceEvent{
-		AddEvent: &model.InstanceAddEvent{Instances: []model.Instance{instanceB}},
+	t.Run("after-ready has no replay and receives increments", func(t *testing.T) {
+		watcher := newStoppedPolarisWatcher(t, nil)
+		watcher.handleWatchSnapshot([]model.Instance{instanceA})
+		notify := &recordingPolarisNotifyListener{}
+		watcher.AddSubscriber(notify.recordInstances)
+		watcher.handleInstanceEvent(&model.InstanceEvent{
+			AddEvent: &model.InstanceAddEvent{Instances: []model.Instance{instanceB}},
+		})
+		want := []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"}}
+		assertPolarisEventsAddress(t, notify.events, want)
 	})
-	expected := []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"}}
-	if !reflect.DeepEqual(notify.events, expected) {
-		t.Fatalf("events after incremental update = %#v, want %#v", notify.events, expected)
-	}
-}
 
-func TestNewPolarisListenerAfterInitialSnapshotDoesNotReplayCurrentInstances(t *testing.T) {
-	serviceName := "com.test.NewListenerAfterSnapshotService"
-	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
-	watcher := newStoppedPolarisWatcher(t, nil)
-	watcher.handleWatchSnapshot([]model.Instance{instanceA})
-
-	listener, err := NewPolarisListener(watcher)
-	if err != nil {
-		t.Fatalf("NewPolarisListener() error = %v", err)
-	}
-	defer listener.Close()
-	assertNoPolarisListenerEvent(t, listener)
-
-	watcher.handleInstanceEvent(&model.InstanceEvent{
-		AddEvent: &model.InstanceAddEvent{Instances: []model.Instance{instanceB}},
-	})
-	assertPolarisListenerEvent(t, listener, remoting.EventTypeAdd, instanceB)
-}
-
-func TestPolarisWatcherReplaysDefensiveCurrentSnapshot(t *testing.T) {
-	serviceName := "com.test.DefensiveCurrentSnapshotService"
-	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
-	watcher := newStoppedPolarisWatcher(t, nil)
-	watcher.addSubscriberWithInitialSnapshot(nil, func(_ remoting.EventType, instances []model.Instance) {
-		if len(instances) > 0 {
-			instances[0] = instanceB
+	t.Run("NewPolarisListener wrapper", func(t *testing.T) {
+		watcher := newStoppedPolarisWatcher(t, nil)
+		watcher.handleWatchSnapshot([]model.Instance{instanceA})
+		listener, err := NewPolarisListener(watcher)
+		if err != nil {
+			t.Fatalf("NewPolarisListener() error = %v", err)
 		}
+		defer closeTestPolarisListener(listener)
+		assertNoPolarisListenerEvent(t, listener)
+		watcher.handleInstanceEvent(&model.InstanceEvent{
+			AddEvent: &model.InstanceAddEvent{Instances: []model.Instance{instanceB}},
+		})
+		assertPolarisListenerEvent(t, listener, remoting.EventTypeAdd, instanceB)
 	})
-
-	current := []model.Instance{instanceA}
-	watcher.handleWatchSnapshot(current)
-	current[0] = instanceB
-
-	replayed := &recordingPolarisNotifyListener{}
-	watcher.addSubscriberWithInitialSnapshot(nil, replayed.recordInstances)
-	expected := []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"}}
-	if !reflect.DeepEqual(replayed.events, expected) {
-		t.Fatalf("replayed events = %#v, want %#v", replayed.events, expected)
-	}
 }
 
-func TestCreatePolarisListenerRestoresInitialSubscribeInstancesOnFailure(t *testing.T) {
-	serviceName := "com.test.ListenerFailureService"
-	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	polarisRegistry := &polarisRegistry{
-		watchers:                  make(map[string]*PolarisServiceWatcher),
-		initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance),
-	}
-	notify := &recordingPolarisNotifyListener{}
-	key := newInitialSubscribeInstancesKey(serviceName, notify)
-	polarisRegistry.storeInitialSubscribeInstances(key, []model.Instance{instanceA})
-
-	_, err := polarisRegistry.createPolarisListener(serviceName, notify, func(*PolarisServiceWatcher, []model.Instance) (*polarisListener, error) {
-		return nil, errors.New("listener failed")
-	})
-	if err == nil {
-		t.Fatal("createPolarisListener() error = nil, want failure")
-	}
-	restored, ok := polarisRegistry.takeInitialSubscribeInstances(serviceName, notify)
-	if !ok || len(restored) != 1 || restored[0].GetInstanceKey() != instanceA.GetInstanceKey() {
-		t.Fatalf("restored baseline = (%v, %v), want instance A", restored, ok)
-	}
-}
-
-func TestCreatePolarisListenerDoesNotRestoreOverNewerEmptyInitialSubscribeInstances(t *testing.T) {
-	serviceName := "com.test.ListenerFailureNewerEmptyService"
-	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	polarisRegistry := &polarisRegistry{
-		watchers:                  make(map[string]*PolarisServiceWatcher),
-		initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance),
-	}
-	notify := &recordingPolarisNotifyListener{}
-	key := newInitialSubscribeInstancesKey(serviceName, notify)
-	polarisRegistry.storeInitialSubscribeInstances(key, []model.Instance{instanceA})
-
-	_, err := polarisRegistry.createPolarisListener(serviceName, notify, func(*PolarisServiceWatcher, []model.Instance) (*polarisListener, error) {
-		polarisRegistry.storeInitialSubscribeInstances(key, nil)
-		return nil, errors.New("listener failed after newer empty load")
-	})
-	if err == nil {
-		t.Fatal("createPolarisListener() error = nil, want failure")
-	}
-	restored, ok := polarisRegistry.takeInitialSubscribeInstances(serviceName, notify)
-	if ok || len(restored) != 0 {
-		t.Fatalf("initial subscribe instances = (%v, %v), want newer empty load to win", restored, ok)
-	}
-}
-
-func TestLoadSubscribeInstancesClearsStaleEmptySnapshot(t *testing.T) {
-	serviceName := "com.test.EmptyInitialSnapshotService"
-	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	polarisRegistry := &polarisRegistry{
-		namespace:                 testPolarisNamespace,
-		consumer:                  &fakePolarisConsumer{},
-		initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance),
-	}
-	notify := &recordingPolarisNotifyListener{}
-	key := newInitialSubscribeInstancesKey(serviceName, notify)
-	polarisRegistry.storeInitialSubscribeInstances(key, []model.Instance{instanceA})
-
-	if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
-		t.Fatalf("LoadSubscribeInstances() error = %v", err)
-	}
-	snapshot, ok := polarisRegistry.takeInitialSubscribeInstances(serviceName, notify)
-	if ok || len(snapshot) != 0 {
-		t.Fatalf("takeInitialSubscribeInstances() = (%v, %v), want (empty, false)", snapshot, ok)
-	}
-}
-
-func TestPolarisRegistryInitialSnapshotUsesDefensiveCopy(t *testing.T) {
+func TestPolarisSnapshotsUseDefensiveCopies(t *testing.T) {
 	serviceName := "com.test.DefensiveCopyService"
 	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
 	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
-	polarisRegistry := &polarisRegistry{initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance)}
-	notify := &recordingPolarisNotifyListener{}
+
+	t.Run("subscriber initial snapshot", func(t *testing.T) {
+		watcher := newStoppedPolarisWatcher(t, nil)
+		notify := &recordingPolarisNotifyListener{}
+		initial := []model.Instance{instanceA}
+		watcher.addSubscriberWithInitialSnapshot(initial, notify.recordInstances)
+		initial[0] = instanceB
+		watcher.handleWatchSnapshot(nil)
+		want := []recordedPolarisEvent{{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"}}
+		assertPolarisEventsAddress(t, notify.events, want)
+	})
+
+	t.Run("watcher current state and callback slices", func(t *testing.T) {
+		watcher := newStoppedPolarisWatcher(t, nil)
+		watcher.addSubscriberWithInitialSnapshot(nil, func(_ remoting.EventType, instances []model.Instance) {
+			if len(instances) > 0 {
+				instances[0] = instanceB
+			}
+		})
+		current := []model.Instance{instanceA}
+		watcher.handleWatchSnapshot(current)
+		current[0] = instanceB
+
+		notify := &recordingPolarisNotifyListener{}
+		watcher.addSubscriberWithInitialSnapshot(nil, notify.recordInstances)
+		want := []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"}}
+		assertPolarisEventsAddress(t, notify.events, want)
+	})
+
+	t.Run("pending registry entry", func(t *testing.T) {
+		pr := newTestPolarisRegistry(nil)
+		key := newInitialSubscribeInstancesKey(serviceName, &recordingPolarisNotifyListener{})
+		input := []model.Instance{instanceA}
+		pr.storeInitialSubscribeInstances(key, input)
+		input[0] = instanceB
+
+		entry, pending := pr.loadInitialSubscribeInstances(key)
+		if entry == nil || len(pending) != 1 {
+			t.Fatalf("pending entry = (%p, %v), want one instance", entry, pending)
+		}
+		assertPolarisInstanceIdentity(t, pending[0], instanceA)
+	})
+}
+
+func TestPolarisUnsupportedNotifyListenerFallback(t *testing.T) {
+	serviceName := "com.test.UnsupportedNotifyListenerService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	consumer := &fakePolarisConsumer{instanceResponses: [][]model.Instance{{instanceA}}}
+	pr := newTestPolarisRegistry(consumer)
+	notify := unsupportedPolarisNotifyListener{}
+
+	if err := pr.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
+		t.Fatalf("LoadSubscribeInstances() error = %v", err)
+	}
 	key := newInitialSubscribeInstancesKey(serviceName, notify)
-
-	snapshot := []model.Instance{instanceA}
-	polarisRegistry.storeInitialSubscribeInstances(key, snapshot)
-	snapshot[0] = instanceB
-
-	stored, ok := polarisRegistry.takeInitialSubscribeInstances(serviceName, notify)
-	if !ok {
-		t.Fatal("takeInitialSubscribeInstances() ok = false, want true")
+	entry, instances := pr.loadInitialSubscribeInstances(key)
+	if entry == nil || key.notify != nil || len(instances) != 1 || instances[0].GetInstanceKey() != instanceA.GetInstanceKey() {
+		t.Fatalf("fallback entry = (%#v, %p, %v), want service-scoped instance A", key, entry, instances)
 	}
-	if len(stored) != 1 || stored[0].GetInstanceKey() != instanceA.GetInstanceKey() {
-		t.Fatalf("takeInitialSubscribeInstances() = %v, want instance A", stored)
+
+	watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
+	watcher.handleWatchSnapshot(nil)
+	listener, err := pr.createPolarisListener(serviceName, notify)
+	if err != nil {
+		t.Fatalf("createPolarisListener() error = %v", err)
 	}
+	defer closeTestPolarisListener(listener)
+	assertPolarisListenerEvent(t, listener, remoting.EventTypeDel, instanceA)
+	if entry, _ := pr.loadInitialSubscribeInstances(key); entry != nil {
+		t.Fatalf("fallback entry after listener success = %p, want nil", entry)
+	}
+}
+
+func newTestPolarisRegistry(consumer api.ConsumerAPI) *polarisRegistry {
+	return &polarisRegistry{
+		namespace: testPolarisNamespace,
+		consumer:  consumer,
+		watchers:  make(map[string]*PolarisServiceWatcher),
+	}
+}
+
+func assertPolarisAddSubscriberSignature(_ func(func(remoting.EventType, []model.Instance))) {}
+
+func closeTestPolarisListener(listener *polarisListener) {
+	listener.Close()
+	close(listener.events.In())
+	for range listener.events.Out() {
+	}
+}
+
+func mustStoppedRegistryWatcher(t *testing.T, pr *polarisRegistry, serviceName string) *PolarisServiceWatcher {
+	t.Helper()
+	watcher, err := pr.createPolarisWatcher(serviceName)
+	if err != nil {
+		t.Fatalf("createPolarisWatcher() error = %v", err)
+	}
+	watcher.execOnce.Do(func() {})
+	return watcher
 }
 
 func newStoppedPolarisWatcher(t *testing.T, consumer api.ConsumerAPI) *PolarisServiceWatcher {
@@ -763,12 +590,125 @@ func newStoppedPolarisWatcher(t *testing.T, consumer api.ConsumerAPI) *PolarisSe
 	return watcher
 }
 
-func assertPolarisListenerEvent(
+func assertPolarisListenerEvents(
 	t *testing.T,
 	listener *polarisListener,
+	events []recordedPolarisEvent,
+) []recordedPolarisEvent {
+	t.Helper()
+	actualEvents := make([]recordedPolarisEvent, 0, len(events))
+	for _, expected := range events {
+		select {
+		case value := <-listener.events.Out():
+			event, ok := value.(*config_center.ConfigChangeEvent)
+			if !ok {
+				t.Fatalf("listener event type = %T, want *config_center.ConfigChangeEvent", value)
+			}
+			instance, ok := event.Value.(model.Instance)
+			if !ok {
+				t.Fatalf("listener event value type = %T, want model.Instance", event.Value)
+			}
+			actual := recordedPolarisEventFromInstance(event.ConfigType, instance)
+			assertPolarisEventAddress(t, actual, expected)
+			actualEvents = append(actualEvents, actual)
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for listener event %#v", expected)
+		}
+	}
+	assertNoPolarisListenerEvent(t, listener)
+	return actualEvents
+}
+
+func recordedPolarisEventFromInstance(action remoting.EventType, instance model.Instance) recordedPolarisEvent {
+	return recordedPolarisEvent{
+		action:   action,
+		host:     instance.GetHost(),
+		port:     strconv.Itoa(int(instance.GetPort())),
+		id:       instance.GetId(),
+		revision: instance.GetMetadata()[testPolarisRevisionKey],
+	}
+}
+
+func assertPolarisEventsAddress(t *testing.T, actual, expected []recordedPolarisEvent) {
+	t.Helper()
+	if len(actual) != len(expected) {
+		t.Fatalf("event count = %d, want %d; events = %#v", len(actual), len(expected), actual)
+	}
+	for i := range expected {
+		assertPolarisEventAddress(t, actual[i], expected[i])
+	}
+}
+
+func assertPolarisEventAddress(t *testing.T, actual, expected recordedPolarisEvent) {
+	t.Helper()
+	if actual.action != expected.action || actual.host != expected.host || actual.port != expected.port {
+		t.Fatalf(
+			"event address = (action=%v host=%s port=%s), want (action=%v host=%s port=%s)",
+			actual.action,
+			actual.host,
+			actual.port,
+			expected.action,
+			expected.host,
+			expected.port,
+		)
+	}
+}
+
+func assertPolarisEventInstance(
+	t *testing.T,
+	actual recordedPolarisEvent,
 	action remoting.EventType,
-	instance model.Instance,
+	expected model.Instance,
 ) {
+	t.Helper()
+	want := recordedPolarisEventFromInstance(action, expected)
+	if actual != want {
+		t.Fatalf("event instance = %#v, want %#v", actual, want)
+	}
+}
+
+func assertPolarisInstanceIdentity(t *testing.T, actual, expected model.Instance) {
+	t.Helper()
+	if actual.GetInstanceKey() != expected.GetInstanceKey() ||
+		actual.GetId() != expected.GetId() ||
+		actual.GetMetadata()[testPolarisRevisionKey] != expected.GetMetadata()[testPolarisRevisionKey] {
+		t.Fatalf(
+			"instance = (key=%v id=%s revision=%s), want (key=%v id=%s revision=%s)",
+			actual.GetInstanceKey(),
+			actual.GetId(),
+			actual.GetMetadata()[testPolarisRevisionKey],
+			expected.GetInstanceKey(),
+			expected.GetId(),
+			expected.GetMetadata()[testPolarisRevisionKey],
+		)
+	}
+}
+
+func assertPolarisWatchRequest(
+	t *testing.T,
+	actual *api.WatchServiceRequest,
+	expected *api.WatchServiceRequest,
+	serviceName string,
+) {
+	t.Helper()
+	if actual == nil {
+		t.Fatal("WatchService() request is nil")
+	}
+	if actual.Key.Namespace != testPolarisNamespace || actual.Key.Service != serviceName {
+		t.Fatalf(
+			"WatchService() request key = (%s, %s), want (%s, %s)",
+			actual.Key.Namespace,
+			actual.Key.Service,
+			testPolarisNamespace,
+			serviceName,
+		)
+	}
+	if actual != expected {
+		t.Fatalf("WatchService() request = %p, want watcher subscribeParam %p", actual, expected)
+	}
+}
+
+func assertPolarisListenerEvent(t *testing.T, listener *polarisListener, action remoting.EventType, instance model.Instance) {
 	t.Helper()
 	select {
 	case value := <-listener.events.Out():
@@ -776,11 +716,8 @@ func assertPolarisListenerEvent(
 		if !ok {
 			t.Fatalf("listener event type = %T, want *config_center.ConfigChangeEvent", value)
 		}
-		actualInstance, ok := event.Value.(model.Instance)
-		if !ok {
-			t.Fatalf("listener event value type = %T, want model.Instance", event.Value)
-		}
-		if event.ConfigType != action || actualInstance.GetInstanceKey() != instance.GetInstanceKey() {
+		actual, ok := event.Value.(model.Instance)
+		if !ok || event.ConfigType != action || actual.GetInstanceKey() != instance.GetInstanceKey() {
 			t.Fatalf("listener event = %#v, want action=%v instance=%v", event, action, instance)
 		}
 	case <-time.After(time.Second):
@@ -793,7 +730,7 @@ func assertNoPolarisListenerEvent(t *testing.T, listener *polarisListener) {
 	select {
 	case event := <-listener.events.Out():
 		t.Fatalf("unexpected listener event: %#v", event)
-	case <-time.After(50 * time.Millisecond):
+	case <-time.After(20 * time.Millisecond):
 	}
 }
 
@@ -806,14 +743,10 @@ func newPolarisConsumerURL(serviceName string) *common.URL {
 }
 
 func newPolarisTestInstance(id string, host string, port uint32, serviceName string, valid bool) model.Instance {
-	metadata := map[string]string{
-		"interface": serviceName,
-		"path":      "/" + serviceName,
-	}
+	metadata := map[string]string{"interface": serviceName, "path": "/" + serviceName}
 	if !valid {
 		metadata = nil
 	}
-
 	instance := &namingpb.Instance{
 		Id:       &wrappers.StringValue{Value: id},
 		Host:     &wrappers.StringValue{Value: host},

--- a/registry/polaris/registry_test.go
+++ b/registry/polaris/registry_test.go
@@ -18,6 +18,7 @@
 package polaris
 
 import (
+	"errors"
 	"reflect"
 	"strconv"
 	"testing"
@@ -37,6 +38,7 @@ import (
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/config_center"
 	"dubbo.apache.org/dubbo-go/v3/registry"
 	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
@@ -45,13 +47,20 @@ const testPolarisNamespace = "test"
 
 type fakePolarisConsumer struct {
 	api.ConsumerAPI
-	instances      []model.Instance
-	watchInstances []model.Instance
-	watchCalls     int
+	instances         []model.Instance
+	instanceResponses [][]model.Instance
+	getCalls          int
+	watchInstances    []model.Instance
+	watchCalls        int
 }
 
 func (f *fakePolarisConsumer) GetInstances(_ *api.GetInstancesRequest) (*model.InstancesResponse, error) {
-	instances := append([]model.Instance(nil), f.instances...)
+	instances := f.instances
+	if f.getCalls < len(f.instanceResponses) {
+		instances = f.instanceResponses[f.getCalls]
+	}
+	f.getCalls++
+	instances = append([]model.Instance(nil), instances...)
 	return &model.InstancesResponse{Instances: instances}, nil
 }
 
@@ -77,6 +86,12 @@ type recordingPolarisNotifyListener struct {
 	events  []recordedPolarisEvent
 	eventCh chan recordedPolarisEvent
 }
+
+type nonComparablePolarisNotifyListener []recordedPolarisEvent
+
+func (nonComparablePolarisNotifyListener) Notify(*registry.ServiceEvent) {}
+
+func (nonComparablePolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
 
 func (r *recordingPolarisNotifyListener) Notify(event *registry.ServiceEvent) {
 	r.record(recordedPolarisEvent{
@@ -122,23 +137,24 @@ func TestPolarisSubscribeInitialSnapshotTransfer(t *testing.T) {
 	}
 	notify := &recordingPolarisNotifyListener{eventCh: make(chan recordedPolarisEvent, 3)}
 	polarisRegistry := &polarisRegistry{
-		namespace:        testPolarisNamespace,
-		consumer:         consumer,
-		watchers:         make(map[string]*PolarisServiceWatcher),
-		initialSnapshots: make(map[string][]model.Instance),
+		namespace:                 testPolarisNamespace,
+		consumer:                  consumer,
+		watchers:                  make(map[string]*PolarisServiceWatcher),
+		initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance),
 	}
 
 	if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
 		t.Fatalf("LoadSubscribeInstances() error = %v", err)
 	}
 
-	_, err := polarisRegistry.createPolarisListener(serviceName, func(watcher *PolarisServiceWatcher) (*polarisListener, error) {
+	_, err := polarisRegistry.createPolarisListener(serviceName, notify, func(watcher *PolarisServiceWatcher, initialSnapshot []model.Instance) (*polarisListener, error) {
 		resp, watchErr := watcher.consumer.WatchService(watcher.subscribeParam)
 		if watchErr != nil {
 			return nil, watchErr
 		}
-		watcher.subscribers = append(watcher.subscribers, notify.recordInstances)
-		watcher.handleInitialWatchSnapshot(resp.GetAllInstancesResp.Instances)
+		watcher.execOnce.Do(func() {})
+		watcher.addSubscriberWithInitialSnapshot(initialSnapshot, notify.recordInstances)
+		watcher.handleWatchSnapshot(resp.GetAllInstancesResp.Instances)
 		return &polarisListener{}, nil
 	})
 	if err != nil {
@@ -171,68 +187,112 @@ func TestPolarisSubscribeInitialSnapshotTransfer(t *testing.T) {
 
 func TestPolarisInitialSnapshotReconciliation(t *testing.T) {
 	serviceName := "com.test.InitialSnapshotService"
-	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
-	invalidInstance := newPolarisTestInstance("invalid", "10.0.0.9", 20009, serviceName, false)
-	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	instanceA := newPolarisTestInstance(
+		"instance-a",
+		"10.0.0.1",
+		20001,
+		serviceName,
+		true,
+	)
+	invalidInstance := newPolarisTestInstance(
+		"invalid",
+		"10.0.0.9",
+		20009,
+		serviceName,
+		false,
+	)
+	instanceB := newPolarisTestInstance(
+		"instance-b",
+		"10.0.0.2",
+		20002,
+		serviceName,
+		true,
+	)
 
-	tests := []struct {
-		name     string
-		current  []model.Instance
-		expected []recordedPolarisEvent
-	}{
-		{
-			name:    "A is replaced by B",
-			current: []model.Instance{instanceB},
-			expected: []recordedPolarisEvent{
-				{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
-				{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
-				{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
+	t.Run("A is replaced by B", func(t *testing.T) {
+		testPolarisInitialSnapshotReconciliation(
+			t,
+			serviceName,
+			instanceA,
+			invalidInstance,
+			[]model.Instance{instanceB},
+			[]recordedPolarisEvent{
+				{
+					action: remoting.EventTypeAdd,
+					host:   "10.0.0.1",
+					port:   "20001",
+				},
+				{
+					action: remoting.EventTypeDel,
+					host:   "10.0.0.1",
+					port:   "20001",
+				},
+				{
+					action: remoting.EventTypeAdd,
+					host:   "10.0.0.2",
+					port:   "20002",
+				},
 			},
-		},
-		{
-			name:    "first watcher snapshot is empty",
-			current: []model.Instance{},
-			expected: []recordedPolarisEvent{
-				{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
-				{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+		)
+	})
+
+	t.Run("first watcher snapshot is empty", func(t *testing.T) {
+		testPolarisInitialSnapshotReconciliation(
+			t,
+			serviceName,
+			instanceA,
+			invalidInstance,
+			nil,
+			[]recordedPolarisEvent{
+				{
+					action: remoting.EventTypeAdd,
+					host:   "10.0.0.1",
+					port:   "20001",
+				},
+				{
+					action: remoting.EventTypeDel,
+					host:   "10.0.0.1",
+					port:   "20001",
+				},
 			},
-		},
+		)
+	})
+}
+
+func testPolarisInitialSnapshotReconciliation(t *testing.T, serviceName string, instanceA model.Instance, invalidInstance model.Instance, current []model.Instance, expected []recordedPolarisEvent) {
+	t.Helper()
+
+	notify := &recordingPolarisNotifyListener{}
+	consumer := &fakePolarisConsumer{
+		instances: []model.Instance{instanceA, invalidInstance},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			notify := &recordingPolarisNotifyListener{}
-			consumer := &fakePolarisConsumer{instances: []model.Instance{instanceA, invalidInstance}}
-			polarisRegistry := &polarisRegistry{
-				namespace:        testPolarisNamespace,
-				consumer:         consumer,
-				initialSnapshots: make(map[string][]model.Instance),
-			}
+	polarisRegistry := &polarisRegistry{
+		namespace:                 testPolarisNamespace,
+		consumer:                  consumer,
+		initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance),
+	}
 
-			if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
-				t.Fatalf("LoadSubscribeInstances() error = %v", err)
-			}
+	if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
+		t.Fatalf("LoadSubscribeInstances() error = %v", err)
+	}
 
-			initial, ok := polarisRegistry.takeInitialSnapshot(serviceName)
-			if !ok {
-				t.Fatal("initial snapshot was not saved")
-			}
-			if len(initial) != 1 || initial[0].GetInstanceKey() != instanceA.GetInstanceKey() {
-				t.Fatalf("initial snapshot = %v, want only instance A", initial)
-			}
+	initial, ok := polarisRegistry.takeInitialSubscribeInstances(serviceName, notify)
+	if !ok {
+		t.Fatal("initial snapshot was not saved")
+	}
 
-			watcher, err := newPolarisWatcher(nil, consumer)
-			if err != nil {
-				t.Fatalf("newPolarisWatcher() error = %v", err)
-			}
-			watcher.setInitialSnapshot(initial)
-			watcher.subscribers = append(watcher.subscribers, notify.recordInstances)
-			watcher.handleInitialWatchSnapshot(tt.current)
+	if len(initial) != 1 ||
+		initial[0].GetInstanceKey() != instanceA.GetInstanceKey() {
+		t.Fatalf("initial snapshot = %v, want only instance A", initial)
+	}
 
-			if !reflect.DeepEqual(notify.events, tt.expected) {
-				t.Fatalf("events = %#v, want %#v", notify.events, tt.expected)
-			}
-		})
+	watcher := newStoppedPolarisWatcher(t, consumer)
+	watcher.addSubscriberWithInitialSnapshot(initial, notify.recordInstances)
+	watcher.handleWatchSnapshot(current)
+
+	if !reflect.DeepEqual(notify.events, expected) {
+		t.Fatalf("events = %#v, want %#v", notify.events, expected)
 	}
 }
 
@@ -266,30 +326,388 @@ func TestMissingInitialInstancesPreservesInitialOrder(t *testing.T) {
 	}
 }
 
-func TestPolarisWatcherInitialSnapshotConsumedOnce(t *testing.T) {
+func TestPolarisSubscriberInitialSnapshotReconciledOnce(t *testing.T) {
 	serviceName := "com.test.OneShotService"
 	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
 	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
-	watcher, err := newPolarisWatcher(nil, nil)
-	if err != nil {
-		t.Fatalf("newPolarisWatcher() error = %v", err)
-	}
+	watcher := newStoppedPolarisWatcher(t, nil)
+	notify := &recordingPolarisNotifyListener{}
 
 	snapshot := []model.Instance{instanceA}
-	watcher.setInitialSnapshot(snapshot)
+	watcher.addSubscriberWithInitialSnapshot(snapshot, notify.recordInstances)
 	snapshot[0] = instanceB
+	watcher.handleWatchSnapshot([]model.Instance{instanceB})
+	watcher.handleWatchSnapshot([]model.Instance{instanceB})
 
-	first, ok := watcher.takeInitialSnapshot()
-	if !ok {
-		t.Fatal("first takeInitialSnapshot() ok = false, want true")
+	expected := []recordedPolarisEvent{
+		{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+		{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
+		{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
 	}
-	if len(first) != 1 || first[0].GetInstanceKey() != instanceA.GetInstanceKey() {
-		t.Fatalf("first takeInitialSnapshot() = %v, want instance A", first)
+	if !reflect.DeepEqual(notify.events, expected) {
+		t.Fatalf("events = %#v, want %#v", notify.events, expected)
+	}
+	if len(watcher.subscribers) != 1 || !watcher.subscribers[0].reconciled || watcher.subscribers[0].initialSnapshot != nil {
+		t.Fatalf("subscriber state = %#v, want reconciled state with cleared baseline", watcher.subscribers)
+	}
+}
+
+func TestPolarisReusedWatcherReconcilesSecondSubscriberAfterDelete(t *testing.T) {
+	serviceName := "com.test.ReusedWatcherService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	consumer := &fakePolarisConsumer{instances: []model.Instance{instanceA}}
+	polarisRegistry := &polarisRegistry{
+		namespace:                 testPolarisNamespace,
+		consumer:                  consumer,
+		watchers:                  make(map[string]*PolarisServiceWatcher),
+		initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance),
 	}
 
-	watcher.setInitialSnapshot([]model.Instance{instanceB})
-	if second, ok := watcher.takeInitialSnapshot(); ok || len(second) != 0 {
-		t.Fatalf("second takeInitialSnapshot() = (%v, %v), want (empty, false)", second, ok)
+	watcher, err := polarisRegistry.createPolarisWatcher(serviceName)
+	if err != nil {
+		t.Fatalf("createPolarisWatcher() error = %v", err)
+	}
+	watcher.execOnce.Do(func() {})
+
+	firstNotify := &recordingPolarisNotifyListener{}
+	firstListener, err := polarisRegistry.createPolarisListener(serviceName, firstNotify, newPolarisListener)
+	if err != nil {
+		t.Fatalf("createPolarisListener(first) error = %v", err)
+	}
+	defer firstListener.Close()
+	if firstListener.watcher != watcher {
+		t.Fatal("first listener did not use the shared watcher")
+	}
+	watcher.handleWatchSnapshot([]model.Instance{instanceA})
+	assertPolarisListenerEvent(t, firstListener, remoting.EventTypeAdd, instanceA)
+
+	second := &recordingPolarisNotifyListener{}
+	if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), second); err != nil {
+		t.Fatalf("LoadSubscribeInstances() error = %v", err)
+	}
+	watcher.handleInstanceEvent(&model.InstanceEvent{
+		DeleteEvent: &model.InstanceDeleteEvent{Instances: []model.Instance{instanceA}},
+	})
+	assertPolarisListenerEvent(t, firstListener, remoting.EventTypeDel, instanceA)
+
+	if expected := []recordedPolarisEvent{
+		{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
+	}; !reflect.DeepEqual(second.events, expected) {
+		t.Fatalf("second subscriber events before joining = %#v, want %#v", second.events, expected)
+	}
+
+	secondListener, err := polarisRegistry.createPolarisListener(serviceName, second, newPolarisListener)
+	if err != nil {
+		t.Fatalf("createPolarisListener(second) error = %v", err)
+	}
+	defer secondListener.Close()
+	if secondListener.watcher != watcher {
+		t.Fatal("second listener did not reuse the shared watcher")
+	}
+	assertPolarisListenerEvent(t, secondListener, remoting.EventTypeDel, instanceA)
+
+	assertNoPolarisListenerEvent(t, firstListener)
+
+	watcher.handleWatchSnapshot(nil)
+	assertNoPolarisListenerEvent(t, secondListener)
+}
+
+func TestPolarisInitialSubscribeInstancesAreScopedToNotifyListener(t *testing.T) {
+	serviceName := "com.test.ListenerScopedBaselineService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	consumer := &fakePolarisConsumer{instanceResponses: [][]model.Instance{{instanceA}, {instanceB}}}
+	polarisRegistry := &polarisRegistry{
+		namespace: testPolarisNamespace,
+		consumer:  consumer,
+		watchers:  make(map[string]*PolarisServiceWatcher),
+	}
+	firstNotify := &recordingPolarisNotifyListener{}
+	secondNotify := &recordingPolarisNotifyListener{}
+	url := newPolarisConsumerURL(serviceName)
+
+	if err := polarisRegistry.LoadSubscribeInstances(url, firstNotify); err != nil {
+		t.Fatalf("LoadSubscribeInstances(first) error = %v", err)
+	}
+	if err := polarisRegistry.LoadSubscribeInstances(url, secondNotify); err != nil {
+		t.Fatalf("LoadSubscribeInstances(second) error = %v", err)
+	}
+
+	watcher, err := polarisRegistry.createPolarisWatcher(serviceName)
+	if err != nil {
+		t.Fatalf("createPolarisWatcher() error = %v", err)
+	}
+	watcher.execOnce.Do(func() {})
+	watcher.handleWatchSnapshot(nil)
+
+	firstListener, err := polarisRegistry.createPolarisListener(serviceName, firstNotify, newPolarisListener)
+	if err != nil {
+		t.Fatalf("createPolarisListener(first) error = %v", err)
+	}
+	defer firstListener.Close()
+	assertPolarisListenerEvent(t, firstListener, remoting.EventTypeDel, instanceA)
+
+	secondListener, err := polarisRegistry.createPolarisListener(serviceName, secondNotify, newPolarisListener)
+	if err != nil {
+		t.Fatalf("createPolarisListener(second) error = %v", err)
+	}
+	defer secondListener.Close()
+	assertPolarisListenerEvent(t, secondListener, remoting.EventTypeDel, instanceB)
+}
+
+func TestPolarisEmptyLoadDoesNotClearAnotherListenerBaseline(t *testing.T) {
+	serviceName := "com.test.ListenerScopedEmptyBaselineService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	consumer := &fakePolarisConsumer{instanceResponses: [][]model.Instance{{instanceA}, nil}}
+	polarisRegistry := &polarisRegistry{
+		namespace: testPolarisNamespace,
+		consumer:  consumer,
+		watchers:  make(map[string]*PolarisServiceWatcher),
+	}
+	firstNotify := &recordingPolarisNotifyListener{}
+	secondNotify := &recordingPolarisNotifyListener{}
+	url := newPolarisConsumerURL(serviceName)
+
+	if err := polarisRegistry.LoadSubscribeInstances(url, firstNotify); err != nil {
+		t.Fatalf("LoadSubscribeInstances(first) error = %v", err)
+	}
+	if err := polarisRegistry.LoadSubscribeInstances(url, secondNotify); err != nil {
+		t.Fatalf("LoadSubscribeInstances(second) error = %v", err)
+	}
+
+	watcher, err := polarisRegistry.createPolarisWatcher(serviceName)
+	if err != nil {
+		t.Fatalf("createPolarisWatcher() error = %v", err)
+	}
+	watcher.execOnce.Do(func() {})
+	watcher.handleWatchSnapshot(nil)
+
+	firstListener, err := polarisRegistry.createPolarisListener(serviceName, firstNotify, newPolarisListener)
+	if err != nil {
+		t.Fatalf("createPolarisListener(first) error = %v", err)
+	}
+	defer firstListener.Close()
+	assertPolarisListenerEvent(t, firstListener, remoting.EventTypeDel, instanceA)
+
+	secondListener, err := polarisRegistry.createPolarisListener(serviceName, secondNotify, newPolarisListener)
+	if err != nil {
+		t.Fatalf("createPolarisListener(second) error = %v", err)
+	}
+	defer secondListener.Close()
+	assertNoPolarisListenerEvent(t, secondListener)
+}
+
+func TestPolarisLoadSupportsNonComparableNotifyListener(t *testing.T) {
+	serviceName := "com.test.NonComparableNotifyListenerService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	consumer := &fakePolarisConsumer{instances: []model.Instance{instanceA}}
+	polarisRegistry := &polarisRegistry{namespace: testPolarisNamespace, consumer: consumer}
+	notify := nonComparablePolarisNotifyListener{}
+
+	if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
+		t.Fatalf("LoadSubscribeInstances() error = %v", err)
+	}
+	if consumer.getCalls != 1 {
+		t.Fatalf("GetInstances() calls = %d, want 1", consumer.getCalls)
+	}
+	stored, ok := polarisRegistry.takeInitialSubscribeInstances(serviceName, notify)
+	if !ok || len(stored) != 1 || stored[0].GetInstanceKey() != instanceA.GetInstanceKey() {
+		t.Fatalf("initial subscribe instances = (%v, %v), want instance A", stored, ok)
+	}
+}
+
+func TestPolarisInitialSubscribeInstancesStateClearedAfterListenerCreation(t *testing.T) {
+	serviceName := "com.test.InitialSubscribeInstancesCleanupService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	notify := &recordingPolarisNotifyListener{}
+	polarisRegistry := &polarisRegistry{
+		namespace: testPolarisNamespace,
+		consumer:  &fakePolarisConsumer{instances: []model.Instance{instanceA}},
+		watchers:  make(map[string]*PolarisServiceWatcher),
+	}
+	if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
+		t.Fatalf("LoadSubscribeInstances() error = %v", err)
+	}
+	watcher, err := polarisRegistry.createPolarisWatcher(serviceName)
+	if err != nil {
+		t.Fatalf("createPolarisWatcher() error = %v", err)
+	}
+	watcher.execOnce.Do(func() {})
+
+	listener, err := polarisRegistry.createPolarisListener(serviceName, notify, newPolarisListener)
+	if err != nil {
+		t.Fatalf("createPolarisListener() error = %v", err)
+	}
+	defer listener.Close()
+	if len(polarisRegistry.initialSubscribeInstances) != 0 || len(polarisRegistry.initialSubscribeVersions) != 0 {
+		t.Fatalf("initial subscribe instances state = (%d snapshots, %d versions), want empty", len(polarisRegistry.initialSubscribeInstances), len(polarisRegistry.initialSubscribeVersions))
+	}
+}
+
+func TestPolarisWatcherTracksIncrementalCurrentInstances(t *testing.T) {
+	serviceName := "com.test.IncrementalStateService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	instanceC := newPolarisTestInstance("instance-c", "10.0.0.3", 20003, serviceName, true)
+	replacementB := newPolarisTestInstance("replacement-b", "10.0.0.2", 20002, serviceName, true)
+	watcher := newStoppedPolarisWatcher(t, nil)
+	notify := &recordingPolarisNotifyListener{}
+	watcher.addSubscriberWithInitialSnapshot(nil, notify.recordInstances)
+	watcher.handleWatchSnapshot([]model.Instance{instanceA})
+
+	watcher.handleInstanceEvent(&model.InstanceEvent{
+		AddEvent: &model.InstanceAddEvent{Instances: []model.Instance{instanceB}},
+	})
+	watcher.handleInstanceEvent(&model.InstanceEvent{
+		UpdateEvent: &model.InstanceUpdateEvent{UpdateList: []model.OneInstanceUpdate{
+			{Before: instanceA, After: instanceC},
+			{Before: instanceB, After: replacementB},
+		}},
+	})
+	watcher.handleInstanceEvent(&model.InstanceEvent{
+		DeleteEvent: &model.InstanceDeleteEvent{Instances: []model.Instance{instanceC}},
+	})
+
+	if len(watcher.currentInstances) != 1 || watcher.currentInstances[0].GetId() != replacementB.GetId() {
+		t.Fatalf("currentInstances = %v, want only replacement B", watcher.currentInstances)
+	}
+	expectedEvents := []recordedPolarisEvent{
+		{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
+		{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
+		{action: remoting.EventTypeUpdate, host: "10.0.0.3", port: "20003"},
+		{action: remoting.EventTypeUpdate, host: "10.0.0.2", port: "20002"},
+		{action: remoting.EventTypeDel, host: "10.0.0.3", port: "20003"},
+	}
+	if !reflect.DeepEqual(notify.events, expectedEvents) {
+		t.Fatalf("incremental events = %#v, want %#v", notify.events, expectedEvents)
+	}
+
+}
+
+func TestPolarisAddSubscriberBeforeInitialSnapshotReceivesCurrentInstances(t *testing.T) {
+	serviceName := "com.test.AddSubscriberBeforeSnapshotService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	watcher := newStoppedPolarisWatcher(t, nil)
+	notify := &recordingPolarisNotifyListener{}
+
+	watcher.AddSubscriber(notify.recordInstances)
+	watcher.handleWatchSnapshot([]model.Instance{instanceA})
+
+	expected := []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"}}
+	if !reflect.DeepEqual(notify.events, expected) {
+		t.Fatalf("events = %#v, want %#v", notify.events, expected)
+	}
+}
+
+func TestPolarisAddSubscriberAfterInitialSnapshotDoesNotReplayCurrentInstances(t *testing.T) {
+	serviceName := "com.test.AddSubscriberAfterSnapshotService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	watcher := newStoppedPolarisWatcher(t, nil)
+	watcher.handleWatchSnapshot([]model.Instance{instanceA})
+	notify := &recordingPolarisNotifyListener{}
+
+	watcher.AddSubscriber(notify.recordInstances)
+	if len(notify.events) != 0 {
+		t.Fatalf("events after AddSubscriber() = %#v, want no replay", notify.events)
+	}
+
+	watcher.handleInstanceEvent(&model.InstanceEvent{
+		AddEvent: &model.InstanceAddEvent{Instances: []model.Instance{instanceB}},
+	})
+	expected := []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"}}
+	if !reflect.DeepEqual(notify.events, expected) {
+		t.Fatalf("events after incremental update = %#v, want %#v", notify.events, expected)
+	}
+}
+
+func TestNewPolarisListenerAfterInitialSnapshotDoesNotReplayCurrentInstances(t *testing.T) {
+	serviceName := "com.test.NewListenerAfterSnapshotService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	watcher := newStoppedPolarisWatcher(t, nil)
+	watcher.handleWatchSnapshot([]model.Instance{instanceA})
+
+	listener, err := NewPolarisListener(watcher)
+	if err != nil {
+		t.Fatalf("NewPolarisListener() error = %v", err)
+	}
+	defer listener.Close()
+	assertNoPolarisListenerEvent(t, listener)
+
+	watcher.handleInstanceEvent(&model.InstanceEvent{
+		AddEvent: &model.InstanceAddEvent{Instances: []model.Instance{instanceB}},
+	})
+	assertPolarisListenerEvent(t, listener, remoting.EventTypeAdd, instanceB)
+}
+
+func TestPolarisWatcherReplaysDefensiveCurrentSnapshot(t *testing.T) {
+	serviceName := "com.test.DefensiveCurrentSnapshotService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	watcher := newStoppedPolarisWatcher(t, nil)
+	watcher.addSubscriberWithInitialSnapshot(nil, func(_ remoting.EventType, instances []model.Instance) {
+		if len(instances) > 0 {
+			instances[0] = instanceB
+		}
+	})
+
+	current := []model.Instance{instanceA}
+	watcher.handleWatchSnapshot(current)
+	current[0] = instanceB
+
+	replayed := &recordingPolarisNotifyListener{}
+	watcher.addSubscriberWithInitialSnapshot(nil, replayed.recordInstances)
+	expected := []recordedPolarisEvent{{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"}}
+	if !reflect.DeepEqual(replayed.events, expected) {
+		t.Fatalf("replayed events = %#v, want %#v", replayed.events, expected)
+	}
+}
+
+func TestCreatePolarisListenerRestoresInitialSubscribeInstancesOnFailure(t *testing.T) {
+	serviceName := "com.test.ListenerFailureService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	polarisRegistry := &polarisRegistry{
+		watchers:                  make(map[string]*PolarisServiceWatcher),
+		initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance),
+	}
+	notify := &recordingPolarisNotifyListener{}
+	key := newInitialSubscribeInstancesKey(serviceName, notify)
+	polarisRegistry.storeInitialSubscribeInstances(key, []model.Instance{instanceA})
+
+	_, err := polarisRegistry.createPolarisListener(serviceName, notify, func(*PolarisServiceWatcher, []model.Instance) (*polarisListener, error) {
+		return nil, errors.New("listener failed")
+	})
+	if err == nil {
+		t.Fatal("createPolarisListener() error = nil, want failure")
+	}
+	restored, ok := polarisRegistry.takeInitialSubscribeInstances(serviceName, notify)
+	if !ok || len(restored) != 1 || restored[0].GetInstanceKey() != instanceA.GetInstanceKey() {
+		t.Fatalf("restored baseline = (%v, %v), want instance A", restored, ok)
+	}
+}
+
+func TestCreatePolarisListenerDoesNotRestoreOverNewerEmptyInitialSubscribeInstances(t *testing.T) {
+	serviceName := "com.test.ListenerFailureNewerEmptyService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	polarisRegistry := &polarisRegistry{
+		watchers:                  make(map[string]*PolarisServiceWatcher),
+		initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance),
+	}
+	notify := &recordingPolarisNotifyListener{}
+	key := newInitialSubscribeInstancesKey(serviceName, notify)
+	polarisRegistry.storeInitialSubscribeInstances(key, []model.Instance{instanceA})
+
+	_, err := polarisRegistry.createPolarisListener(serviceName, notify, func(*PolarisServiceWatcher, []model.Instance) (*polarisListener, error) {
+		polarisRegistry.storeInitialSubscribeInstances(key, nil)
+		return nil, errors.New("listener failed after newer empty load")
+	})
+	if err == nil {
+		t.Fatal("createPolarisListener() error = nil, want failure")
+	}
+	restored, ok := polarisRegistry.takeInitialSubscribeInstances(serviceName, notify)
+	if ok || len(restored) != 0 {
+		t.Fatalf("initial subscribe instances = (%v, %v), want newer empty load to win", restored, ok)
 	}
 }
 
@@ -297,17 +715,20 @@ func TestLoadSubscribeInstancesClearsStaleEmptySnapshot(t *testing.T) {
 	serviceName := "com.test.EmptyInitialSnapshotService"
 	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
 	polarisRegistry := &polarisRegistry{
-		namespace:        testPolarisNamespace,
-		consumer:         &fakePolarisConsumer{},
-		initialSnapshots: make(map[string][]model.Instance),
+		namespace:                 testPolarisNamespace,
+		consumer:                  &fakePolarisConsumer{},
+		initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance),
 	}
-	polarisRegistry.storeInitialSnapshot(serviceName, []model.Instance{instanceA})
+	notify := &recordingPolarisNotifyListener{}
+	key := newInitialSubscribeInstancesKey(serviceName, notify)
+	polarisRegistry.storeInitialSubscribeInstances(key, []model.Instance{instanceA})
 
-	if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), &recordingPolarisNotifyListener{}); err != nil {
+	if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
 		t.Fatalf("LoadSubscribeInstances() error = %v", err)
 	}
-	if snapshot, ok := polarisRegistry.takeInitialSnapshot(serviceName); ok || len(snapshot) != 0 {
-		t.Fatalf("takeInitialSnapshot() = (%v, %v), want (empty, false)", snapshot, ok)
+	snapshot, ok := polarisRegistry.takeInitialSubscribeInstances(serviceName, notify)
+	if ok || len(snapshot) != 0 {
+		t.Fatalf("takeInitialSubscribeInstances() = (%v, %v), want (empty, false)", snapshot, ok)
 	}
 }
 
@@ -315,18 +736,64 @@ func TestPolarisRegistryInitialSnapshotUsesDefensiveCopy(t *testing.T) {
 	serviceName := "com.test.DefensiveCopyService"
 	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
 	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
-	polarisRegistry := &polarisRegistry{initialSnapshots: make(map[string][]model.Instance)}
+	polarisRegistry := &polarisRegistry{initialSubscribeInstances: make(map[initialSubscribeInstancesKey][]model.Instance)}
+	notify := &recordingPolarisNotifyListener{}
+	key := newInitialSubscribeInstancesKey(serviceName, notify)
 
 	snapshot := []model.Instance{instanceA}
-	polarisRegistry.storeInitialSnapshot(serviceName, snapshot)
+	polarisRegistry.storeInitialSubscribeInstances(key, snapshot)
 	snapshot[0] = instanceB
 
-	stored, ok := polarisRegistry.takeInitialSnapshot(serviceName)
+	stored, ok := polarisRegistry.takeInitialSubscribeInstances(serviceName, notify)
 	if !ok {
-		t.Fatal("takeInitialSnapshot() ok = false, want true")
+		t.Fatal("takeInitialSubscribeInstances() ok = false, want true")
 	}
 	if len(stored) != 1 || stored[0].GetInstanceKey() != instanceA.GetInstanceKey() {
-		t.Fatalf("takeInitialSnapshot() = %v, want instance A", stored)
+		t.Fatalf("takeInitialSubscribeInstances() = %v, want instance A", stored)
+	}
+}
+
+func newStoppedPolarisWatcher(t *testing.T, consumer api.ConsumerAPI) *PolarisServiceWatcher {
+	t.Helper()
+	watcher, err := newPolarisWatcher(nil, consumer)
+	if err != nil {
+		t.Fatalf("newPolarisWatcher() error = %v", err)
+	}
+	watcher.execOnce.Do(func() {})
+	return watcher
+}
+
+func assertPolarisListenerEvent(
+	t *testing.T,
+	listener *polarisListener,
+	action remoting.EventType,
+	instance model.Instance,
+) {
+	t.Helper()
+	select {
+	case value := <-listener.events.Out():
+		event, ok := value.(*config_center.ConfigChangeEvent)
+		if !ok {
+			t.Fatalf("listener event type = %T, want *config_center.ConfigChangeEvent", value)
+		}
+		actualInstance, ok := event.Value.(model.Instance)
+		if !ok {
+			t.Fatalf("listener event value type = %T, want model.Instance", event.Value)
+		}
+		if event.ConfigType != action || actualInstance.GetInstanceKey() != instance.GetInstanceKey() {
+			t.Fatalf("listener event = %#v, want action=%v instance=%v", event, action, instance)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for action=%v instance=%v", action, instance)
+	}
+}
+
+func assertNoPolarisListenerEvent(t *testing.T, listener *polarisListener) {
+	t.Helper()
+	select {
+	case event := <-listener.events.Out():
+		t.Fatalf("unexpected listener event: %#v", event)
+	case <-time.After(50 * time.Millisecond):
 	}
 }
 

--- a/registry/polaris/registry_test.go
+++ b/registry/polaris/registry_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 )
 
 import (
@@ -44,12 +45,26 @@ const testPolarisNamespace = "test"
 
 type fakePolarisConsumer struct {
 	api.ConsumerAPI
-	instances []model.Instance
+	instances      []model.Instance
+	watchInstances []model.Instance
+	watchCalls     int
 }
 
 func (f *fakePolarisConsumer) GetInstances(_ *api.GetInstancesRequest) (*model.InstancesResponse, error) {
 	instances := append([]model.Instance(nil), f.instances...)
 	return &model.InstancesResponse{Instances: instances}, nil
+}
+
+func (f *fakePolarisConsumer) WatchService(_ *api.WatchServiceRequest) (*model.WatchServiceResponse, error) {
+	f.watchCalls++
+	eventChannel := make(chan model.SubScribeEvent)
+	close(eventChannel)
+	return &model.WatchServiceResponse{
+		EventChannel: eventChannel,
+		GetAllInstancesResp: &model.InstancesResponse{
+			Instances: append([]model.Instance(nil), f.watchInstances...),
+		},
+	}, nil
 }
 
 type recordedPolarisEvent struct {
@@ -59,11 +74,12 @@ type recordedPolarisEvent struct {
 }
 
 type recordingPolarisNotifyListener struct {
-	events []recordedPolarisEvent
+	events  []recordedPolarisEvent
+	eventCh chan recordedPolarisEvent
 }
 
 func (r *recordingPolarisNotifyListener) Notify(event *registry.ServiceEvent) {
-	r.events = append(r.events, recordedPolarisEvent{
+	r.record(recordedPolarisEvent{
 		action: event.Action,
 		host:   event.Service.Ip,
 		port:   event.Service.Port,
@@ -81,11 +97,75 @@ func (r *recordingPolarisNotifyListener) NotifyAll(events []*registry.ServiceEve
 
 func (r *recordingPolarisNotifyListener) recordInstances(action remoting.EventType, instances []model.Instance) {
 	for _, instance := range instances {
-		r.events = append(r.events, recordedPolarisEvent{
+		r.record(recordedPolarisEvent{
 			action: action,
 			host:   instance.GetHost(),
 			port:   strconv.Itoa(int(instance.GetPort())),
 		})
+	}
+}
+
+func (r *recordingPolarisNotifyListener) record(event recordedPolarisEvent) {
+	r.events = append(r.events, event)
+	if r.eventCh != nil {
+		r.eventCh <- event
+	}
+}
+
+func TestPolarisSubscribeInitialSnapshotTransfer(t *testing.T) {
+	serviceName := "com.test.SubscribeSnapshotTransferService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	consumer := &fakePolarisConsumer{
+		instances:      []model.Instance{instanceA},
+		watchInstances: []model.Instance{instanceB},
+	}
+	notify := &recordingPolarisNotifyListener{eventCh: make(chan recordedPolarisEvent, 3)}
+	polarisRegistry := &polarisRegistry{
+		namespace:        testPolarisNamespace,
+		consumer:         consumer,
+		watchers:         make(map[string]*PolarisServiceWatcher),
+		initialSnapshots: make(map[string][]model.Instance),
+	}
+
+	if err := polarisRegistry.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
+		t.Fatalf("LoadSubscribeInstances() error = %v", err)
+	}
+
+	_, err := polarisRegistry.createPolarisListener(serviceName, func(watcher *PolarisServiceWatcher) (*polarisListener, error) {
+		resp, watchErr := watcher.consumer.WatchService(watcher.subscribeParam)
+		if watchErr != nil {
+			return nil, watchErr
+		}
+		watcher.subscribers = append(watcher.subscribers, notify.recordInstances)
+		watcher.handleInitialWatchSnapshot(resp.GetAllInstancesResp.Instances)
+		return &polarisListener{}, nil
+	})
+	if err != nil {
+		t.Fatalf("createPolarisListener() error = %v", err)
+	}
+	if consumer.watchCalls != 1 {
+		t.Fatalf("WatchService() calls = %d, want 1", consumer.watchCalls)
+	}
+
+	expected := []recordedPolarisEvent{
+		{action: remoting.EventTypeAdd, host: "10.0.0.1", port: "20001"},
+		{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+		{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
+	}
+	actual := make([]recordedPolarisEvent, 0, len(expected))
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	for range expected {
+		select {
+		case event := <-notify.eventCh:
+			actual = append(actual, event)
+		case <-timer.C:
+			t.Fatalf("timed out waiting for events, got %#v", actual)
+		}
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("events = %#v, want %#v", actual, expected)
 	}
 }
 

--- a/registry/polaris/registry_test.go
+++ b/registry/polaris/registry_test.go
@@ -110,7 +110,7 @@ type unsupportedFuncPolarisNotifyListener func()
 type unsupportedChanPolarisNotifyListener chan struct{}
 
 type unsupportedStructPolarisNotifyListener struct {
-	events []recordedPolarisEvent
+	_ []recordedPolarisEvent
 }
 
 type runtimeUnhashablePolarisNotifyListener struct {

--- a/registry/polaris/registry_test.go
+++ b/registry/polaris/registry_test.go
@@ -19,8 +19,10 @@ package polaris
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 )
@@ -101,9 +103,62 @@ type recordingPolarisNotifyListener struct {
 
 type unsupportedPolarisNotifyListener []recordedPolarisEvent
 
+type unsupportedMapPolarisNotifyListener map[string]int
+
+type unsupportedFuncPolarisNotifyListener func()
+
+type unsupportedChanPolarisNotifyListener chan struct{}
+
+type unsupportedStructPolarisNotifyListener struct {
+	events []recordedPolarisEvent
+}
+
+type runtimeUnhashablePolarisNotifyListener struct {
+	state any
+}
+
+type comparableValuePolarisNotifyListener struct {
+	id       int
+	recorder *recordingPolarisNotifyListener
+}
+
+type nilablePolarisNotifyListener struct{}
+
 func (unsupportedPolarisNotifyListener) Notify(*registry.ServiceEvent) {}
 
 func (unsupportedPolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
+
+func (unsupportedMapPolarisNotifyListener) Notify(*registry.ServiceEvent) {}
+
+func (unsupportedMapPolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
+
+func (unsupportedFuncPolarisNotifyListener) Notify(*registry.ServiceEvent) {}
+
+func (unsupportedFuncPolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
+
+func (unsupportedChanPolarisNotifyListener) Notify(*registry.ServiceEvent) {}
+
+func (unsupportedChanPolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
+
+func (unsupportedStructPolarisNotifyListener) Notify(*registry.ServiceEvent) {}
+
+func (unsupportedStructPolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
+
+func (runtimeUnhashablePolarisNotifyListener) Notify(*registry.ServiceEvent) {}
+
+func (runtimeUnhashablePolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
+
+func (l comparableValuePolarisNotifyListener) Notify(event *registry.ServiceEvent) {
+	l.recorder.Notify(event)
+}
+
+func (l comparableValuePolarisNotifyListener) NotifyAll(events []*registry.ServiceEvent, callback func()) {
+	l.recorder.NotifyAll(events, callback)
+}
+
+func (*nilablePolarisNotifyListener) Notify(*registry.ServiceEvent) {}
+
+func (*nilablePolarisNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
 
 func (r *recordingPolarisNotifyListener) Notify(event *registry.ServiceEvent) {
 	r.record(
@@ -321,11 +376,11 @@ func TestPolarisInitialSubscribeInstancesAreListenerScoped(t *testing.T) {
 		t.Fatalf("LoadSubscribeInstances(first empty) error = %v", err)
 	}
 
-	firstKey := newInitialSubscribeInstancesKey(serviceName, firstNotify)
+	firstKey := mustInitialSubscribeInstancesKey(t, serviceName, firstNotify)
 	if entry, instances := pr.loadInitialSubscribeInstances(firstKey); entry != nil || len(instances) != 0 {
 		t.Fatalf("first pending entry = (%p, %v), want empty", entry, instances)
 	}
-	secondKey := newInitialSubscribeInstancesKey(serviceName, secondNotify)
+	secondKey := mustInitialSubscribeInstancesKey(t, serviceName, secondNotify)
 	secondEntry, instances := pr.loadInitialSubscribeInstances(secondKey)
 	if secondEntry == nil || len(instances) != 1 || instances[0].GetInstanceKey() != instanceB.GetInstanceKey() {
 		t.Fatalf("second pending entry = (%p, %v), want instance B", secondEntry, instances)
@@ -351,6 +406,68 @@ func TestPolarisInitialSubscribeInstancesAreListenerScoped(t *testing.T) {
 	remaining, remainingInstances := pr.loadInitialSubscribeInstances(secondKey)
 	if remaining != newEntry || len(remainingInstances) != 1 || remainingInstances[0].GetInstanceKey() != instanceB.GetInstanceKey() {
 		t.Fatalf("newer pending entry = (%p, %v), want preserved instance B", remaining, remainingInstances)
+	}
+}
+
+func TestPolarisComparableValueNotifyListenersKeepIndependentBaselines(t *testing.T) {
+	serviceName := "com.test.ComparableValueListenerService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	consumer := &fakePolarisConsumer{instanceResponses: [][]model.Instance{{instanceA}, {instanceB}}}
+	pr := newTestPolarisRegistry(consumer)
+	recorder1 := &recordingPolarisNotifyListener{}
+	recorder2 := &recordingPolarisNotifyListener{}
+	listener1 := comparableValuePolarisNotifyListener{id: 1, recorder: recorder1}
+	listener2 := comparableValuePolarisNotifyListener{id: 2, recorder: recorder2}
+	url := newPolarisConsumerURL(serviceName)
+
+	if err := pr.LoadSubscribeInstances(url, listener1); err != nil {
+		t.Fatalf("LoadSubscribeInstances(listener1) error = %v", err)
+	}
+	if err := pr.LoadSubscribeInstances(url, listener2); err != nil {
+		t.Fatalf("LoadSubscribeInstances(listener2) error = %v", err)
+	}
+	if len(pr.initialSubscribeInstances) != 2 {
+		t.Errorf("pending entry count = %d, want 2", len(pr.initialSubscribeInstances))
+	}
+
+	key1 := mustInitialSubscribeInstancesKey(t, serviceName, listener1)
+	key2 := mustInitialSubscribeInstancesKey(t, serviceName, listener2)
+	entry1, pending1 := pr.loadInitialSubscribeInstances(key1)
+	entry2, pending2 := pr.loadInitialSubscribeInstances(key2)
+	if entry1 == nil || len(pending1) != 1 || pending1[0].GetInstanceKey() != instanceA.GetInstanceKey() {
+		t.Errorf("listener1 pending entry = (%p, %v), want instance A", entry1, pending1)
+	}
+	if entry2 == nil || len(pending2) != 1 || pending2[0].GetInstanceKey() != instanceB.GetInstanceKey() {
+		t.Errorf("listener2 pending entry = (%p, %v), want instance B", entry2, pending2)
+	}
+
+	watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
+	watcher.handleWatchSnapshot([]model.Instance{instanceB})
+	polarisListener1, err := pr.createPolarisListener(serviceName, listener1)
+	if err != nil {
+		t.Fatalf("createPolarisListener(listener1) error = %v", err)
+	}
+	defer closeTestPolarisListener(polarisListener1)
+	assertPolarisListenerEvents(t, polarisListener1, []recordedPolarisEvent{
+		{action: remoting.EventTypeDel, host: "10.0.0.1", port: "20001"},
+		{action: remoting.EventTypeAdd, host: "10.0.0.2", port: "20002"},
+	})
+	if pending, _ := pr.loadInitialSubscribeInstances(key1); pending != nil {
+		t.Errorf("listener1 pending entry after listener success = %p, want nil", pending)
+	}
+	if pending, instances := pr.loadInitialSubscribeInstances(key2); pending != entry2 || len(instances) != 1 || instances[0].GetInstanceKey() != instanceB.GetInstanceKey() {
+		t.Errorf("listener2 pending entry = (%p, %v), want preserved instance B", pending, instances)
+	}
+
+	polarisListener2, err := pr.createPolarisListener(serviceName, listener2)
+	if err != nil {
+		t.Fatalf("createPolarisListener(listener2) error = %v", err)
+	}
+	defer closeTestPolarisListener(polarisListener2)
+	assertPolarisListenerEvent(t, polarisListener2, remoting.EventTypeAdd, instanceB)
+	if pending, _ := pr.loadInitialSubscribeInstances(key2); pending != nil {
+		t.Errorf("listener2 pending entry after listener success = %p, want nil", pending)
 	}
 }
 
@@ -433,6 +550,104 @@ func TestPolarisWatcherTracksCurrentState(t *testing.T) {
 	}
 }
 
+func TestPolarisWatcherClearsRemovedInstanceReferences(t *testing.T) {
+	serviceName := "com.test.ClearRemovedReferencesService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	instanceB := newPolarisTestInstance("instance-b", "10.0.0.2", 20002, serviceName, true)
+	instanceC := newPolarisTestInstance("instance-c", "10.0.0.3", 20003, serviceName, true)
+	missing := newPolarisTestInstance("missing", "10.0.0.9", 20009, serviceName, true)
+
+	t.Run("partial delete clears tail and preserves notification", func(t *testing.T) {
+		watcher := newStoppedPolarisWatcher(t, nil)
+		watcher.handleWatchSnapshot([]model.Instance{instanceA, instanceB, instanceC})
+		backing := watcher.currentInstances
+		notify := &recordingPolarisNotifyListener{}
+		watcher.AddSubscriber(notify.recordInstances)
+
+		watcher.handleInstanceEvent(&model.InstanceEvent{
+			DeleteEvent: &model.InstanceDeleteEvent{Instances: []model.Instance{instanceB, instanceC}},
+		})
+
+		if len(watcher.currentInstances) != 1 {
+			t.Fatalf("current instance count = %d, want 1", len(watcher.currentInstances))
+		}
+		assertPolarisInstanceIdentity(t, watcher.currentInstances[0], instanceA)
+		if &watcher.currentInstances[0] != &backing[0] {
+			t.Fatal("current instances did not reuse the original backing array")
+		}
+		for i, instance := range backing[len(watcher.currentInstances):] {
+			if instance != nil {
+				t.Errorf("removed backing slot %d = %v, want nil", i+len(watcher.currentInstances), instance)
+			}
+		}
+		assertPolarisEventsAddress(t, notify.events, []recordedPolarisEvent{
+			{action: remoting.EventTypeDel, host: "10.0.0.2", port: "20002"},
+			{action: remoting.EventTypeDel, host: "10.0.0.3", port: "20003"},
+		})
+	})
+
+	t.Run("delete all clears every slot", func(t *testing.T) {
+		watcher := newStoppedPolarisWatcher(t, nil)
+		watcher.handleWatchSnapshot([]model.Instance{instanceA, instanceB, instanceC})
+		backing := watcher.currentInstances
+
+		watcher.removeCurrentInstancesLocked([]model.Instance{instanceA, instanceB, instanceC})
+
+		if len(watcher.currentInstances) != 0 {
+			t.Fatalf("current instance count = %d, want 0", len(watcher.currentInstances))
+		}
+		for i, instance := range backing {
+			if instance != nil {
+				t.Errorf("removed backing slot %d = %v, want nil", i, instance)
+			}
+		}
+	})
+
+	t.Run("delete missing instance preserves order and storage", func(t *testing.T) {
+		watcher := newStoppedPolarisWatcher(t, nil)
+		watcher.handleWatchSnapshot([]model.Instance{instanceA, instanceB, instanceC})
+		backing := watcher.currentInstances
+
+		watcher.removeCurrentInstancesLocked([]model.Instance{missing})
+
+		if len(watcher.currentInstances) != 3 {
+			t.Fatalf("current instance count = %d, want 3", len(watcher.currentInstances))
+		}
+		for i, want := range []model.Instance{instanceA, instanceB, instanceC} {
+			assertPolarisInstanceIdentity(t, watcher.currentInstances[i], want)
+		}
+		if &watcher.currentInstances[0] != &backing[0] {
+			t.Fatal("current instances did not preserve the original backing array")
+		}
+	})
+
+	t.Run("empty removal preserves current instances", func(t *testing.T) {
+		watcher := newStoppedPolarisWatcher(t, nil)
+		watcher.handleWatchSnapshot([]model.Instance{instanceA, instanceB})
+		backing := watcher.currentInstances
+
+		watcher.removeCurrentInstancesLocked(nil)
+
+		if len(watcher.currentInstances) != 2 {
+			t.Fatalf("current instance count = %d, want 2", len(watcher.currentInstances))
+		}
+		assertPolarisInstanceIdentity(t, watcher.currentInstances[0], instanceA)
+		assertPolarisInstanceIdentity(t, watcher.currentInstances[1], instanceB)
+		if &watcher.currentInstances[0] != &backing[0] {
+			t.Fatal("current instances did not preserve the original backing array")
+		}
+	})
+
+	t.Run("empty current instances is safe", func(t *testing.T) {
+		watcher := newStoppedPolarisWatcher(t, nil)
+		watcher.removeCurrentInstancesLocked([]model.Instance{instanceA})
+		watcher.removeCurrentInstancesLocked(nil)
+		if len(watcher.currentInstances) != 0 {
+			t.Fatalf("current instance count = %d, want 0", len(watcher.currentInstances))
+		}
+	})
+}
+
 func TestPolarisApplicationSubscriberCompatibility(t *testing.T) {
 	serviceName := "com.test.ApplicationSubscriberService"
 	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
@@ -511,7 +726,7 @@ func TestPolarisSnapshotsUseDefensiveCopies(t *testing.T) {
 
 	t.Run("pending registry entry", func(t *testing.T) {
 		pr := newTestPolarisRegistry(nil)
-		key := newInitialSubscribeInstancesKey(serviceName, &recordingPolarisNotifyListener{})
+		key := mustInitialSubscribeInstancesKey(t, serviceName, &recordingPolarisNotifyListener{})
 		input := []model.Instance{instanceA}
 		pr.storeInitialSubscribeInstances(key, input)
 		input[0] = instanceB
@@ -524,20 +739,98 @@ func TestPolarisSnapshotsUseDefensiveCopies(t *testing.T) {
 	})
 }
 
-func TestPolarisUnsupportedNotifyListenerFallback(t *testing.T) {
-	serviceName := "com.test.UnsupportedNotifyListenerService"
+func TestPolarisRejectsInvalidNotifyListenerIdentities(t *testing.T) {
+	serviceName := "com.test.InvalidNotifyListenerService"
+	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
+	var typedNil *nilablePolarisNotifyListener
+	var nilSlice unsupportedPolarisNotifyListener
+	var nilMap unsupportedMapPolarisNotifyListener
+	var nilFunc unsupportedFuncPolarisNotifyListener
+	var nilChan unsupportedChanPolarisNotifyListener
+	tests := []struct {
+		name          string
+		notify        registry.NotifyListener
+		withInstances bool
+	}{
+		{name: "nil interface", notify: nil},
+		{name: "typed nil pointer", notify: typedNil, withInstances: true},
+		{name: "typed nil slice", notify: nilSlice, withInstances: true},
+		{name: "typed nil map", notify: nilMap, withInstances: true},
+		{name: "typed nil func", notify: nilFunc, withInstances: true},
+		{name: "typed nil chan", notify: nilChan, withInstances: true},
+		{name: "non-comparable slice", notify: unsupportedPolarisNotifyListener{}, withInstances: true},
+		{name: "non-comparable map", notify: unsupportedMapPolarisNotifyListener{}, withInstances: true},
+		{name: "non-comparable func", notify: unsupportedFuncPolarisNotifyListener(func() {}), withInstances: true},
+		{name: "non-comparable struct", notify: unsupportedStructPolarisNotifyListener{}, withInstances: true},
+		{
+			name:          "runtime-unhashable interface field",
+			notify:        runtimeUnhashablePolarisNotifyListener{state: []int{1}},
+			withInstances: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+" load", func(t *testing.T) {
+			var responses [][]model.Instance
+			if tt.withInstances {
+				responses = [][]model.Instance{{instanceA}}
+			}
+			consumer := &fakePolarisConsumer{instanceResponses: responses}
+			pr := newTestPolarisRegistry(consumer)
+			err := callPolarisRegistryWithoutPanic(t, func() error {
+				return pr.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), tt.notify)
+			})
+			if err == nil {
+				t.Errorf("LoadSubscribeInstances() error = nil, want invalid listener error")
+			} else if listenerType := fmt.Sprintf("%T", tt.notify); !strings.Contains(err.Error(), listenerType) {
+				t.Errorf("LoadSubscribeInstances() error = %q, want listener type %q", err, listenerType)
+			}
+			if consumer.getCalls != 0 {
+				t.Errorf("GetInstances() calls = %d, want 0", consumer.getCalls)
+			}
+			if len(pr.initialSubscribeInstances) != 0 {
+				t.Errorf("pending entry count = %d, want 0", len(pr.initialSubscribeInstances))
+			}
+		})
+
+		t.Run(tt.name+" create listener", func(t *testing.T) {
+			pr := newTestPolarisRegistry(nil)
+			mustStoppedRegistryWatcher(t, pr, serviceName)
+			var listener *polarisListener
+			err := callPolarisRegistryWithoutPanic(t, func() error {
+				var createErr error
+				listener, createErr = pr.createPolarisListener(serviceName, tt.notify)
+				return createErr
+			})
+			if listener != nil {
+				closeTestPolarisListener(listener)
+			}
+			if err == nil {
+				t.Errorf("createPolarisListener() error = nil, want invalid listener error")
+			} else if listenerType := fmt.Sprintf("%T", tt.notify); !strings.Contains(err.Error(), listenerType) {
+				t.Errorf("createPolarisListener() error = %q, want listener type %q", err, listenerType)
+			}
+			if len(pr.initialSubscribeInstances) != 0 {
+				t.Errorf("pending entry count = %d, want 0", len(pr.initialSubscribeInstances))
+			}
+		})
+	}
+}
+
+func TestPolarisPointerNotifyListenerKeepsBaseline(t *testing.T) {
+	serviceName := "com.test.PointerNotifyListenerService"
 	instanceA := newPolarisTestInstance("instance-a", "10.0.0.1", 20001, serviceName, true)
 	consumer := &fakePolarisConsumer{instanceResponses: [][]model.Instance{{instanceA}}}
 	pr := newTestPolarisRegistry(consumer)
-	notify := unsupportedPolarisNotifyListener{}
+	notify := &recordingPolarisNotifyListener{}
 
 	if err := pr.LoadSubscribeInstances(newPolarisConsumerURL(serviceName), notify); err != nil {
 		t.Fatalf("LoadSubscribeInstances() error = %v", err)
 	}
-	key := newInitialSubscribeInstancesKey(serviceName, notify)
+	key := mustInitialSubscribeInstancesKey(t, serviceName, notify)
 	entry, instances := pr.loadInitialSubscribeInstances(key)
-	if entry == nil || key.notify != nil || len(instances) != 1 || instances[0].GetInstanceKey() != instanceA.GetInstanceKey() {
-		t.Fatalf("fallback entry = (%#v, %p, %v), want service-scoped instance A", key, entry, instances)
+	if entry == nil || len(instances) != 1 || instances[0].GetInstanceKey() != instanceA.GetInstanceKey() {
+		t.Fatalf("pointer listener pending entry = (%p, %v), want instance A", entry, instances)
 	}
 
 	watcher := mustStoppedRegistryWatcher(t, pr, serviceName)
@@ -548,8 +841,8 @@ func TestPolarisUnsupportedNotifyListenerFallback(t *testing.T) {
 	}
 	defer closeTestPolarisListener(listener)
 	assertPolarisListenerEvent(t, listener, remoting.EventTypeDel, instanceA)
-	if entry, _ := pr.loadInitialSubscribeInstances(key); entry != nil {
-		t.Fatalf("fallback entry after listener success = %p, want nil", entry)
+	if pending, _ := pr.loadInitialSubscribeInstances(key); pending != nil {
+		t.Fatalf("pointer listener pending entry after listener success = %p, want nil", pending)
 	}
 }
 
@@ -559,6 +852,29 @@ func newTestPolarisRegistry(consumer api.ConsumerAPI) *polarisRegistry {
 		consumer:  consumer,
 		watchers:  make(map[string]*PolarisServiceWatcher),
 	}
+}
+
+func callPolarisRegistryWithoutPanic(t *testing.T, call func() error) (err error) {
+	t.Helper()
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			t.Errorf("registry call panicked: %v", recovered)
+		}
+	}()
+	return call()
+}
+
+func mustInitialSubscribeInstancesKey(
+	t *testing.T,
+	serviceName string,
+	notify registry.NotifyListener,
+) initialSubscribeInstancesKey {
+	t.Helper()
+	key, err := newInitialSubscribeInstancesKey(serviceName, notify)
+	if err != nil {
+		t.Fatalf("newInitialSubscribeInstancesKey() error = %v", err)
+	}
+	return key
 }
 
 func assertPolarisAddSubscriberSignature(_ func(func(remoting.EventType, []model.Instance))) {}


### PR DESCRIPTION
### Description
Fixes #3480

This PR fixes a potential stale provider issue in the Polaris interface-level registry path.

`LoadSubscribeInstances` synchronously loads the initial provider instances and notifies `RegistryDirectory` with incremental `ADD` events. Later, the first successful `WatchService` response contains the current full instance snapshot, but the existing implementation also forwards it only as incremental `ADD` events.

If provider A is loaded synchronously and disappears or is replaced by provider B before the watcher is established, the directory receives:

```
LoadSubscribeInstances: [A] -> ADD(A)
WatchService snapshot:  [B] -> ADD(B)
```

The fix stores the valid instances notified by `LoadSubscribeInstances` as a per-service initial snapshot and transfers it to the corresponding `PolarisServiceWatcher` before listener creation can start the watcher.

When the first successful `WatchService` full snapshot arrives, the watcher compares it with the initial snapshot using `model.InstanceKey`. Instances present in the initial snapshot but absent from the current snapshot emit `DEL` events first, after which the current instances continue to be published as `ADD` events.

For example:
```
Initial snapshot: [A]
First watcher snapshot: [B]
Emitted events: DEL(A), ADD(B)
```

The initial snapshot is consumed only once. Failed `WatchService` attempts do not consume it, and the existing add, update, delete, and reconnect behavior after the first successful snapshot remains unchanged.

This change is limited to the Polaris interface-level registry path and does not affect the application-level service discovery path.

This PR also adds regression tests covering:

- the initial provider A being replaced by B;
- an empty first watcher snapshot removing the initial provider;
- the production snapshot-transfer path before listener creation;
- identical instance keys with different Polaris instance IDs;
- one-time snapshot consumption;
- invalid instances not entering the initial baseline;
- empty loads clearing stale baselines;
- defensive copying of registry and watcher snapshots;
- stable ordering of generated delete events.

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
