### PR TITLE
fix: isolate metadata URL snapshots

### DIFF
--- a/metadata/info/metadata_info.go
+++ b/metadata/info/metadata_info.go
@@ -110,9 +110,9 @@ func (info *MetadataInfo) AddService(url *common.URL) {
 // addServiceWithoutLock adds a service URL without acquiring the lock.
 // The caller must hold info.mu.Lock() before calling this method.
 func (info *MetadataInfo) addServiceWithoutLock(url *common.URL) {
+	url = addUrl(info.exportedServiceURLs, url)
 	service := NewServiceInfoWithURL(url)
 	info.Services[service.GetMatchKey()] = service
-	addUrl(info.exportedServiceURLs, url)
 	if info.App == "" {
 		info.App = url.GetParam(constant.ApplicationKey, "")
 	}
@@ -121,11 +121,13 @@ func (info *MetadataInfo) addServiceWithoutLock(url *common.URL) {
 	}
 }
 
-func addUrl(m map[string][]*common.URL, url *common.URL) {
+func addUrl(m map[string][]*common.URL, url *common.URL) *common.URL {
+	url = url.Clone()
 	if _, ok := m[url.ServiceKey()]; !ok {
 		m[url.ServiceKey()] = make([]*common.URL, 0)
 	}
 	m[url.ServiceKey()] = append(m[url.ServiceKey()], url)
+	return url
 }
 
 func removeUrl(m map[string][]*common.URL, url *common.URL) {
@@ -183,7 +185,9 @@ func (info *MetadataInfo) GetExportedServiceURLs() []*common.URL {
 
 	res := make([]*common.URL, 0)
 	for _, urls := range info.exportedServiceURLs {
-		res = append(res, urls...)
+		for _, url := range urls {
+			res = append(res, cloneURL(url))
+		}
 	}
 	return res
 }
@@ -194,16 +198,18 @@ func (info *MetadataInfo) GetSubscribedURLs() []*common.URL {
 
 	res := make([]*common.URL, 0)
 	for _, urls := range info.subscribedServiceURLs {
-		res = append(res, urls...)
+		for _, url := range urls {
+			res = append(res, cloneURL(url))
+		}
 	}
 	return res
 }
 
-// GetServices returns a deep copy of the Services map for safe iteration by external callers.
-// Each ServiceInfo is fully copied with lazy fields eagerly populated to prevent write-on-read races.
+// GetServices returns a detached copy of the Services map for safe iteration by external callers.
+// Each ServiceInfo has detached Params and URL containers, with lazy fields eagerly populated.
 func (info *MetadataInfo) GetServices() map[string]*ServiceInfo {
-	info.mu.Lock()
-	defer info.mu.Unlock()
+	info.mu.RLock()
+	defer info.mu.RUnlock()
 
 	cp := make(map[string]*ServiceInfo, len(info.Services))
 	for k, v := range info.Services {
@@ -223,16 +229,15 @@ func (info *MetadataInfo) ReplaceExportedServices(urls []*common.URL) {
 	}
 }
 
-// Snapshot creates a deep copy of the MetadataInfo for safe concurrent access.
-// The caller can modify the snapshot without affecting the original.
+// Snapshot creates a copy of the MetadataInfo for safe concurrent access.
+// The caller can modify its maps and URL containers without affecting the original.
 func (info *MetadataInfo) Snapshot() MetadataInfo {
 	info.mu.RLock()
 	defer info.mu.RUnlock()
 
 	services := make(map[string]*ServiceInfo, len(info.Services))
 	for k, v := range info.Services {
-		si := *v
-		services[k] = &si
+		services[k] = v.DeepCopy()
 	}
 	return MetadataInfo{
 		App:      info.App,
@@ -352,10 +357,19 @@ func (si *ServiceInfo) GetServiceKey() string {
 	return si.ServiceKey
 }
 
-// DeepCopy returns a fully independent copy of ServiceInfo with lazy fields eagerly populated.
+// DeepCopy returns a copy with detached Params and URL containers.
+// Lazy fields are populated on the copy without mutating the source.
 func (si *ServiceInfo) DeepCopy() *ServiceInfo {
 	params := make(map[string]string, len(si.Params))
 	maps.Copy(params, si.Params)
+	serviceKey := si.ServiceKey
+	if serviceKey == "" {
+		serviceKey = common.ServiceKey(si.Name, si.Group, si.Version)
+	}
+	matchKey := si.MatchKey
+	if matchKey == "" {
+		matchKey = common.MatchKey(serviceKey, si.Protocol)
+	}
 	return &ServiceInfo{
 		Name:       si.Name,
 		Group:      si.Group,
@@ -364,10 +378,17 @@ func (si *ServiceInfo) DeepCopy() *ServiceInfo {
 		Port:       si.Port,
 		Path:       si.Path,
 		Params:     params,
-		ServiceKey: si.GetServiceKey(),
-		MatchKey:   si.GetMatchKey(),
-		URL:        si.URL,
+		ServiceKey: serviceKey,
+		MatchKey:   matchKey,
+		URL:        cloneURL(si.URL),
 	}
+}
+
+func cloneURL(url *common.URL) *common.URL {
+	if url == nil {
+		return nil
+	}
+	return url.Clone()
 }
 
 // toDescString returns a deterministic string representation of ServiceInfo

--- a/metadata/info/metadata_info_test.go
+++ b/metadata/info/metadata_info_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -81,6 +82,83 @@ func TestMetadataInfoAddServiceBackfillsApplicationTag(t *testing.T) {
 	assert.Equal(t, "gray", metadataInfo.Tag)
 }
 
+func TestMetadataInfoCopiesExportedServiceURLs(t *testing.T) {
+	metadataInfo := NewMetadataInfo("foo", "")
+	url := serviceUrl.Clone()
+	expectedPath := url.Path
+	expectedMethods := append([]string(nil), url.Methods...)
+	url.SubURL = common.NewURLWithOptions(common.WithPath("nested"))
+	expectedSubURLPath := url.SubURL.Path
+	sharedAttribute := &struct{ Value string }{Value: "shared"}
+	url.SetParam("snapshot-param", "before")
+	url.SetAttribute("snapshot-attribute", "before")
+	url.SetAttribute("shared-attribute", sharedAttribute)
+
+	metadataInfo.AddService(url)
+	url.Path = "/caller-mutated"
+	url.Methods[0] = "caller-mutated"
+	url.SubURL.Path = "/caller-mutated"
+	url.SetParam("snapshot-param", "caller-mutated")
+	url.SetAttribute("snapshot-attribute", "caller-mutated")
+
+	urls := metadataInfo.GetExportedServiceURLs()
+	require.Len(t, urls, 1)
+	assert.NotSame(t, url, urls[0])
+	assert.Equal(t, expectedPath, urls[0].Path)
+	assert.Equal(t, expectedMethods, urls[0].Methods)
+	require.NotNil(t, urls[0].SubURL)
+	assert.NotSame(t, url.SubURL, urls[0].SubURL)
+	assert.Equal(t, expectedSubURLPath, urls[0].SubURL.Path)
+	assert.Equal(t, "before", urls[0].GetParam("snapshot-param", ""))
+	attribute, ok := urls[0].GetAttribute("snapshot-attribute")
+	require.True(t, ok)
+	assert.Equal(t, "before", attribute)
+	attribute, ok = urls[0].GetAttribute("shared-attribute")
+	require.True(t, ok)
+	assert.Same(t, sharedAttribute, attribute)
+
+	urls[0].Path = "/getter-mutated"
+	urls[0].Methods[0] = "getter-mutated"
+	urls[0].SubURL.Path = "/getter-mutated"
+	urls[0].SetParam("snapshot-param", "getter-mutated")
+	urls[0].SetAttribute("snapshot-attribute", "getter-mutated")
+
+	freshURLs := metadataInfo.GetExportedServiceURLs()
+	require.Len(t, freshURLs, 1)
+	assert.NotSame(t, urls[0], freshURLs[0])
+	assert.Equal(t, expectedPath, freshURLs[0].Path)
+	assert.Equal(t, expectedMethods, freshURLs[0].Methods)
+	require.NotNil(t, freshURLs[0].SubURL)
+	assert.NotSame(t, urls[0].SubURL, freshURLs[0].SubURL)
+	assert.Equal(t, expectedSubURLPath, freshURLs[0].SubURL.Path)
+	assert.Equal(t, "before", freshURLs[0].GetParam("snapshot-param", ""))
+	attribute, ok = freshURLs[0].GetAttribute("snapshot-attribute")
+	require.True(t, ok)
+	assert.Equal(t, "before", attribute)
+}
+
+func TestMetadataInfoReplaceExportedServicesCopiesURLs(t *testing.T) {
+	metadataInfo := NewMetadataInfo("foo", "")
+	url := serviceUrl.Clone()
+	expectedPath := url.Path
+	url.SetParam("snapshot-param", "before")
+
+	metadataInfo.ReplaceExportedServices([]*common.URL{url})
+	url.Path = "/caller-mutated"
+	url.SetParam("snapshot-param", "caller-mutated")
+
+	urls := metadataInfo.GetExportedServiceURLs()
+	require.Len(t, urls, 1)
+	assert.NotSame(t, url, urls[0])
+	assert.Equal(t, expectedPath, urls[0].Path)
+	assert.Equal(t, "before", urls[0].GetParam("snapshot-param", ""))
+
+	service := requireOnlyService(t, metadataInfo.GetServices())
+	assert.NotSame(t, url, service.URL)
+	assert.Equal(t, expectedPath, service.URL.Path)
+	assert.Equal(t, "before", service.URL.GetParam("snapshot-param", ""))
+}
+
 func TestMetadataInfoRemoveServiceWithClonedURL(t *testing.T) {
 	metadataInfo := NewMetadataInfo("foo", "")
 	url, err := common.NewURL("dubbo://127.0.0.1:20000?application=foo&interface=com.foo.Bar&methods=GetPetByID%2CGetPetTypes&side=provider&version=1.0.0")
@@ -105,8 +183,10 @@ func TestMetadataInfoRemoveServiceKeepsRemainingMatchKeyService(t *testing.T) {
 	metadataInfo.RemoveService(url1.Clone())
 
 	require.Len(t, metadataInfo.Services, 1)
-	assert.Len(t, metadataInfo.GetExportedServiceURLs(), 1)
-	assert.Equal(t, url2, metadataInfo.GetExportedServiceURLs()[0])
+	remainingURLs := metadataInfo.GetExportedServiceURLs()
+	require.Len(t, remainingURLs, 1)
+	assert.True(t, url2.URLEqual(remainingURLs[0]))
+	assert.NotSame(t, url2, remainingURLs[0])
 }
 
 func TestHessian(t *testing.T) {
@@ -134,6 +214,32 @@ func TestMetadataInfoAddSubscribeURL(t *testing.T) {
 	assert.NotEmpty(t, info.GetSubscribedURLs())
 	info.RemoveSubscribeURL(serviceUrl)
 	assert.Empty(t, info.GetSubscribedURLs())
+}
+
+func TestMetadataInfoCopiesSubscribedURLs(t *testing.T) {
+	metadataInfo := NewMetadataInfo("foo", "")
+	url := serviceUrl.Clone()
+	expectedPath := url.Path
+	url.SetParam("snapshot-param", "before")
+
+	metadataInfo.AddSubscribeURL(url)
+	url.Path = "/caller-mutated"
+	url.SetParam("snapshot-param", "caller-mutated")
+
+	urls := metadataInfo.GetSubscribedURLs()
+	require.Len(t, urls, 1)
+	assert.NotSame(t, url, urls[0])
+	assert.Equal(t, expectedPath, urls[0].Path)
+	assert.Equal(t, "before", urls[0].GetParam("snapshot-param", ""))
+
+	urls[0].Path = "/getter-mutated"
+	urls[0].SetParam("snapshot-param", "getter-mutated")
+
+	freshURLs := metadataInfo.GetSubscribedURLs()
+	require.Len(t, freshURLs, 1)
+	assert.NotSame(t, urls[0], freshURLs[0])
+	assert.Equal(t, expectedPath, freshURLs[0].Path)
+	assert.Equal(t, "before", freshURLs[0].GetParam("snapshot-param", ""))
 }
 
 func TestMetadataInfoRemoveSubscribeURLWithClonedURL(t *testing.T) {
@@ -224,6 +330,134 @@ func TestMetadataInfoGetServices(t *testing.T) {
 
 	// A fresh call reflects the removal
 	assert.Empty(t, metadataInfo.GetServices())
+}
+
+func TestMetadataInfoServiceSnapshotsCopyURL(t *testing.T) {
+	metadataInfo := NewMetadataInfo("foo", "")
+	url := serviceUrl.Clone()
+	expectedPath := url.Path
+	metadataInfo.AddService(url)
+	url.Path = "/caller-mutated"
+
+	service := requireOnlyService(t, metadataInfo.GetServices())
+	assert.NotSame(t, url, service.URL)
+	assert.Equal(t, expectedPath, service.URL.Path)
+	service.URL.Path = "/getter-mutated"
+	service.Params["caller-mutation"] = "getter"
+
+	freshService := requireOnlyService(t, metadataInfo.GetServices())
+	assert.Equal(t, expectedPath, freshService.URL.Path)
+	assert.NotContains(t, freshService.Params, "caller-mutation")
+
+	snapshotService := requireOnlyService(t, metadataInfo.Snapshot().Services)
+	snapshotService.URL.Path = "/snapshot-mutated"
+	snapshotService.Params["caller-mutation"] = "snapshot"
+
+	freshService = requireOnlyService(t, metadataInfo.GetServices())
+	assert.Equal(t, expectedPath, freshService.URL.Path)
+	assert.NotContains(t, freshService.Params, "caller-mutation")
+}
+
+func TestMetadataInfoSnapshotDoesNotInitializeSourceLazyFields(t *testing.T) {
+	metadataInfo := NewMetadataInfo("foo", "")
+	service := &ServiceInfo{
+		Name:     "com.foo.Bar",
+		Group:    "test",
+		Version:  "1.0.0",
+		Protocol: "tri",
+		Params:   map[string]string{"timeout": "1000"},
+	}
+	metadataInfo.Services["service"] = service
+
+	snapshotService := metadataInfo.Snapshot().Services["service"]
+
+	assert.Empty(t, service.ServiceKey)
+	assert.Empty(t, service.MatchKey)
+	assert.Equal(t, common.ServiceKey(service.Name, service.Group, service.Version), snapshotService.ServiceKey)
+	assert.Equal(t, common.MatchKey(snapshotService.ServiceKey, service.Protocol), snapshotService.MatchKey)
+	assert.Nil(t, snapshotService.URL)
+	snapshotService.Params["timeout"] = "2000"
+	assert.Equal(t, "1000", service.Params["timeout"])
+}
+
+func TestMetadataInfoConcurrentURLSnapshotMutation(t *testing.T) {
+	metadataInfo := NewMetadataInfo("foo", "")
+	metadataInfo.AddService(serviceUrl)
+	metadataInfo.AddSubscribeURL(serviceUrl)
+
+	const iterations = 100
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(2)
+	go func() {
+		defer waitGroup.Done()
+		for i := range iterations {
+			replacement := testServiceURL("replacement." + strconv.Itoa(i))
+			metadataInfo.ReplaceExportedServices([]*common.URL{replacement})
+
+			transient := testServiceURL("transient." + strconv.Itoa(i))
+			metadataInfo.AddService(transient)
+			metadataInfo.RemoveService(transient.Clone())
+
+			subscription := testServiceURL("subscription." + strconv.Itoa(i))
+			metadataInfo.AddSubscribeURL(subscription)
+			metadataInfo.RemoveSubscribeURL(subscription.Clone())
+		}
+	}()
+	go func() {
+		defer waitGroup.Done()
+		for i := range iterations {
+			mutateURLSnapshots(metadataInfo.GetExportedServiceURLs(), i)
+			mutateURLSnapshots(metadataInfo.GetSubscribedURLs(), i)
+			mutateServiceSnapshots(metadataInfo.GetServices(), i)
+			mutateServiceSnapshots(metadataInfo.Snapshot().Services, i)
+		}
+	}()
+	waitGroup.Wait()
+
+	exportedURLs := metadataInfo.GetExportedServiceURLs()
+	require.Len(t, exportedURLs, 1)
+	assert.Equal(t, "replacement.99", exportedURLs[0].Interface())
+	require.Len(t, metadataInfo.GetSubscribedURLs(), 1)
+}
+
+func testServiceURL(service string) *common.URL {
+	url := serviceUrl.Clone()
+	url.Path = "/" + service
+	url.SetParam(constant.InterfaceKey, service)
+	return url
+}
+
+func mutateURLSnapshots(urls []*common.URL, iteration int) {
+	for _, url := range urls {
+		url.Path = "/snapshot-" + strconv.Itoa(iteration)
+		url.SetParam("snapshot-param", strconv.Itoa(iteration))
+		url.SetAttribute("snapshot-attribute", iteration)
+		if len(url.Methods) > 0 {
+			url.Methods[0] = "snapshot-mutated"
+		}
+		if url.SubURL != nil {
+			url.SubURL.Path = "/snapshot-mutated"
+		}
+	}
+}
+
+func mutateServiceSnapshots(services map[string]*ServiceInfo, iteration int) {
+	for _, service := range services {
+		service.Params["snapshot-param"] = strconv.Itoa(iteration)
+		if service.URL != nil {
+			mutateURLSnapshots([]*common.URL{service.URL}, iteration)
+		}
+	}
+}
+
+func requireOnlyService(t *testing.T, services map[string]*ServiceInfo) *ServiceInfo {
+	t.Helper()
+	require.Len(t, services, 1)
+	var onlyService *ServiceInfo
+	for _, service := range services {
+		onlyService = service
+	}
+	return onlyService
 }
 
 func TestServiceInfoJavaClassName(t *testing.T) {

--- a/metadata/metadata_service_test.go
+++ b/metadata/metadata_service_test.go
@@ -43,6 +43,62 @@ var (
 	url, _ = common.NewURL("dubbo://127.0.0.1:20000?application=foo&category=providers&check=false&dubbo=dubbo-go+v1.5.0&interface=com.foo.Bar&methods=GetPetByID%2CGetPetTypes&organization=Apache&owner=foo&revision=1.0.0&side=provider&version=1.0.0")
 )
 
+func assertURLSnapshotEqual(t testing.TB, expected, actual *common.URL) {
+	t.Helper()
+	require.NotNil(t, expected)
+	require.NotNil(t, actual)
+	assert.Equal(t, snapshotURLValue(expected), snapshotURLValue(actual))
+	assert.NotSame(t, expected, actual)
+}
+
+type urlValue struct {
+	Protocol     string
+	Location     string
+	IP           string
+	Port         string
+	PrimitiveURL string
+	Path         string
+	Username     string
+	Password     string
+	Methods      []string
+	Params       map[string][]string
+	Attributes   map[string]any
+	SubURL       *urlValue
+}
+
+func snapshotURLValue(url *common.URL) *urlValue {
+	if url == nil {
+		return nil
+	}
+	attributes := make(map[string]any)
+	url.RangeAttributes(func(key string, value any) bool {
+		attributes[key] = value
+		return true
+	})
+	return &urlValue{
+		Protocol:     url.Protocol,
+		Location:     url.Location,
+		IP:           url.Ip,
+		Port:         url.Port,
+		PrimitiveURL: url.PrimitiveURL,
+		Path:         url.Path,
+		Username:     url.Username,
+		Password:     url.Password,
+		Methods:      append([]string(nil), url.Methods...),
+		Params:       map[string][]string(url.CopyParams()),
+		Attributes:   attributes,
+		SubURL:       snapshotURLValue(url.SubURL),
+	}
+}
+
+func assertURLSnapshotsEqual(t testing.TB, expected, actual []*common.URL) {
+	t.Helper()
+	require.Len(t, actual, len(expected))
+	for i := range expected {
+		assertURLSnapshotEqual(t, expected[i], actual[i])
+	}
+}
+
 func newMetadataMap() map[string]*info.MetadataInfo {
 	metadataInfo := info.NewAppMetadataInfo("dubbo-app")
 	metadataInfo.Revision = "1"
@@ -61,7 +117,7 @@ func TestDefaultMetadataServiceGetExportedServiceURLs(t *testing.T) {
 	got, err := mts.GetExportedServiceURLs()
 	require.NoError(t, err)
 	assert.Len(t, got, 1)
-	assert.Equal(t, url, got[0])
+	assertURLSnapshotEqual(t, url, got[0])
 }
 
 func TestDefaultMetadataServiceGetExportedURLs(t *testing.T) {
@@ -144,7 +200,7 @@ func TestDefaultMetadataServiceGetExportedURLs(t *testing.T) {
 			}
 			got, err := mts.GetExportedURLs(tt.args.serviceInterface, tt.args.group, tt.args.version, tt.args.protocol)
 			require.NoError(t, err)
-			assert.Equalf(t, tt.want, got, "GetExportedURLs(%v, %v, %v, %v)", tt.args.serviceInterface, tt.args.group, tt.args.version, tt.args.protocol)
+			assertURLSnapshotsEqual(t, tt.want, got)
 		})
 	}
 }
@@ -238,7 +294,7 @@ func TestDefaultMetadataServiceGetSubscribedURLs(t *testing.T) {
 			}
 			got, err := mts.GetSubscribedURLs()
 			require.NoError(t, err)
-			assert.Equalf(t, tt.want, got, "GetSubscribedURLs()")
+			assertURLSnapshotsEqual(t, tt.want, got)
 		})
 	}
 }

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -60,7 +60,7 @@ func TestAddService(t *testing.T) {
 			meta := registryMetadataInfo[tt.args.registryId]
 			meta.App = tt.args.url.GetParam(constant.ApplicationKey, "")
 			meta.Tag = tt.args.url.GetParam(constant.ApplicationTagKey, "")
-			assert.Equal(t, tt.args.url, meta.GetExportedServiceURLs()[0])
+			assertURLSnapshotsEqual(t, []*common.URL{tt.args.url}, meta.GetExportedServiceURLs())
 		})
 	}
 }
@@ -93,7 +93,7 @@ func TestAddSubscribeURL(t *testing.T) {
 			meta := registryMetadataInfo[tt.args.registryId]
 			meta.App = tt.args.url.GetParam(constant.ApplicationKey, "")
 			meta.Tag = tt.args.url.GetParam(constant.ApplicationTagKey, "")
-			assert.Equal(t, tt.args.url, meta.GetSubscribedURLs()[0])
+			assertURLSnapshotsEqual(t, []*common.URL{tt.args.url}, meta.GetSubscribedURLs())
 		})
 	}
 }

--- a/registry/servicediscovery/service_discovery_registry_test.go
+++ b/registry/servicediscovery/service_discovery_registry_test.go
@@ -292,8 +292,10 @@ func TestServiceDiscoveryRegistryUnRegisterServicePartialFailSyncsMetadata(t *te
 
 	metaInfo := metadata.GetMetadataInfo(regID)
 	require.NotNil(t, metaInfo)
-	require.Len(t, metaInfo.GetExportedServiceURLs(), 1)
-	assert.Equal(t, providerURL1, metaInfo.GetExportedServiceURLs()[0])
+	remainingURLs := metaInfo.GetExportedServiceURLs()
+	require.Len(t, remainingURLs, 1)
+	assert.Equal(t, providerURL1.Clone(), remainingURLs[0])
+	assert.NotSame(t, providerURL1, remainingURLs[0])
 	assert.Len(t, metaInfo.Services, 1)
 
 	expectedRevision := createInstance(metaInfo, providerURL1, regID).GetMetadata()[constant.ExportedServicesRevisionPropertyName]
@@ -342,8 +344,10 @@ func TestServiceDiscoveryRegistryUnRegisterWithoutTrackedInstancesReconcilesMeta
 	err = reg.UnRegister(providerURL1.Clone())
 	require.NoError(t, err)
 
-	require.Len(t, metaInfo.GetExportedServiceURLs(), 1)
-	assert.Equal(t, providerURL2, metaInfo.GetExportedServiceURLs()[0])
+	remainingURLs := metaInfo.GetExportedServiceURLs()
+	require.Len(t, remainingURLs, 1)
+	assert.Equal(t, providerURL2.Clone(), remainingURLs[0])
+	assert.NotSame(t, providerURL2, remainingURLs[0])
 	assert.Len(t, metaInfo.Services, 1)
 
 	expectedRevision := createInstance(metaInfo, providerURL2, regID).GetMetadata()[constant.ExportedServicesRevisionPropertyName]


### PR DESCRIPTION
Fixes #3248

## Summary

- clone exported and subscribed URLs on ingress and return detached URL snapshots from public getters
- keep each stored service and its exported-URL index on the same owned URL while isolating caller mutations
- deep-copy ServiceInfo params and URL containers without initializing lazy keys on the source
- use read locking for service snapshots now that copy operations are read-only
- cover add/replace/getter ownership, nested URL state, shallow attribute-value boundaries, lazy fields, and concurrent mutation

## Scope

This PR makes URL containers, params, methods, nested URLs, and attribute maps structurally independent. Arbitrary mutable attribute values retain the shallow-copy behavior defined by common.URL.Clone.

## Testing

- `go test ./metadata/info -count=20`
- `go test -race ./metadata/info -count=10`
- `go test ./metadata/... -count=1`
- `go test -race ./metadata/... -count=1`
- `go test ./registry/servicediscovery -run 'TestServiceDiscoveryRegistryUnRegister(ServicePartialFailSyncsMetadata|WithoutTrackedInstancesReconcilesMetadata)$' -count=20`
- `go test -race ./registry/servicediscovery -run 'TestServiceDiscoveryRegistryUnRegister(ServicePartialFailSyncsMetadata|WithoutTrackedInstancesReconcilesMetadata)$' -count=10`
- `go test ./registry/servicediscovery -count=1`
- `go vet ./metadata/...`
- `golangci-lint run ./metadata/... ./registry/servicediscovery --timeout=10m`
- `make check-fmt`
- `make test`

## Checklist

- [x] Target branch is `develop`
- [x] New behavior is covered by tests
- [x] Formatting, lint, race, and full test suites pass locally
- [x] Commit includes a Signed-off-by trailer