### PR TITLE
feat(generic): validate generic mode and clarify config API (#3472)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -135,6 +135,19 @@ func (cli *Client) NewService(service any, opts ...ReferenceOption) (*Connection
 // NewGenericService creates a GenericService for making generic calls without pre-generated stubs.
 // The referenceStr parameter specifies the service interface name (e.g., "org.apache.dubbo.samples.UserProvider").
 //
+// Defaults:
+//   - generic mode (generalization format): "true" (Map). Override with client.WithGenericType.
+//   - transport serialization: Hessian2. Override with client.WithSerialization.
+//
+// The generic mode and the transport serialization are two independent settings:
+// the former decides how objects are generalized, the latter how they are encoded on
+// the wire. Passing an unknown generic mode returns an error instead of silently
+// falling back to the Map generalizer.
+//
+// Whether the "class" field is kept in Map (generic=true) results is controlled by
+// the global "generic.include.class" configuration (default true). It only affects
+// the Map generalizer and currently has no per-reference override.
+//
 // Example usage:
 //
 //	genericService, err := cli.NewGenericService("org.apache.dubbo.samples.UserProvider",

--- a/client/options.go
+++ b/client/options.go
@@ -138,6 +138,12 @@ func (refOpts *ReferenceOptions) init(opts ...ReferenceOption) error {
 		refConf.Serialization = constant.ProtobufSerialization
 	}
 
+	// validate generic type, fail fast on unknown value instead of
+	// silently falling back to the Map generalizer at runtime
+	if err := internal.ValidateGenericType(refConf.Generic); err != nil {
+		return err
+	}
+
 	return commonCfg.Verify(refOpts)
 }
 
@@ -360,8 +366,17 @@ func WithGeneric() ReferenceOption {
 	}
 }
 
-// WithGenericType sets the generic serialization type for generic call
-// Valid values: "true" (default), "gson", "protobuf", "protobuf-json"
+// WithGenericType sets the generic mode (generalization format), which decides how
+// business objects are generalized into a generic structure.
+//
+// Valid values: "true" (default, Map), "gson", "protobuf-json", "bean".
+// "protobuf" is kept as a legacy compatibility value and is not recommended.
+// An unknown value is rejected when the reference is created (see init()), rather
+// than silently falling back to the Map generalizer.
+//
+// Note: the generic mode is different from the transport serialization set via
+// WithSerialization; the latter controls the on-the-wire encoding (hessian2 /
+// protobuf / json / msgpack).
 func WithGenericType(genericType string) ReferenceOption {
 	return func(opts *ReferenceOptions) {
 		opts.Reference.Generic = genericType

--- a/internal/config.go
+++ b/internal/config.go
@@ -215,3 +215,34 @@ func ValidateRegistryIDs(ids []string, regs map[string]*global.RegistryConfig) e
 	}
 	return nil
 }
+
+// IsGenericMode reports whether a generic value denotes a generic call. It is the
+// single source of truth for the accepted generic modes so that callers (config
+// validation, protocol-level routing) stay in sync instead of each maintaining its
+// own list. An empty value means the call is not generic.
+//
+// Recognized modes: "true" (Map, default), "gson", "protobuf-json", "bean", and the
+// legacy "protobuf" (kept for compatibility, not recommended).
+func IsGenericMode(generic string) bool {
+	if generic == "" {
+		return false
+	}
+	return strings.EqualFold(generic, constant.GenericSerializationDefault) ||
+		strings.EqualFold(generic, constant.GenericSerializationGson) ||
+		strings.EqualFold(generic, constant.GenericSerializationProtobufJson) ||
+		strings.EqualFold(generic, constant.GenericSerializationBean) ||
+		strings.EqualFold(generic, constant.GenericSerializationProtobuf)
+}
+
+// ValidateGenericType validates the generic serialization type (generic mode).
+// An empty value means the call is not generic and is allowed. Unknown values fail
+// fast instead of silently falling back to the Map generalizer.
+//
+// Valid values: "true" (Map, default), "gson", "protobuf-json", "bean".
+// "protobuf" is kept as a legacy compatibility value and is not recommended.
+func ValidateGenericType(generic string) error {
+	if generic == "" || IsGenericMode(generic) {
+		return nil
+	}
+	return fmt.Errorf("invalid generic type %q, valid values: true, gson, protobuf-json, bean", generic)
+}

--- a/internal/config_test.go
+++ b/internal/config_test.go
@@ -326,3 +326,32 @@ func TestValidateMethodConfig(t *testing.T) {
 		assert.Contains(t, err.Error(), "tps.limit.interval")
 	})
 }
+
+func TestValidateGenericType(t *testing.T) {
+	tests := []struct {
+		name    string
+		generic string
+		wantErr bool
+	}{
+		{"empty means non-generic", "", false},
+		{"map default", constant.GenericSerializationDefault, false},
+		{"gson", constant.GenericSerializationGson, false},
+		{"protobuf-json", constant.GenericSerializationProtobufJson, false},
+		{"bean", constant.GenericSerializationBean, false},
+		{"protobuf legacy compat", constant.GenericSerializationProtobuf, false},
+		{"case insensitive", "TRUE", false},
+		{"unknown value", "bad-type", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGenericType(tt.generic)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.generic)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/protocol/triple/triple.go
+++ b/protocol/triple/triple.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 )
 
@@ -151,7 +150,7 @@ func (tp *TripleProtocol) Refer(url *common.URL) base.Invoker {
 	// Use NewTripleInvoker for:
 	// 1. New protoc-gen-go-triple stub code (has ClientInfoKey)
 	// 2. Non-IDL mode (IDLMode == NONIDL)
-	// 3. Generic call (generic=true/gson/protobuf/protobuf-json)
+	// 3. Generic call (generic=true/gson/protobuf/protobuf-json/bean)
 	if ok || IDLMode == constant.NONIDL || isGenericCall {
 		// new triple invoker supporting $invoke for generic calls
 		invoker, err = NewTripleInvoker(url)
@@ -231,15 +230,12 @@ func (tp *TripleProtocol) HostHTTPHandler(url *common.URL, handler http.Handler)
 	return nil
 }
 
-// isGenericCall checks if the generic parameter indicates a generic call
+// isGenericCall checks if the generic parameter indicates a generic call.
+// It delegates to internal.IsGenericMode so the accepted mode set stays in sync
+// with reference-creation validation (internal.ValidateGenericType), which is why
+// "bean" is recognized here too and routes to the $invoke-capable NewTripleInvoker.
 func isGenericCall(generic string) bool {
-	if generic == "" {
-		return false
-	}
-	return strings.EqualFold(generic, constant.GenericSerializationDefault) ||
-		strings.EqualFold(generic, constant.GenericSerializationGson) ||
-		strings.EqualFold(generic, constant.GenericSerializationProtobuf) ||
-		strings.EqualFold(generic, constant.GenericSerializationProtobufJson)
+	return internal.IsGenericMode(generic)
 }
 
 func NewTripleProtocol() *TripleProtocol {

--- a/protocol/triple/triple_test.go
+++ b/protocol/triple/triple_test.go
@@ -311,6 +311,9 @@ func Test_isGenericCall(t *testing.T) {
 		{"protobuf-json", "protobuf-json", true},
 		{"PROTOBUF-JSON", "PROTOBUF-JSON", true},
 		{"Protobuf-Json", "Protobuf-Json", true},
+		{"bean", "bean", true},
+		{"BEAN", "BEAN", true},
+		{"Bean", "Bean", true},
 
 		// invalid generic serialization types
 		{"false", "false", false},


### PR DESCRIPTION
### What this PR does

Part of #3472 (泛化调用优化). This PR covers the `client` + config-validation slice: it makes an unknown generic mode fail fast at reference-creation time instead of silently falling back to the Map generalizer at runtime, and clarifies the generic-call configuration API. It also unifies the accepted generic-mode set between reference-creation validation and Triple's invoker routing so that `bean` is recognized consistently.

### Changes

- **`internal/config.go`**: add `ValidateGenericType`, accepting `true` / `gson` / `protobuf-json` / `bean` (case-insensitive; empty = non-generic). `protobuf` is currently kept as a legacy compatibility value. Unknown values return a clear error. Extract the accepted-mode decision into a shared `IsGenericMode` predicate so validation and protocol-level routing share one source of truth.
- **`client/options.go`**: wire the validation into `ReferenceOptions.init`, so `WithGenericType("bad-type")` is rejected when the reference is created. Rewrite `WithGenericType` docs to distinguish **generic mode** (generalization format) from **transport serialization** (on-the-wire encoding).
- **`client/client.go`**: document `NewGenericService` defaults (generic mode `true`/Map, transport serialization Hessian2), that the two settings are independent, and the scope of `generic.include.class` (Map-only, global config, no per-reference override).
- **`protocol/triple/triple.go`**: route `isGenericCall` through `internal.IsGenericMode` so a Triple reference created with `WithGenericType("bean")` is recognized as generic and dispatched to the `$invoke`-capable `NewTripleInvoker` instead of `NewDubbo3Invoker`. The previously accepted modes (`true`/`gson`/`protobuf`/`protobuf-json`) are unchanged.
- **`internal/config_test.go`** / **`protocol/triple/triple_test.go`**: table-driven tests covering all valid modes, case-insensitivity, empty, and unknown values, plus `bean` cases for `isGenericCall`.

### Scope note (updated after review)

An earlier revision added `WithGenericIncludeClass(bool)`. It has been **removed**: `generic.include.class` is only read by `MapGeneralizer` from the global config (`filter/generic/generalizer/map.go:getGenericIncludeClass`) and does not consult reference/URL params, so the option was a no-op. Per #3472 §4 ("如果本次不新增 API,则……仅补充注释和文档"), this PR keeps `generic.include.class` as **global-config only** and documents its scope, rather than shipping a non-functional per-reference API. A real per-reference override can be added later once the generalizer reads it.

### Acceptance criteria (from #3472 §3/§4)

- [x] `NewGenericService(..., WithGenericType("bad-type"))` returns a clear error instead of falling back.
- [x] generic mode vs transport serialization documented and disambiguated.
- [x] `generic.include.class` scope documented (Map-only, global config).
- [x] Triple recognizes `bean` as a generic mode and routes it to the `$invoke`-capable `NewTripleInvoker` (shared with reference-creation validation via `internal.IsGenericMode`).
- [x] ~~`generic.include.class` per-reference API~~ — intentionally scoped out (see Scope note).

### Follow-up: converge the last checker

The accepted-mode sets previously diverged across three checkers. This PR shares a single predicate (`internal.IsGenericMode`) between reference-creation validation and Triple routing, so both now agree and `bean` reaches the `$invoke` path:

| checker | true | gson | protobuf-json | bean | protobuf |
| --- | --- | --- | --- | --- | --- |
| `ValidateGenericType` (this PR, via `IsGenericMode`) | ✅ | ✅ | ✅ | ✅ | ✅ |
| `protocol/triple/triple.go:isGenericCall` (this PR, via `IsGenericMode`) | ✅ | ✅ | ✅ | ✅ | ✅ |
| `filter/generic/util.go:isGeneric` | ✅ | ✅ | ✅ | ✅ | ❌ |

The only remaining divergence is `filter/generic/util.go:isGeneric`, which omits the legacy `protobuf`. Routing it through the shared predicate would silently re-introduce `protobuf` into the filter path — a behavior change in a separate slice/owner of #3472 — so it is intentionally left out here and tracked as a follow-up together with the `protobuf` deprecation decision.

### Verification

`go build ./...` and `go test ./internal/ ./client/ ./protocol/triple/` pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
