### PR TITLE
fix(loadbalance/consistenthashing): prevent nil-selector cache and empty-ring panics

### DIFF
--- a/cluster/loadbalance/consistenthashing/loadbalance.go
+++ b/cluster/loadbalance/consistenthashing/loadbalance.go
@@ -25,6 +25,10 @@ import (
 )
 
 import (
+	"github.com/dubbogo/gost/log/logger"
+)
+
+import (
 	"dubbo.apache.org/dubbo-go/v3/cluster/loadbalance"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
@@ -60,6 +64,9 @@ func newConshashLoadBalance() loadbalance.LoadBalance {
 
 // Select gets invoker based on load balancing strategy
 func (lb *conshashLoadBalance) Select(invokers []base.Invoker, invocation base.Invocation) base.Invoker {
+	if len(invokers) == 0 {
+		return nil
+	}
 	methodName := invocation.MethodName()
 	key := invokers[0].GetURL().ServiceKey() + "." + methodName
 
@@ -78,14 +85,24 @@ func (lb *conshashLoadBalance) Select(invokers []base.Invoker, invocation base.I
 	selector, ok := selectors[key]
 	selectorsMu.RUnlock()
 
-	if !ok || selector.hashCode != hashCode {
-		selectorsMu.Lock()
-		selector, ok = selectors[key]
-		if !ok || selector.hashCode != hashCode {
-			selectors[key] = newSelector(invokers, methodName, hashCode)
-		}
-		selector = selectors[key]
-		selectorsMu.Unlock()
+	if ok && selector != nil && selector.hashCode == hashCode {
+		return selector.Select(invocation)
 	}
+
+	selectorsMu.Lock()
+	selector, ok = selectors[key]
+	if !ok || selector == nil || selector.hashCode != hashCode {
+		built, err := newSelector(invokers, methodName, hashCode)
+		if err != nil {
+			selectorsMu.Unlock()
+			// Do not cache a nil selector: a malformed hash.arguments value
+			// would otherwise be stored and nil-deref on the next Select.
+			logger.Warnf("[Loadbalance][ConsistentHash] build selector failed, key=%s err=%v, degrade to the first invoker", key, err)
+			return invokers[0]
+		}
+		selector = built
+		selectors[key] = selector
+	}
+	selectorsMu.Unlock()
 	return selector.Select(invocation)
 }

--- a/cluster/loadbalance/consistenthashing/loadbalance_test.go
+++ b/cluster/loadbalance/consistenthashing/loadbalance_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 import (
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -60,7 +61,7 @@ func (s *consistentHashSelectorSuite) SetupTest() {
 	var invokers []base.Invoker
 	url, _ := common.NewURL(url20000)
 	invokers = append(invokers, base.NewBaseInvoker(url))
-	s.selector = newSelector(invokers, "echo", 999944)
+	s.selector, _ = newSelector(invokers, "echo", 999944)
 }
 
 func (s *consistentHashSelectorSuite) TestToKey() {
@@ -78,7 +79,10 @@ func TestToKeyWithArgumentIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 	invokers = append(invokers, base.NewBaseInvoker(url))
-	sel := newSelector(invokers, "echo", 999944)
+	sel, err := newSelector(invokers, "echo", 999944)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	key := sel.toKey([]any{"ignored", "used"})
 	if key != "used" {
@@ -156,4 +160,46 @@ func (s *consistentHashLoadBalanceSuite) TestConcurrentSelect() {
 		}(i)
 	}
 	wg.Wait()
+}
+
+// TestSelectDegradesOnBadHashArguments verifies that a non-numeric
+// hash.arguments value no longer poisons the selector cache with nil and no
+// longer panics; instead Select degrades to the first invoker. Regression #3510.
+func TestSelectDegradesOnBadHashArguments(t *testing.T) {
+	// clear any cached selector so the test starts from a clean state
+	selectorsMu.Lock()
+	clear(selectors)
+	selectorsMu.Unlock()
+
+	url, _ := common.NewURL("dubbo://192.168.1.0:20000/org.apache.demo.BadArgs?methods.echo.hash.arguments=0,notanumber")
+	invokers := []base.Invoker{base.NewBaseInvoker(url)}
+	lb := newConshashLoadBalance()
+	inv := invocation.NewRPCInvocation("echo", []any{"a"}, nil)
+
+	got := lb.Select(invokers, inv)
+	assert.NotNil(t, got)
+	assert.Equal(t, invokers[0], got)
+
+	// a nil selector must not have been cached
+	selectorsMu.RLock()
+	cached, ok := selectors[invokers[0].GetURL().ServiceKey()+".echo"]
+	selectorsMu.RUnlock()
+	assert.False(t, ok && cached == nil, "nil selector must not be cached")
+}
+
+// TestSelectHandlesSmallHashNodes verifies that hash.nodes < 4 (which yields
+// an empty ring) no longer panics on an empty c.keys. Regression #3510.
+func TestSelectHandlesSmallHashNodes(t *testing.T) {
+	selectorsMu.Lock()
+	clear(selectors)
+	selectorsMu.Unlock()
+
+	url, _ := common.NewURL("dubbo://192.168.1.0:20000/org.apache.demo.SmallNodes?methods.echo.hash.nodes=2")
+	invokers := []base.Invoker{base.NewBaseInvoker(url)}
+	lb := newConshashLoadBalance()
+	inv := invocation.NewRPCInvocation("echo", []any{"a"}, nil)
+
+	got := lb.Select(invokers, inv)
+	assert.NotNil(t, got)
+	assert.Equal(t, invokers[0], got)
 }

--- a/cluster/loadbalance/consistenthashing/selector.go
+++ b/cluster/loadbalance/consistenthashing/selector.go
@@ -43,18 +43,27 @@ type selector struct {
 }
 
 func newSelector(invokers []base.Invoker, methodName string,
-	hashCode uint32) *selector {
+	hashCode uint32) (*selector, error) {
 
 	selector := &selector{}
 	selector.virtualInvokers = make(map[uint32]base.Invoker)
 	selector.hashCode = hashCode
 	url := invokers[0].GetURL()
 	selector.replicaNum = url.GetMethodParamIntValue(methodName, HashNodes, 160)
+	if selector.replicaNum < 4 {
+		// hash.nodes below 4 yields replicaNum/4 == 0 digests, i.e. an empty
+		// ring, which would make selectForKey index an empty slice and panic.
+		// Clamp to the minimum so each invoker gets at least one virtual node.
+		selector.replicaNum = 4
+	}
 	indices := re.Split(url.GetMethodParam(methodName, HashArguments, "0"), -1)
 	for _, index := range indices {
 		i, err := strconv.Atoi(index)
 		if err != nil {
-			return nil
+			// A malformed hash.arguments value must not poison the selector
+			// cache with a nil selector (which would nil-deref on the next
+			// Select). Surface it as an error so the caller degrades instead.
+			return nil, fmt.Errorf("invalid hash.arguments index %q: %w", index, err)
 		}
 		selector.argumentIndex = append(selector.argumentIndex, i)
 	}
@@ -71,7 +80,7 @@ func newSelector(invokers []base.Invoker, methodName string,
 		}
 	}
 	sort.Sort(selector.keys)
-	return selector
+	return selector, nil
 }
 
 // Select gets invoker based on load balancing strategy
@@ -97,6 +106,11 @@ func (c *selector) toKey(args []any) string {
 }
 
 func (c *selector) selectForKey(hash uint32) base.Invoker {
+	if len(c.keys) == 0 {
+		// Defensive: an empty ring (e.g. a future regression in replicaNum
+		// clamping) must not panic on c.keys[idx].
+		return nil
+	}
 	idx := sort.Search(len(c.keys), func(i int) bool {
 		return c.keys[i] >= hash
 	})


### PR DESCRIPTION
## What

Two panic paths in the consistent-hash load balancer that are distinct from the map race fixed in #3317 and the `toKey` panics fixed in #3430 / #3432.

## Why

1. **Nil selector cached.** `newSelector` returned `nil` when `hash.arguments` contained a non-numeric index (`strconv.Atoi` failure). That `nil` was stored in `selectors[key]`; the next `Select` for the same key nil-dereferenced it (`selector.hashCode` at `loadbalance.go:81`, then `selector.Select`).

```go
// selector.go (before)
i, err := strconv.Atoi(index)
if err != nil {
    return nil            // nil cached in selectors[key]
}
```

2. **Empty ring.** With `hash.nodes < 4`, `replicaNum/4 == 0`, so the ring (`selector.keys`) was never populated. `selectForKey` then did `c.keys[idx]` on an empty slice → index-out-of-range panic.

```go
// selector.go selectForKey (before)
if idx == len(c.keys) { idx = 0 }
return c.virtualInvokers[c.keys[idx]]   // c.keys empty → panic
```

## Fix

- `newSelector` returns `(*selector, error)`; a bad `hash.arguments` index surfaces as an error instead of `nil`.
- `Select` no longer caches a nil selector; on `newSelector` error it warns and degrades to `invokers[0]`. It also nil-guards any cached selector (so a stale nil from a prior build can't crash a later call).
- `newSelector` clamps `replicaNum` to `>= 4` so the ring is never empty.
- `selectForKey` guards `len(c.keys)==0` defensively.

## Tests

- `TestSelectDegradesOnBadHashArguments`: non-numeric `hash.arguments` no longer panics, degrades to `invokers[0]`, and does not cache a nil selector.
- `TestSelectHandlesSmallHashNodes`: `hash.nodes=2` no longer panics.
- Updated the two existing `newSelector` call sites for the new signature.

Full `consistenthashing` package passes under `-race`.

Fixes #3510