### PR TITLE
fix(cluster/directory/static): guard invokers with a dedicated RWMutex

### DIFF
--- a/cluster/directory/static/directory.go
+++ b/cluster/directory/static/directory.go
@@ -18,6 +18,10 @@
 package static
 
 import (
+	"sync"
+)
+
+import (
 	"github.com/dubbogo/gost/log/logger"
 
 	perrors "github.com/pkg/errors"
@@ -33,6 +37,10 @@ import (
 type directory struct {
 	*base.Directory
 	invokers []protocolbase.Invoker
+	// lock guards invokers against the race between List/IsAvailable (read) and
+	// Destroy (write). base.Directory.mutex is unexported and not accessible
+	// from this package. See #3520.
+	lock sync.RWMutex
 }
 
 // NewDirectory Create a new staticDirectory with invokers
@@ -62,10 +70,16 @@ func (dir *directory) IsAvailable() bool {
 		return false
 	}
 
-	if len(dir.invokers) == 0 {
+	// Snapshot invokers under lock: Destroy reassigns the slice header (under
+	// lock below), so an unlocked read races it. See #3520.
+	dir.lock.RLock()
+	invokers := dir.invokers
+	dir.lock.RUnlock()
+
+	if len(invokers) == 0 {
 		return false
 	}
-	for _, invoker := range dir.invokers {
+	for _, invoker := range invokers {
 		if !invoker.IsAvailable() {
 			return false
 		}
@@ -75,9 +89,14 @@ func (dir *directory) IsAvailable() bool {
 
 // List List invokers
 func (dir *directory) List(invocation protocolbase.Invocation) []protocolbase.Invoker {
+	// Snapshot invokers under lock, then release before touching the router
+	// chain (which takes base.Directory.mutex) so the two locks never nest.
+	dir.lock.RLock()
 	l := len(dir.invokers)
 	invokers := make([]protocolbase.Invoker, l)
 	copy(invokers, dir.invokers)
+	dir.lock.RUnlock()
+
 	routerChain := dir.RouterChain()
 
 	if routerChain == nil {
@@ -90,6 +109,12 @@ func (dir *directory) List(invocation protocolbase.Invocation) []protocolbase.In
 // Destroy Destroy
 func (dir *directory) Destroy() {
 	dir.DoDestroy(func() {
+		// Guard the invokers write with the same lock List/IsAvailable read
+		// under. DoDestroy already holds base.Directory.mutex; this lock is
+		// never held while waiting for base.Directory.mutex (List/IsAvailable
+		// release it before calling RouterChain), so there is no deadlock.
+		dir.lock.Lock()
+		defer dir.lock.Unlock()
 		for _, ivk := range dir.invokers {
 			ivk.Destroy()
 		}

--- a/cluster/directory/static/directory_test.go
+++ b/cluster/directory/static/directory_test.go
@@ -19,6 +19,7 @@ package static
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 )
 
@@ -57,4 +58,27 @@ func TestStaticDirDestroy(t *testing.T) {
 	assert.True(t, staticDir.IsAvailable())
 	staticDir.Destroy()
 	assert.False(t, staticDir.IsAvailable())
+}
+
+// TestStaticDirListVsDestroyRace verifies that concurrent List/IsAvailable and
+// Destroy do not race on dir.invokers. Run with -race. Regression for #3520.
+func TestStaticDirListVsDestroyRace(t *testing.T) {
+	invokers := []base.Invoker{}
+	for i := range 10 {
+		url, _ := common.NewURL(fmt.Sprintf("dubbo://192.168.1.%v:20000/com.ikurento.user.UserProvider", i))
+		invokers = append(invokers, base.NewBaseInvoker(url))
+	}
+
+	staticDir := NewDirectory(invokers)
+	inv := &invocation.RPCInvocation{}
+
+	var wg sync.WaitGroup
+	const rounds = 50
+	for range rounds {
+		wg.Add(3)
+		go func() { defer wg.Done(); _ = staticDir.List(inv) }()
+		go func() { defer wg.Done(); staticDir.IsAvailable() }()
+		go func() { defer wg.Done(); staticDir.Destroy() }()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## What

`List` and `IsAvailable` read `dir.invokers` without a lock, while `Destroy` reassigns it under `base.Directory.mutex` (via `DoDestroy`). The unlocked reads race the write (data race on the slice header).

## Why

```go
// cluster/directory/static/directory.go
func (dir *directory) IsAvailable() bool {
    ...
    if len(dir.invokers) == 0 { ... }                 // unlocked read
    for _, invoker := range dir.invokers { ... }      // unlocked range
}
func (dir *directory) List(...) []protocolbase.Invoker {
    l := len(dir.invokers); ... copy(invokers, dir.invokers)  // unlocked read
}
func (dir *directory) Destroy() {
    dir.DoDestroy(func() { ...; dir.invokers = []protocolbase.Invoker{} })  // write under base.Directory.mutex
}
```

`base.Directory.mutex` is unexported and not accessible from the `static` package, so the static directory needs its own lock for `invokers`.

## Fix

Add a `sync.RWMutex` to the static `directory`:

- `IsAvailable`/`List` snapshot `invokers` under `RLock` and iterate the snapshot.
- `List` releases the lock **before** calling `RouterChain()` (which takes `base.Directory.mutex`) so the two locks never nest — no deadlock.
- `Destroy`'s closure writes `invokers` under the new lock (inside `DoDestroy`, which holds `base.Directory.mutex`; no other path holds the new lock while waiting for `base.Directory.mutex`).

## Tests

Added `TestStaticDirListVsDestroyRace`: 50 rounds of concurrent `List`/`IsAvailable`/`Destroy`, passing under `-race`.

Fixes #3520