### PR TITLE
fix(remoting): enforce async request timeout to avoid PendingResponse leak

### DIFF
--- a/remoting/exchange_client.go
+++ b/remoting/exchange_client.go
@@ -19,6 +19,7 @@ package remoting
 
 import (
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -169,6 +170,29 @@ func (client *ExchangeClient) AsyncRequest(invocation *base.Invocation, url *com
 		RemovePendingResponse(SequenceType(request.ID))
 		result.Err = err
 		return err
+	}
+	// The async path returns immediately and (unlike the sync path) does not
+	// enforce the timeout on the pending response: if no reply arrives — e.g.
+	// the connection drops before the server responds — the pending entry
+	// would leak in the global pendingResponses map and the AsyncCallback would
+	// never fire. Install a timer that, if the reply has not arrived by
+	// `timeout`, removes the pending and invokes the callback with a timeout
+	// error. RemovePendingResponse is an atomic load-and-delete, so the timer
+	// and the reply path (Response.Handle) cannot both win the callback.
+	// See #3529.
+	if timeout > 0 {
+		reqID := request.ID
+		to := timeout
+		time.AfterFunc(to, func() {
+			pr := RemovePendingResponse(SequenceType(reqID))
+			if pr == nil {
+				return // reply already handled by Response.Handle
+			}
+			if pr.Callback != nil {
+				pr.Err = fmt.Errorf("remote async request timeout: requestID=%d timeout=%s", reqID, to.String())
+				pr.Callback(pr.GetCallResponse())
+			}
+		})
 	}
 	result.Rest = rsp.response
 	return nil

--- a/remoting/exchange_client_test.go
+++ b/remoting/exchange_client_test.go
@@ -160,3 +160,37 @@ func countPendingResponses() int {
 	})
 	return n
 }
+
+// TestExchangeClientAsyncRequestTimeoutCallback verifies that when an async
+// request never receives a reply (e.g. the connection drops before the server
+// responds), the pending response is removed and the AsyncCallback is invoked
+// with a timeout error instead of leaking forever. Regression for #3529
+// (distinct from the write-error cleanup in TestExchangeClientAsyncRequestErrorCleanup).
+func TestExchangeClientAsyncRequestTimeoutCallback(t *testing.T) {
+	m := &mockClient{available: true} // Request succeeds, no reply delivered (simulates conn drop)
+	ec := NewExchangeClient(testURL(), m, 5*time.Second, true)
+
+	before := countPendingResponses()
+	res := &result.RPCResult{}
+
+	var (
+		got common.CallbackResponse
+		wg  sync.WaitGroup
+	)
+	wg.Add(1)
+	cb := func(response common.CallbackResponse) {
+		got = response
+		wg.Done()
+	}
+
+	err := ec.AsyncRequest(newTestInvocation(), testURL(), 200*time.Millisecond, cb, res)
+	require.NoError(t, err)
+
+	wg.Wait()
+
+	acr, ok := got.(AsyncCallbackResponse)
+	require.True(t, ok, "callback received %T, want AsyncCallbackResponse", got)
+	assert.Error(t, acr.Cause)
+	assert.Contains(t, acr.Cause.Error(), "timeout")
+	assert.Equal(t, before, countPendingResponses(), "pendingResponses leaked after async timeout")
+}

--- a/remoting/exchange_client_test.go
+++ b/remoting/exchange_client_test.go
@@ -190,7 +190,7 @@ func TestExchangeClientAsyncRequestTimeoutCallback(t *testing.T) {
 
 	acr, ok := got.(AsyncCallbackResponse)
 	require.True(t, ok, "callback received %T, want AsyncCallbackResponse", got)
-	assert.Error(t, acr.Cause)
+	require.Error(t, acr.Cause)
 	assert.Contains(t, acr.Cause.Error(), "timeout")
 	assert.Equal(t, before, countPendingResponses(), "pendingResponses leaked after async timeout")
 }


### PR DESCRIPTION
## What

`ExchangeClient.AsyncRequest` leaked a `PendingResponse` and never invoked the `AsyncCallback` when no reply arrived (e.g. the connection dropped before the server responded).

## Why

```go
// remoting/exchange_client.go AsyncRequest (before)
rsp := NewPendingResponse(request.ID)
rsp.Callback = callback
AddPendingResponse(rsp)
err := client.client.Request(request, timeout, rsp)
if err != nil {
    RemovePendingResponse(SequenceType(request.ID))   // only the write-error path cleans up
    result.Err = err
    return err
}
result.Rest = rsp.response
return nil   // no timeout enforcement; no removal/callback on no-reply
```

The async path returns immediately (getty returns immediately for callback requests, so the `timeout` argument was ignored). The only removal sites are `Response.Handle` (on reply) and the write-error branch. If the write succeeds and the connection drops before the server replies, `getty`'s `removeSession`/`close` never fail the in-flight `pendingResponses`, so the entry leaks in the global `sync.Map` and the `AsyncCallback` never fires — the caller hangs. Distinct from #3440 (write-error-path cleanup); this is the no-reply / connection-drop path.

## Fix

After a successful `client.client.Request`, install `time.AfterFunc(timeout, ...)` that calls `RemovePendingResponse(seq)`. If it returns non-nil (reply has not arrived), invoke `pr.Callback(pr.GetCallResponse())` with a timeout error. `RemovePendingResponse` is an atomic load-and-delete (`sync.Map`), so the timer and the reply path (`Response.Handle`) cannot both win the pending — exactly-once callback. `timeout == 0` preserves the previous wait-forever behavior.

## Tests

Added `TestExchangeClientAsyncRequestTimeoutCallback`: a mock client whose `Request` succeeds and never delivers a reply (simulating connection drop); asserts the `AsyncCallback` fires with a timeout error and the global map does not leak. `remoting` package passes under `-race`.

Fixes #3530