### PR TITLE
fix(registry/servicediscovery): dispatch NotifyAll outside OnEvent's mutex

### DIFF
--- a/registry/servicediscovery/service_instances_changed_listener_impl.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl.go
@@ -92,7 +92,9 @@ func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error
 	}
 
 	lstn.mutex.Lock()
-	defer lstn.mutex.Unlock()
+	// No early return between Lock and the explicit Unlock below; the metadata
+	// build loop uses `continue`, not `return`. The lock is released before the
+	// NotifyAll dispatch (see below) so it is not held across external callbacks.
 
 	lstn.allInstances[ce.ServiceName] = ce.Instances
 	revisionToInstances := make(map[string][]registry.ServiceInstance, len(lstn.revisionToMetadata))
@@ -175,6 +177,17 @@ func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error
 	}
 
 	lstn.serviceUrls = newServiceURLs
+	// Snapshot each listener and its events under the lock, then dispatch
+	// outside the lock: holding lstn.mutex across the external NotifyAll
+	// callback lets a slow/blocking consumer stall every other OnEvent on this
+	// listener, and a callback that re-enters AddListenerAndNotify/
+	// RemoveListener (both take lstn.mutex) on the same listener self-deadlocks
+	// (sync.Mutex is not reentrant). See #3527.
+	type notifyJob struct {
+		notify registry.NotifyListener
+		events []*registry.ServiceEvent
+	}
+	jobs := make([]notifyJob, 0, len(lstn.listeners))
 	for key, notifyListener := range lstn.listeners {
 		urls := lstn.serviceUrls[key]
 		events := make([]*registry.ServiceEvent, 0, len(urls))
@@ -184,7 +197,12 @@ func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error
 				Service: url,
 			})
 		}
-		notifyListener.NotifyAll(events, func() {})
+		jobs = append(jobs, notifyJob{notify: notifyListener, events: events})
+	}
+	lstn.mutex.Unlock()
+
+	for _, job := range jobs {
+		job.notify.NotifyAll(job.events, func() {})
 	}
 
 	return nil

--- a/registry/servicediscovery/service_instances_changed_listener_impl_onevent_test.go
+++ b/registry/servicediscovery/service_instances_changed_listener_impl_onevent_test.go
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package servicediscovery
+
+import (
+	"testing"
+	"time"
+)
+
+import (
+	gxset "github.com/dubbogo/gost/container/set"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/metadata/info"
+	"dubbo.apache.org/dubbo-go/v3/registry"
+)
+
+// noopNotifyListener is a registry.NotifyListener that does nothing.
+type noopNotifyListener struct{}
+
+func (noopNotifyListener) Notify(*registry.ServiceEvent)              {}
+func (noopNotifyListener) NotifyAll([]*registry.ServiceEvent, func()) {}
+
+// reentrantNotifyListener's NotifyAll re-enters lstn.AddListenerAndNotify,
+// which acquires lstn.mutex. Before #3527, OnEvent held lstn.mutex across the
+// NotifyAll dispatch, so this self-deadlocked (sync.Mutex is not reentrant).
+type reentrantNotifyListener struct {
+	lstn      *ServiceInstancesChangedListenerImpl
+	triggered chan struct{}
+}
+
+func (r *reentrantNotifyListener) Notify(*registry.ServiceEvent) {}
+func (r *reentrantNotifyListener) NotifyAll(_ []*registry.ServiceEvent, _ func()) {
+	// Re-enter the same listener under the same mutex that OnEvent used to hold.
+	r.lstn.AddListenerAndNotify("reentrant-key", noopNotifyListener{})
+	close(r.triggered)
+}
+
+// TestOnEvent_NoDeadlockOnReentrantNotify verifies that a NotifyAll callback
+// re-entering AddListenerAndNotify on the same listener no longer self-deadlocks.
+// Regression for #3527 (OnEvent held lstn.mutex across the external callback).
+func TestOnEvent_NoDeadlockOnReentrantNotify(t *testing.T) {
+	lstn := &ServiceInstancesChangedListenerImpl{
+		app:                "test-app",
+		registryId:         "test-reg",
+		serviceNames:       gxset.NewSet("svc"),
+		listeners:          make(map[string]registry.NotifyListener),
+		serviceUrls:        make(map[string][]*common.URL),
+		revisionToMetadata: make(map[string]*info.MetadataInfo),
+		allInstances:       make(map[string][]registry.ServiceInstance),
+	}
+	triggered := make(chan struct{})
+	lstn.listeners["k"] = &reentrantNotifyListener{lstn: lstn, triggered: triggered}
+
+	// An event with no instances exercises the notify dispatch without needing
+	// the metadata cache; each listener is notified with an empty event list.
+	done := make(chan error, 1)
+	go func() { done <- lstn.OnEvent(registry.NewServiceInstancesChangedEvent("svc", nil)) }()
+
+	select {
+	case <-triggered:
+		// NotifyAll ran and re-entered AddListenerAndNotify without deadlocking.
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnEvent deadlocked: NotifyAll callback could not re-enter AddListenerAndNotify")
+	}
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnEvent did not return")
+	}
+
+	// the re-entrant registration must have taken effect
+	assert.Contains(t, lstn.listeners, "reentrant-key")
+}


### PR DESCRIPTION
## What

`ServiceInstancesChangedListenerImpl.OnEvent` held `lstn.mutex` across the consumer `NotifyAll` dispatch — a `sync.Mutex` is not reentrant, so a `NotifyAll` callback that re-enters `AddListenerAndNotify`/`RemoveListener` on the same listener self-deadlocked, and a slow/blocking consumer stalled every other `OnEvent` on that listener.

## Why

```go
// registry/servicediscovery/service_instances_changed_listener_impl.go (before)
func (lstn *ServiceInstancesChangedListenerImpl) OnEvent(e observer.Event) error {
    ...
    lstn.mutex.Lock()
    defer lstn.mutex.Unlock()
    // ... rebuild allInstances / revisionToMetadata / serviceUrls ...
    for key, notifyListener := range lstn.listeners {
        ...
        notifyListener.NotifyAll(events, func() {})   // external callback UNDER lock
    }
    return nil
}
```

`AddListenerAndNotify` and `RemoveListener` both acquire `lstn.mutex`. A consumer `NotifyAll` that synchronously re-subscribes (directory re-subscription on notification) re-enters `AddListenerAndNotify` → `Lock` on an already-held (same-goroutine) mutex → deadlock. Independently, holding the lock across an external callback serializes all instance-change processing behind the slowest consumer. This is the same class of issue the reviewer flagged on PR #3442 (do not hold a registry lock across external calls). The sibling `AddListenerAndNotify` already snapshots under the lock and notifies outside; `OnEvent` did not.

## Fix

Snapshot `(notifyListener, events)` pairs under `lstn.mutex`, explicitly `Unlock()`, then dispatch `NotifyAll` outside the lock. There is no early `return` between `Lock` and the explicit `Unlock` (the build loop uses `continue`, not `return`), so the mutex is not leaked.

## Tests

Added `TestOnEvent_NoDeadlockOnReentrantNotify`: a `NotifyAll` callback that re-enters `AddListenerAndNotify` on the same listener. Verified it deadlocks (2s timeout) on the old code and passes on the fixed code. `servicediscovery` package passes under `-race`.

Fixes #3528