### PR TITLE
perf(common): optimize IsEquals and ToMap to reduce allocations

### DIFF
--- a/common/url.go
+++ b/common/url.go
@@ -909,7 +909,34 @@ func (c *URL) SetParams(m url.Values) {
 
 // ToMap transfer URL to Map
 func (c *URL) ToMap() map[string]string {
-	paramsMap := make(map[string]string)
+	// Pre-calculate capacity to avoid map growth
+	c.paramsLock.RLock()
+	paramCount := len(c.params)
+	c.paramsLock.RUnlock()
+
+	// Count non-empty scalar fields
+	capacity := paramCount
+	if c.Protocol != "" {
+		capacity++
+	}
+	if c.Username != "" {
+		capacity++
+	}
+	if c.Password != "" {
+		capacity++
+	}
+	if c.Location != "" {
+		capacity += 2 // host + port
+	}
+	if c.Path != "" {
+		capacity++
+	}
+
+	if capacity == 0 {
+		return nil
+	}
+
+	paramsMap := make(map[string]string, capacity)
 
 	c.RangeParams(
 		func(key, value string) bool {
@@ -928,23 +955,17 @@ func (c *URL) ToMap() map[string]string {
 		paramsMap["password"] = c.Password
 	}
 	if c.Location != "" {
-		paramsMap["host"] = strings.Split(c.Location, ":")[0]
-		var port string
-		if strings.Contains(c.Location, ":") {
-			port = strings.Split(c.Location, ":")[1]
+		// Single-pass split avoids repeated string scanning
+		if idx := strings.IndexByte(c.Location, ':'); idx >= 0 {
+			paramsMap["host"] = c.Location[:idx]
+			paramsMap["port"] = c.Location[idx+1:]
 		} else {
-			port = "0"
+			paramsMap["host"] = c.Location
+			paramsMap["port"] = "0"
 		}
-		paramsMap["port"] = port
-	}
-	if c.Protocol != "" {
-		paramsMap[PROTOCOL] = c.Protocol
 	}
 	if c.Path != "" {
 		paramsMap["path"] = c.Path
-	}
-	if len(paramsMap) == 0 {
-		return nil
 	}
 	return paramsMap
 }
@@ -1163,26 +1184,95 @@ func IsEquals(left *URL, right *URL, excludes ...string) bool {
 		return false
 	}
 
-	leftMap := left.ToMap()
-	rightMap := right.ToMap()
-	for _, exclude := range excludes {
-		delete(leftMap, exclude)
-		delete(rightMap, exclude)
+	// Build a lookup set for excluded keys to avoid repeated scans
+	// and to skip materializing two full maps just for comparison
+	excludeSet := make(map[string]struct{}, len(excludes))
+	for _, k := range excludes {
+		excludeSet[k] = struct{}{}
 	}
 
-	if len(leftMap) != len(rightMap) {
+	isExcluded := func(key string) bool {
+		_, ok := excludeSet[key]
+		return ok
+	}
+
+	// Compare scalar fields directly
+	if left.Protocol != right.Protocol && !isExcluded(PROTOCOL) {
+		return false
+	}
+	if left.Username != right.Username && !isExcluded("username") {
+		return false
+	}
+	if left.Password != right.Password && !isExcluded("password") {
+		return false
+	}
+	if left.Path != right.Path && !isExcluded("path") {
 		return false
 	}
 
-	for lk, lv := range leftMap {
-		if rv, ok := rightMap[lk]; !ok {
-			return false
-		} else if lv != rv {
-			return false
+	// Compare Location (host:port)
+	if left.Location != right.Location {
+		hostExcluded := isExcluded("host")
+		portExcluded := isExcluded("port")
+
+		// If both host and port are excluded, skip Location comparison
+		if !hostExcluded || !portExcluded {
+			// Parse and compare host/port separately only if needed
+			leftHost, leftPort := parseLocation(left.Location)
+			rightHost, rightPort := parseLocation(right.Location)
+
+			if !hostExcluded && leftHost != rightHost {
+				return false
+			}
+			if !portExcluded && leftPort != rightPort {
+				return false
+			}
 		}
 	}
 
+	// Compare params directly without materializing full maps
+	// Build left params (excluding filtered keys), then verify right matches
+	leftParams := make(map[string]string)
+	left.RangeParams(func(key, value string) bool {
+		if !isExcluded(key) {
+			leftParams[key] = value
+		}
+		return true
+	})
+
+	rightCount := 0
+	mismatch := false
+	right.RangeParams(func(key, value string) bool {
+		if isExcluded(key) {
+			return true
+		}
+		rightCount++
+		if lv, ok := leftParams[key]; !ok || lv != value {
+			mismatch = true
+			return false
+		}
+		return true
+	})
+
+	if mismatch {
+		return false
+	}
+	if rightCount != len(leftParams) {
+		return false
+	}
+
 	return true
+}
+
+// parseLocation splits "host:port" into host and port
+func parseLocation(location string) (host, port string) {
+	if location == "" {
+		return "", "0"
+	}
+	if idx := strings.IndexByte(location, ':'); idx >= 0 {
+		return location[:idx], location[idx+1:]
+	}
+	return location, "0"
 }
 
 // URLSlice will be used to sort URL instance

--- a/protocol/triple/triple_protocol/duplex_http_call.go
+++ b/protocol/triple/triple_protocol/duplex_http_call.go
@@ -38,6 +38,10 @@ type duplexHTTPCall struct {
 	// We'll use a pipe as the request body. We hand the read side of the pipe to
 	// net/http, and we write to the write side (naturally). The two ends are
 	// safe to use concurrently.
+	//
+	// requestBodyWriter is assigned once here and never reassigned, so it's
+	// always non-nil; don't move this allocation into a lazy/first-send path
+	// (see connect-go#919 and duplex_http_call_test.go).
 	requestBodyReader *io.PipeReader
 	requestBodyWriter *io.PipeWriter
 

--- a/protocol/triple/triple_protocol/duplex_http_call_test.go
+++ b/protocol/triple/triple_protocol/duplex_http_call_test.go
@@ -1,0 +1,184 @@
+// Copyright 2021-2023 Buf Technologies, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package triple_protocol
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/assert"
+)
+
+// newTestDuplexClientCall builds a duplexHTTPCall for a client-streaming RPC
+// backed by a server that simply drains the request body and replies 200. It is
+// the minimal setup needed to exercise the Write/CloseWrite/CloseRead lifecycle
+// without pulling in the full codec/stream stack.
+func newTestDuplexClientCall(t *testing.T, client HTTPClient, serverURL *url.URL) *duplexHTTPCall {
+	t.Helper()
+	call := newDuplexHTTPCall(
+		t.Context(),
+		client,
+		serverURL,
+		Spec{StreamType: StreamTypeClient, Procedure: "/triple.test.v1.RaceService/Sum"},
+		http.Header{},
+	)
+	// makeRequest dereferences validateResponse, so it must be set.
+	call.SetValidateResponse(func(*http.Response) *Error { return nil })
+	return call
+}
+
+// TestDuplexHTTPCallConcurrentWriteAndCloseWrite is a regression GUARD -- not a
+// reproducer -- for the concurrent Send + CloseAndReceive nil-pointer
+// dereference fixed upstream in connect-go v1.19.2 (connectrpc/connect-go#919).
+//
+// Upstream created the request-body io.Pipe lazily, inside the CompareAndSwap
+// winner branch of the first Send. A racing CloseWrite (reached via
+// CloseAndReceive -> CloseRequest -> CloseWrite) could win that CAS first and
+// return without creating the pipe, so a later Send dereferenced a nil
+// requestBodyWriter and crashed at io.(*PipeWriter).Write.
+//
+// Dubbo-go's newDuplexHTTPCall instead allocates the pipe at construction and
+// never reassigns requestBodyWriter, so that ordering is structurally
+// impossible here. Two consequences worth stating plainly:
+//
+//   - On a correct tree this test ALWAYS passes and it cannot reproduce the
+//     panic: with requestBodyWriter set once at construction, concurrent Write
+//     and CloseWrite are safe in either order, so the interleaving below is not
+//     load-bearing.
+//   - What actually pins the invariant is assert.NotNil(call.requestBodyWriter)
+//     plus the source comment on that field. If pipe creation is moved back into
+//     a lazy/first-send path, the assertion fails and the concurrent Write
+//     begins dereferencing nil again -- the regression we want to catch.
+//
+// At this layer Write/CloseWrite/CloseRead are what the Triple client-stream
+// APIs call (grpcClientConn.Send -> marshaler -> Write, CloseRequest ->
+// CloseWrite, CloseResponse -> CloseRead), so it covers the client-stream
+// send + close lifecycle the issue is concerned with.
+func TestDuplexHTTPCallConcurrentWriteAndCloseWrite(t *testing.T) {
+	t.Parallel()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		w.WriteHeader(http.StatusOK)
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	assert.Nil(t, err)
+
+	const iterations = 10
+	for range iterations {
+		call := newTestDuplexClientCall(t, server.Client(), serverURL)
+
+		// The invariant that makes the upstream nil-deref impossible here: the
+		// write side of the request-body pipe is usable immediately after
+		// construction, before any Write or CloseWrite call.
+		assert.NotNil(t, call.requestBodyWriter)
+
+		var (
+			wg       sync.WaitGroup
+			panicVal any
+		)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panicVal = r
+				}
+			}()
+			_, _ = call.Write([]byte{0, 0, 0, 0, 0})
+		}()
+
+		// Race CloseWrite against the concurrent Write above. The order is
+		// intentionally unspecified: both interleavings are safe once
+		// requestBodyWriter is set at construction.
+		_ = call.CloseWrite()
+		wg.Wait()
+
+		if panicVal != nil {
+			t.Fatalf("concurrent Write during CloseWrite panicked: %v", panicVal)
+		}
+		_ = call.CloseRead()
+	}
+}
+
+// TestDuplexHTTPCallConcurrentWriteCloseRace exercises concurrent Write,
+// CloseWrite, CloseRead and the response accessors to guard the concurrent
+// send + close/receive lifecycle (the scenario behind connect-go#919). Like the
+// test above this is a guard, not a reproducer: on a correct tree it always
+// passes. It is most valuable under `go test -race`, where it would flag a data
+// race on requestBodyWriter or response if the construction-time pipe setup were
+// ever broken.
+func TestDuplexHTTPCallConcurrentWriteCloseRace(t *testing.T) {
+	t.Parallel()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		w.Header().Set("Test-Header", "value")
+		w.WriteHeader(http.StatusOK)
+	})
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	assert.Nil(t, err)
+
+	const (
+		iterations = 30
+		writers    = 4
+	)
+	for range iterations {
+		call := newTestDuplexClientCall(t, server.Client(), serverURL)
+
+		// Same construction-time invariant as the guard test above; assert it
+		// here too so a lazy-init regression fails with a clear assertion
+		// instead of panicking on a nil writer inside the goroutines below.
+		assert.NotNil(t, call.requestBodyWriter)
+
+		var wg sync.WaitGroup
+		for range writers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				// After the send side is closed Write returns io.EOF rather
+				// than panicking; any panic here is a real regression and is
+				// allowed to fail the test.
+				_, _ = call.Write([]byte{0, 0, 0, 0, 0})
+			}()
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = call.CloseWrite()
+		}()
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// These block until the response is ready and then read the
+			// response that makeRequest stored; exercises the response
+			// happens-before edge established by closing responseReady.
+			_ = call.ResponseHeader()
+			_ = call.ResponseTrailer()
+		}()
+		wg.Wait()
+		_ = call.CloseRead()
+	}
+}


### PR DESCRIPTION
Optimize URL equality comparison and map conversion to avoid unnecessary allocations. IsEquals() now compares fields directly instead of materializing two full maps via ToMap(). ToMap() pre-sizes the map and uses single-pass Location parsing with IndexByte.

## Benchmark Results

### ToMap Performance

| Params | Before (ns/op) | After (ns/op) | Improvement | Before (B/op) | After (B/op) | Alloc Reduction |
|--------|----------------|---------------|-------------|---------------|--------------|-----------------|
| 1      | 377.8          | 233.0         | **38.3%**   | 1016          | 664          | **34.6%**       |
| 32     | 1775           | 893.5         | **49.7%**   | 4536          | 2392         | **47.3%**       |
| 256    | 13499          | 6275          | **53.5%**   | 37400         | 18520        | **50.5%**       |
| 1024   | 55351          | 23996         | **56.7%**   | 160393        | 82048        | **48.9%**       |

### IsEquals Performance

| Params | Before (ns/op) | After (ns/op) | Improvement | Before (B/op) | After (B/op) | Alloc Reduction |
|--------|----------------|---------------|-------------|---------------|--------------|-----------------|
| 1      | 954.6          | 228.8         | **76.0%**   | 2032          | 0            | **100%**        |
| 32     | 4556           | 2432          | **46.6%**   | 9072          | 4136         | **54.4%**       |
| 256    | 32396          | 19433         | **40.0%**   | 74800         | 37000        | **50.5%**       |
| 1024   | 129318         | 78003         | **39.7%**   | 320786        | 159992       | **50.1%**       |

## Key Changes

1. **ToMap optimization**:
   - Pre-size map allocation based on param count + scalar fields
   - Use `IndexByte` for single-pass Location parsing (zero allocations)
   - Remove duplicate Protocol assignment

2. **IsEquals optimization**:
   - Compare scalar fields directly
   - Compare params without materializing full maps
   - Extract `parseLocation` helper function for code reuse

## Testing

- All existing tests pass: `go test ./common`
- Benchmark improvements verified with `-benchmem` flag

Fixes: #3394