### PR TITLE
fix(registry/servicediscovery): guard ServiceMappingChangedListenerImpl.Stop with mux

### DIFF
--- a/registry/servicediscovery/service_mapping_change_listener_impl.go
+++ b/registry/servicediscovery/service_mapping_change_listener_impl.go
@@ -114,5 +114,10 @@ func (lstn *ServiceMappingChangedListenerImpl) OnEvent(e observer.Event) error {
 
 // Stop on ServiceMappingChangedEvent the service mapping change event
 func (lstn *ServiceMappingChangedListenerImpl) Stop() {
+	// Guard with the same mux that OnEvent reads `stop` under. The previous
+	// unlocked write raced OnEvent (which reads `stop` under mux) and let a
+	// mapping event be processed after the listener had been stopped. See #3518.
+	lstn.mux.Lock()
+	defer lstn.mux.Unlock()
 	lstn.stop = ServiceMappingListenerStop
 }

--- a/registry/servicediscovery/service_mapping_change_listener_impl_test.go
+++ b/registry/servicediscovery/service_mapping_change_listener_impl_test.go
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package servicediscovery
+
+import (
+	"sync"
+	"testing"
+)
+
+import (
+	gxset "github.com/dubbogo/gost/container/set"
+
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+)
+
+// TestServiceMappingChangedListener_StopRace verifies that Stop() (which now
+// takes lstn.mux) and OnEvent() (which reads `stop` under lstn.mux) do not race
+// on the `stop` field. Run with -race. Regression for the issue where Stop wrote
+// `stop` outside the mutex that OnEvent reads it under.
+func TestServiceMappingChangedListener_StopRace(t *testing.T) {
+	regURL, _ := common.NewURL("service-discovery://localhost:12345")
+	svcURL, _ := common.NewURL("dubbo://127.0.0.1:20000/IFoo")
+	lstn := NewMappingListener(regURL, svcURL, gxset.NewSet("app1"), nil)
+
+	// OnEvent(nil) acquires mux, reads `stop`, then early-returns (a nil event is
+	// not a *ServiceMappingChangeEvent), exercising exactly the Stop-vs-OnEvent
+	// race on `stop`.
+	var wg sync.WaitGroup
+	const rounds = 100
+	for range rounds {
+		wg.Add(2)
+		go func() { defer wg.Done(); lstn.Stop() }()
+		go func() { defer wg.Done(); _ = lstn.OnEvent(nil) }()
+	}
+	wg.Wait()
+
+	// After the concurrent Stops complete the listener must be stopped.
+	lstn.mux.Lock()
+	defer lstn.mux.Unlock()
+	assert.Equal(t, ServiceMappingListenerStop, lstn.stop)
+}


### PR DESCRIPTION
## What

`ServiceMappingChangedListenerImpl.Stop` writes the `stop` field **without** `lstn.mux`, while `OnEvent` reads `stop` **under** `lstn.mux`. The unlocked write races `OnEvent` (data race on the `int` field) and lets a mapping event be processed after the listener has been stopped.

## Why

```go
// registry/servicediscovery/service_mapping_change_listener_impl.go
func (lstn *ServiceMappingChangedListenerImpl) OnEvent(e observer.Event) error {
    lstn.mux.Lock()
    defer lstn.mux.Unlock()
    if lstn.stop == ServiceMappingListenerStop { ... }   // read under mux
    ...
}

func (lstn *ServiceMappingChangedListenerImpl) Stop() {
    lstn.stop = ServiceMappingListenerStop                 // write WITHOUT mux
}
```

`Stop` is reached from `serviceDiscoveryRegistry.stopListen` (under the registry's `s.lock`, not `lstn.mux`), so a concurrent `UnSubscribe` and a `ServiceMappingChangedEvent` delivered to `OnEvent` race on `stop`. `go test -race` flags it.

## Fix

Acquire `lstn.mux` in `Stop` before writing `stop`. `Stop` is not called re-entrantly from `OnEvent`'s held-`mux` call stack (it is reached via `UnSubscribe`/`stopListen`, independent of the `OnEvent` → `SubscribeURL` path), so there is no self-deadlock.

## Tests

Added `TestServiceMappingChangedListener_StopRace`: 100 rounds of concurrent `Stop()` vs `OnEvent(nil)` (which acquires `mux`, reads `stop`, early-returns), passing under `-race`.

Fixes #3518