### PR TITLE
fix(hessian2): guard argsTypes.(string) in unpackRequestBody

### DIFF
--- a/protocol/dubbo/hessian2/hessian_request.go
+++ b/protocol/dubbo/hessian2/hessian_request.go
@@ -229,7 +229,14 @@ func unpackRequestBody(decoder *hessian.Decoder, reqObj any) error {
 	}
 	req[4] = argsTypes
 
-	ats := DescRegex.FindAllString(argsTypes.(string), -1)
+	// argsTypes must be a string descriptor (e.g. "Ljava/lang/String;"). A null
+	// or non-string value (malformed/hostile request) would otherwise panic on
+	// the type assertion. Surface it as an error instead. See #3523.
+	argsTypesStr, ok := argsTypes.(string)
+	if !ok {
+		return perrors.Errorf("hessian2: invalid argument types descriptor, expected string, got %T", argsTypes)
+	}
+	ats := DescRegex.FindAllString(argsTypesStr, -1)
 	var arg any
 	for range ats {
 		arg, err = decoder.Decode()

--- a/protocol/dubbo/hessian2/hessian_request_test.go
+++ b/protocol/dubbo/hessian2/hessian_request_test.go
@@ -158,3 +158,22 @@ func TestIssue192(t *testing.T) {
 		})
 	}
 }
+
+// TestUnpackRequestBody_NilArgsTypes verifies that a request whose
+// argument-types descriptor field is a Hessian null no longer panics on the
+// unchecked argsTypes.(string) assertion; instead it returns an error.
+// Regression for #3523.
+func TestUnpackRequestBody_NilArgsTypes(t *testing.T) {
+	enc := hessian.NewEncoder()
+	_ = enc.Encode("2.0.2")        // dubbo version
+	_ = enc.Encode("com.test.Foo") // path
+	_ = enc.Encode("v1")           // service version
+	_ = enc.Encode("echo")         // method
+	_ = enc.Encode(nil)            // argsTypes = Hessian null  <-- used to panic
+
+	dec := hessian.NewDecoder(enc.Buffer())
+	req := make([]any, 7)
+	err := unpackRequestBody(dec, req)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "argument types descriptor")
+}


### PR DESCRIPTION
## What

`unpackRequestBody` panics on an unchecked `argsTypes.(string)` assertion when the argument-types descriptor field of a Dubbo Hessian2 request is a Hessian `null` (or any non-string), crashing the server-side goroutine handling the request.

## Why

```go
// protocol/dubbo/hessian2/hessian_request.go:226-232
argsTypes, err = decoder.Decode()
if err != nil {
    return perrors.WithStack(err)
}
req[4] = argsTypes

ats := DescRegex.FindAllString(argsTypes.(string), -1)   // unchecked assertion
```

`decoder.Decode()` returns `(nil, nil)` for a Hessian null marker (no error), so a malformed/hostile request whose argsTypes field is null reaches the assertion and panics — dropping the connection / tripping `recover`.

## Fix

Comma-ok assertion; on a non-string argsTypes, return a descriptive error instead of panicking. An empty-string argsTypes (zero args) still decodes unchanged.

```go
argsTypesStr, ok := argsTypes.(string)
if !ok {
    return perrors.Errorf("hessian2: invalid argument types descriptor, expected string, got %T", argsTypes)
}
ats := DescRegex.FindAllString(argsTypesStr, -1)
```

## Tests

Added `TestUnpackRequestBody_NilArgsTypes`: encodes a request whose argsTypes field is a Hessian null and asserts `unpackRequestBody` returns an error (no panic). `protocol/dubbo/hessian2` package passes.

Fixes #3524