### PR TITLE
refactor: use GenericException from dubbo-go-hessian2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Workiva/go-datastructures v1.0.52
 	github.com/alibaba/sentinel-golang v1.0.4
 	github.com/apache/dubbo-getty v1.4.10
-	github.com/apache/dubbo-go-hessian2 v1.12.5
+	github.com/apache/dubbo-go-hessian2 v1.13.2
 	github.com/apolloconfig/agollo/v4 v4.4.0
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/creasty/defaults v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -73,7 +73,6 @@ github.com/alibabacloud-go/tea v1.1.17/go.mod h1:nXxjm6CIFkBhwW4FQkNrolwbfon8Svy
 github.com/alibabacloud-go/tea-utils v1.4.4 h1:lxCDvNCdTo9FaXKKq45+4vGETQUKNOW/qKTcX9Sk53o=
 github.com/alibabacloud-go/tea-utils v1.4.4/go.mod h1:KNcT0oXlZZxOXINnZBs6YvgOd5aYp9U67G+E3R8fcQw=
 github.com/aliyun/alibaba-cloud-sdk-go v1.61.18/go.mod h1:v8ESoHo4SyHmuB4b1tJqDHxfTGEciD+yhvOU/5s1Rfk=
-github.com/aliyun/alibaba-cloud-sdk-go v1.61.1704/go.mod h1:RcDobYh8k5VP6TNybz9m++gL3ijVI5wueVr0EM10VsU=
 github.com/aliyun/alibaba-cloud-sdk-go v1.61.1800 h1:ie/8RxBOfKZWcrbYSJi2Z8uX8TcOlSMwPlEJh83OeOw=
 github.com/aliyun/alibaba-cloud-sdk-go v1.61.1800/go.mod h1:RcDobYh8k5VP6TNybz9m++gL3ijVI5wueVr0EM10VsU=
 github.com/aliyun/alibabacloud-dkms-gcs-go-sdk v0.2.2 h1:rWkH6D2XlXb/Y+tNAQROxBzp3a0p92ni+pXcaHBe/WI=
@@ -85,8 +84,8 @@ github.com/apache/dubbo-getty v1.4.10 h1:ZmkpHJa/qgS0evX2tTNqNCz6rClI/9Wwp7ctyMm
 github.com/apache/dubbo-getty v1.4.10/go.mod h1:V64WqLIxksEgNu5aBJBOxNIvpOZyfUJ7J/DXBlKSUoA=
 github.com/apache/dubbo-go-hessian2 v1.9.1/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
 github.com/apache/dubbo-go-hessian2 v1.9.3/go.mod h1:xQUjE7F8PX49nm80kChFvepA/AvqAZ0oh/UaB6+6pBE=
-github.com/apache/dubbo-go-hessian2 v1.12.5 h1:19lJz2Md0EYF2bOtEvFqXEQRYvLz04GfsoocsBWlLWQ=
-github.com/apache/dubbo-go-hessian2 v1.12.5/go.mod h1:QP9Tc0w/B/mDopjusebo/c7GgEfl6Lz8jeuFg8JA6yw=
+github.com/apache/dubbo-go-hessian2 v1.13.2 h1:A15pmQMReoT0ho74j/B4m+mhCs+bngqyCGXDOvUwxmY=
+github.com/apache/dubbo-go-hessian2 v1.13.2/go.mod h1:BBLS7rwDB/q+xPJs5T66iyUI6TuAQC/m0mqok+JtEj0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apolloconfig/agollo/v4 v4.4.0 h1:bIIRTEN4f7HgLx97/cNpduEvP9qQ7BkCyDOI2j800VM=
@@ -193,7 +192,6 @@ github.com/dubbogo/go-zookeeper v1.0.4-0.20211212162352-f9d2183d89d5 h1:XoR8SSVz
 github.com/dubbogo/go-zookeeper v1.0.4-0.20211212162352-f9d2183d89d5/go.mod h1:fn6n2CAEer3novYgk9ULLwAjuV8/g4DdC2ENwRb6E+c=
 github.com/dubbogo/gost v1.9.0/go.mod h1:pPTjVyoJan3aPxBPNUX0ADkXjPibLo+/Ib0/fADXSG8=
 github.com/dubbogo/gost v1.11.18/go.mod h1:vIcP9rqz2KsXHPjsAwIUtfJIJjppQLQDcYaZTy/61jI=
-github.com/dubbogo/gost v1.13.1/go.mod h1:9HMXBv+WBMRWhF3SklpqDjkS/01AKWm2SrVdz/A0xJI=
 github.com/dubbogo/gost v1.14.3 h1:bInkIjdImMo9ENTDdCcs4YlQ/vz5rP/rjcnLakK5x24=
 github.com/dubbogo/gost v1.14.3/go.mod h1:WydBuEOkwKEm9mcWLlOnmsVe1ELFgrNPmC5SzXdPv4A=
 github.com/dubbogo/grpc-go v1.42.9/go.mod h1:F1T9hnUvYGW4JLK1QNriavpOkhusU677ovPzLkk6zHM=
@@ -546,7 +544,6 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
 github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOAqxQCu2WE=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
-github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
@@ -587,7 +584,6 @@ github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOl
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nacos-group/nacos-sdk-go v1.0.8/go.mod h1:hlAPn3UdzlxIlSILAyOXKxjFSvDJ9oLzTJ9hLAK1KzA=
-github.com/nacos-group/nacos-sdk-go/v2 v2.1.2/go.mod h1:ys/1adWeKXXzbNWfRNbaFlX/t6HVLWdpsNDvmoWTw0g=
 github.com/nacos-group/nacos-sdk-go/v2 v2.2.5 h1:r0wwT7PayEjvEHzWXwr1ROi/JSqzujM4w+1L5ikThzQ=
 github.com/nacos-group/nacos-sdk-go/v2 v2.2.5/go.mod h1:OObBon0prVJVPoIbSZxpEkFiBfL0d1LcBtuAMiNn+8c=
 github.com/natefinch/lumberjack v2.0.0+incompatible h1:4QJd3OLAMgj7ph+yZTuX13Ld4UpgHp07nNdFX7mqFfM=
@@ -661,7 +657,6 @@ github.com/prometheus/client_golang v1.9.0/go.mod h1:FqZLKOZnGdFAhOK4nqGHa7D66Id
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.11.1/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
 github.com/prometheus/client_golang v1.12.1/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
-github.com/prometheus/client_golang v1.12.2/go.mod h1:3Z9XVyYiZYEO+YQWt3RD2R3jrbd179Rt297l4aS6nDY=
 github.com/prometheus/client_golang v1.19.1 h1:wZWJDwK+NameRJuPGDhlnFgx8e8HN3XHQeLaYJFJBOE=
 github.com/prometheus/client_golang v1.19.1/go.mod h1:mP78NwGzrVks5S2H6ab8+ZZGJLZUq1hoULYBAYBw1Ho=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -881,7 +876,6 @@ go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.10.0 h1:9qC72Qh0+3MqyJbAn8YU5xVq1frD8bn3JtD2oXtafVQ=
 go.uber.org/atomic v1.10.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=
 go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
@@ -1117,7 +1111,6 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210816074244-15123e1e1f71/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211106132015-ebca88c72f68/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1153,7 +1146,6 @@ golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxb
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20201208040808-7e3f01d25324/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20220722155302-e5dcc9cfc0b9/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
 golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -1349,7 +1341,6 @@ google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQ
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.46.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.46.2/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
-google.golang.org/grpc v1.48.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc v1.64.1 h1:LKtvyfbX3UGVPFcGqJ9ItpVWW6oN/2XqTxfAnwRRXiA=
 google.golang.org/grpc v1.64.1/go.mod h1:hiQF4LFZelK2WKaP6W0L92zGHtiQdZxk8CrSdvyjeP0=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/protocol/dubbo/hessian2/generic_exception_compat_test.go
+++ b/protocol/dubbo/hessian2/generic_exception_compat_test.go
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hessian2_test
+
+import (
+	"testing"
+)
+
+import (
+	dubbohessian "dubbo.apache.org/dubbo-go/v3/protocol/dubbo/hessian2"
+)
+
+// TestGenericExceptionCompat verifies that the backward-compatible GenericException
+// type alias and ToGenericException function are still accessible from the original
+// import path (dubbo.apache.org/dubbo-go/v3/protocol/dubbo/hessian2).
+//
+// This test uses an external package (hessian2_test) so it validates the public API
+// surface as an external consumer would.
+func TestGenericExceptionCompat(t *testing.T) {
+	// 1) Type alias — should compile and create a valid struct literal
+	ge := dubbohessian.GenericException{
+		ExceptionClass:   "com.example.TestException",
+		ExceptionMessage: "test error",
+	}
+	if ge.Error() == "" {
+		t.Fatal("GenericException.Error() should not be empty")
+	}
+
+	// 2) ToGenericException — Deprecated forwarding function
+	result, ok := dubbohessian.ToGenericException(ge)
+	if !ok || result == nil {
+		t.Fatal("ToGenericException should return (non-nil, true) for a valid GenericException")
+	}
+	if result.ExceptionClass != "com.example.TestException" {
+		t.Fatalf("unexpected ExceptionClass: got %q, want %q",
+			result.ExceptionClass, "com.example.TestException")
+	}
+
+	// 3) ToGenericException with a string (legacy path)
+	result2, ok2 := dubbohessian.ToGenericException("java exception: com.example.Err - something went wrong")
+	if !ok2 || result2 == nil {
+		t.Fatal("ToGenericException should handle legacy string format")
+	}
+}

--- a/protocol/dubbo/hessian2/generic_exception_compat_test.go
+++ b/protocol/dubbo/hessian2/generic_exception_compat_test.go
@@ -53,7 +53,15 @@ func TestGenericExceptionCompat(t *testing.T) {
 
 	// 3) ToGenericException with a string (legacy path)
 	result2, ok2 := dubbohessian.ToGenericException("java exception: com.example.Err - something went wrong")
-	if !ok2 || result2 == nil {
-		t.Fatal("ToGenericException should handle legacy string format")
+	if !ok2 {
+		t.Fatal("ToGenericException should return true for legacy string format")
+	}
+	if result2.ExceptionClass != "java.lang.Exception" {
+		t.Fatalf("unexpected ExceptionClass: got %q, want %q",
+			result2.ExceptionClass, "java.lang.Exception")
+	}
+	if result2.ExceptionMessage != "com.example.Err - something went wrong" {
+		t.Fatalf("unexpected ExceptionMessage: got %q, want %q",
+			result2.ExceptionMessage, "com.example.Err - something went wrong")
 	}
 }

--- a/protocol/dubbo/hessian2/hessian_dubbo.go
+++ b/protocol/dubbo/hessian2/hessian_dubbo.go
@@ -242,7 +242,7 @@ func (h *HessianCodec) ReadBody(rspObj any) error {
 		if !ok {
 			return perrors.Errorf("java exception: %v", exception)
 		}
-		if g, ok := ToGenericException(exception); ok {
+		if g, ok := hessian.ToGenericException(exception); ok {
 			rsp.Exception = g
 		} else if e, ok := exception.(error); ok {
 			rsp.Exception = e

--- a/protocol/dubbo/hessian2/hessian_response.go
+++ b/protocol/dubbo/hessian2/hessian_response.go
@@ -46,6 +46,7 @@ type GenericException = hessian.GenericException
 func ToGenericException(expt any) (*GenericException, bool) {
 	return hessian.ToGenericException(expt)
 }
+
 // DubboResponse dubbo response
 type DubboResponse struct {
 	RspObj      any

--- a/protocol/dubbo/hessian2/hessian_response.go
+++ b/protocol/dubbo/hessian2/hessian_response.go
@@ -41,51 +41,6 @@ type DubboResponse struct {
 	Attachments map[string]any
 }
 
-// GenericException keeps Java exception class and message.
-type GenericException struct {
-	ExceptionClass   string
-	ExceptionMessage string
-}
-
-// Error returns a readable error string.
-func (e GenericException) Error() string {
-	if e.ExceptionClass == "" {
-		return e.ExceptionMessage
-	}
-	if e.ExceptionMessage == "" {
-		return e.ExceptionClass
-	}
-	return "java exception: " + e.ExceptionClass + " - " + e.ExceptionMessage
-}
-
-// ToGenericException converts decoded exception to GenericException when possible.
-func ToGenericException(expt any) (*GenericException, bool) {
-	switch v := expt.(type) {
-	case *GenericException:
-		return v, true
-	case GenericException:
-		return &v, true
-	case *java_exception.DubboGenericException:
-		return &GenericException{ExceptionClass: v.ExceptionClass, ExceptionMessage: v.ExceptionMessage}, true
-	case java_exception.DubboGenericException:
-		return &GenericException{ExceptionClass: v.ExceptionClass, ExceptionMessage: v.ExceptionMessage}, true
-	case java_exception.Throwabler:
-		return &GenericException{ExceptionClass: v.JavaClassName(), ExceptionMessage: v.Error()}, true
-	case string:
-		return parseLegacyException(v), true
-	}
-	return nil, false
-}
-
-func parseLegacyException(exStr string) *GenericException {
-	const prefix = "java exception:"
-	msg := strings.TrimSpace(exStr)
-	if strings.HasPrefix(msg, prefix) {
-		msg = strings.TrimSpace(strings.TrimPrefix(msg, prefix))
-	}
-	return &GenericException{ExceptionClass: "java.lang.Exception", ExceptionMessage: msg}
-}
-
 // NewResponse create a new DubboResponse
 func NewResponse(rspObj any, exception error, attachments map[string]any) *DubboResponse {
 	if attachments == nil {
@@ -163,9 +118,9 @@ func packResponse(header DubboHeader, ret any) ([]byte, error) {
 					return nil, perrors.Errorf("encoding response failed: %v", err)
 				}
 				switch ex := response.Exception.(type) {
-				case *GenericException:
+				case *hessian.GenericException:
 					err = encoder.Encode(java_exception.NewDubboGenericException(ex.ExceptionClass, ex.ExceptionMessage))
-				case GenericException:
+				case hessian.GenericException:
 					err = encoder.Encode(java_exception.NewDubboGenericException(ex.ExceptionClass, ex.ExceptionMessage))
 				case java_exception.Throwabler:
 					err = encoder.Encode(ex)
@@ -253,7 +208,7 @@ func unpackResponseBody(decoder *hessian.Decoder, resp any) error {
 			}
 		}
 
-		if g, ok := ToGenericException(expt); ok {
+		if g, ok := hessian.ToGenericException(expt); ok {
 			response.Exception = g
 		} else if e, ok := expt.(error); ok {
 			response.Exception = e

--- a/protocol/dubbo/hessian2/hessian_response.go
+++ b/protocol/dubbo/hessian2/hessian_response.go
@@ -34,6 +34,18 @@ import (
 	perrors "github.com/pkg/errors"
 )
 
+// GenericException is a type alias of hessian.GenericException for backward
+// compatibility.
+//
+// Deprecated: Use hessian.GenericException from github.com/apache/dubbo-go-hessian2 instead.
+type GenericException = hessian.GenericException
+
+// ToGenericException converts decoded exception to GenericException when possible.
+//
+// Deprecated: Use hessian.ToGenericException from github.com/apache/dubbo-go-hessian2 instead.
+func ToGenericException(expt any) (*GenericException, bool) {
+	return hessian.ToGenericException(expt)
+}
 // DubboResponse dubbo response
 type DubboResponse struct {
 	RspObj      any

--- a/protocol/dubbo/hessian2/hessian_response.go
+++ b/protocol/dubbo/hessian2/hessian_response.go
@@ -38,13 +38,49 @@ import (
 // compatibility.
 //
 // Deprecated: Use hessian.GenericException from github.com/apache/dubbo-go-hessian2 instead.
-type GenericException = hessian.GenericException
+type GenericException struct {
+	ExceptionClass   string
+	ExceptionMessage string
+}
+
+func (e GenericException) Error() string {
+	if e.ExceptionClass == "" {
+		return e.ExceptionMessage
+	}
+	if e.ExceptionMessage == "" {
+		return e.ExceptionClass
+	}
+	return "java exception: " + e.ExceptionClass + " - " + e.ExceptionMessage
+}
 
 // ToGenericException converts decoded exception to GenericException when possible.
 //
 // Deprecated: Use hessian.ToGenericException from github.com/apache/dubbo-go-hessian2 instead.
 func ToGenericException(expt any) (*GenericException, bool) {
-	return hessian.ToGenericException(expt)
+	switch v := expt.(type) {
+	case *GenericException:
+		return v, true
+	case GenericException:
+		return &v, true
+	case *java_exception.DubboGenericException:
+		return &GenericException{ExceptionClass: v.ExceptionClass, ExceptionMessage: v.ExceptionMessage}, true
+	case java_exception.DubboGenericException:
+		return &GenericException{ExceptionClass: v.ExceptionClass, ExceptionMessage: v.ExceptionMessage}, true
+	case java_exception.Throwabler:
+		return &GenericException{ExceptionClass: v.JavaClassName(), ExceptionMessage: v.Error()}, true
+	case string:
+		return parseLegacyException(v), true
+	}
+	return nil, false
+}
+
+func parseLegacyException(exStr string) *GenericException {
+	const prefix = "java exception:"
+	msg := strings.TrimSpace(exStr)
+	if after, ok := strings.CutPrefix(msg, prefix); ok {
+		msg = strings.TrimSpace(after)
+	}
+	return &GenericException{ExceptionClass: "java.lang.Exception", ExceptionMessage: msg}
 }
 
 // DubboResponse dubbo response

--- a/protocol/dubbo/hessian2/hessian_response.go
+++ b/protocol/dubbo/hessian2/hessian_response.go
@@ -34,8 +34,7 @@ import (
 	perrors "github.com/pkg/errors"
 )
 
-// GenericException is a type alias of hessian.GenericException for backward
-// compatibility.
+// GenericException is a legacy-compatible type.
 //
 // Deprecated: Use hessian.GenericException from github.com/apache/dubbo-go-hessian2 instead.
 type GenericException struct {

--- a/protocol/dubbo/impl/hessian.go
+++ b/protocol/dubbo/impl/hessian.go
@@ -87,9 +87,9 @@ func marshalResponse(encoder *hessian.Encoder, p DubboPackage) ([]byte, error) {
 			if response.Exception != nil { // throw error
 				_ = encoder.Encode(resWithException)
 				switch ex := response.Exception.(type) {
-				case *hessian2.GenericException:
+				case *hessian.GenericException:
 					_ = encoder.Encode(java_exception.NewDubboGenericException(ex.ExceptionClass, ex.ExceptionMessage))
-				case hessian2.GenericException:
+				case hessian.GenericException:
 					_ = encoder.Encode(java_exception.NewDubboGenericException(ex.ExceptionClass, ex.ExceptionMessage))
 				case java_exception.Throwabler:
 					_ = encoder.Encode(ex)
@@ -301,7 +301,7 @@ func unmarshalResponseBody(body []byte, p *DubboPackage) error {
 			}
 		}
 
-		if g, ok := hessian2.ToGenericException(expt); ok {
+		if g, ok := hessian.ToGenericException(expt); ok {
 			response.Exception = g
 		} else if e, ok := expt.(error); ok {
 			response.Exception = e
@@ -328,7 +328,7 @@ func unmarshalResponseBody(body []byte, p *DubboPackage) error {
 			}
 		}
 
-		return perrors.WithStack(hessian.ReflectResponse(rsp, response.RspObj))
+		return perrors.WithStack(hessian2.ReflectResponse(rsp, response.RspObj))
 
 	case RESPONSE_NULL_VALUE, RESPONSE_NULL_VALUE_WITH_ATTACHMENTS:
 		if rspType == RESPONSE_NULL_VALUE_WITH_ATTACHMENTS {

--- a/protocol/dubbo/impl/hessian_test.go
+++ b/protocol/dubbo/impl/hessian_test.go
@@ -34,7 +34,6 @@ import (
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
-	"dubbo.apache.org/dubbo-go/v3/protocol/dubbo/hessian2"
 )
 
 const (
@@ -512,7 +511,7 @@ func TestMarshalResponse(t *testing.T) {
 				ResponseStatus: Response_OK,
 			},
 			Body: &ResponsePayload{
-				Exception: hessian2.GenericException{
+				Exception: hessian.GenericException{
 					ExceptionClass:   "com.example.UserNotFoundException",
 					ExceptionMessage: "user not found",
 				},
@@ -721,7 +720,7 @@ func TestUnmarshalResponseBody(t *testing.T) {
 		require.NoError(t, err)
 
 		response := EnsureResponsePayload(pkg.Body)
-		ge, ok := response.Exception.(*hessian2.GenericException)
+		ge, ok := response.Exception.(*hessian.GenericException)
 		require.True(t, ok)
 		assert.Equal(t, "com.example.UserNotFoundException", ge.ExceptionClass)
 		assert.Equal(t, "user not found", ge.ExceptionMessage)
@@ -787,7 +786,7 @@ func TestUnmarshalResponseBody(t *testing.T) {
 		require.NoError(t, err)
 
 		response := EnsureResponsePayload(pkg.Body)
-		ge, ok := response.Exception.(*hessian2.GenericException)
+		ge, ok := response.Exception.(*hessian.GenericException)
 		require.True(t, ok)
 		assert.Equal(t, "java.lang.Exception", ge.ExceptionClass)
 		assert.Equal(t, "user not found", ge.ExceptionMessage)

--- a/protocol/dubbo3/dubbo3_protocol_test.go
+++ b/protocol/dubbo3/dubbo3_protocol_test.go
@@ -30,6 +30,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+import (
+	"dubbo.apache.org/dubbo-go/v3/protocol/dubbo/hessian2"
+)
+
 type MockUser struct {
 	Name string
 }
@@ -85,7 +89,7 @@ func TestDubbo3UnaryService_GetReqParamsInterfaces(t *testing.T) {
 func subTest(t *testing.T, val, paramsInterfaces any) {
 	list := paramsInterfaces.([]any)
 	for k := range list {
-		err := hessian.ReflectResponse(val, list[k])
+		err := hessian2.ReflectResponse(val, list[k])
 		require.NoError(t, err)
 	}
 }

--- a/protocol/grpc/grpc_invoker.go
+++ b/protocol/grpc/grpc_invoker.go
@@ -25,8 +25,6 @@ import (
 )
 
 import (
-	hessian2 "github.com/apache/dubbo-go-hessian2"
-
 	"github.com/dubbogo/gost/log/logger"
 
 	"github.com/pkg/errors"
@@ -40,6 +38,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	gracefulshutdown "dubbo.apache.org/dubbo-go/v3/graceful_shutdown"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
+	"dubbo.apache.org/dubbo-go/v3/protocol/dubbo/hessian2"
 	"dubbo.apache.org/dubbo-go/v3/protocol/result"
 )
 


### PR DESCRIPTION
### Description
Fixes #3361 (completes the second phase of the issue.)

This PR removes the duplicate `GenericException` definition from dubbo-go and migrates all usages to the `GenericException` provided by [dubbo-go-hessian2](https://github.com/apache/dubbo-go-hessian2).

### Changes
- Upgrade [dubbo-go-hessian2 ](https://github.com/apache/dubbo-go-hessian2)dependency from _v1.12.5_ to the latest version, which provides `GenericException` support

- Remove the duplicate `GenericException` definition and `ToGenericException()`  from dubbo-go, and uses the `GenericException` implementation provided by [dubbo-go-hessian2](https://github.com/apache/dubbo-go-hessian2)

- During the [dubbo-go-hessian2](https://github.com/apache/dubbo-go-hessian2) dependency upgrade, `ReflectResponse()` was found to have been deprecated and moved to dubbo-go in an earlier version(see [dubbo-go-hessian2#364](https://github.com/apache/dubbo-go-hessian2/pull/364)).This PR also updates the references to `ReflectResponse()` that previously came from [dubbo-go-hessian2](https://github.com/apache/dubbo-go-hessian2) to use the implementation provided by dubbo-go.

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
