### PR TITLE
fix: synchronize registry exporter lifecycle publication

### DIFF
--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -67,6 +67,28 @@ type registryProtocol struct {
 	serviceConfigurationListeners *sync.Map
 	providerConfigurationListener *providerConfigurationListener
 	once                          sync.Once
+	exportLocksMu                 sync.Mutex
+	exportLocks                   map[string]*keyedExportLock
+	lifecycleMu                   sync.Mutex
+	lifecycleWG                   sync.WaitGroup
+	shutdownMu                    sync.Mutex
+	stopping                      bool
+	destroyed                     bool
+}
+
+type keyedExportLock struct {
+	sync.Mutex
+	references int
+}
+
+type exportPlan struct {
+	originInvoker                base.Invoker
+	registryURL                  *common.URL
+	providerURL                  *common.URL
+	overriderURL                 *common.URL
+	overrideSubscribeListener    *overrideSubscribeListener
+	serviceConfigurationListener *serviceConfigurationListener
+	key                          string
 }
 
 func init() {
@@ -75,8 +97,68 @@ func init() {
 
 func newRegistryProtocol() *registryProtocol {
 	return &registryProtocol{
-		registries: &sync.Map{},
-		bounds:     &sync.Map{},
+		registries:  &sync.Map{},
+		bounds:      &sync.Map{},
+		exportLocks: make(map[string]*keyedExportLock),
+	}
+}
+
+func (proto *registryProtocol) beginLifecycleOperation() bool {
+	proto.lifecycleMu.Lock()
+	defer proto.lifecycleMu.Unlock()
+	if proto.stopping {
+		return false
+	}
+	proto.lifecycleWG.Add(1)
+	return true
+}
+
+func (proto *registryProtocol) isStopping() bool {
+	proto.lifecycleMu.Lock()
+	defer proto.lifecycleMu.Unlock()
+	return proto.stopping
+}
+
+func (proto *registryProtocol) lockExportKeys(firstKey string, secondKey string) func() {
+	keys := []string{firstKey}
+	if secondKey != firstKey {
+		if secondKey < firstKey {
+			keys = []string{secondKey, firstKey}
+		} else {
+			keys = append(keys, secondKey)
+		}
+	}
+
+	proto.exportLocksMu.Lock()
+	locks := make([]*keyedExportLock, 0, len(keys))
+	for _, key := range keys {
+		lock := proto.exportLocks[key]
+		if lock == nil {
+			lock = &keyedExportLock{}
+			proto.exportLocks[key] = lock
+		}
+		lock.references++
+		locks = append(locks, lock)
+	}
+	proto.exportLocksMu.Unlock()
+
+	for _, lock := range locks {
+		lock.Lock()
+	}
+	return func() {
+		for index := len(locks) - 1; index >= 0; index-- {
+			locks[index].Unlock()
+		}
+
+		proto.exportLocksMu.Lock()
+		defer proto.exportLocksMu.Unlock()
+		for index, key := range keys {
+			lock := locks[index]
+			lock.references--
+			if lock.references == 0 && proto.exportLocks[key] == lock {
+				delete(proto.exportLocks, key)
+			}
+		}
 	}
 }
 
@@ -227,79 +309,137 @@ func (proto *registryProtocol) Refer(url *common.URL) base.Invoker {
 
 // Export provider service to registry center
 func (proto *registryProtocol) Export(originInvoker base.Invoker) base.Exporter {
-	registryUrl := getRegistryUrl(originInvoker)
-	providerUrl := getProviderUrl(originInvoker)
+	if !proto.beginLifecycleOperation() {
+		return nil
+	}
+	defer proto.lifecycleWG.Done()
+	return proto.export(originInvoker)
+}
 
-	ensureShutdownAttributes(registryUrl, providerUrl)
-	commonConfig.EnsureApplicationAttribute(registryUrl, providerUrl)
+func (proto *registryProtocol) export(originInvoker base.Invoker) base.Exporter {
+	plan := proto.prepareExport(originInvoker)
+	unlock := proto.lockExportKeys(plan.key, plan.key)
+	defer unlock()
+	if proto.isStopping() {
+		return nil
+	}
+	return proto.exportLocked(plan)
+}
+
+func (proto *registryProtocol) prepareExport(originInvoker base.Invoker) *exportPlan {
+	registryURL := getRegistryUrl(originInvoker)
+	providerURL := getProviderUrl(originInvoker)
+
+	ensureShutdownAttributes(registryURL, providerURL)
+	commonConfig.EnsureApplicationAttribute(registryURL, providerURL)
 
 	proto.once.Do(func() {
-		proto.initConfigurationListeners(providerUrl)
+		proto.initConfigurationListeners(providerURL)
 	})
 
-	overriderUrl := getSubscribedOverrideUrl(providerUrl)
+	overriderURL := getSubscribedOverrideUrl(providerURL)
 	// Deprecated! subscribe to override rules in 2.6.x or before.
-	overrideSubscribeListener := newOverrideSubscribeListener(overriderUrl, originInvoker, proto)
-	proto.overrideListeners.Store(overriderUrl.String(), overrideSubscribeListener)
-	proto.providerConfigurationListener.OverrideUrl(providerUrl)
-	serviceConfigurationListener := newServiceConfigurationListener(overrideSubscribeListener, providerUrl)
-	proto.serviceConfigurationListeners.Store(providerUrl.ServiceKey(), serviceConfigurationListener)
-	serviceConfigurationListener.OverrideUrl(providerUrl)
+	overrideSubscribeListener := newOverrideSubscribeListener(overriderURL, originInvoker, proto)
+	proto.providerConfigurationListener.OverrideUrl(providerURL)
+	serviceConfigurationListener := newServiceConfigurationListener(overrideSubscribeListener, providerURL)
+	serviceConfigurationListener.OverrideUrl(providerURL)
 
+	return &exportPlan{
+		originInvoker:                originInvoker,
+		registryURL:                  registryURL,
+		providerURL:                  providerURL,
+		overriderURL:                 overriderURL,
+		overrideSubscribeListener:    overrideSubscribeListener,
+		serviceConfigurationListener: serviceConfigurationListener,
+		key:                          getCacheKey(originInvoker),
+	}
+}
+
+func (proto *registryProtocol) exportLocked(plan *exportPlan) base.Exporter {
 	// export invoker
-	exporter := proto.doLocalExport(originInvoker, providerUrl)
+	exporter, created := proto.doLocalExport(plan.key, plan.originInvoker, plan.providerURL)
 
 	// update health status
-	// health.SetServingStatusServing(registryUrl.Service())
+	// health.SetServingStatusServing(plan.registryURL.Service())
 
-	if len(registryUrl.Protocol) > 0 {
+	if len(plan.registryURL.Protocol) > 0 {
 		// url to registry
-		reg := proto.getRegistry(registryUrl)
-		registeredProviderUrl := getUrlToRegistry(providerUrl, registryUrl)
+		reg := proto.getRegistry(plan.registryURL)
+		registeredProviderURL := getUrlToRegistry(plan.providerURL, plan.registryURL)
 
-		err := reg.Register(registeredProviderUrl)
+		err := reg.Register(registeredProviderURL)
 		if err != nil {
 			logger.Errorf("[Registry] provider service %v register registry %v error, err=%s",
-				providerUrl.Key(), registryUrl.Key(), err.Error())
+				plan.providerURL.Key(), plan.registryURL.Key(), err.Error())
+			if created {
+				proto.bounds.CompareAndDelete(plan.key, exporter)
+				exporter.UnExport()
+			}
 			return nil
 		}
 
+		proto.overrideListeners.Store(plan.overriderURL.String(), plan.overrideSubscribeListener)
+		proto.serviceConfigurationListeners.Store(plan.providerURL.ServiceKey(), plan.serviceConfigurationListener)
+		exporter.SetLifecycleURLs(registeredProviderURL, plan.overriderURL)
+
 		go func() {
-			if err := reg.Subscribe(overriderUrl, overrideSubscribeListener); err != nil {
-				logger.Warnf("[Registry] reg.subscribe(overriderUrl=%v) = err=%v", overriderUrl, err)
+			if proto.isStopping() {
+				return
+			}
+			if err := reg.Subscribe(plan.overriderURL, plan.overrideSubscribeListener); err != nil {
+				logger.Warnf("[Registry] reg.subscribe(overriderUrl=%v) = err=%v", plan.overriderURL, err)
 			}
 		}()
-
-		exporter.SetRegisterUrl(registeredProviderUrl)
-		exporter.SetSubscribeUrl(overriderUrl)
-
 	} else {
+		proto.overrideListeners.Store(plan.overriderURL.String(), plan.overrideSubscribeListener)
+		proto.serviceConfigurationListeners.Store(plan.providerURL.ServiceKey(), plan.serviceConfigurationListener)
+		exporter.SetLifecycleURLs(nil, nil)
 		logger.Warnf("[Registry] provider service %v do not regist to registry %v, possible direct connection provider",
-			providerUrl.Key(), registryUrl.Key())
+			plan.providerURL.Key(), plan.registryURL.Key())
 	}
 
 	return exporter
 }
 
-func (proto *registryProtocol) doLocalExport(originInvoker base.Invoker, providerUrl *common.URL) *exporterChangeableWrapper {
-	key := getCacheKey(originInvoker)
+func (proto *registryProtocol) doLocalExport(
+	key string,
+	originInvoker base.Invoker,
+	providerUrl *common.URL,
+) (*exporterChangeableWrapper, bool) {
 	cachedExporter, loaded := proto.bounds.Load(key)
-	if !loaded {
-		// new Exporter
-		invokerDelegate := newInvokerDelegate(originInvoker, providerUrl)
-		cachedExporter = newExporterChangeableWrapper(originInvoker,
-			extension.GetProtocol(protocolwrapper.FILTER).Export(invokerDelegate))
-		proto.bounds.Store(key, cachedExporter)
+	if loaded {
+		return cachedExporter.(*exporterChangeableWrapper), false
 	}
-	return cachedExporter.(*exporterChangeableWrapper)
+
+	invokerDelegate := newInvokerDelegate(originInvoker, providerUrl)
+	newExporter := newExporterChangeableWrapper(originInvoker,
+		extension.GetProtocol(protocolwrapper.FILTER).Export(invokerDelegate))
+	cachedExporter, loaded = proto.bounds.LoadOrStore(key, newExporter)
+	if loaded {
+		newExporter.UnExport()
+		return cachedExporter.(*exporterChangeableWrapper), false
+	}
+	return newExporter, true
 }
 
 func (proto *registryProtocol) reExport(invoker base.Invoker, newUrl *common.URL) {
-	key := getCacheKey(invoker)
-	if oldExporter, loaded := proto.bounds.Load(key); loaded {
-		wrappedNewInvoker := newInvokerDelegate(invoker, newUrl)
+	if !proto.beginLifecycleOperation() {
+		return
+	}
+	defer proto.lifecycleWG.Done()
+
+	wrappedNewInvoker := newInvokerDelegate(invoker, newUrl)
+	oldKey := getCacheKey(invoker)
+	newKey := getCacheKey(wrappedNewInvoker)
+	unlock := proto.lockExportKeys(oldKey, newKey)
+	defer unlock()
+	if proto.isStopping() {
+		return
+	}
+
+	if oldExporter, loaded := proto.bounds.Load(oldKey); loaded {
 		oldExporter.(base.Exporter).UnExport()
-		proto.bounds.Delete(key)
+		proto.bounds.CompareAndDelete(oldKey, oldExporter)
 
 		oldProviderURL := getProviderUrl(invoker)
 		oldOverrideURL := getSubscribedOverrideUrl(oldProviderURL)
@@ -310,7 +450,7 @@ func (proto *registryProtocol) reExport(invoker base.Invoker, newUrl *common.URL
 		if err := registerServiceMap(invoker); err != nil {
 			logger.Errorf("[Registry] reExport failed, err=%s", err.Error())
 		}
-		proto.Export(wrappedNewInvoker)
+		proto.exportLocked(proto.prepareExport(wrappedNewInvoker))
 		// TODO:  unregister & unsubscribe
 	}
 }
@@ -491,27 +631,49 @@ func getSubscribedOverrideUrl(providerUrl *common.URL) *common.URL {
 
 // Destroy registry protocol
 func (proto *registryProtocol) Destroy() {
+	proto.shutdownMu.Lock()
+	defer proto.shutdownMu.Unlock()
+
+	proto.lifecycleMu.Lock()
+	if proto.destroyed {
+		proto.lifecycleMu.Unlock()
+		return
+	}
+	proto.stopping = true
+	proto.destroyed = true
+	proto.lifecycleMu.Unlock()
+	proto.lifecycleWG.Wait()
+
 	proto.bounds.Range(func(key, value any) bool {
 		// protocol holds the exporters actually, instead, registry holds them in order to avoid export repeatedly, so
 		// the work for unexport should be finished in protocol.UnExport(), see also config.destroyProviderProtocols().
 		exporter := value.(*exporterChangeableWrapper)
-		reg := proto.getRegistry(getRegistryUrl(exporter.originInvoker))
-		if err := reg.UnRegister(exporter.registerUrl); err != nil {
-			logger.Warnf("[Registry] unRegister consumer url failed, url=%s err=%v", exporter.registerUrl.String(), err)
+		registerUrl, subscribeUrl, unregistered := exporter.LifecycleURLs()
+		var reg registry.Registry
+		registryUrl := getRegistryUrl(exporter.originInvoker)
+		if registerUrl != nil && len(registryUrl.Protocol) > 0 {
+			reg = proto.getRegistry(registryUrl)
+			if !unregistered {
+				if err := reg.UnRegister(registerUrl); err != nil {
+					logger.Warnf("[Registry] unRegister consumer url failed, url=%s err=%v", registerUrl.String(), err)
+				} else {
+					exporter.MarkUnregistered()
+				}
+			}
 		}
-		proto.unsubscribeOverrideListener(reg, exporter.subscribeUrl)
+		proto.unsubscribeOverrideListener(reg, subscribeUrl)
 		proto.serviceConfigurationListeners.Delete(getProviderUrl(exporter.originInvoker).ServiceKey())
 
 		// close all protocol server after consumerUpdateWait + stepTimeout(max time wait during
 		// waitAndAcceptNewRequests procedure)
-		go func() {
-			wait := destroyWaitDuration(exporter.registerUrl)
+		go func(exporter *exporterChangeableWrapper, registerUrl *common.URL, key any) {
+			wait := destroyWaitDuration(registerUrl)
 			if wait > 0 {
 				<-time.After(wait)
 			}
 			exporter.UnExport()
 			proto.bounds.Delete(key)
-		}()
+		}(exporter, registerUrl, key)
 		return true
 	})
 
@@ -527,7 +689,6 @@ func (proto *registryProtocol) Destroy() {
 		proto.serviceConfigurationListeners.Delete(key)
 		return true
 	})
-
 }
 
 func destroyWaitDuration(url *common.URL) time.Duration {
@@ -556,11 +717,33 @@ func destroyWaitDuration(url *common.URL) time.Duration {
 // UnregisterRegistries only unregisters exported services from registries during graceful shutdown.
 // Protocol servers keep running until the later destroy phase.
 func (proto *registryProtocol) UnregisterRegistries() {
+	proto.shutdownMu.Lock()
+	defer proto.shutdownMu.Unlock()
+
+	proto.lifecycleMu.Lock()
+	if proto.destroyed {
+		proto.lifecycleMu.Unlock()
+		return
+	}
+	proto.stopping = true
+	proto.lifecycleMu.Unlock()
+	proto.lifecycleWG.Wait()
+
 	proto.bounds.Range(func(_, value any) bool {
 		exporter := value.(*exporterChangeableWrapper)
-		reg := proto.getRegistry(getRegistryUrl(exporter.originInvoker))
-		if err := reg.UnRegister(exporter.registerUrl); err != nil {
-			logger.Warnf("[Registry] unRegister consumer url failed, url=%s err=%v", exporter.registerUrl.String(), err)
+		registerUrl, _, unregistered := exporter.LifecycleURLs()
+		if registerUrl == nil || unregistered {
+			return true
+		}
+		registryUrl := getRegistryUrl(exporter.originInvoker)
+		if len(registryUrl.Protocol) == 0 {
+			return true
+		}
+		reg := proto.getRegistry(registryUrl)
+		if err := reg.UnRegister(registerUrl); err != nil {
+			logger.Warnf("[Registry] unRegister consumer url failed, url=%s err=%v", registerUrl.String(), err)
+		} else {
+			exporter.MarkUnregistered()
 		}
 		return true
 	})
@@ -639,8 +822,10 @@ type exporterChangeableWrapper struct {
 	base.Exporter
 	originInvoker base.Invoker
 	exporter      base.Exporter
+	lifecycleMu   sync.RWMutex
 	registerUrl   *common.URL
 	subscribeUrl  *common.URL
+	unregistered  bool
 }
 
 func (e *exporterChangeableWrapper) UnExport() {
@@ -648,11 +833,36 @@ func (e *exporterChangeableWrapper) UnExport() {
 }
 
 func (e *exporterChangeableWrapper) SetRegisterUrl(registerUrl *common.URL) {
+	e.lifecycleMu.Lock()
+	defer e.lifecycleMu.Unlock()
 	e.registerUrl = registerUrl
+	e.unregistered = false
 }
 
 func (e *exporterChangeableWrapper) SetSubscribeUrl(subscribeUrl *common.URL) {
+	e.lifecycleMu.Lock()
+	defer e.lifecycleMu.Unlock()
 	e.subscribeUrl = subscribeUrl
+}
+
+func (e *exporterChangeableWrapper) SetLifecycleURLs(registerUrl *common.URL, subscribeUrl *common.URL) {
+	e.lifecycleMu.Lock()
+	defer e.lifecycleMu.Unlock()
+	e.registerUrl = registerUrl
+	e.subscribeUrl = subscribeUrl
+	e.unregistered = false
+}
+
+func (e *exporterChangeableWrapper) LifecycleURLs() (*common.URL, *common.URL, bool) {
+	e.lifecycleMu.RLock()
+	defer e.lifecycleMu.RUnlock()
+	return e.registerUrl, e.subscribeUrl, e.unregistered
+}
+
+func (e *exporterChangeableWrapper) MarkUnregistered() {
+	e.lifecycleMu.Lock()
+	defer e.lifecycleMu.Unlock()
+	e.unregistered = true
 }
 
 func (e *exporterChangeableWrapper) GetInvoker() base.Invoker {

--- a/registry/protocol/protocol_test.go
+++ b/registry/protocol/protocol_test.go
@@ -18,6 +18,7 @@
 package protocol
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -220,7 +221,8 @@ func TestExportCopiesProviderAttributesToRegistryURL(t *testing.T) {
 	assert.Same(t, applicationConfig, applicationRaw)
 
 	wrapper := exporter.(*exporterChangeableWrapper)
-	registeredShutdownRaw, ok := wrapper.registerUrl.GetAttribute(constant.ShutdownConfigPrefix)
+	registerURL, _, _ := wrapper.LifecycleURLs()
+	registeredShutdownRaw, ok := registerURL.GetAttribute(constant.ShutdownConfigPrefix)
 	require.True(t, ok)
 	assert.Same(t, shutdownConfig, registeredShutdownRaw)
 }
@@ -393,7 +395,8 @@ func TestDestroyUnsubscribesOverrideListener(t *testing.T) {
 	regProtocol.Destroy()
 
 	assert.Equal(t, 1, recordingRegistry.unSubscribeCount)
-	assert.Equal(t, exporter.subscribeUrl.String(), recordingRegistry.unSubscribeURL.String())
+	_, subscribeURL, _ := exporter.LifecycleURLs()
+	assert.Equal(t, subscribeURL.String(), recordingRegistry.unSubscribeURL.String())
 	assert.Same(t, listener, recordingRegistry.unSubscribeListener)
 	assert.Equal(t, 0, registry.CountSyncMapEntries(regProtocol.overrideListeners))
 	assert.Equal(t, 0, registry.CountSyncMapEntries(regProtocol.serviceConfigurationListeners))
@@ -514,7 +517,8 @@ func TestReExportUnsubscribesOldOverrideListener(t *testing.T) {
 	regProtocol.reExport(originInvoker, newURL)
 
 	assert.Equal(t, 1, recordingRegistry.unSubscribeCount)
-	assert.Equal(t, exporter.subscribeUrl.String(), recordingRegistry.unSubscribeURL.String())
+	_, subscribeURL, _ := exporter.LifecycleURLs()
+	assert.Equal(t, subscribeURL.String(), recordingRegistry.unSubscribeURL.String())
 	assert.Same(t, listener, recordingRegistry.unSubscribeListener)
 	assert.Equal(t, 1, registry.CountSyncMapEntries(regProtocol.overrideListeners))
 	assert.Equal(t, 1, registry.CountSyncMapEntries(regProtocol.serviceConfigurationListeners))
@@ -522,12 +526,13 @@ func TestReExportUnsubscribesOldOverrideListener(t *testing.T) {
 
 func TestUnsubscribeOverrideListenerKeepsUnexpectedListenerType(t *testing.T) {
 	regProtocol, recordingRegistry, _, exporter, _ := newRegistryProtocolWithSubscribedExporter(t)
-	regProtocol.overrideListeners.Store(exporter.subscribeUrl.String(), "unexpected-listener")
+	_, subscribeURL, _ := exporter.LifecycleURLs()
+	regProtocol.overrideListeners.Store(subscribeURL.String(), "unexpected-listener")
 
-	regProtocol.unsubscribeOverrideListener(recordingRegistry, exporter.subscribeUrl)
+	regProtocol.unsubscribeOverrideListener(recordingRegistry, subscribeURL)
 
 	assert.Equal(t, 0, recordingRegistry.unSubscribeCount)
-	_, ok := regProtocol.overrideListeners.Load(exporter.subscribeUrl.String())
+	_, ok := regProtocol.overrideListeners.Load(subscribeURL.String())
 	assert.True(t, ok)
 }
 
@@ -627,6 +632,450 @@ type unsubscribeRecordingRegistry struct {
 	unSubscribeURL      *common.URL
 	unSubscribeListener registry.NotifyListener
 	unSubscribeCount    int
+}
+
+type lifecycleRecordingRegistry struct {
+	*registry.MockRegistry
+	registerStartedOnce sync.Once
+	registerStarted     chan struct{}
+	allowRegister       <-chan struct{}
+	blockRegisterCall   int
+	registerErr         error
+	mu                  sync.Mutex
+	registerCount       int
+	registerURL         *common.URL
+	unregisterURL       *common.URL
+	unregisterCount     int
+	registered          bool
+}
+
+func (r *lifecycleRecordingRegistry) Register(url *common.URL) error {
+	r.mu.Lock()
+	r.registerCount++
+	registerCall := r.registerCount
+	blockRegisterCall := r.blockRegisterCall
+	r.mu.Unlock()
+
+	if blockRegisterCall == 0 || registerCall == blockRegisterCall {
+		if r.registerStarted != nil {
+			r.registerStartedOnce.Do(func() {
+				close(r.registerStarted)
+			})
+		}
+		if r.allowRegister != nil {
+			<-r.allowRegister
+		}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.registerErr != nil {
+		return r.registerErr
+	}
+	r.registerURL = url
+	r.registered = true
+	return nil
+}
+
+func (r *lifecycleRecordingRegistry) UnRegister(url *common.URL) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.unregisterURL = url
+	r.unregisterCount++
+	r.registered = false
+	return nil
+}
+
+func (r *lifecycleRecordingRegistry) Subscribe(*common.URL, registry.NotifyListener) error {
+	return nil
+}
+
+func (r *lifecycleRecordingRegistry) UnSubscribe(*common.URL, registry.NotifyListener) error {
+	return nil
+}
+
+func (r *lifecycleRecordingRegistry) snapshot() (*common.URL, *common.URL, int, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.registerURL, r.unregisterURL, r.unregisterCount, r.registered
+}
+
+func newLifecycleTestInvoker(t *testing.T, registryScheme string, service string) base.Invoker {
+	t.Helper()
+
+	registryURL, err := common.NewURL(registryScheme + "://127.0.0.1:1111")
+	require.NoError(t, err)
+	providerURL, err := common.NewURL(
+		"dubbo://127.0.0.1:20000/"+service,
+		common.WithAttribute(constant.ApplicationKey, &global.ApplicationConfig{Name: "lifecycle-test"}),
+		common.WithAttribute(constant.ShutdownConfigPrefix, &global.ShutdownConfig{
+			StepTimeout:            "0s",
+			ConsumerUpdateWaitTime: "0s",
+		}),
+	)
+	require.NoError(t, err)
+	registryURL.SubURL = providerURL
+	return base.NewBaseInvoker(registryURL)
+}
+
+func installLifecycleRecordingRegistry(
+	t *testing.T,
+	registryScheme string,
+	recordingRegistry *lifecycleRecordingRegistry,
+) {
+	t.Helper()
+	extension.SetRegistry(registryScheme, func(url *common.URL) (registry.Registry, error) {
+		mockRegistry, err := registry.NewMockRegistry(url)
+		if err != nil {
+			return nil, err
+		}
+		recordingRegistry.MockRegistry = mockRegistry.(*registry.MockRegistry)
+		return recordingRegistry, nil
+	})
+	extension.SetProtocol(protocolwrapper.FILTER, protocolwrapper.NewMockProtocolFilter)
+}
+
+type lifecycleRecordingProtocol struct {
+	unexported chan<- time.Time
+}
+
+func (p *lifecycleRecordingProtocol) Export(invoker base.Invoker) base.Exporter {
+	return &recordingExporter{invoker: invoker, unexported: p.unexported}
+}
+
+func (*lifecycleRecordingProtocol) Refer(*common.URL) base.Invoker {
+	return nil
+}
+
+func (*lifecycleRecordingProtocol) Destroy() {}
+
+func TestDestroyWaitsForExporterLifecyclePublication(t *testing.T) {
+	const registryScheme = "lifecycle-blocking"
+	registerStarted := make(chan struct{})
+	allowRegister := make(chan struct{})
+	recordingRegistry := &lifecycleRecordingRegistry{
+		registerStarted: registerStarted,
+		allowRegister:   allowRegister,
+	}
+	installLifecycleRecordingRegistry(t, registryScheme, recordingRegistry)
+
+	regProtocol := newRegistryProtocol()
+	invoker := newLifecycleTestInvoker(t, registryScheme, "org.apache.dubbo-go.lifecycleService")
+	exportDone := make(chan base.Exporter, 1)
+	go func() {
+		exportDone <- regProtocol.Export(invoker)
+	}()
+	select {
+	case <-registerStarted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "registration did not start")
+	}
+
+	destroyDone := make(chan struct{})
+	go func() {
+		regProtocol.Destroy()
+		close(destroyDone)
+	}()
+	require.Eventually(t, func() bool {
+		regProtocol.lifecycleMu.Lock()
+		defer regProtocol.lifecycleMu.Unlock()
+		return regProtocol.stopping
+	}, time.Second, time.Millisecond)
+	select {
+	case <-destroyDone:
+		require.FailNow(t, "destroy observed an exporter before registration completed")
+	default:
+	}
+
+	close(allowRegister)
+	var exporter base.Exporter
+	select {
+	case exporter = <-exportDone:
+	case <-time.After(time.Second):
+		require.FailNow(t, "export did not complete")
+	}
+	require.NotNil(t, exporter)
+	select {
+	case <-destroyDone:
+	case <-time.After(time.Second):
+		require.FailNow(t, "destroy did not complete")
+	}
+
+	wrapper := exporter.(*exporterChangeableWrapper)
+	registerURL, subscribeURL, _ := wrapper.LifecycleURLs()
+	require.NotNil(t, registerURL)
+	require.NotNil(t, subscribeURL)
+	registeredURL, unregisteredURL, unregisterCount, registered := recordingRegistry.snapshot()
+	assert.Same(t, registeredURL, registerURL)
+	assert.Same(t, registeredURL, unregisteredURL)
+	assert.Equal(t, 1, unregisterCount)
+	assert.False(t, registered)
+}
+
+func TestRegistrationFailureRemovesUnpublishedExporter(t *testing.T) {
+	const registryScheme = "lifecycle-failing"
+	recordingRegistry := &lifecycleRecordingRegistry{registerErr: errors.New("register failed")}
+	installLifecycleRecordingRegistry(t, registryScheme, recordingRegistry)
+
+	regProtocol := newRegistryProtocol()
+	exporter := regProtocol.Export(newLifecycleTestInvoker(
+		t,
+		registryScheme,
+		"org.apache.dubbo-go.failedLifecycleService",
+	))
+
+	assert.Nil(t, exporter)
+	assert.Zero(t, registry.CountSyncMapEntries(regProtocol.bounds))
+	assert.Zero(t, registry.CountSyncMapEntries(regProtocol.overrideListeners))
+	assert.Zero(t, registry.CountSyncMapEntries(regProtocol.serviceConfigurationListeners))
+	regProtocol.Destroy()
+}
+
+func TestBlockedExportDoesNotDelayDifferentProvider(t *testing.T) {
+	const (
+		blockingRegistryScheme = "lifecycle-blocked-provider"
+		readyRegistryScheme    = "lifecycle-ready-provider"
+	)
+	registerStarted := make(chan struct{})
+	allowRegister := make(chan struct{})
+	blockingRegistry := &lifecycleRecordingRegistry{
+		registerStarted: registerStarted,
+		allowRegister:   allowRegister,
+	}
+	readyRegistry := &lifecycleRecordingRegistry{}
+	installLifecycleRecordingRegistry(t, blockingRegistryScheme, blockingRegistry)
+	installLifecycleRecordingRegistry(t, readyRegistryScheme, readyRegistry)
+
+	regProtocol := newRegistryProtocol()
+	blockedInvoker := newLifecycleTestInvoker(
+		t,
+		blockingRegistryScheme,
+		"org.apache.dubbo-go.blockedLifecycleService",
+	)
+	readyInvoker := newLifecycleTestInvoker(
+		t,
+		readyRegistryScheme,
+		"org.apache.dubbo-go.readyLifecycleService",
+	)
+	blockedExportDone := make(chan base.Exporter, 1)
+	go func() {
+		blockedExportDone <- regProtocol.Export(blockedInvoker)
+	}()
+	select {
+	case <-registerStarted:
+	case <-time.After(time.Second):
+		require.FailNow(t, "blocking registration did not start")
+	}
+
+	readyExportDone := make(chan base.Exporter, 1)
+	go func() {
+		readyExportDone <- regProtocol.Export(readyInvoker)
+	}()
+	select {
+	case exporter := <-readyExportDone:
+		require.NotNil(t, exporter)
+	case <-time.After(time.Second):
+		require.FailNow(t, "an unrelated provider export was blocked")
+	}
+
+	close(allowRegister)
+	select {
+	case exporter := <-blockedExportDone:
+		require.NotNil(t, exporter)
+	case <-time.After(time.Second):
+		require.FailNow(t, "blocked export did not complete")
+	}
+	regProtocol.Destroy()
+}
+
+func TestReExportWaitsForExporterLifecyclePublication(t *testing.T) {
+	t.Run("different cache keys", func(t *testing.T) {
+		const registryScheme = "lifecycle-reexport-different-key"
+		registerStarted := make(chan struct{})
+		allowRegister := make(chan struct{})
+		var releaseRegister sync.Once
+		release := func() {
+			releaseRegister.Do(func() {
+				close(allowRegister)
+			})
+		}
+		recordingRegistry := &lifecycleRecordingRegistry{
+			registerStarted:   registerStarted,
+			allowRegister:     allowRegister,
+			blockRegisterCall: 2,
+		}
+		installLifecycleRecordingRegistry(t, registryScheme, recordingRegistry)
+		unexported := make(chan time.Time, 4)
+		extension.SetProtocol(protocolwrapper.FILTER, func() base.Protocol {
+			return &lifecycleRecordingProtocol{unexported: unexported}
+		})
+
+		regProtocol := newRegistryProtocol()
+		t.Cleanup(func() {
+			release()
+			regProtocol.Destroy()
+		})
+		invoker := newLifecycleTestInvoker(
+			t,
+			registryScheme,
+			"org.apache.dubbo-go.reexportLifecycleService",
+		)
+		oldExporter := regProtocol.Export(invoker)
+		require.NotNil(t, oldExporter)
+		oldKey := getCacheKey(invoker)
+
+		repeatedExportDone := make(chan base.Exporter, 1)
+		go func() {
+			repeatedExportDone <- regProtocol.Export(invoker)
+		}()
+		select {
+		case <-registerStarted:
+		case <-time.After(time.Second):
+			require.FailNow(t, "repeated registration did not start")
+		}
+
+		newURL := invoker.GetURL().Clone()
+		newURL.SubURL = invoker.GetURL().SubURL.Clone()
+		newURL.SubURL.SetParam(constant.ClusterKey, "reconfigured")
+		newKey := getCacheKey(newInvokerDelegate(invoker, newURL))
+		require.NotEqual(t, oldKey, newKey)
+
+		reExportStarted := make(chan struct{})
+		reExportDone := make(chan struct{})
+		go func() {
+			close(reExportStarted)
+			regProtocol.reExport(invoker, newURL)
+			close(reExportDone)
+		}()
+		<-reExportStarted
+
+		select {
+		case <-unexported:
+			require.FailNow(t, "re-export closed an exporter whose registration was still in progress")
+		case <-time.After(100 * time.Millisecond):
+		}
+		bound, loaded := regProtocol.bounds.Load(oldKey)
+		require.True(t, loaded)
+		require.Same(t, oldExporter, bound)
+
+		release()
+		select {
+		case exporter := <-repeatedExportDone:
+			require.Same(t, oldExporter, exporter)
+		case <-time.After(time.Second):
+			require.FailNow(t, "repeated export did not complete")
+		}
+		select {
+		case <-reExportDone:
+		case <-time.After(time.Second):
+			require.FailNow(t, "re-export did not complete")
+		}
+
+		_, oldLoaded := regProtocol.bounds.Load(oldKey)
+		assert.False(t, oldLoaded)
+		newBound, newLoaded := regProtocol.bounds.Load(newKey)
+		require.True(t, newLoaded)
+		registerURL, subscribeURL, _ := newBound.(*exporterChangeableWrapper).LifecycleURLs()
+		require.NotNil(t, registerURL)
+		require.NotNil(t, subscribeURL)
+		select {
+		case <-unexported:
+		case <-time.After(time.Second):
+			require.FailNow(t, "old exporter was not closed after its registration completed")
+		}
+		select {
+		case <-unexported:
+			require.FailNow(t, "old exporter was closed more than once")
+		default:
+		}
+		regProtocol.exportLocksMu.Lock()
+		assert.Empty(t, regProtocol.exportLocks)
+		regProtocol.exportLocksMu.Unlock()
+	})
+
+	t.Run("same cache key", func(t *testing.T) {
+		const registryScheme = "lifecycle-reexport-same-key"
+		recordingRegistry := &lifecycleRecordingRegistry{}
+		installLifecycleRecordingRegistry(t, registryScheme, recordingRegistry)
+		unexported := make(chan time.Time, 4)
+		extension.SetProtocol(protocolwrapper.FILTER, func() base.Protocol {
+			return &lifecycleRecordingProtocol{unexported: unexported}
+		})
+
+		regProtocol := newRegistryProtocol()
+		t.Cleanup(regProtocol.Destroy)
+		invoker := newLifecycleTestInvoker(
+			t,
+			registryScheme,
+			"org.apache.dubbo-go.sameKeyReexportLifecycleService",
+		)
+		require.NotNil(t, regProtocol.Export(invoker))
+		oldKey := getCacheKey(invoker)
+
+		newURL := invoker.GetURL().Clone()
+		newURL.SubURL = invoker.GetURL().SubURL.Clone()
+		newURL.SubURL.SetParam("dynamic", "false")
+		newKey := getCacheKey(newInvokerDelegate(invoker, newURL))
+		require.Equal(t, oldKey, newKey)
+
+		reExportDone := make(chan struct{})
+		go func() {
+			regProtocol.reExport(invoker, newURL)
+			close(reExportDone)
+		}()
+		select {
+		case <-reExportDone:
+		case <-time.After(time.Second):
+			require.FailNow(t, "same-key re-export deadlocked")
+		}
+
+		newBound, loaded := regProtocol.bounds.Load(newKey)
+		require.True(t, loaded)
+		registerURL, subscribeURL, _ := newBound.(*exporterChangeableWrapper).LifecycleURLs()
+		require.NotNil(t, registerURL)
+		require.NotNil(t, subscribeURL)
+		select {
+		case <-unexported:
+		case <-time.After(time.Second):
+			require.FailNow(t, "same-key re-export did not close the old exporter")
+		}
+		regProtocol.exportLocksMu.Lock()
+		assert.Empty(t, regProtocol.exportLocks)
+		regProtocol.exportLocksMu.Unlock()
+	})
+}
+
+func TestConcurrentUnregisterAndDestroyUnregisterOnlyOnce(t *testing.T) {
+	const registryScheme = "lifecycle-unregister-once"
+	recordingRegistry := &lifecycleRecordingRegistry{}
+	installLifecycleRecordingRegistry(t, registryScheme, recordingRegistry)
+
+	regProtocol := newRegistryProtocol()
+	require.NotNil(t, regProtocol.Export(newLifecycleTestInvoker(
+		t,
+		registryScheme,
+		"org.apache.dubbo-go.unregisterLifecycleService",
+	)))
+
+	start := make(chan struct{})
+	var shutdown sync.WaitGroup
+	shutdown.Add(2)
+	go func() {
+		defer shutdown.Done()
+		<-start
+		regProtocol.UnregisterRegistries()
+	}()
+	go func() {
+		defer shutdown.Done()
+		<-start
+		regProtocol.Destroy()
+	}()
+	close(start)
+	shutdown.Wait()
+
+	_, _, unregisterCount, registered := recordingRegistry.snapshot()
+	assert.Equal(t, 1, unregisterCount)
+	assert.False(t, registered)
 }
 
 func (r *unsubscribeRecordingRegistry) UnSubscribe(url *common.URL, notifyListener registry.NotifyListener) error {


### PR DESCRIPTION
### Description
Fixes #3248

This PR addresses the `exporterChangeableWrapper` lifecycle-publication race called out in the lifecycle-management section of the umbrella issue.

`registryProtocol.Export` previously stored a wrapper in `bounds` before its register and subscribe URLs were initialized. Concurrent shutdown or re-export paths could therefore observe a partially published exporter, unregister a nil/wrong URL, or close an exporter whose registration was still in progress.

The change:

- gates `Export` and `reExport` against shutdown with a lifecycle barrier;
- serializes publication per cache key while keeping unrelated providers independent;
- locks old/new cache keys in deterministic order during re-export;
- publishes lifecycle URLs atomically and rolls back a newly created exporter when registration fails;
- makes graceful unregister and destroy idempotent for the same wrapper;
- removes keyed locks when their last holder/waiter exits;
- cleans configuration listeners during destroy.

The timing tests cover blocked registration versus destroy, registration rollback, unrelated-provider progress, old/new-key re-export, same-key re-export, and concurrent unregister/destroy.

Scope note: this is a focused fix for the wrapper publication/shutdown race. It does not redesign the existing one-URL-pair-per-provider multi-registry model. It also does not change the mixed `Registry.Subscribe` contract; strict subscribe readiness/cancellation requires a follow-up API design because some registry implementations run `Subscribe` as a long-lived loop.

### Testing

- `make check-fmt`
- `make test`
- `go test ./registry/protocol -count=10`
- focused lifecycle tests with `-count=20`
- `go test -race ./registry/protocol -count=10`
- `go vet ./registry/protocol`
- `golangci-lint run ./registry/protocol/...`

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
