### PR TITLE
fix: synchronize REST service config maps

### DIFF
--- a/protocol/rest/config/rest_config.go
+++ b/protocol/rest/config/rest_config.go
@@ -18,11 +18,18 @@
 package config
 
 import (
+	"maps"
+	"sync"
+)
+
+import (
 	"github.com/creasty/defaults"
 )
 
 var (
+	restConsumerServiceConfigMu  sync.RWMutex
 	restConsumerServiceConfigMap map[string]*RestServiceConfig
+	restProviderServiceConfigMu  sync.RWMutex
 	restProviderServiceConfigMap map[string]*RestServiceConfig
 )
 
@@ -124,30 +131,44 @@ func (c *RestMethodConfig) UnmarshalYAML(unmarshal func(any) error) error {
 
 // GetRestConsumerServiceConfig returns consumer service config by id.
 func GetRestConsumerServiceConfig(id string) *RestServiceConfig {
+	restConsumerServiceConfigMu.RLock()
+	defer restConsumerServiceConfigMu.RUnlock()
 	return restConsumerServiceConfigMap[id]
 }
 
 // GetRestProviderServiceConfig returns provider service config by id.
 func GetRestProviderServiceConfig(id string) *RestServiceConfig {
+	restProviderServiceConfigMu.RLock()
+	defer restProviderServiceConfigMu.RUnlock()
 	return restProviderServiceConfigMap[id]
 }
 
 // SetRestConsumerServiceConfigMap sets consumer service configs map.
 func SetRestConsumerServiceConfigMap(configMap map[string]*RestServiceConfig) {
+	configMap = maps.Clone(configMap)
+	restConsumerServiceConfigMu.Lock()
 	restConsumerServiceConfigMap = configMap
+	restConsumerServiceConfigMu.Unlock()
 }
 
 // SetRestProviderServiceConfigMap sets provider service configs map.
 func SetRestProviderServiceConfigMap(configMap map[string]*RestServiceConfig) {
+	configMap = maps.Clone(configMap)
+	restProviderServiceConfigMu.Lock()
 	restProviderServiceConfigMap = configMap
+	restProviderServiceConfigMu.Unlock()
 }
 
 // GetRestConsumerServiceConfigMap returns the consumer service configs map.
 func GetRestConsumerServiceConfigMap() map[string]*RestServiceConfig {
-	return restConsumerServiceConfigMap
+	restConsumerServiceConfigMu.RLock()
+	defer restConsumerServiceConfigMu.RUnlock()
+	return maps.Clone(restConsumerServiceConfigMap)
 }
 
 // GetRestProviderServiceConfigMap returns the provider service configs map.
 func GetRestProviderServiceConfigMap() map[string]*RestServiceConfig {
-	return restProviderServiceConfigMap
+	restProviderServiceConfigMu.RLock()
+	defer restProviderServiceConfigMu.RUnlock()
+	return maps.Clone(restProviderServiceConfigMap)
 }

--- a/protocol/rest/config/rest_config_test.go
+++ b/protocol/rest/config/rest_config_test.go
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"sync"
+	"testing"
+)
+
+type restServiceConfigMapAccessors struct {
+	set    func(map[string]*RestServiceConfig)
+	get    func(string) *RestServiceConfig
+	getAll func() map[string]*RestServiceConfig
+}
+
+func restServiceConfigMapAccessorTests() map[string]restServiceConfigMapAccessors {
+	return map[string]restServiceConfigMapAccessors{
+		"consumer": {
+			set:    SetRestConsumerServiceConfigMap,
+			get:    GetRestConsumerServiceConfig,
+			getAll: GetRestConsumerServiceConfigMap,
+		},
+		"provider": {
+			set:    SetRestProviderServiceConfigMap,
+			get:    GetRestProviderServiceConfig,
+			getAll: GetRestProviderServiceConfigMap,
+		},
+	}
+}
+
+func TestRestServiceConfigMapIsolation(t *testing.T) {
+	for name, accessors := range restServiceConfigMapAccessorTests() {
+		t.Run(name, func(t *testing.T) {
+			original := accessors.getAll()
+			t.Cleanup(func() {
+				accessors.set(original)
+			})
+
+			first := &RestServiceConfig{InterfaceName: "first"}
+			input := map[string]*RestServiceConfig{"first": first}
+			accessors.set(input)
+
+			delete(input, "first")
+			input["second"] = &RestServiceConfig{InterfaceName: "second"}
+			if got := accessors.get("first"); got != first {
+				t.Fatalf("setter retained caller map: got %p, want %p", got, first)
+			}
+			if got := accessors.get("second"); got != nil {
+				t.Fatalf("setter exposed later caller mutation: got %#v", got)
+			}
+
+			snapshot := accessors.getAll()
+			if got := snapshot["first"]; got != first {
+				t.Fatalf("snapshot changed value identity: got %p, want %p", got, first)
+			}
+			delete(snapshot, "first")
+			snapshot["second"] = &RestServiceConfig{InterfaceName: "second"}
+			if got := accessors.get("first"); got != first {
+				t.Fatalf("snapshot mutation changed registry: got %p, want %p", got, first)
+			}
+			if got := accessors.get("second"); got != nil {
+				t.Fatalf("snapshot mutation added registry value: got %#v", got)
+			}
+
+			replacement := &RestServiceConfig{InterfaceName: "replacement"}
+			accessors.set(map[string]*RestServiceConfig{"second": replacement})
+			if got := accessors.get("first"); got != nil {
+				t.Fatalf("replacement retained stale value: got %#v", got)
+			}
+			if got := accessors.get("second"); got != replacement {
+				t.Fatalf("replacement stored wrong value: got %p, want %p", got, replacement)
+			}
+
+			accessors.set(nil)
+			if got := accessors.getAll(); got != nil {
+				t.Fatalf("nil map semantics changed: got %#v", got)
+			}
+		})
+	}
+}
+
+func TestRestServiceConfigMapConcurrentAccess(t *testing.T) {
+	for name, accessors := range restServiceConfigMapAccessorTests() {
+		t.Run(name, func(t *testing.T) {
+			original := accessors.getAll()
+			t.Cleanup(func() {
+				accessors.set(original)
+			})
+			accessors.set(map[string]*RestServiceConfig{
+				"service": {InterfaceName: "initial"},
+			})
+
+			const (
+				goroutines = 16
+				iterations = 200
+			)
+			start := make(chan struct{})
+			var wg sync.WaitGroup
+			for i := 0; i < goroutines; i++ {
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					<-start
+					for j := 0; j < iterations; j++ {
+						input := map[string]*RestServiceConfig{
+							"service": {InterfaceName: "published"},
+						}
+						accessors.set(input)
+						delete(input, "service")
+					}
+				}()
+				go func() {
+					defer wg.Done()
+					<-start
+					for j := 0; j < iterations; j++ {
+						if got := accessors.get("service"); got == nil {
+							t.Error("single getter observed caller-side map deletion")
+							return
+						}
+						snapshot := accessors.getAll()
+						if snapshot["service"] == nil {
+							t.Error("snapshot getter observed caller-side map deletion")
+							return
+						}
+						delete(snapshot, "service")
+					}
+				}()
+			}
+			close(start)
+			wg.Wait()
+		})
+	}
+}


### PR DESCRIPTION
Fixes #3248

## Summary

- protect the REST consumer and provider service-config maps with independent RWMutexes
- shallow-clone setter inputs before atomic publication so later caller map mutations cannot change registered membership
- read single entries under the corresponding read lock and return structural snapshots from whole-map getters
- preserve nil-map behavior and existing RestServiceConfig pointer identity
- add input/output isolation, replacement, nil, and concurrent access coverage for both maps

## Scope

This PR addresses structural map ownership and concurrency for the REST configuration registries. It intentionally does not deep-clone the pointed RestServiceConfig values or claim deep object immutability.

## Testing

- `go test ./protocol/rest/config/... -count=20`
- `go test -race ./protocol/rest/config/... -count=10`
- `go test ./protocol/rest/... -count=1`
- `go vet ./protocol/rest/config/...`
- `golangci-lint run ./protocol/rest/config/... --timeout=10m`
- `make check-fmt`
- `make test`

## Checklist

- [x] Target branch is `develop`
- [x] New behavior is covered by tests
- [x] Formatting, lint, race, and full test suites pass locally
- [x] Commit includes a Signed-off-by trailer