### PR TITLE
fix(p2c/adaptivesvc): read singleton instance only through sync.Once

### DIFF
--- a/cluster/cluster/adaptivesvc/cluster.go
+++ b/cluster/cluster/adaptivesvc/cluster.go
@@ -42,11 +42,12 @@ func init() {
 type adaptiveServiceCluster struct{}
 
 func newAdaptiveServiceCluster() clusterpkg.Cluster {
-	if instance == nil {
-		once.Do(func() {
-			instance = &adaptiveServiceCluster{}
-		})
-	}
+	// Always go through once.Do so the read of `instance` has a happens-before
+	// relation to the write inside Do. The previous `if instance == nil` fast
+	// path read `instance` without synchronization, racing the first-time write.
+	once.Do(func() {
+		instance = &adaptiveServiceCluster{}
+	})
 	return instance
 }
 

--- a/cluster/loadbalance/p2c/loadbalance.go
+++ b/cluster/loadbalance/p2c/loadbalance.go
@@ -90,14 +90,15 @@ func defaultRnd(n int) (i, j int) {
 // randomPicker parameter is designed ONLY FOR TEST purposes.
 // Thread-safe via sync.Once.
 func newP2CLoadBalance(r randomPicker) loadbalance.LoadBalance {
-	if r == nil {
-		r = defaultRnd
-	}
-	if instance == nil {
-		once.Do(func() {
-			instance = &p2cLoadBalance{randomPicker: r}
-		})
-	}
+	// Always go through once.Do so the read of `instance` has a happens-before
+	// relation to the write inside Do. The previous `if instance == nil` fast
+	// path read `instance` without synchronization, racing the first-time write.
+	once.Do(func() {
+		if r == nil {
+			r = defaultRnd
+		}
+		instance = &p2cLoadBalance{randomPicker: r}
+	})
 	return instance
 }
 

--- a/cluster/loadbalance/p2c/loadbalance_test.go
+++ b/cluster/loadbalance/p2c/loadbalance_test.go
@@ -18,6 +18,7 @@
 package p2c
 
 import (
+	"sync"
 	"testing"
 )
 
@@ -204,4 +205,21 @@ func TestLoadBalance(t *testing.T) {
 		assert.Equal(t, ivkArr[1].GetURL().String(), ivk.GetURL().String())
 	})
 
+}
+
+// TestNewP2CLoadBalanceConcurrent verifies the singleton factory is race-free
+// when many goroutines race the first-time initialization. Run with -race.
+// Regression for #3521 (read of `instance` outside once.Do).
+func TestNewP2CLoadBalanceConcurrent(t *testing.T) {
+	var wg sync.WaitGroup
+	const n = 100
+	for range n {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			lb := newP2CLoadBalance(nil)
+			assert.NotNil(t, lb)
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
## What

`newP2CLoadBalance` and `newAdaptiveServiceCluster` read the package-level `instance` **outside** `sync.Once.Do` (an `if instance == nil` fast path + `return instance`), racing first-time concurrent initialization.

## Why

```go
var (
    once     sync.Once
    instance loadbalance.LoadBalance
)

func newP2CLoadBalance(r randomPicker) loadbalance.LoadBalance {
    if r == nil { r = defaultRnd }
    if instance == nil {              // unsynchronized read
        once.Do(func() { instance = &p2cLoadBalance{...} })
    }
    return instance                  // unsynchronized read when check was false
}
```

`sync.Once.Do` only establishes happens-before for callers that **call `Do`**. A goroutine that observes `instance != nil` (check false) skips `Do` and reads `instance` with no happens-before to the goroutine that wrote it inside `Do`. Two concurrent first-time callers race on `instance`. The identical pattern is in `cluster/cluster/adaptivesvc/cluster.go:newAdaptiveServiceCluster`. Both factories are registered in `init()`, so concurrent RPCs at process start hit this path. `go test -race` flags it.

## Fix

Drop the `if instance == nil` fast path; always `once.Do(...)` then `return instance`. `sync.Once.Do` guarantees all callers see the writes done inside `Do`, and there is no read of `instance` outside `Do`. The p2c `r == nil` defaulting moves inside the `once.Do` closure (only the first call's `r` is used, identical to before).

## Tests

Added `TestNewP2CLoadBalanceConcurrent`: 100 goroutines racing the factory, passing under `-race`. `p2c` package passes under `-race`.

Fixes #3522