### PR TITLE
feat(router): support static script router config

### DIFF
--- a/cluster/router/script/router.go
+++ b/cluster/router/script/router.go
@@ -43,7 +43,14 @@ import (
 type ScriptRouter struct {
 	applicationName string
 
-	mu         sync.RWMutex
+	mu          sync.RWMutex
+	enabled     bool
+	scriptType  string
+	rawScript   string
+	staticRules map[string]scriptRule
+}
+
+type scriptRule struct {
 	enabled    bool
 	scriptType string
 	rawScript  string
@@ -66,6 +73,47 @@ func parseRoute(routeContent string) (*global.RouterConfig, error) {
 	return routerConfig, nil
 }
 
+// SetStaticConfig applies a RouterConfig directly, bypassing YAML parsing.
+func (s *ScriptRouter) SetStaticConfig(cfg *global.RouterConfig) {
+	if cfg == nil || cfg.Scope != constant.RouterScopeApplication || cfg.Key == "" || cfg.ScriptType == "" || cfg.Script == "" {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	storageKey := strings.Join([]string{cfg.Key, constant.ScriptRouterRuleSuffix}, "")
+	if oldRule, ok := s.staticRules[storageKey]; ok && oldRule.enabled && oldRule.scriptType != "" {
+		in, err := ins.GetInstances(oldRule.scriptType)
+		if err != nil {
+			logger.Errorf("[Router][Script] GetInstances failed to destroy static config, error=%v", err)
+		} else {
+			in.Destroy(oldRule.rawScript)
+		}
+	}
+	delete(s.staticRules, storageKey)
+
+	enabled := cfg.Enabled == nil || *cfg.Enabled
+	if !enabled {
+		logger.Infof("[Router][Script] static config is disabled, key=%s, type=%s", cfg.Key, cfg.ScriptType)
+		return
+	}
+
+	in, err := ins.GetInstances(cfg.ScriptType)
+	if err != nil {
+		logger.Errorf("[Router][Script] GetInstances failed for static config, error=%v", err)
+		return
+	}
+	if err = in.Compile(cfg.Script); err != nil {
+		logger.Errorf("[Router][Script] compile static script failed, error=%v", err)
+		return
+	}
+	if s.staticRules == nil {
+		s.staticRules = make(map[string]scriptRule)
+	}
+	s.staticRules[storageKey] = scriptRule{enabled: true, scriptType: cfg.ScriptType, rawScript: cfg.Script}
+}
+
 func (s *ScriptRouter) Process(event *config_center.ConfigChangeEvent) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -85,6 +133,10 @@ func (s *ScriptRouter) Process(event *config_center.ConfigChangeEvent) {
 	rawConf, ok := event.Value.(string)
 	if !ok {
 		logger.Errorf("[Router][Script] route config value must be string, actualType=%T", event.Value)
+		return
+	}
+	if strings.TrimSpace(rawConf) == "" {
+		logger.Infof("[Router][Script] script rule is empty, key=%s", event.Key)
 		return
 	}
 	cfg, err := parseRoute(rawConf)
@@ -159,9 +211,18 @@ func (s *ScriptRouter) Route(invokers []base.Invoker, _ *common.URL, invocation 
 
 	s.mu.RLock()
 	enabled, scriptType, rawScript := s.enabled, s.scriptType, s.rawScript
+	if !enabled || scriptType == "" || rawScript == "" {
+		if url := invokers[0].GetURL(); url != nil {
+			providerApplication := url.GetParam("application", "")
+			staticKey := strings.Join([]string{providerApplication, constant.ScriptRouterRuleSuffix}, "")
+			if rule, ok := s.staticRules[staticKey]; ok {
+				enabled, scriptType, rawScript = rule.enabled, rule.scriptType, rule.rawScript
+			}
+		}
+	}
 	s.mu.RUnlock()
 
-	if !enabled || s.scriptType == "" || s.rawScript == "" {
+	if !enabled || scriptType == "" || rawScript == "" {
 		return invokers
 	}
 
@@ -218,6 +279,11 @@ func (s *ScriptRouter) Notify(invokers []base.Invoker) {
 		value, err = dynamicConfiguration.GetRule(listenTarget)
 		if err != nil {
 			logger.Errorf("[Router][Script] query script rule failed, applicationName=%s listenTarget=%s error=%v", s.applicationName, listenTarget, err)
+			return
+		}
+		if value == "" {
+			logger.Infof("[Router][Script] script rule is empty, listenTarget=%s", listenTarget)
+			return
 		}
 		s.Process(&config_center.ConfigChangeEvent{Key: listenTarget, Value: value, ConfigType: remoting.EventTypeUpdate})
 	}

--- a/cluster/router/script/router_test.go
+++ b/cluster/router/script/router_test.go
@@ -28,7 +28,9 @@ import (
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/config_center"
+	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
 	"dubbo.apache.org/dubbo-go/v3/remoting"
@@ -255,6 +257,170 @@ func TestScriptRouterProcessDelSkipsConfigBody(t *testing.T) {
 	assert.False(t, s.enabled)
 	assert.Empty(t, s.scriptType)
 	assert.Empty(t, s.rawScript)
+}
+
+func TestScriptRouterSetStaticConfig(t *testing.T) {
+	staticScriptForPort := func(port string) string {
+		return `(function route(invokers, invocation, context) {
+		var result = [];
+		for (var i = 0; i < invokers.length; i++) {
+			if (invokers[i].GetURL().Port === "` + port + `") {
+				result.push(invokers[i]);
+			}
+		}
+		return result;
+	}(invokers, invocation, context));`
+	}
+
+	t.Run("apply static script config", func(t *testing.T) {
+		invokers, inv, _ := getRouteCheckArgs()
+		s := NewScriptRouter()
+		s.SetStaticConfig(&global.RouterConfig{
+			Scope:      constant.RouterScopeApplication,
+			Key:        "BDTService",
+			ScriptType: "javascript",
+			Script:     staticScriptForPort("20001"),
+		})
+
+		got := s.Route(invokers, nil, inv)
+		assert.Len(t, got, 1)
+		assert.Equal(t, "20001", got[0].GetURL().Port)
+	})
+
+	t.Run("ignore disabled static script config", func(t *testing.T) {
+		invokers, inv, _ := getRouteCheckArgs()
+		enabled := false
+		s := NewScriptRouter()
+		s.SetStaticConfig(&global.RouterConfig{
+			Scope:      constant.RouterScopeApplication,
+			Key:        "BDTService",
+			Enabled:    &enabled,
+			ScriptType: "javascript",
+			Script:     staticScriptForPort("20001"),
+		})
+
+		got := s.Route(invokers, nil, inv)
+		assert.True(t, checkInvokersSame(got, invokers))
+	})
+
+	t.Run("ignore config without script", func(t *testing.T) {
+		invokers, inv, _ := getRouteCheckArgs()
+		s := NewScriptRouter()
+		s.SetStaticConfig(&global.RouterConfig{
+			Scope: constant.RouterScopeApplication,
+			Key:   "BDTService",
+		})
+
+		got := s.Route(invokers, nil, inv)
+		assert.True(t, checkInvokersSame(got, invokers))
+	})
+
+	t.Run("ignore config without key", func(t *testing.T) {
+		invokers, inv, _ := getRouteCheckArgs()
+		s := NewScriptRouter()
+		s.SetStaticConfig(&global.RouterConfig{
+			Scope:      constant.RouterScopeApplication,
+			ScriptType: "javascript",
+			Script:     staticScriptForPort("20001"),
+		})
+
+		got := s.Route(invokers, nil, inv)
+		assert.True(t, checkInvokersSame(got, invokers))
+	})
+
+	t.Run("replace previous static script config", func(t *testing.T) {
+		invokers, inv, _ := getRouteCheckArgs()
+		s := NewScriptRouter()
+		s.SetStaticConfig(&global.RouterConfig{
+			Scope:      constant.RouterScopeApplication,
+			Key:        "BDTService",
+			ScriptType: "javascript",
+			Script:     staticScriptForPort("20001"),
+		})
+		s.SetStaticConfig(&global.RouterConfig{
+			Scope:      constant.RouterScopeApplication,
+			Key:        "BDTService",
+			ScriptType: "javascript",
+			Script:     staticScriptForPort("20002"),
+		})
+
+		got := s.Route(invokers, nil, inv)
+		assert.Len(t, got, 1)
+		assert.Equal(t, "20002", got[0].GetURL().Port)
+	})
+
+	t.Run("select static script config by provider application", func(t *testing.T) {
+		invokers, inv, _ := getRouteCheckArgs()
+		s := NewScriptRouter()
+		s.SetStaticConfig(&global.RouterConfig{
+			Scope:      constant.RouterScopeApplication,
+			Key:        "BDTService",
+			ScriptType: "javascript",
+			Script:     staticScriptForPort("20002"),
+		})
+		s.SetStaticConfig(&global.RouterConfig{
+			Scope:      constant.RouterScopeApplication,
+			Key:        "OtherService",
+			ScriptType: "javascript",
+			Script:     staticScriptForPort("20001"),
+		})
+
+		got := s.Route(invokers, nil, inv)
+		assert.Len(t, got, 1)
+		assert.Equal(t, "20002", got[0].GetURL().Port)
+		assert.Len(t, s.staticRules, 2)
+	})
+
+	t.Run("replace stale config with unsupported script type", func(t *testing.T) {
+		invokers, inv, _ := getRouteCheckArgs()
+		s := &ScriptRouter{
+			staticRules: map[string]scriptRule{
+				"BDTService" + constant.ScriptRouterRuleSuffix: {
+					enabled:    true,
+					scriptType: "unsupported",
+					rawScript:  "old script",
+				},
+			},
+		}
+		s.SetStaticConfig(&global.RouterConfig{
+			Scope:      constant.RouterScopeApplication,
+			Key:        "BDTService",
+			ScriptType: "javascript",
+			Script:     staticScriptForPort("20001"),
+		})
+
+		got := s.Route(invokers, nil, inv)
+		assert.Len(t, got, 1)
+		assert.Equal(t, "20001", got[0].GetURL().Port)
+	})
+
+	t.Run("disable unsupported script type", func(t *testing.T) {
+		invokers, inv, _ := getRouteCheckArgs()
+		s := NewScriptRouter()
+		s.SetStaticConfig(&global.RouterConfig{
+			Scope:      constant.RouterScopeApplication,
+			Key:        "BDTService",
+			ScriptType: "unsupported",
+			Script:     staticScriptForPort("20001"),
+		})
+
+		got := s.Route(invokers, nil, inv)
+		assert.True(t, checkInvokersSame(got, invokers))
+	})
+
+	t.Run("disable invalid static script", func(t *testing.T) {
+		invokers, inv, _ := getRouteCheckArgs()
+		s := NewScriptRouter()
+		s.SetStaticConfig(&global.RouterConfig{
+			Scope:      constant.RouterScopeApplication,
+			Key:        "BDTService",
+			ScriptType: "javascript",
+			Script:     "bad input",
+		})
+
+		got := s.Route(invokers, nil, inv)
+		assert.True(t, checkInvokersSame(got, invokers))
+	})
 }
 
 func checkInvokersSame(invokers []base.Invoker, otherInvokers []base.Invoker) bool {


### PR DESCRIPTION
## What

- Add `SetStaticConfig` support to `ScriptRouter` for application-scoped router configs.
- Compile static JavaScript rules through the same engine used by dynamic rules.
- Keep static rules isolated by provider application and replace or disable them safely.
- Cover enabled, disabled, invalid, replacement, and cross-application behavior.

## Why

Issue #3203 identifies static ScriptRouter configuration as an outstanding router gap. `RouterConfig` already carries `ScriptType` and `Script`, and the router-chain bootstrap already broadcasts static configs to routers that implement `StaticConfigSetter`, but `ScriptRouter` did not implement that interface.

This recreates the final reviewed state of #3419 on the latest `develop`. The original PR cannot be reopened because its fork/head repository was deleted.

## User impact

Applications can configure provider-application-specific script routing locally through `client.WithRouter`, without requiring a config-center rule. Dynamic rules still take precedence when present.

## Validation

- `go test ./cluster/router/script`
- `go test ./cluster/router/...`
- `go test -race ./cluster/router/script`
- `go test ./cluster/router/script -run '^TestScriptRouterSetStaticConfig$' -count=10`
- `go vet ./cluster/router/script/...`
- `golangci-lint run ./cluster/router/script --timeout=10m`
- `make check-fmt`
- `git diff origin/develop...HEAD --check`

## Documentation

The previously requested website follow-up, apache/dubbo-website#3214, was also closed after its head repository was deleted and will need to be recreated separately. This PR remains a draft while that follow-up is outstanding.

Refs #3203
Supersedes #3419
