### PR TITLE
fix: synchronize condition matcher registries

### DIFF
--- a/cluster/router/condition/matcher/extension.go
+++ b/cluster/router/condition/matcher/extension.go
@@ -17,24 +17,40 @@
 
 package matcher
 
+import (
+	"sync"
+)
+
 var (
-	matchers = make(map[string]func() ConditionMatcherFactory)
+	matchersMu sync.RWMutex
+	matchers   = make(map[string]func() ConditionMatcherFactory)
 )
 
 // SetMatcherFactory sets create matcherFactory function with @name
 func SetMatcherFactory(name string, fun func() ConditionMatcherFactory) {
+	matchersMu.Lock()
+	defer matchersMu.Unlock()
 	matchers[name] = fun
 }
 
 // GetMatcherFactory gets create matcherFactory function by name
 func GetMatcherFactory(name string) ConditionMatcherFactory {
-	if matchers[name] == nil {
+	matchersMu.RLock()
+	factory := matchers[name]
+	matchersMu.RUnlock()
+	if factory == nil {
 		panic("matcher_factory for " + name + " is not existing, make sure you have imported the package.")
 	}
-	return matchers[name]()
+	return factory()
 }
 
 // GetMatcherFactories gets all create matcherFactory function
 func GetMatcherFactories() map[string]func() ConditionMatcherFactory {
-	return matchers
+	matchersMu.RLock()
+	defer matchersMu.RUnlock()
+	factories := make(map[string]func() ConditionMatcherFactory, len(matchers))
+	for name, factory := range matchers {
+		factories[name] = factory
+	}
+	return factories
 }

--- a/cluster/router/condition/matcher/extension_test.go
+++ b/cluster/router/condition/matcher/extension_test.go
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package matcher
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestGetMatcherFactoriesReturnsSnapshot(t *testing.T) {
+	const (
+		registeredName = "snapshot-registered-matcher"
+		injectedName   = "snapshot-injected-matcher"
+	)
+	t.Cleanup(func() {
+		matchersMu.Lock()
+		delete(matchers, registeredName)
+		matchersMu.Unlock()
+	})
+	SetMatcherFactory(registeredName, NewArgumentMatcherFactory)
+
+	snapshot := GetMatcherFactories()
+	delete(snapshot, registeredName)
+	snapshot[injectedName] = NewAttachmentMatcherFactory
+
+	current := GetMatcherFactories()
+	if _, ok := current[registeredName]; !ok {
+		t.Fatalf("deleting from the returned map removed %q from the registry", registeredName)
+	}
+	if _, ok := current[injectedName]; ok {
+		t.Fatalf("adding to the returned map injected %q into the registry", injectedName)
+	}
+}
+
+func TestMatcherFactoryRegistryConcurrentAccess(t *testing.T) {
+	const (
+		name       = "concurrent-matcher"
+		iterations = 1000
+		readers    = 4
+	)
+	t.Cleanup(func() {
+		matchersMu.Lock()
+		delete(matchers, name)
+		matchersMu.Unlock()
+	})
+	SetMatcherFactory(name, NewArgumentMatcherFactory)
+
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(readers + 1)
+	go func() {
+		defer waitGroup.Done()
+		for index := 0; index < iterations; index++ {
+			if index%2 == 0 {
+				SetMatcherFactory(name, NewArgumentMatcherFactory)
+			} else {
+				SetMatcherFactory(name, NewAttachmentMatcherFactory)
+			}
+		}
+	}()
+	for range readers {
+		go func() {
+			defer waitGroup.Done()
+			for range iterations {
+				_ = GetMatcherFactory(name)
+				_ = GetMatcherFactories()
+			}
+		}()
+	}
+	waitGroup.Wait()
+}

--- a/cluster/router/condition/matcher/pattern_value/extension.go
+++ b/cluster/router/condition/matcher/pattern_value/extension.go
@@ -17,24 +17,40 @@
 
 package pattern_value
 
+import (
+	"sync"
+)
+
 var (
-	valuePatterns = make(map[string]func() ValuePattern)
+	valuePatternsMu sync.RWMutex
+	valuePatterns   = make(map[string]func() ValuePattern)
 )
 
 // SetValuePattern sets create valuePattern function with @name
 func SetValuePattern(name string, fun func() ValuePattern) {
+	valuePatternsMu.Lock()
+	defer valuePatternsMu.Unlock()
 	valuePatterns[name] = fun
 }
 
 // GetValuePattern gets create valuePattern function by name
 func GetValuePattern(name string) ValuePattern {
-	if valuePatterns[name] == nil {
+	valuePatternsMu.RLock()
+	pattern := valuePatterns[name]
+	valuePatternsMu.RUnlock()
+	if pattern == nil {
 		panic("value_pattern for " + name + " is not existing, make sure you have imported the package.")
 	}
-	return valuePatterns[name]()
+	return pattern()
 }
 
 // GetValuePatterns gets all create valuePattern function
 func GetValuePatterns() map[string]func() ValuePattern {
-	return valuePatterns
+	valuePatternsMu.RLock()
+	defer valuePatternsMu.RUnlock()
+	patterns := make(map[string]func() ValuePattern, len(valuePatterns))
+	for name, pattern := range valuePatterns {
+		patterns[name] = pattern
+	}
+	return patterns
 }

--- a/cluster/router/condition/matcher/pattern_value/extension_test.go
+++ b/cluster/router/condition/matcher/pattern_value/extension_test.go
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package pattern_value
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestGetValuePatternsReturnsSnapshot(t *testing.T) {
+	const (
+		registeredName = "snapshot-registered-pattern"
+		injectedName   = "snapshot-injected-pattern"
+	)
+	t.Cleanup(func() {
+		valuePatternsMu.Lock()
+		delete(valuePatterns, registeredName)
+		valuePatternsMu.Unlock()
+	})
+	SetValuePattern(registeredName, NewWildcardValuePattern)
+
+	snapshot := GetValuePatterns()
+	delete(snapshot, registeredName)
+	snapshot[injectedName] = NewScopeValuePattern
+
+	current := GetValuePatterns()
+	if _, ok := current[registeredName]; !ok {
+		t.Fatalf("deleting from the returned map removed %q from the registry", registeredName)
+	}
+	if _, ok := current[injectedName]; ok {
+		t.Fatalf("adding to the returned map injected %q into the registry", injectedName)
+	}
+}
+
+func TestValuePatternRegistryConcurrentAccess(t *testing.T) {
+	const (
+		name       = "concurrent-pattern"
+		iterations = 1000
+		readers    = 4
+	)
+	t.Cleanup(func() {
+		valuePatternsMu.Lock()
+		delete(valuePatterns, name)
+		valuePatternsMu.Unlock()
+	})
+	SetValuePattern(name, NewWildcardValuePattern)
+
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(readers + 1)
+	go func() {
+		defer waitGroup.Done()
+		for index := 0; index < iterations; index++ {
+			if index%2 == 0 {
+				SetValuePattern(name, NewWildcardValuePattern)
+			} else {
+				SetValuePattern(name, NewScopeValuePattern)
+			}
+		}
+	}()
+	for range readers {
+		go func() {
+			defer waitGroup.Done()
+			for range iterations {
+				_ = GetValuePattern(name)
+				_ = GetValuePatterns()
+			}
+		}()
+	}
+	waitGroup.Wait()
+}


### PR DESCRIPTION
Fixes #3248

## Summary

- protect the condition matcher and pattern-value extension registries with independent RWMutexes
- copy factories while holding a read lock, then invoke them after unlocking so extension constructors can safely re-enter registration APIs
- return structural snapshots from GetAllMatcher and GetAllValuePattern so callers cannot mutate global registration state
- add snapshot-isolation and concurrent access coverage for both registries

## Scope

This PR addresses only the extension-safety and API-hygiene subitems of #3248 for the condition router registries. It does not change matcher semantics or route evaluation.

## Testing

- `go test ./cluster/router/condition/matcher/... -count=20`
- `go test -race ./cluster/router/condition/matcher/... -count=10`
- `go test ./cluster/router/condition/... -count=10`
- `go test -race ./cluster/router/condition/... -count=10`
- `go vet ./cluster/router/condition/...`
- `golangci-lint run ./cluster/router/condition/...`
- `make check-fmt`
- `make test`

## Checklist

- [x] Target branch is `develop`
- [x] New behavior is covered by tests
- [x] Formatting, lint, race, and full test suites pass locally
- [x] Commit includes a Signed-off-by trailer