### PR TITLE
fix(config-center): synchronize Apollo listener lifecycle

### DIFF
--- a/config_center/apollo/impl.go
+++ b/config_center/apollo/impl.go
@@ -52,10 +52,12 @@ type apolloConfiguration struct {
 	cc.BaseDynamicConfiguration
 	url *common.URL
 
-	listeners sync.Map
-	appConf   *config.AppConfig
-	parser    parser.ConfigurationParser
-	client    agollo.Client
+	listenerMu           sync.Mutex
+	listeners            sync.Map
+	registeringListeners map[*apolloListener]struct{}
+	appConf              *config.AppConfig
+	parser               parser.ConfigurationParser
+	client               agollo.Client
 }
 
 func newApolloConfiguration(url *common.URL) (*apolloConfiguration, error) {
@@ -85,24 +87,54 @@ func newApolloConfiguration(url *common.URL) (*apolloConfiguration, error) {
 func (c *apolloConfiguration) AddListener(key string, listener cc.ConfigurationListener, opts ...cc.Option) {
 	tmpOpts := cc.NewOptions(opts...)
 	key = tmpOpts.Center.Group + key
-	al := newApolloListener()
-	l, ok := c.listeners.LoadOrStore(key, al)
-	if !ok {
-		c.client.AddChangeListener(al)
+
+	c.listenerMu.Lock()
+	if l, ok := c.listeners.Load(key); ok {
+		l.(*apolloListener).AddListener(listener)
+		c.listenerMu.Unlock()
+		return
 	}
-	l.(*apolloListener).AddListener(listener)
+	al := newApolloListener()
+	al.AddListener(listener)
+	c.listeners.Store(key, al)
+	if c.registeringListeners == nil {
+		c.registeringListeners = make(map[*apolloListener]struct{})
+	}
+	c.registeringListeners[al] = struct{}{}
+	c.listenerMu.Unlock()
+
+	c.client.AddChangeListener(al)
+
+	c.listenerMu.Lock()
+	delete(c.registeringListeners, al)
+	current, ok := c.listeners.Load(key)
+	shouldUnregister := !ok || current != al || al.IsEmpty()
+	c.listenerMu.Unlock()
+	if shouldUnregister {
+		c.client.RemoveChangeListener(al)
+	}
 }
 
 func (c *apolloConfiguration) RemoveListener(key string, listener cc.ConfigurationListener, opts ...cc.Option) {
 	tmpOpts := cc.NewOptions(opts...)
 	key = tmpOpts.Center.Group + key
+
+	c.listenerMu.Lock()
 	l, ok := c.listeners.Load(key)
-	if ok {
-		al := l.(*apolloListener)
-		al.RemoveListener(listener)
-		if al.IsEmpty() {
-			c.client.RemoveChangeListener(al)
-		}
+	if !ok {
+		c.listenerMu.Unlock()
+		return
+	}
+	al := l.(*apolloListener)
+	if !al.RemoveListener(listener) {
+		c.listenerMu.Unlock()
+		return
+	}
+	c.listeners.Delete(key)
+	_, registering := c.registeringListeners[al]
+	c.listenerMu.Unlock()
+	if !registering {
+		c.client.RemoveChangeListener(al)
 	}
 }
 

--- a/config_center/apollo/impl_listener_test.go
+++ b/config_center/apollo/impl_listener_test.go
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package apollo
+
+import (
+	"sync"
+	"testing"
+)
+
+import (
+	"github.com/apolloconfig/agollo/v4"
+	"github.com/apolloconfig/agollo/v4/storage"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+import (
+	cc "dubbo.apache.org/dubbo-go/v3/config_center"
+)
+
+type trackingApolloClient struct {
+	agollo.Client
+
+	mu              sync.Mutex
+	active          map[storage.ChangeListener]struct{}
+	addCount        int
+	removeCount     int
+	onAdd           func(storage.ChangeListener)
+	removeStarted   chan struct{}
+	releaseRemove   chan struct{}
+	removeStartOnce sync.Once
+}
+
+func newTrackingApolloClient() *trackingApolloClient {
+	return &trackingApolloClient{
+		active: make(map[storage.ChangeListener]struct{}),
+	}
+}
+
+func (c *trackingApolloClient) AddChangeListener(listener storage.ChangeListener) {
+	c.mu.Lock()
+	c.active[listener] = struct{}{}
+	c.addCount++
+	onAdd := c.onAdd
+	c.mu.Unlock()
+	if onAdd != nil {
+		onAdd(listener)
+	}
+}
+
+func (c *trackingApolloClient) RemoveChangeListener(listener storage.ChangeListener) {
+	if c.removeStarted != nil {
+		c.removeStartOnce.Do(func() {
+			close(c.removeStarted)
+		})
+		<-c.releaseRemove
+	}
+	c.mu.Lock()
+	delete(c.active, listener)
+	c.removeCount++
+	c.mu.Unlock()
+}
+
+func (c *trackingApolloClient) state() (int, int, int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.addCount, c.removeCount, len(c.active)
+}
+
+func TestApolloConfigurationAddsListenerBeforeRegistration(t *testing.T) {
+	client := newTrackingApolloClient()
+	listener := &countingListener{}
+	client.onAdd = func(registered storage.ChangeListener) {
+		registered.OnNewestChange(testFullChangeEvent())
+	}
+	configuration := &apolloConfiguration{client: client}
+
+	configuration.AddListener("application", listener)
+
+	assert.Equal(t, int64(1), listener.count.Load())
+	addCount, removeCount, activeCount := client.state()
+	assert.Equal(t, 1, addCount)
+	assert.Zero(t, removeCount)
+	assert.Equal(t, 1, activeCount)
+}
+
+func TestApolloConfigurationAllowsReentrantRemovalDuringRegistration(t *testing.T) {
+	client := newTrackingApolloClient()
+	configuration := &apolloConfiguration{client: client}
+	const key = "application"
+	storedKey := cc.NewOptions().Center.Group + key
+	var listener *callbackListener
+	listener = &callbackListener{process: func(*cc.ConfigChangeEvent) {
+		configuration.RemoveListener(key, listener)
+	}}
+	client.onAdd = func(registered storage.ChangeListener) {
+		registered.OnNewestChange(testFullChangeEvent())
+	}
+
+	configuration.AddListener(key, listener)
+
+	_, ok := configuration.listeners.Load(storedKey)
+	assert.False(t, ok)
+	addCount, removeCount, activeCount := client.state()
+	assert.Equal(t, 1, addCount)
+	assert.Equal(t, 1, removeCount)
+	assert.Zero(t, activeCount)
+}
+
+func TestApolloConfigurationListenerLifecycle(t *testing.T) {
+	client := newTrackingApolloClient()
+	configuration := &apolloConfiguration{client: client}
+	first := &countingListener{}
+	second := &countingListener{}
+	const key = "application"
+	storedKey := cc.NewOptions().Center.Group + key
+
+	configuration.AddListener(key, first)
+	configuration.AddListener(key, second)
+	configuration.RemoveListener(key, first)
+
+	stored, ok := configuration.listeners.Load(storedKey)
+	require.True(t, ok)
+	assert.False(t, stored.(*apolloListener).IsEmpty())
+	addCount, removeCount, activeCount := client.state()
+	assert.Equal(t, 1, addCount)
+	assert.Zero(t, removeCount)
+	assert.Equal(t, 1, activeCount)
+
+	configuration.RemoveListener(key, second)
+	_, ok = configuration.listeners.Load(storedKey)
+	assert.False(t, ok)
+	addCount, removeCount, activeCount = client.state()
+	assert.Equal(t, 1, addCount)
+	assert.Equal(t, 1, removeCount)
+	assert.Zero(t, activeCount)
+
+	configuration.AddListener(key, first)
+	_, ok = configuration.listeners.Load(storedKey)
+	assert.True(t, ok)
+	addCount, removeCount, activeCount = client.state()
+	assert.Equal(t, 2, addCount)
+	assert.Equal(t, 1, removeCount)
+	assert.Equal(t, 1, activeCount)
+}
+
+func TestApolloConfigurationSerializesRemoveAndReAdd(t *testing.T) {
+	client := newTrackingApolloClient()
+	configuration := &apolloConfiguration{client: client}
+	first := &countingListener{}
+	second := &countingListener{}
+	const key = "application"
+	storedKey := cc.NewOptions().Center.Group + key
+	configuration.AddListener(key, first)
+	previous, ok := configuration.listeners.Load(storedKey)
+	require.True(t, ok)
+
+	client.removeStarted = make(chan struct{})
+	client.releaseRemove = make(chan struct{})
+	removeDone := make(chan struct{})
+	go func() {
+		configuration.RemoveListener(key, first)
+		close(removeDone)
+	}()
+	waitForSignal(t, client.removeStarted)
+
+	addDone := make(chan struct{})
+	go func() {
+		configuration.AddListener(key, second)
+		close(addDone)
+	}()
+	waitForSignal(t, addDone)
+	close(client.releaseRemove)
+	waitForSignal(t, removeDone)
+
+	current, ok := configuration.listeners.Load(storedKey)
+	require.True(t, ok)
+	assert.NotSame(t, previous, current)
+	assert.False(t, current.(*apolloListener).IsEmpty())
+	addCount, removeCount, activeCount := client.state()
+	assert.Equal(t, 2, addCount)
+	assert.Equal(t, 1, removeCount)
+	assert.Equal(t, 1, activeCount)
+}

--- a/config_center/apollo/impl_test.go
+++ b/config_center/apollo/impl_test.go
@@ -75,15 +75,18 @@ const (
 }`
 )
 
-var mockConfigRes = `{
-	"appId": "testApplication_yang",
-	"cluster": "default",
-	"namespaceName": "mockDubbogo.yaml",
-	"configurations":{
-		"content":"dubbo:\n  application:\n     name: \"demo-server\"\n     version: \"2.0\"\n"
-    },
-	"releaseKey": "20191104105242-0f13805d89f834a4"
-}`
+var (
+	mockConfigResMu sync.RWMutex
+	mockConfigRes   = `{
+		"appId": "testApplication_yang",
+		"cluster": "default",
+		"namespaceName": "mockDubbogo.yaml",
+		"configurations":{
+			"content":"dubbo:\n  application:\n     name: \"demo-server\"\n     version: \"2.0\"\n"
+	    },
+		"releaseKey": "20191104105242-0f13805d89f834a4"
+	}`
+)
 
 func initApollo() *httptest.Server {
 	return runMockConfigServer()
@@ -95,8 +98,23 @@ func configCacheResponse(rw http.ResponseWriter, _ *http.Request) {
 }
 
 func configResponse(rw http.ResponseWriter, _ *http.Request) {
+	mockConfigResMu.RLock()
 	result := mockConfigRes
+	mockConfigResMu.RUnlock()
 	fmt.Fprintf(rw, "%s", result)
+}
+
+func setMockConfigResponse(t *testing.T, response string) {
+	t.Helper()
+	mockConfigResMu.Lock()
+	previous := mockConfigRes
+	mockConfigRes = response
+	mockConfigResMu.Unlock()
+	t.Cleanup(func() {
+		mockConfigResMu.Lock()
+		mockConfigRes = previous
+		mockConfigResMu.Unlock()
+	})
 }
 
 func configCacheJsonResponse(rw http.ResponseWriter, _ *http.Request) {
@@ -193,6 +211,7 @@ func initMockApollo(t *testing.T) *apolloConfiguration {
 	params.Set(constant.ConfigBackupConfigKey, "false")
 
 	apollo := initApollo()
+	t.Cleanup(apollo.Close)
 	apolloUrl := strings.ReplaceAll(apollo.URL, "http", "apollo")
 	apolloCfgURL, err := common.NewURL(apolloUrl, common.WithParams(params))
 	require.NoError(t, err)
@@ -258,7 +277,7 @@ func TestListener(t *testing.T) {
 	listener := &apolloDataListener{}
 	listener.wg.Add(2)
 	apollo := initMockApollo(t)
-	mockConfigRes = `{
+	setMockConfigResponse(t, `{
 	"appId": "testApplication_yang",
 	"cluster": "default",
 	"namespaceName": "mockDubbogo.yaml",
@@ -266,29 +285,24 @@ func TestListener(t *testing.T) {
 		"registries.hangzhouzk.username": "11111"
 	},
 	"releaseKey": "20191104105242-0f13805d89f834a4"
-}`
+}`)
 	// test add
 	apollo.AddListener(mockNamespace, listener)
 	listener.wg.Wait()
-	assert.Equal(t, "mockDubbogo.yaml", listener.event)
-	assert.Positive(t, listener.count)
+	event, count := listener.snapshot()
+	assert.Equal(t, "mockDubbogo.yaml", event)
+	assert.Positive(t, count)
 
 	// test remove
 	apollo.RemoveListener(mockNamespace, listener)
-	listenerCount := 0
-	apollo.listeners.Range(func(_, value any) bool {
-		apolloListener := value.(*apolloListener)
-		for e := range apolloListener.listeners {
-			t.Logf("listener:%v", e)
-			listenerCount++
-		}
-		return true
-	})
-	assert.Equal(t, 0, listenerCount)
+	storedKey := config_center.NewOptions().Center.Group + mockNamespace
+	_, ok := apollo.listeners.Load(storedKey)
+	assert.False(t, ok)
 }
 
 type apolloDataListener struct {
 	wg    sync.WaitGroup
+	mu    sync.Mutex
 	count int
 	event string
 }
@@ -297,9 +311,17 @@ func (l *apolloDataListener) Process(configType *config_center.ConfigChangeEvent
 	if configType.ConfigType != remoting.EventTypeUpdate {
 		return
 	}
-	l.wg.Done()
+	l.mu.Lock()
 	l.count++
 	l.event = configType.Key
+	l.mu.Unlock()
+	l.wg.Done()
+}
+
+func (l *apolloDataListener) snapshot() (string, int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.event, l.count
 }
 
 // custom parser with concurrent safety

--- a/config_center/apollo/listener.go
+++ b/config_center/apollo/listener.go
@@ -18,6 +18,10 @@
 package apollo
 
 import (
+	"sync"
+)
+
+import (
 	"github.com/apolloconfig/agollo/v4/storage"
 
 	"github.com/dubbogo/gost/log/logger"
@@ -31,6 +35,7 @@ import (
 )
 
 type apolloListener struct {
+	mu        sync.RWMutex
 	listeners map[config_center.ConfigurationListener]struct{}
 }
 
@@ -53,7 +58,7 @@ func (a *apolloListener) OnNewestChange(changeEvent *storage.FullChangeEvent) {
 		return
 	}
 	content := string(b)
-	for listener := range a.listeners {
+	for _, listener := range a.snapshotListeners() {
 		listener.Process(&config_center.ConfigChangeEvent{
 			ConfigType: remoting.EventTypeUpdate,
 			Key:        changeEvent.Namespace,
@@ -64,17 +69,33 @@ func (a *apolloListener) OnNewestChange(changeEvent *storage.FullChangeEvent) {
 
 // AddListener adds a listener for apollo
 func (a *apolloListener) AddListener(l config_center.ConfigurationListener) {
-	if _, ok := a.listeners[l]; !ok {
-		a.listeners[l] = struct{}{}
-	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.listeners[l] = struct{}{}
 }
 
 // RemoveListener removes listeners of apollo
-func (a *apolloListener) RemoveListener(l config_center.ConfigurationListener) {
+func (a *apolloListener) RemoveListener(l config_center.ConfigurationListener) bool {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	delete(a.listeners, l)
+	return len(a.listeners) == 0
 }
 
 // IsEmpty Check if listeners is empty
 func (a *apolloListener) IsEmpty() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
 	return len(a.listeners) == 0
+}
+
+func (a *apolloListener) snapshotListeners() []config_center.ConfigurationListener {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	listeners := make([]config_center.ConfigurationListener, 0, len(a.listeners))
+	for listener := range a.listeners {
+		listeners = append(listeners, listener)
+	}
+	return listeners
 }

--- a/config_center/apollo/listener_test.go
+++ b/config_center/apollo/listener_test.go
@@ -18,7 +18,10 @@
 package apollo
 
 import (
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 import (
@@ -36,6 +39,22 @@ type recordingListener struct {
 
 func (r *recordingListener) Process(e *config_center.ConfigChangeEvent) {
 	r.events = append(r.events, e)
+}
+
+type countingListener struct {
+	count atomic.Int64
+}
+
+func (c *countingListener) Process(*config_center.ConfigChangeEvent) {
+	c.count.Add(1)
+}
+
+type callbackListener struct {
+	process func(*config_center.ConfigChangeEvent)
+}
+
+func (c *callbackListener) Process(event *config_center.ConfigChangeEvent) {
+	c.process(event)
 }
 
 func TestApolloListener(t *testing.T) {
@@ -68,5 +87,96 @@ func TestApolloListener(t *testing.T) {
 	l.RemoveListener(rec)
 	if !l.IsEmpty() {
 		t.Fatalf("listener should be empty after remove")
+	}
+}
+
+func TestApolloListenerConcurrentAccess(t *testing.T) {
+	listener := newApolloListener()
+	first := &countingListener{}
+	second := &countingListener{}
+	change := testFullChangeEvent()
+
+	const iterations = 200
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(4)
+	go toggleListenerMembership(listener, first, iterations, &waitGroup)
+	go toggleListenerMembership(listener, second, iterations, &waitGroup)
+	go dispatchListenerChanges(listener, change, iterations, &waitGroup)
+	go observeListenerEmpty(listener, iterations, &waitGroup)
+	waitGroup.Wait()
+
+	firstBefore := first.count.Load()
+	secondBefore := second.count.Load()
+	listener.AddListener(first)
+	listener.AddListener(second)
+	listener.OnNewestChange(change)
+	if got := first.count.Load(); got != firstBefore+1 {
+		t.Fatalf("first listener count = %d, want %d", got, firstBefore+1)
+	}
+	if got := second.count.Load(); got != secondBefore+1 {
+		t.Fatalf("second listener count = %d, want %d", got, secondBefore+1)
+	}
+	listener.RemoveListener(first)
+	listener.RemoveListener(second)
+	if !listener.IsEmpty() {
+		t.Fatal("listener should be empty after cleanup")
+	}
+}
+
+func TestApolloListenerAllowsReentrantRemoval(t *testing.T) {
+	listener := newApolloListener()
+	var self *callbackListener
+	self = &callbackListener{process: func(*config_center.ConfigChangeEvent) {
+		listener.RemoveListener(self)
+	}}
+	listener.AddListener(self)
+
+	returned := make(chan struct{})
+	go func() {
+		listener.OnNewestChange(testFullChangeEvent())
+		close(returned)
+	}()
+	waitForSignal(t, returned)
+	if !listener.IsEmpty() {
+		t.Fatal("listener should be empty after removing itself")
+	}
+}
+
+func toggleListenerMembership(listener *apolloListener, target config_center.ConfigurationListener, iterations int, waitGroup *sync.WaitGroup) {
+	defer waitGroup.Done()
+	for range iterations {
+		listener.AddListener(target)
+		listener.RemoveListener(target)
+	}
+}
+
+func dispatchListenerChanges(listener *apolloListener, change *storage.FullChangeEvent, iterations int, waitGroup *sync.WaitGroup) {
+	defer waitGroup.Done()
+	for range iterations {
+		listener.OnNewestChange(change)
+	}
+}
+
+func observeListenerEmpty(listener *apolloListener, iterations int, waitGroup *sync.WaitGroup) {
+	defer waitGroup.Done()
+	for range iterations {
+		listener.IsEmpty()
+	}
+}
+
+func testFullChangeEvent() *storage.FullChangeEvent {
+	change := &storage.FullChangeEvent{
+		Changes: map[string]any{"k": "v"},
+	}
+	change.Namespace = "application"
+	return change
+}
+
+func waitForSignal(t *testing.T, signal <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for listener operation")
 	}
 }


### PR DESCRIPTION
## Summary

- synchronize Apollo listener membership and callback snapshots
- attach the first configuration listener before registering with the Apollo client
- remove empty listener groups so a later add performs a fresh registration
- keep Apollo SDK calls outside the local lifecycle lock and compensate synchronous reentrant removals

## Root cause

The listener map was read, written, and iterated concurrently without synchronization. The last listener removal also left the empty group in the configuration map, so adding a listener again reused an unregistered group. Registering the Apollo callback before adding the first configuration listener could additionally miss a synchronous initial change.

## Validation

- `go test ./config_center/apollo -run 'TestApollo(Listener|Configuration)' -count=20`
- `go test -race ./config_center/apollo -run '^(TestApollo.*|TestListener)$' -count=10`
- `go test ./config_center/... -count=1`
- `go vet ./config_center/...`
- `golangci-lint run ./config_center/apollo`
- `make check-fmt`
- `make test`

Part of #3248.
