### PR TITLE
fix(proxy/filter): nil-guard GetServiceByServiceKey in pass_through & generic filter

### DIFF
--- a/filter/generic/service_filter.go
+++ b/filter/generic/service_filter.go
@@ -81,6 +81,11 @@ func (f *genericServiceFilter) Invoke(ctx context.Context, invoker base.Invoker,
 	// get the type of the argument
 	ivkURL := invoker.GetURL()
 	svc := common.ServiceMap.GetServiceByServiceKey(ivkURL.Protocol, ivkURL.ServiceKey())
+	if svc == nil {
+		return &result.RPCResult{
+			Err: perrors.Errorf("\"%s\" service is not found, protocol: %s", ivkURL.ServiceKey(), ivkURL.Protocol),
+		}
+	}
 	method := svc.Method()[mtdName]
 	if method == nil {
 		return &result.RPCResult{

--- a/proxy/proxy_factory/invoker_test.go
+++ b/proxy/proxy_factory/invoker_test.go
@@ -155,6 +155,21 @@ func TestPassThroughProxyInvoker_Invoke(t *testing.T) {
 		result := invoker.Invoke(context.Background(), inv)
 		assert.EqualError(t, result.Error(), "the param type is not []byte")
 	})
+
+	t.Run("service not registered returns error instead of panicking", func(t *testing.T) {
+		// a service key that was never registered in ServiceMap -> GetServiceByServiceKey returns nil.
+		u := newURL("pass-unregistered-protocol", "PassThroughUnregistered")
+		unreg := &PassThroughProxyInvoker{
+			ProxyInvoker: &ProxyInvoker{BaseInvoker: *base.NewBaseInvoker(u)},
+		}
+		inv := invocation.NewRPCInvocationWithOptions(
+			invocation.WithMethodName("RawMethod"),
+			invocation.WithArguments([]any{[]byte("payload")}),
+		)
+		result := unreg.Invoke(context.Background(), inv)
+		require.Error(t, result.Error())
+		assert.Contains(t, result.Error().Error(), "not found")
+	})
 }
 
 func TestProxyInvoker_InvokeVariadicCallSliceGating(t *testing.T) {

--- a/proxy/proxy_factory/pass_through.go
+++ b/proxy/proxy_factory/pass_through.go
@@ -87,6 +87,10 @@ func (pi *PassThroughProxyInvoker) Invoke(ctx context.Context, invocation base.I
 
 	arguments := invocation.Arguments()
 	srv := common.ServiceMap.GetServiceByServiceKey(url.Protocol, url.ServiceKey())
+	if srv == nil {
+		result.Err = perrors.Errorf("service %s is not found, protocol: %s", url.ServiceKey(), url.Protocol)
+		return result
+	}
 
 	var args [][]byte
 	if len(arguments) > 0 {


### PR DESCRIPTION
## What

`PassThroughProxyInvoker.Invoke` and the generic `service_filter` dereference `common.ServiceMap.GetServiceByServiceKey(...).Method()` without a nil check, panicking when the service key is not registered. The default `ProxyInvoker` already guards this.

## Why

```go
// common/rpc_service.go GetServiceByServiceKey — returns nil when not registered
if s, ok := sm.serviceMap[protocol]; ok {
    if srv, ok := s[serviceKey]; ok { return srv }
    return nil
}
return nil
```

```go
// filter/generic/service_filter.go:83-84 (before)
svc := common.ServiceMap.GetServiceByServiceKey(ivkURL.Protocol, ivkURL.ServiceKey())
method := svc.Method()[mtdName]   // nil deref

// proxy/proxy_factory/pass_through.go:89,103 (before)
srv := common.ServiceMap.GetServiceByServiceKey(url.Protocol, url.ServiceKey())
...
method := srv.Method()["Service"]   // nil deref
```

The default invoker guards it (`proxy/proxy_factory/default.go:111-115`); these two do not. A generic (`$invoke`) or pass-through invocation for an unregistered service key (dynamic re-export desync, post-unexport, protocol mismatch) crashes the provider goroutine instead of returning an error.

## Fix

Mirror the default invoker's guard in both call sites — return a clear "service not found" error instead of nil-derefing.

## Tests

Added a `TestPassThroughProxyInvoker_Invoke` sub-test "service not registered returns error instead of panicking" using a never-registered protocol/interface, asserting the result is an error (no panic). `proxy/proxy_factory` and `filter/generic` pass under `-race`.

Fixes #3535