### PR TITLE
fix(registry/servicediscovery): lock + snapshot listener map in DataChange/callbacks

### DIFF
--- a/registry/etcdv3/service_discovery.go
+++ b/registry/etcdv3/service_discovery.go
@@ -277,26 +277,41 @@ func (e *etcdV3ServiceDiscovery) registerServiceWatcher(serviceName string) erro
 
 // DataChange when child data change should DispatchEventByServiceName
 func (e *etcdV3ServiceDiscovery) DataChange(eventType remoting.Event) bool {
-	if eventType.Action == remoting.EventTypeUpdate {
-		instance := &registry.DefaultServiceInstance{}
-		err := jsonutil.DecodeJSON([]byte(eventType.Content), &instance)
-		if err != nil {
-			instance.ServiceName = ""
-		}
-
-		// notify instance listener instance change
-		name := instance.ServiceName
-		instances := e.GetInstances(name)
-		for _, lis := range e.instanceListenerMap[instance.ServiceName].Values() {
-
-			instanceLis := lis.(registry.ServiceInstancesChangedListener)
-			err = instanceLis.OnEvent(registry.NewServiceInstancesChangedEvent(name, instances))
-		}
-		if err != nil {
-			return false
-		}
+	if eventType.Action != remoting.EventTypeUpdate {
+		return true
+	}
+	instance := &registry.DefaultServiceInstance{}
+	if err := jsonutil.DecodeJSON([]byte(eventType.Content), &instance); err != nil {
+		// Previously the decode failure blanked ServiceName to "" and then looked
+		// up instanceListenerMap[""], a silent no-op. Fail fast and log instead.
+		logger.Errorf("[Registry][Etcdv3] decode instance failed, content=%s err=%v", eventType.Content, err)
+		return false
 	}
 
+	// notify instance listener instance change
+	name := instance.ServiceName
+	instances := e.GetInstances(name)
+	// Snapshot the listener set under initLock (the writers
+	// registerServiceInstanceListener/registerServiceWatcher use the same lock)
+	// and dispatch outside the lock: an unlocked read races the writers and
+	// holding the lock across OnEvent would block other listeners. See #3512.
+	initLock.Lock()
+	set, ok := e.instanceListenerMap[name]
+	listeners := make([]registry.ServiceInstancesChangedListener, 0)
+	if ok && set != nil {
+		for _, lis := range set.Values() {
+			listeners = append(listeners, lis.(registry.ServiceInstancesChangedListener))
+		}
+	}
+	initLock.Unlock()
+
+	var err error
+	for _, lis := range listeners {
+		err = lis.OnEvent(registry.NewServiceInstancesChangedEvent(name, instances))
+	}
+	if err != nil {
+		return false
+	}
 	return true
 }
 

--- a/registry/etcdv3/service_discovery.go
+++ b/registry/etcdv3/service_discovery.go
@@ -309,10 +309,7 @@ func (e *etcdV3ServiceDiscovery) DataChange(eventType remoting.Event) bool {
 	for _, lis := range listeners {
 		err = lis.OnEvent(registry.NewServiceInstancesChangedEvent(name, instances))
 	}
-	if err != nil {
-		return false
-	}
-	return true
+	return err == nil
 }
 
 // newEtcdV3ServiceDiscovery

--- a/registry/nacos/service_discovery.go
+++ b/registry/nacos/service_discovery.go
@@ -316,10 +316,24 @@ func (n *nacosServiceDiscovery) AddListener(listener registry.ServiceInstancesCh
 					})
 				}
 
+				// Snapshot the listener set under listenerLock (registerInstanceListener
+				// and Destroy mutate the map under the same lock) and dispatch outside
+				// the lock: an unlocked read races the writers (Destroy can clear the
+				// map after this callback is scheduled) and holding the lock across
+				// OnEvent would block other listeners. See #3512.
+				n.listenerLock.Lock()
+				set, ok := n.instanceListenerMap[serviceName]
+				listeners := make([]registry.ServiceInstancesChangedListener, 0)
+				if ok && set != nil {
+					for _, lis := range set.Values() {
+						listeners = append(listeners, lis.(registry.ServiceInstancesChangedListener))
+					}
+				}
+				n.listenerLock.Unlock()
+
 				var e error
-				for _, lis := range n.instanceListenerMap[serviceName].Values() {
-					instanceListener := lis.(registry.ServiceInstancesChangedListener)
-					e = instanceListener.OnEvent(registry.NewServiceInstancesChangedEvent(serviceName, instances))
+				for _, lis := range listeners {
+					e = lis.OnEvent(registry.NewServiceInstancesChangedEvent(serviceName, instances))
 				}
 
 				if e != nil {

--- a/registry/zookeeper/service_discovery.go
+++ b/registry/zookeeper/service_discovery.go
@@ -274,11 +274,15 @@ func (zksd *zookeeperServiceDiscovery) DataChange(eventType remoting.Event) bool
 	// get service name in zk path
 	serviceName, _, _ := strings.Cut(path, constant.PathSeparator)
 
-	var err error
 	instances := zksd.GetInstances(serviceName)
-	for _, lis := range zksd.instanceListenerMap[serviceName].Values() {
-		instanceListener := lis.(registry.ServiceInstancesChangedListener)
-		err = instanceListener.OnEvent(registry.NewServiceInstancesChangedEvent(serviceName, instances))
+	// Snapshot the listener set under listenLock (AddListener/Destroy mutate the
+	// map under the same lock) and dispatch outside the lock: an unlocked read
+	// races the writers (fatal "concurrent map read and map write") and holding
+	// the lock across OnEvent would block other listeners. See #3512.
+	listeners := zksd.snapshotListeners(serviceName)
+	var err error
+	for _, lis := range listeners {
+		err = lis.OnEvent(registry.NewServiceInstancesChangedEvent(serviceName, instances))
 	}
 
 	if err != nil {
@@ -286,6 +290,23 @@ func (zksd *zookeeperServiceDiscovery) DataChange(eventType remoting.Event) bool
 		return false
 	}
 	return true
+}
+
+// snapshotListeners returns a snapshot of the listeners registered for
+// serviceName under listenLock. The returned slice is safe to iterate without
+// the lock.
+func (zksd *zookeeperServiceDiscovery) snapshotListeners(serviceName string) []registry.ServiceInstancesChangedListener {
+	zksd.listenLock.Lock()
+	defer zksd.listenLock.Unlock()
+	set, ok := zksd.instanceListenerMap[serviceName]
+	if !ok || set == nil {
+		return nil
+	}
+	out := make([]registry.ServiceInstancesChangedListener, 0, set.Size())
+	for _, lis := range set.Values() {
+		out = append(out, lis.(registry.ServiceInstancesChangedListener))
+	}
+	return out
 }
 
 // toCuratorInstance convert to curator's service instance

--- a/registry/zookeeper/service_discovery_test.go
+++ b/registry/zookeeper/service_discovery_test.go
@@ -18,10 +18,15 @@
 package zookeeper
 
 import (
+	"reflect"
+	"sync"
 	"testing"
 )
 
 import (
+	gxset "github.com/dubbogo/gost/container/set"
+	"github.com/dubbogo/gost/gof/observer"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -44,4 +49,42 @@ func Test_newZookeeperServiceDiscovery(t *testing.T) {
 func Test_zookeeperServiceDiscovery_DataChange(t *testing.T) {
 	serviceDiscovery := &zookeeperServiceDiscovery{}
 	assert.Equal(t, registry.DefaultPageSize, serviceDiscovery.GetDefaultPageSize())
+}
+
+// mockChangedListener is a minimal ServiceInstancesChangedListener for tests.
+type mockChangedListener struct{ name string }
+
+func (m *mockChangedListener) OnEvent(observer.Event) error                         { return nil }
+func (m *mockChangedListener) AddListenerAndNotify(string, registry.NotifyListener) {}
+func (m *mockChangedListener) RemoveListener(string)                                {}
+func (m *mockChangedListener) GetServiceNames() *gxset.HashSet                      { return gxset.NewSet(m.name) }
+func (m *mockChangedListener) Accept(observer.Event) bool                           { return true }
+func (m *mockChangedListener) GetEventType() reflect.Type                           { return nil }
+func (m *mockChangedListener) GetPriority() int                                     { return 0 }
+
+// TestZookeeperServiceDiscovery_SnapshotListeners verifies the listener map is
+// read under listenLock and a missing key is a safe no-op. Regression for #3512
+// (unlocked map read racing AddListener/Destroy).
+func TestZookeeperServiceDiscovery_SnapshotListeners(t *testing.T) {
+	sd := &zookeeperServiceDiscovery{
+		instanceListenerMap: map[string]*gxset.HashSet{
+			"svc-a": gxset.NewSet(&mockChangedListener{name: "a1"}, &mockChangedListener{name: "a2"}),
+		},
+	}
+	assert.Nil(t, sd.snapshotListeners("missing"))
+	assert.Len(t, sd.snapshotListeners("svc-a"), 2)
+
+	// Concurrent snapshot vs concurrent map mutation under listenLock must be race-free.
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Add(2)
+		go func() { defer wg.Done(); _ = sd.snapshotListeners("svc-a") }()
+		go func() {
+			defer wg.Done()
+			sd.listenLock.Lock()
+			sd.instanceListenerMap["svc-a"] = gxset.NewSet(&mockChangedListener{name: "x"})
+			sd.listenLock.Unlock()
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## What

The Zookeeper / etcdv3 / Nacos service-discovery backends read `instanceListenerMap[serviceName]` inside their watcher/subscription callbacks **without holding the lock** that `AddListener` / `registerInstanceListener` / `Destroy` mutate it under. Concurrent subscribe/unsubscribe therefore triggers a fatal `concurrent map read and map write`.

## Why

- **zookeeper** `registry/zookeeper/service_discovery.go:279` — `DataChange` iterates `zksd.instanceListenerMap[serviceName].Values()` with no `listenLock`, while `AddListener` (`:238`) and (via `Destroy`) mutate the map under `listenLock`.
- **etcdv3** `registry/etcdv3/service_discovery.go:290` — `DataChange` reads `e.instanceListenerMap[...]` with no `initLock`, while `registerServiceInstanceListener`/`registerServiceWatcher` write under `initLock`. Additionally, the decode-error path blanked `ServiceName` to `""` and then looked up `instanceListenerMap[""]` — a silent no-op rather than a real failure.
- **nacos** `registry/nacos/service_discovery.go:320` — the `SubscribeCallback` reads `n.instanceListenerMap[serviceName]` with no `listenerLock`, while `registerInstanceListener` and `Destroy` mutate it under `listenerLock`; an in-flight callback delivered after `Destroy` clears the map is a live race.

(`gxset.HashSet.Values()` does not panic on a nil receiver, so the issue is the concurrent map access, not a nil deref.)

## Fix

Snapshot the listener set under the writer lock, then iterate the snapshot **outside** the lock to dispatch — this both eliminates the race and stops a slow `OnEvent` from blocking every other listener:

- **zookeeper** `DataChange`: snapshot under `listenLock` via a new `snapshotListeners` helper; dispatch outside the lock.
- **etcdv3** `DataChange`: snapshot under `initLock`; on decode error, log and `return false` instead of blanking `ServiceName`.
- **nacos** `SubscribeCallback`: snapshot under `listenerLock` before `OnEvent`.

## Tests

Added `TestZookeeperServiceDiscovery_SnapshotListeners` covering: missing key (safe no-op), present key (returns registered listeners), and concurrent snapshot-vs-mutation race-freedom under `-race`. `registry/zookeeper`, `registry/etcdv3`, `registry/nacos` all pass under `-race`.

Fixes #3512