### PR TITLE
style: clean up minor review issues

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -138,8 +138,8 @@ func (conf *InmemoryConfiguration) GetSubProperty(subKey string) map[string]stru
 	conf.store.Range(func(key, _ any) bool {
 		if idx := strings.Index(key.(string), subKey); idx >= 0 {
 			after := key.(string)[idx+len(subKey):]
-			if found := strings.Contains(after, "."); found {
-				properties[after[0:strings.Index(after, ".")]] = struct{}{}
+			if idx := strings.Index(after, "."); idx >= 0 {
+				properties[after[0:idx]] = struct{}{}
 			}
 
 		}

--- a/remoting/exchange_test.go
+++ b/remoting/exchange_test.go
@@ -43,7 +43,7 @@ func TestSequenceIDConcurrent(t *testing.T) {
 	var wg sync.WaitGroup
 	ids := make(chan int64, 50)
 	for range 50 {
-		wg.Go(func() { ; ids <- SequenceID() })
+		wg.Go(func() { ids <- SequenceID() })
 	}
 	wg.Wait()
 	close(ids)


### PR DESCRIPTION
## What changed

Follow-up to #3471.

- Avoid scanning the same suffix twice in \\GetSubProperty\\ by reusing the \\strings.Index\\ result.
- Remove an unnecessary blank statement from \\TestSequenceIDConcurrent\\.

## Verification

- \\gofmt -w common/config/environment.go remoting/exchange_test.go\\
- \\go test ./common/config ./remoting -count=1\\
- \\go vet ./common/config ./remoting\\
- \\git diff --check\\
- \\wsl bash -lc 'cd /mnt/d/test/github/dubbo-go && go test ./common/config ./remoting -count=1'\\

Note: I also started \\go test ./... -count=1\\; it ran through many packages without failures but was interrupted after several minutes of no output, so it is not listed as a passing verification.

Co-authored-by: OmX <omx@oh-my-codex.dev>