### PR TITLE
fix(triple): deliver server response attachments via response trailer/header

### DIFF
--- a/protocol/triple/server.go
+++ b/protocol/triple/server.go
@@ -556,7 +556,7 @@ func (s *Server) registerUnaryMethodHandler(procedure string, m common.MethodInf
 			// todo(DMwangnima): modify InfoInvoker to get a unified processing logic
 			// please refer to server/InfoInvoker.Invoke()
 			triResp := wrapTripleResponse(res.Result())
-			appendTripleOutgoingAttachments(ctx, res.Attachments())
+			appendTripleOutgoingAttachments(triResp, res.Attachments())
 			return triResp, res.Error()
 		},
 		opts...,
@@ -635,15 +635,27 @@ func wrapTripleResponse(result any) *tri.Response {
 	return tri.NewResponse([]any{result})
 }
 
-func appendTripleOutgoingAttachments(ctx context.Context, attachments map[string]any) {
+// appendTripleOutgoingAttachments writes provider response attachments onto the
+// response's trailer/header. The triple handler merges response.Header() and
+// response.Trailer() into the connection's outgoing headers/trailers (see
+// handler.go), so writing here is what actually delivers the attachments to the
+// client. The previous implementation called tri.AppendToOutgoingContext(ctx,
+// ...), which returns a new context that the unary handler closure cannot
+// propagate back to the framework, so the attachments were silently dropped.
+func appendTripleOutgoingAttachments(resp *tri.Response, attachments map[string]any) {
+	if resp == nil || len(attachments) == 0 {
+		return
+	}
 	for k, v := range attachments {
 		switch val := v.(type) {
 		case string:
-			tri.AppendToOutgoingContext(ctx, k, val)
+			resp.Trailer().Set(k, val)
 		case []string:
 			for _, item := range val {
-				tri.AppendToOutgoingContext(ctx, k, item)
+				resp.Trailer().Add(k, item)
 			}
+		default:
+			resp.Header().Set(k, fmt.Sprintf("%v", v))
 		}
 	}
 }

--- a/protocol/triple/server_test.go
+++ b/protocol/triple/server_test.go
@@ -1056,18 +1056,24 @@ func TestWrapTripleResponse(t *testing.T) {
 }
 
 func TestAppendTripleOutgoingAttachments(t *testing.T) {
-	ctx := tri.NewOutgoingContext(context.Background(), make(http.Header))
-	appendTripleOutgoingAttachments(ctx, map[string]any{
+	resp := tri.NewResponse(nil)
+	appendTripleOutgoingAttachments(resp, map[string]any{
 		"one":   "1",
 		"multi": []string{"a", "b"},
 		"omit":  100,
 	})
 
-	outgoing := tri.ExtractFromOutgoingContext(ctx)
-	require.NotNil(t, outgoing)
-	assert.Equal(t, []string{"1"}, outgoing.Values("one"))
-	assert.Equal(t, []string{"a", "b"}, outgoing.Values("multi"))
-	assert.Empty(t, outgoing.Values("omit"))
+	// string and []string land on the trailer; non-string lands on the header.
+	assert.Equal(t, []string{"1"}, resp.Trailer().Values("One"))
+	assert.Equal(t, []string{"a", "b"}, resp.Trailer().Values("Multi"))
+	assert.Equal(t, []string{"100"}, resp.Header().Values("Omit"))
+
+	// nil response and empty attachments are no-ops.
+	appendTripleOutgoingAttachments(nil, map[string]any{"x": "y"})
+	resp2 := tri.NewResponse(nil)
+	appendTripleOutgoingAttachments(resp2, nil)
+	assert.Empty(t, resp2.Trailer())
+	assert.Empty(t, resp2.Header())
 }
 
 const tripleServerDefaultImplementationKey = "/"


### PR DESCRIPTION
## What

Provider response attachments set via `res.Attachments()` were silently dropped and never reached the client.

## Why

`appendTripleOutgoingAttachments` called `tri.AppendToOutgoingContext(ctx, ...)` and **discarded the returned context**. `context.Context` is immutable; the unary handler closure cannot propagate a reassigned `ctx` back to the framework, so `handler.go`'s `ExtractFromOutgoingContext(ctx)` always read the original server context — which is never initialized with an outgoing context (`handler.go:112` only sets `handlerOutgoingKey`, not `extraDataKey`) — and returned `nil`. The `mergeHeaders(conn.ResponseTrailer(), nil)` therefore wrote nothing.

This was latent since #2928 switched the server path from `triResp.Trailer().Set` to `AppendToOutgoingContext`. The existing unit test masked it because it pre-initialized the context with `tri.NewOutgoingContext(...)`, so the `!ok` branch (which creates a throwaway new context) never ran.

## Fix

Write attachments directly onto the `*tri.Response`'s `Trailer()`/`Header()`. The triple handler already merges `response.Header()` and `response.Trailer()` into the connection's outgoing headers/trailers (`handler.go:126-127`), so this is the path that actually reaches the client.

- `string` → `Trailer().Set`
- `[]string` → `Trailer().Add` (preserves all values; pre-#2928 only kept `val[0]`)
- non-string → `Header().Set` (formatted)

## Tests

Updated `TestAppendTripleOutgoingAttachments` to assert trailer/header population (instead of the pre-initialized context that masked the bug). Added nil-response and empty-attachments no-op cases.

Fixes #3511