### PR TITLE
fix(cluster): nil-guard lb.Select results to avoid doSelectInvoker panic

### DIFF
--- a/cluster/cluster/adaptivesvc/cluster_invoker.go
+++ b/cluster/cluster/adaptivesvc/cluster_invoker.go
@@ -64,6 +64,12 @@ func (ivk *adaptiveServiceClusterInvoker) Invoke(ctx context.Context, invocation
 
 	// select a node by the loadBalance
 	invoker := lb.Select(invokers, invocation)
+	if invoker == nil {
+		// P2C may return nil on a transient metrics-layer error. Degrade to the
+		// first invoker instead of nil-dereferencing. See #3513.
+		logger.Warnf("[Cluster][AdaptiveSvc] load balance %s returned no invoker, degrade to the first invoker", lbKey)
+		invoker = invokers[0]
+	}
 
 	// invoke
 	invocation.SetAttachment(constant.AdaptiveServiceEnabledKey, constant.AdaptiveServiceIsEnabled)

--- a/cluster/cluster/base/cluster_invoker.go
+++ b/cluster/cluster/base/cluster_invoker.go
@@ -158,6 +158,15 @@ func (invoker *BaseClusterInvoker) doSelectInvoker(lb loadbalance.LoadBalance, i
 	}
 
 	selectedInvoker := lb.Select(invokers, invocation)
+	if selectedInvoker == nil {
+		// A load-balance implementation may return nil on a transient internal
+		// error (e.g. P2C on a metrics-layer error, consistent-hash on a marshal
+		// failure). Degrade to the first invoker instead of nil-dereferencing.
+		// See #3513.
+		logger.Warnf("[Cluster] load balance %T returned nil for serviceKey=%s, degrade to the first invoker",
+			lb, invokers[0].GetURL().ServiceKey())
+		selectedInvoker = invokers[0]
+	}
 
 	// judge if the selected Invoker is invoked and available
 	if (!selectedInvoker.IsAvailable() && invoker.AvailableCheck) || isInvoked(selectedInvoker, invoked) {
@@ -170,6 +179,11 @@ func (invoker *BaseClusterInvoker) doSelectInvoker(lb loadbalance.LoadBalance, i
 				break
 			}
 			reselectedInvoker := lb.Select(otherInvokers, invocation)
+			if reselectedInvoker == nil {
+				// LB transient failure during reselect: stop retrying and fall
+				// through to the (already non-nil) selectedInvoker.
+				break
+			}
 			if isInvoked(reselectedInvoker, invoked) {
 				otherInvokers = getOtherInvokers(otherInvokers, reselectedInvoker)
 				continue

--- a/cluster/cluster/base/cluster_invoker_test.go
+++ b/cluster/cluster/base/cluster_invoker_test.go
@@ -160,3 +160,27 @@ func (d *mockDirectory) IsAvailable() bool                                   { r
 func (d *mockDirectory) Destroy()                                            {}
 func (d *mockDirectory) List(protocolbase.Invocation) []protocolbase.Invoker { return d.invokers }
 func (d *mockDirectory) Subscribe(*common.URL) error                         { return nil }
+
+// nilLoadBalance always returns nil from Select, simulating a transient
+// load-balance failure (P2C metrics error, consistent-hash marshal error, etc.).
+type nilLoadBalance struct{}
+
+func (nilLoadBalance) Select([]protocolbase.Invoker, protocolbase.Invocation) protocolbase.Invoker {
+	return nil
+}
+
+// TestDoSelectDegradesWhenLbReturnsNil verifies doSelectInvoker degrades to the
+// first invoker instead of nil-dereferencing when lb.Select returns nil for a
+// non-empty invoker list. Regression for #3513.
+func TestDoSelectDegradesWhenLbReturnsNil(t *testing.T) {
+	var invokers []protocolbase.Invoker
+	for i := range 3 {
+		url, _ := common.NewURL(fmt.Sprintf(baseClusterInvokerFormat, i))
+		invokers = append(invokers, clusterpkg.NewMockInvoker(url, 1))
+	}
+	b := &BaseClusterInvoker{AvailableCheck: true}
+	inv := invocation.NewRPCInvocation(baseClusterInvokerMethodName, nil, nil)
+	selected := b.DoSelect(nilLoadBalance{}, inv, invokers, nil)
+	assert.NotNil(t, selected)
+	assert.Contains(t, invokers, selected)
+}

--- a/cluster/loadbalance/p2c/loadbalance.go
+++ b/cluster/loadbalance/p2c/loadbalance.go
@@ -19,7 +19,6 @@ package p2c
 
 import (
 	"errors"
-	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -139,17 +138,21 @@ func (l *p2cLoadBalance) Select(invokers []base.Invoker, invocation base.Invocat
 		return nil
 	}
 
-	// Convert interface to int, if the type is unexpected, panic immediately
+	// Convert interface to int. An unexpected type means the metrics layer is
+	// corrupted; degrade (return nil) so the cluster layer can fall back to an
+	// available invoker instead of crashing the process. See #3513.
 	remainingI, ok := remainingIIface.(uint64)
 	if !ok {
-		panic(fmt.Sprintf("[Loadbalance][P2C] type check failed: key=%s expected=uint64 actual=%T",
-			metrics.HillClimbing, remainingIIface))
+		logger.Warnf("[Loadbalance][P2C] remaining metrics type invalid, key=%s actual=%T, degrade",
+			metrics.HillClimbing, remainingIIface)
+		return nil
 	}
 
 	remainingJ, ok := remainingJIface.(uint64)
 	if !ok {
-		panic(fmt.Sprintf("[Loadbalance][P2C] type check failed: key=%s expected=uint64 actual=%T",
-			metrics.HillClimbing, remainingJIface))
+		logger.Warnf("[Loadbalance][P2C] remaining metrics type invalid, key=%s actual=%T, degrade",
+			metrics.HillClimbing, remainingJIface)
+		return nil
 	}
 
 	logger.Debugf("[Loadbalance][P2C] compare remaining capacity i=%d val=%d j=%d val=%d", i, remainingI, j, remainingJ)


### PR DESCRIPTION
## What

`base.doSelectInvoker` (and the `adaptivesvc` fast path) nil-dereference the result of `lb.Select` when a load-balance implementation returns `nil` for a non-empty invoker list, crashing the process on a transient error.

## Why

Several `LoadBalance` implementations can return `nil` for non-empty input:

- **P2C** (`cluster/loadbalance/p2c/loadbalance.go:128,139`) returns `nil` on a non-`ErrMetricsNotFound` metrics error, and `panic()` outright when the metrics value is not `uint64`.
- **ConsistentHash** (`cluster/loadbalance/consistenthashing/loadbalance.go:71`) returns `nil` when `json.Marshal(invoker)` fails.

`base/cluster_invoker.go:163` then calls `selectedInvoker.IsAvailable()` (and the reselect loop dereferences `reselectedInvoker`) with no nil guard → nil-pointer panic. The `adaptivesvc` fast path (`cluster/cluster/adaptivesvc/cluster_invoker.go:66-70`) forces P2C and dereferences the result the same way.

## Fix

- `base.doSelectInvoker`: if `lb.Select` returns `nil` for the initial selection, warn and degrade to `invokers[0]`; on a `nil` reselect, stop retrying and fall through.
- `adaptivesvc` fast path: degrade to `invokers[0]` when P2C returns `nil`.
- `p2c`: replace the two `panic()` calls on an unexpected metrics type with `logger.Warnf` + `return nil`, so the cluster nil-guard can fall back instead of crashing.

## Tests

Added `TestDoSelectDegradesWhenLbReturnsNil` with a nil-returning `LoadBalance` mock asserting `DoSelect` degrades to an invoker from the list rather than panicking. `p2c`, `base`, `adaptivesvc`, `consistenthashing` packages pass under `-race`.

Note: `TestFailbackRetryFailed` / `TestRouteCacheGenerationRace` fail on `develop` HEAD already (pre-existing, unrelated to this change).

Fixes #3513