### PR TITLE
[codex] honor m tags during generic realization

### DIFF
--- a/filter/generic/generalizer/map.go
+++ b/filter/generic/generalizer/map.go
@@ -68,7 +68,15 @@ func (g *MapGeneralizer) Realize(obj any, typ reflect.Type) (any, error) {
 		obj = removeClass(obj)
 	}
 	newobj := reflect.New(typ).Interface()
-	err := mapstructure.Decode(obj, newobj)
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result:  newobj,
+		TagName: "m",
+	})
+	if err != nil {
+		return nil, perrors.Errorf("realizing map failed, %v", err)
+	}
+
+	err = decoder.Decode(obj)
 	if err != nil {
 		return nil, perrors.Errorf("realizing map failed, %v", err)
 	}

--- a/filter/generic/generalizer/map_test.go
+++ b/filter/generic/generalizer/map_test.go
@@ -49,6 +49,11 @@ type testPlainObj struct {
 	EeEe int
 }
 
+type testMTagObj struct {
+	UserID string `m:"user_id"`
+	Name   string
+}
+
 func TestObjToMap(t *testing.T) {
 	obj := &testPlainObj{}
 	obj.AaAa = "1"
@@ -69,6 +74,21 @@ func TestObjToMap(t *testing.T) {
 	assert.Equal(t, reflect.Map, reflect.TypeOf(m["caCa"].(map[string]any)["xxYy"]).Kind())
 	assert.Equal(t, "2020-10-29 02:34:00", m["daDa"].(time.Time).Format("2006-01-02 15:04:05"))
 	assert.Equal(t, 100, m["eeEe"].(int))
+}
+
+func TestMTagRoundTrip(t *testing.T) {
+	original := testMTagObj{
+		UserID: "42",
+		Name:   "alice",
+	}
+
+	generalized, err := mockMapGeneralizer.Generalize(original)
+	require.NoError(t, err)
+	assert.Equal(t, "42", generalized.(map[string]any)["user_id"])
+
+	realized, err := mockMapGeneralizer.Realize(generalized, reflect.TypeOf(original))
+	require.NoError(t, err)
+	assert.Equal(t, original, realized)
 }
 
 type testStruct struct {


### PR DESCRIPTION
## What changed

- configure `MapGeneralizer.Realize` to decode struct fields using the `m` tag
- add a round-trip regression test with a genuine field alias (`UserID` -> `user_id`)

## Why

`MapGeneralizer.Generalize` already uses the `m` tag when producing map keys, but `Realize` previously called `mapstructure.Decode` with its default configuration. The default decoder reads `mapstructure` tags rather than `m` tags, so renamed fields were silently ignored and left at their zero values.

Using the same tag in both directions restores symmetric map generalization and realization.

## Impact

Generic calls using the default map generalizer now preserve values for fields whose `m` tag differs from the Go field name, including aliases such as `m:"user_id"`.

## Validation

- `go test ./filter/generic/generalizer -run '^TestMTagRoundTrip$' -count=1 -v`
- `go test ./filter/generic/... -count=1`
- `git diff --check -- filter/generic/generalizer/map.go filter/generic/generalizer/map_test.go`
