### PR TITLE
feat(router): support static affinity router config

### DIFF
--- a/cluster/router/affinity/router.go
+++ b/cluster/router/affinity/router.go
@@ -19,6 +19,7 @@ package affinity
 
 import (
 	"math"
+	"slices"
 	"strings"
 	"sync"
 )
@@ -40,12 +41,21 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
 
+const affinityRuleEmptyLog = "[Router][Affinity] affinity rule is empty: key=%s"
+
 type ServiceAffinityRoute struct {
 	affinityRoute
 }
 
 func newServiceAffinityRoute() *ServiceAffinityRoute {
 	return &ServiceAffinityRoute{}
+}
+
+func (s *ServiceAffinityRoute) SetStaticConfig(cfg *global.RouterConfig) {
+	if cfg == nil || cfg.Scope != constant.RouterScopeService || cfg.AffinityAware.Key == "" {
+		return
+	}
+	s.affinityRoute.SetStaticConfig(cfg)
 }
 
 func (s *ServiceAffinityRoute) Notify(invokers []base.Invoker) {
@@ -70,6 +80,10 @@ func (s *ServiceAffinityRoute) Notify(invokers []base.Invoker) {
 	value, err := dynamicConfiguration.GetRule(key)
 	if err != nil {
 		logger.Errorf("[Router][Affinity] query affinity rule failed: key=%s, err=%v", key, err)
+		return
+	}
+	if value == "" {
+		logger.Infof(affinityRuleEmptyLog, key)
 		return
 	}
 
@@ -100,6 +114,13 @@ func newApplicationAffinityRouter(url *common.URL) *ApplicationAffinityRoute {
 		dynamicConfiguration.AddListener(strings.Join([]string{applicationName, constant.AffinityRuleSuffix}, ""), a)
 	}
 	return a
+}
+
+func (s *ApplicationAffinityRoute) SetStaticConfig(cfg *global.RouterConfig) {
+	if cfg == nil || cfg.Scope != constant.RouterScopeApplication || cfg.AffinityAware.Key == "" {
+		return
+	}
+	s.affinityRoute.SetStaticConfig(cfg)
 }
 
 func (s *ApplicationAffinityRoute) Notify(invokers []base.Invoker) {
@@ -137,30 +158,94 @@ func (s *ApplicationAffinityRoute) Notify(invokers []base.Invoker) {
 			logger.Errorf("[Router][Affinity] query affinity rule failed: key=%s, err=%v", key, err)
 			return
 		}
+		if value == "" {
+			logger.Infof(affinityRuleEmptyLog, key)
+			return
+		}
 
 		s.Process(&config_center.ConfigChangeEvent{Key: key, Value: value, ConfigType: remoting.EventTypeUpdate})
 	}
 }
 
 type affinityRoute struct {
-	mu      sync.RWMutex
+	mu          sync.RWMutex
+	matcher     *condition.FieldMatcher
+	enabled     bool
+	key         string
+	ratio       int32
+	staticRules map[string]affinityRule
+}
+
+type affinityRule struct {
 	matcher *condition.FieldMatcher
-	enabled bool
 	key     string
 	ratio   int32
 }
 
+// SetStaticConfig applies a RouterConfig directly, bypassing YAML parsing.
+// Static and dynamic rules are not merged: later Process updates replace the
+// current state built here.
+func (a *affinityRoute) SetStaticConfig(cfg *global.RouterConfig) {
+	if cfg == nil {
+		return
+	}
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	storageKey := strings.TrimSpace(cfg.Key)
+	if storageKey == "" {
+		logger.Error("[Router][Affinity] static affinity config key is empty")
+		return
+	}
+	delete(a.staticRules, storageKey)
+
+	if cfg.AffinityAware.Ratio < 0 || cfg.AffinityAware.Ratio > 100 {
+		logger.Errorf("[Router][Affinity] invalid static affinity ratio: ratio=%d, expected=0-100", cfg.AffinityAware.Ratio)
+		return
+	}
+
+	key := strings.TrimSpace(cfg.AffinityAware.Key)
+	enabled := cfg.Enabled == nil || *cfg.Enabled
+	if !enabled || key == "" {
+		return
+	}
+
+	rule := strings.Join([]string{key, key}, "=$")
+	f, err := condition.NewFieldMatcher(rule)
+	if err != nil {
+		logger.Errorf("[Router][Affinity] parse static affinity rule failed: key=%s, rule=%s, err=%v", key, rule, err)
+		return
+	}
+
+	if a.staticRules == nil {
+		a.staticRules = make(map[string]affinityRule)
+	}
+	a.staticRules[storageKey] = affinityRule{matcher: &f, key: key, ratio: cfg.AffinityAware.Ratio}
+}
+
 func (a *affinityRoute) Process(event *config_center.ConfigChangeEvent) {
+	var value string
+	switch event.ConfigType {
+	case remoting.EventTypeAdd, remoting.EventTypeUpdate:
+		value, _ = event.Value.(string)
+		if strings.TrimSpace(value) == "" {
+			logger.Infof(affinityRuleEmptyLog, event.Key)
+			return
+		}
+	}
+
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.matcher, a.enabled, a.key, a.ratio = nil, false, "", 0
+	a.staticRules = nil
 
 	switch event.ConfigType {
 	case remoting.EventTypeDel:
 	case remoting.EventTypeAdd, remoting.EventTypeUpdate:
-		cfg, err := parseConfig(event.Value.(string))
+		cfg, err := parseConfig(value)
 		if err != nil {
-			logger.Errorf("[Router][Affinity] parse affinity config failed: key=%s, err=%v", a.key, err)
+			logger.Errorf("[Router][Affinity] parse affinity config failed: key=%s, err=%v", event.Key, err)
 			return
 		}
 
@@ -176,7 +261,7 @@ func (a *affinityRoute) Process(event *config_center.ConfigChangeEvent) {
 		rule := strings.Join([]string{key, key}, "=$")
 		f, err := condition.NewFieldMatcher(rule)
 		if err != nil {
-			logger.Errorf("[Router][Affinity] parse affinity rule failed: key=%s, rule=%s, err=%v", a.key, rule, err)
+			logger.Errorf("[Router][Affinity] parse affinity rule failed: key=%s, rule=%s, err=%v", key, rule, err)
 			return
 		}
 
@@ -191,12 +276,38 @@ func (a *affinityRoute) Route(invokers []base.Invoker, url *common.URL, invocati
 
 	a.mu.RLock()
 	enabled, matcher, ratio := a.enabled, a.matcher, a.ratio
+	staticRules := make(map[string]affinityRule, len(a.staticRules))
+	for key, rule := range a.staticRules {
+		staticRules[key] = rule
+	}
 	a.mu.RUnlock()
 
-	if !enabled {
+	if enabled {
+		return routeByAffinityRule(invokers, url, invocation, matcher, ratio)
+	}
+
+	if len(staticRules) == 0 {
 		return invokers
 	}
 
+	keys := make([]string, 0, len(staticRules))
+	for key := range staticRules {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	res := invokers
+	for _, key := range keys {
+		rule := staticRules[key]
+		res = routeByAffinityRule(res, url, invocation, rule.matcher, rule.ratio)
+	}
+	return res
+}
+
+func routeByAffinityRule(invokers []base.Invoker, url *common.URL, invocation base.Invocation, matcher *condition.FieldMatcher, ratio int32) []base.Invoker {
+	if matcher == nil {
+		return invokers
+	}
 	res := make([]base.Invoker, 0, len(invokers))
 	for _, invoker := range invokers {
 		if matcher.MatchInvoker(url, invoker, invocation) {

--- a/cluster/router/affinity/router_test.go
+++ b/cluster/router/affinity/router_test.go
@@ -18,18 +18,22 @@
 package affinity
 
 import (
+	"math"
 	"testing"
 )
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/cluster/router/condition"
 	"dubbo.apache.org/dubbo-go/v3/common"
+	conf "dubbo.apache.org/dubbo-go/v3/common/config"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/config_center"
+	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
 	"dubbo.apache.org/dubbo-go/v3/remoting"
@@ -235,6 +239,332 @@ affinityAware:
 		})
 	}
 
+}
+
+func TestAffinityRouteSetStaticConfig(t *testing.T) {
+	invokers := buildInvokers()
+	consumerURL := newUrl("consumer://127.0.0.1/com.foo.BarService?env=gray&region=beijing")
+	inv := invocation.NewRPCInvocation("getComment", nil, nil)
+	cfg := &global.RouterConfig{
+		Scope: constant.RouterScopeService,
+		Key:   "service.apache.com",
+		AffinityAware: global.AffinityAware{
+			Key:   "region",
+			Ratio: 20,
+		},
+	}
+
+	a := &affinityRoute{}
+	a.SetStaticConfig(cfg)
+
+	got := a.Route(invokers, consumerURL, inv)
+	want := NewINVOKERS_FILTERS().add("region=$region").filtrate(invokers, consumerURL, inv)
+	assert.Equal(t, want, got)
+}
+
+func TestAffinityRouteSetStaticConfigKeepsRulesByConfigKey(t *testing.T) {
+	invokers := buildInvokers()
+	consumerURL := newUrl("consumer://127.0.0.1/com.foo.BarService?env=gray&region=beijing")
+	inv := invocation.NewRPCInvocation("getComment", nil, nil)
+
+	a := &affinityRoute{}
+	a.SetStaticConfig(&global.RouterConfig{
+		Scope: constant.RouterScopeService,
+		Key:   "service.apache.com.region",
+		AffinityAware: global.AffinityAware{
+			Key:   "region",
+			Ratio: 20,
+		},
+	})
+	a.SetStaticConfig(&global.RouterConfig{
+		Scope: constant.RouterScopeService,
+		Key:   "service.apache.com.env",
+		AffinityAware: global.AffinityAware{
+			Key:   "env",
+			Ratio: 20,
+		},
+	})
+
+	got := a.Route(invokers, consumerURL, inv)
+	want := NewINVOKERS_FILTERS().
+		add("region=$region").
+		add("env=$env").
+		filtrate(invokers, consumerURL, inv)
+	assert.Equal(t, want, got)
+	assert.Len(t, a.staticRules, 2)
+}
+
+func TestAffinityRouteProcessEmptyDynamicRuleKeepsStaticConfig(t *testing.T) {
+	invokers := buildInvokers()
+	consumerURL := newUrl("consumer://127.0.0.1/com.foo.BarService?env=gray&region=beijing")
+	inv := invocation.NewRPCInvocation("getComment", nil, nil)
+
+	a := &affinityRoute{}
+	a.SetStaticConfig(&global.RouterConfig{
+		Scope: constant.RouterScopeService,
+		Key:   "service.apache.com",
+		AffinityAware: global.AffinityAware{
+			Key:   "region",
+			Ratio: 20,
+		},
+	})
+
+	a.Process(&config_center.ConfigChangeEvent{
+		Key:        "service.apache.com.affinity-router",
+		Value:      "",
+		ConfigType: remoting.EventTypeAdd,
+	})
+
+	got := a.Route(invokers, consumerURL, inv)
+	want := NewINVOKERS_FILTERS().add("region=$region").filtrate(invokers, consumerURL, inv)
+	assert.Equal(t, want, got)
+	assert.Len(t, a.staticRules, 1)
+}
+
+type emptyRuleDynamicConfiguration struct {
+	config_center.DynamicConfiguration
+}
+
+func (c *emptyRuleDynamicConfiguration) GetRule(string, ...config_center.Option) (string, error) {
+	return "", nil
+}
+
+func TestAffinityRouteNotifyEmptyDynamicRuleKeepsStaticConfig(t *testing.T) {
+	ccURL := newUrl("mock://127.0.0.1:1111")
+	delegate, err := (&config_center.MockDynamicConfigurationFactory{}).GetDynamicConfiguration(ccURL)
+	require.NoError(t, err)
+
+	env := conf.GetEnvInstance()
+	previous := env.GetDynamicConfiguration()
+	env.SetDynamicConfiguration(&emptyRuleDynamicConfiguration{DynamicConfiguration: delegate})
+	t.Cleanup(func() {
+		env.SetDynamicConfiguration(previous)
+	})
+
+	t.Run("service router", func(t *testing.T) {
+		router := newServiceAffinityRoute()
+		router.SetStaticConfig(&global.RouterConfig{
+			Scope: constant.RouterScopeService,
+			Key:   "com.foo.BarService",
+			AffinityAware: global.AffinityAware{
+				Key:   "region",
+				Ratio: 20,
+			},
+		})
+
+		router.Notify([]base.Invoker{base.NewBaseInvoker(newUrl("dubbo://127.0.0.1/com.foo.BarService"))})
+
+		assert.Len(t, router.staticRules, 1)
+	})
+
+	t.Run("application router", func(t *testing.T) {
+		router := &ApplicationAffinityRoute{currentApplication: "consumer-app"}
+		router.SetStaticConfig(&global.RouterConfig{
+			Scope: constant.RouterScopeApplication,
+			Key:   "provider-app",
+			AffinityAware: global.AffinityAware{
+				Key:   "region",
+				Ratio: 20,
+			},
+		})
+
+		router.Notify([]base.Invoker{base.NewBaseInvoker(newUrl("dubbo://127.0.0.1/com.foo.BarService?application=provider-app"))})
+
+		assert.Len(t, router.staticRules, 1)
+	})
+}
+
+func TestAffinityRouteSetStaticConfigIgnoresInvalidConfig(t *testing.T) {
+	invokers := buildInvokers()
+	consumerURL := newUrl("consumer://127.0.0.1/com.foo.BarService?env=gray&region=beijing")
+	inv := invocation.NewRPCInvocation("getComment", nil, nil)
+	enabled := false
+
+	tests := []struct {
+		name string
+		cfg  *global.RouterConfig
+	}{
+		{
+			name: "nil config",
+		},
+		{
+			name: "disabled",
+			cfg: &global.RouterConfig{
+				Enabled: &enabled,
+				Key:     "service.apache.com",
+				AffinityAware: global.AffinityAware{
+					Key:   "region",
+					Ratio: 20,
+				},
+			},
+		},
+		{
+			name: "empty affinity key",
+			cfg: &global.RouterConfig{
+				Key:           "service.apache.com",
+				AffinityAware: global.AffinityAware{Ratio: 20},
+			},
+		},
+		{
+			name: "bad ratio",
+			cfg: &global.RouterConfig{
+				Key: "service.apache.com",
+				AffinityAware: global.AffinityAware{
+					Key:   "region",
+					Ratio: 101,
+				},
+			},
+		},
+		{
+			name: "invalid matcher key",
+			cfg: &global.RouterConfig{
+				Key: "service.apache.com",
+				AffinityAware: global.AffinityAware{
+					Key:   "=",
+					Ratio: 20,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &affinityRoute{}
+			a.SetStaticConfig(tt.cfg)
+			assert.Equal(t, invokers, a.Route(invokers, consumerURL, inv))
+		})
+	}
+}
+
+func TestAffinityRouteSetStaticConfigEmptyConfigKeyKeepsExistingRules(t *testing.T) {
+	a := &affinityRoute{}
+	a.SetStaticConfig(&global.RouterConfig{
+		Key: "service.apache.com",
+		AffinityAware: global.AffinityAware{
+			Key:   "region",
+			Ratio: 20,
+		},
+	})
+
+	a.SetStaticConfig(&global.RouterConfig{
+		AffinityAware: global.AffinityAware{
+			Key:   "env",
+			Ratio: 20,
+		},
+	})
+
+	assert.Len(t, a.staticRules, 1)
+	assert.Contains(t, a.staticRules, "service.apache.com")
+}
+
+func TestAffinityRouteProcessIgnoresMalformedAndDisabledRules(t *testing.T) {
+	invokers := buildInvokers()
+	consumerURL := newUrl("consumer://127.0.0.1/com.foo.BarService?env=gray&region=beijing")
+	inv := invocation.NewRPCInvocation("getComment", nil, nil)
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{
+			name:  "malformed yaml",
+			value: "affinityAware: [",
+		},
+		{
+			name: "disabled",
+			value: `configVersion: v3.1
+scope: service
+key: service.apache.com
+enabled: false
+runtime: true
+affinityAware:
+  key: region
+  ratio: 20`,
+		},
+		{
+			name: "empty affinity key",
+			value: `configVersion: v3.1
+scope: service
+key: service.apache.com
+enabled: true
+runtime: true
+affinityAware:
+  ratio: 20`,
+		},
+		{
+			name: "invalid matcher key",
+			value: `configVersion: v3.1
+scope: service
+key: service.apache.com
+enabled: true
+runtime: true
+affinityAware:
+  key: =
+  ratio: 20`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := &affinityRoute{}
+			a.Process(&config_center.ConfigChangeEvent{
+				Value:      tt.value,
+				ConfigType: remoting.EventTypeUpdate,
+			})
+
+			assert.Equal(t, invokers, a.Route(invokers, consumerURL, inv))
+		})
+	}
+}
+
+func TestAffinityRouteRouteFallbacks(t *testing.T) {
+	a := &affinityRoute{}
+	assert.Empty(t, a.Route(nil, newUrl("consumer://127.0.0.1/com.foo.BarService"), invocation.NewRPCInvocation("getComment", nil, nil)))
+
+	invokers := buildInvokers()
+	assert.Equal(t, invokers, routeByAffinityRule(invokers, newUrl("consumer://127.0.0.1/com.foo.BarService"), invocation.NewRPCInvocation("getComment", nil, nil), nil, 20))
+	assert.Nil(t, a.URL())
+	assert.Equal(t, int64(math.MinInt64), a.Priority())
+}
+
+func TestAffinityRouteSetStaticConfigScope(t *testing.T) {
+	cfg := &global.RouterConfig{
+		Scope: constant.RouterScopeService,
+		Key:   "service.apache.com",
+		AffinityAware: global.AffinityAware{
+			Key:   "region",
+			Ratio: 20,
+		},
+	}
+	serviceRouter := newServiceAffinityRoute()
+	serviceRouter.SetStaticConfig(nil)
+	assert.False(t, serviceRouter.enabled)
+
+	appScopedCfg := *cfg
+	appScopedCfg.Scope = constant.RouterScopeApplication
+	serviceRouter.SetStaticConfig(&appScopedCfg)
+	assert.Empty(t, serviceRouter.staticRules)
+
+	serviceRouter.SetStaticConfig(cfg)
+	assert.Len(t, serviceRouter.staticRules, 1)
+
+	emptyAffinityCfg := *cfg
+	emptyAffinityCfg.Key = "service.apache.com.empty"
+	emptyAffinityCfg.AffinityAware.Key = ""
+	serviceRouter.SetStaticConfig(&emptyAffinityCfg)
+	assert.Len(t, serviceRouter.staticRules, 1)
+
+	appRouter := &ApplicationAffinityRoute{}
+	appRouter.SetStaticConfig(cfg)
+	assert.Empty(t, appRouter.staticRules)
+
+	cfg.Scope = constant.RouterScopeApplication
+	appRouter.SetStaticConfig(cfg)
+	assert.Len(t, appRouter.staticRules, 1)
+
+	emptyAffinityCfg.Scope = constant.RouterScopeApplication
+	appRouter.SetStaticConfig(&emptyAffinityCfg)
+	assert.Len(t, appRouter.staticRules, 1)
 }
 
 func Test_newApplicationAffinityRouter(t *testing.T) {

--- a/global/config_test.go
+++ b/global/config_test.go
@@ -836,6 +836,10 @@ func TestRouterConfigClone(t *testing.T) {
 			Priority:   10,
 			ScriptType: "javascript",
 			Script:     "1==1",
+			AffinityAware: AffinityAware{
+				Key:   "region",
+				Ratio: 20,
+			},
 			Force: func() *bool {
 				b := true
 				return &b
@@ -872,6 +876,7 @@ func TestRouterConfigClone(t *testing.T) {
 		assert.Equal(t, router.Priority, cloned.Priority)
 		assert.Equal(t, router.ScriptType, cloned.ScriptType)
 		assert.Equal(t, router.Script, cloned.Script)
+		assert.Equal(t, router.AffinityAware, cloned.AffinityAware)
 		assert.NotSame(t, router, cloned)
 		assert.Len(t, cloned.Conditions, 2)
 		assert.Len(t, cloned.Tags, 2)

--- a/global/router_config.go
+++ b/global/router_config.go
@@ -37,6 +37,8 @@ type RouterConfig struct {
 	Tags       []Tag    `yaml:"tags" json:"tags,omitempty" property:"tags"`
 	ScriptType string   `yaml:"type" json:"type,omitempty" property:"type"`
 	Script     string   `yaml:"script" json:"script,omitempty" property:"script"`
+
+	AffinityAware AffinityAware `yaml:"affinityAware" json:"affinityAware,omitempty" property:"affinityAware"`
 }
 
 type Tag struct {
@@ -178,5 +180,7 @@ func (c *RouterConfig) Clone() *RouterConfig {
 		Tags:       newTags,
 		ScriptType: c.ScriptType,
 		Script:     c.Script,
+
+		AffinityAware: c.AffinityAware,
 	}
 }


### PR DESCRIPTION
## What

- Add `AffinityAware` to static `RouterConfig` and preserve it when configs are cloned.
- Implement `SetStaticConfig` for service- and application-scoped affinity routers.
- Keep multiple static affinity rules isolated by config key and apply them deterministically.
- Preserve bootstrap static rules when config center has no dynamic rule.
- Cover valid, invalid, disabled, scope-filtered, multi-rule, and fallback behavior.

## Why

Issue #3203 identifies static AffinityRouter configuration as an outstanding router gap. The affinity router supported dynamic config-center rules, but the static router injection path had neither affinity fields nor a `StaticConfigSetter` implementation.

This recreates the maintainer-approved final state of #3420 on the latest `develop`, while omitting compatibility files that have since been removed upstream. The original PR cannot be reopened because its fork/head repository was deleted.

## User impact

Applications can bootstrap service- or application-scoped affinity routing locally through `client.WithRouter`. Multiple rules remain independent, and an absent dynamic rule no longer erases static configuration.

## Validation

- `GOTOOLCHAIN=go1.25.0+auto go test ./cluster/router/affinity ./global ./cluster/router/... .`
- `go test -race ./cluster/router/affinity`
- `go vet ./cluster/router/affinity ./global ./cluster/router/... .`
- `golangci-lint run ./cluster/router/affinity ./global --timeout=10m`
- `make check-fmt`
- `git diff origin/develop...HEAD --check`

## Documentation

The previously requested website follow-up, apache/dubbo-website#3211, was also closed after its head repository was deleted and will need to be recreated separately. This PR remains a draft while that follow-up is outstanding.

Refs #3203
Supersedes #3420
