### PR TITLE
fix(metadata): nil-guard MetadataServiceV2.GetMetadataInfo on unknown revision

### DIFF
--- a/metadata/metadata_service.go
+++ b/metadata/metadata_service.go
@@ -260,6 +260,14 @@ func (mtsV2 *MetadataServiceV2) GetMetadataInfo(ctx context.Context, req *triple
 	if err != nil {
 		return nil, err
 	}
+	// DefaultMetadataService.GetMetadataInfo returns (nil, nil) for an empty
+	// or unknown revision; dereferencing metadataInfo.App below would panic.
+	// The MetadataServiceV2Handler is exported over triple, so this endpoint is
+	// remotely reachable. See #3534.
+	if metadataInfo == nil {
+		logger.Warnf("[Metadata] metadata info is nil for revision=%s", req.GetRevision())
+		return nil, perrors.Errorf("metadata info not found for revision=%s", req.GetRevision())
+	}
 	return &tripleapi.MetadataInfoV2{
 		App:      metadataInfo.App,
 		Version:  metadataInfo.Revision,

--- a/metadata/metadata_service_test.go
+++ b/metadata/metadata_service_test.go
@@ -418,3 +418,19 @@ func TestDefaultMetadataServiceConcurrentReadAccess(t *testing.T) {
 	}
 	wg.Wait()
 }
+
+// TestMetadataServiceV2GetMetadataInfoNilNoPanic verifies that an unknown
+// revision (for which DefaultMetadataService.GetMetadataInfo returns nil,nil)
+// no longer nil-dereferences metadataInfo.App and instead returns an error.
+// The MetadataServiceV2Handler is exported over triple, so this is remotely
+// reachable. Regression for #3534.
+func TestMetadataServiceV2GetMetadataInfoNilNoPanic(t *testing.T) {
+	// empty metadataMap -> GetMetadataInfo returns (nil, nil) for an unknown revision
+	delegate := &DefaultMetadataService{}
+	svc := &MetadataServiceV2{delegate: delegate}
+
+	got, err := svc.GetMetadataInfo(context.TODO(), &tripleapi.MetadataRequest{Revision: "unknown"})
+	require.Error(t, err)
+	require.Nil(t, got)
+	assert.Contains(t, err.Error(), "metadata info not found")
+}


### PR DESCRIPTION
## What

`MetadataServiceV2.GetMetadataInfo` nil-dereferences the result of `delegate.GetMetadataInfo`, which returns `(nil, nil)` for an unknown/empty revision. The `MetadataServiceV2Handler` is exported over Triple, so this endpoint is remotely reachable.

## Why

```go
// metadata/metadata_service.go
func (mts *DefaultMetadataService) GetMetadataInfo(revision string) (*info.MetadataInfo, error) {
    if revision == "" { return nil, nil }
    ...
    for _, metadataInfo := range mts.metadataMap {
        if metadataInfo.Revision == revision { return metadataInfo, nil }
    }
    return nil, nil   // unknown revision
}

func (mtsV2 *MetadataServiceV2) GetMetadataInfo(...) (*tripleapi.MetadataInfoV2, error) {
    metadataInfo, err := mtsV2.delegate.GetMetadataInfo(req.GetRevision())
    if err != nil { return nil, err }
    return &tripleapi.MetadataInfoV2{
        App:      metadataInfo.App,        // nil deref
        Version:  metadataInfo.Revision,
        Services: convertV2(metadataInfo.GetServices()),
        Tag:      metadataInfo.Tag,
    }, err
}
```

A `getMetadataInfo` triple call with a revision the provider does not have locally (not-yet-published, stale, wrong revision) → `metadataInfo.App` nil-pointer panic → provider-side goroutine crash.

## Fix

```go
if metadataInfo == nil {
    return nil, perrors.Errorf("metadata info not found for revision=%s", req.GetRevision())
}
```

## Tests

Added `TestMetadataServiceV2GetMetadataInfoNilNoPanic`: a `DefaultMetadataService` with an empty `metadataMap` → `GetMetadataInfo` returns `(nil, nil)` for an unknown revision → asserts the V2 method returns an error (no panic). `metadata` package passes under `-race`.

Fixes #3537