### PR TITLE
fix(config_center/zookeeper): fix RemoveListener key mismatch + guard listener set

### DIFF
--- a/config_center/zookeeper/impl.go
+++ b/config_center/zookeeper/impl.go
@@ -104,9 +104,7 @@ func newZookeeperDynamicConfiguration(url *common.URL) (*zookeeperDynamicConfigu
 // AddListener add listener for key
 // TODO this method should has a parameter 'group', and it does not now, so we should concat group and key with '/' manually
 func (c *zookeeperDynamicConfiguration) AddListener(key string, listener config_center.ConfigurationListener, options ...config_center.Option) {
-	key = strings.Join([]string{c.GetURL().GetParam(constant.ConfigNamespaceKey, config_center.DefaultGroup), key}, "/")
-	qualifiedKey := buildPath(c.rootPath, key)
-	c.cacheListener.AddListener(qualifiedKey, listener)
+	c.cacheListener.AddListener(c.qualifyKey(key), listener)
 }
 
 // buildPath build path and format
@@ -119,8 +117,18 @@ func buildPath(rootPath, subPath string) string {
 	return path.Clean(fullPath)
 }
 
+// qualifyKey joins the configured namespace with key and builds the full zk
+// path used as the CacheListener key. AddListener and RemoveListener must use
+// the same qualified key; previously RemoveListener passed the raw caller key
+// and never matched the qualified key stored by AddListener, so every remove
+// was a silent no-op (listener leak). See #3536.
+func (c *zookeeperDynamicConfiguration) qualifyKey(key string) string {
+	key = strings.Join([]string{c.GetURL().GetParam(constant.ConfigNamespaceKey, config_center.DefaultGroup), key}, "/")
+	return buildPath(c.rootPath, key)
+}
+
 func (c *zookeeperDynamicConfiguration) RemoveListener(key string, listener config_center.ConfigurationListener, opions ...config_center.Option) {
-	c.cacheListener.RemoveListener(key, listener)
+	c.cacheListener.RemoveListener(c.qualifyKey(key), listener)
 }
 
 func (c *zookeeperDynamicConfiguration) GetProperties(key string, opts ...config_center.Option) (string, error) {

--- a/config_center/zookeeper/impl_test.go
+++ b/config_center/zookeeper/impl_test.go
@@ -31,6 +31,7 @@ import (
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/config_center"
 )
 
@@ -131,4 +132,24 @@ func mustURL(t *testing.T, raw string) *common.URL {
 	u, err := common.NewURL(raw)
 	require.NoError(t, err)
 	return u
+}
+
+// TestZookeeperDynamicConfigurationQualifyKey verifies AddListener and
+// RemoveListener compute the same qualified key (namespace + buildPath), so
+// remove actually matches the stored entry. Regression for #3536 (RemoveListener
+// passed the raw caller key and never matched AddListener's qualified key).
+func TestZookeeperDynamicConfigurationQualifyKey(t *testing.T) {
+	u, err := common.NewURL("registry://127.0.0.1:2181",
+		common.WithParamsValue(constant.ConfigNamespaceKey, "myns"))
+	require.NoError(t, err)
+	cfg := &zookeeperDynamicConfiguration{rootPath: "/dubbo/config", url: u}
+
+	got := cfg.qualifyKey("app.key")
+	want := buildPath("/dubbo/config", "myns/app.key")
+	require.Equal(t, want, got)
+
+	// default namespace when the param is absent
+	u2, _ := common.NewURL("registry://127.0.0.1:2181")
+	cfg2 := &zookeeperDynamicConfiguration{rootPath: "/dubbo/config", url: u2}
+	require.Equal(t, buildPath("/dubbo/config", config_center.DefaultGroup+"/app.key"), cfg2.qualifyKey("app.key"))
 }

--- a/config_center/zookeeper/listener.go
+++ b/config_center/zookeeper/listener.go
@@ -33,7 +33,7 @@ import (
 
 // CacheListener defines keyListeners and rootPath
 type CacheListener struct {
-	// key is zkNode Path and value is set of listeners
+	// key is zkNode Path and value is *listenerSet (mutex-guarded set of listeners)
 	keyListeners    sync.Map
 	zkEventListener *zookeeper.ZkEventListener
 	rootPath        string
@@ -44,27 +44,58 @@ func NewCacheListener(rootPath string, listener *zookeeper.ZkEventListener) *Cac
 	return &CacheListener{zkEventListener: listener, rootPath: rootPath}
 }
 
+// listenerSet is a mutex-guarded set of ConfigurationListeners. AddListener and
+// RemoveListener run on router/config goroutines while DataChange runs on the
+// zk event goroutine; guarding the inner map avoids a fatal concurrent map
+// read+write. See #3536.
+type listenerSet struct {
+	mu        sync.Mutex
+	listeners map[config_center.ConfigurationListener]struct{}
+}
+
+func newListenerSet() *listenerSet {
+	return &listenerSet{listeners: make(map[config_center.ConfigurationListener]struct{})}
+}
+
+func (s *listenerSet) add(l config_center.ConfigurationListener) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.listeners[l] = struct{}{}
+}
+
+func (s *listenerSet) remove(l config_center.ConfigurationListener) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.listeners, l)
+}
+
+// snapshot returns a slice copy of the listeners under the lock, safe to
+// iterate outside the lock so listener.Process is not called while holding it.
+func (s *listenerSet) snapshot() []config_center.ConfigurationListener {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]config_center.ConfigurationListener, 0, len(s.listeners))
+	for l := range s.listeners {
+		out = append(out, l)
+	}
+	return out
+}
+
 // AddListener will add a listener if loaded
 func (l *CacheListener) AddListener(key string, listener config_center.ConfigurationListener) {
 	// FIXME do not use Client.ExistW, cause it has a bug(can not watch zk node that do not exist)
 	_, _, _, err := l.zkEventListener.Client.Conn.ExistsW(key)
-	// reference from https://stackoverflow.com/questions/34018908/golang-why-dont-we-have-a-set-datastructure
-	// make a map[your type]struct{} like set in java
 	if err != nil {
 		return
 	}
-	listeners, loaded := l.keyListeners.LoadOrStore(key, map[config_center.ConfigurationListener]struct{}{listener: {}})
-	if loaded {
-		listeners.(map[config_center.ConfigurationListener]struct{})[listener] = struct{}{}
-		l.keyListeners.Store(key, listeners)
-	}
+	actual, _ := l.keyListeners.LoadOrStore(key, newListenerSet())
+	actual.(*listenerSet).add(listener)
 }
 
 // RemoveListener will delete a listener if loaded
 func (l *CacheListener) RemoveListener(key string, listener config_center.ConfigurationListener) {
-	listeners, loaded := l.keyListeners.Load(key)
-	if loaded {
-		delete(listeners.(map[config_center.ConfigurationListener]struct{}), listener)
+	if listeners, ok := l.keyListeners.Load(key); ok {
+		listeners.(*listenerSet).remove(listener)
 	}
 }
 
@@ -78,7 +109,7 @@ func (l *CacheListener) DataChange(event remoting.Event) bool {
 	key, group := l.pathToKeyGroup(event.Path)
 	defer metrics.Publish(metricsConfigCenter.NewIncMetricEvent(key, group, changeType, metricsConfigCenter.Zookeeper))
 	if listeners, ok := l.keyListeners.Load(event.Path); ok {
-		for listener := range listeners.(map[config_center.ConfigurationListener]struct{}) {
+		for _, listener := range listeners.(*listenerSet).snapshot() {
 			listener.Process(&config_center.ConfigChangeEvent{
 				Key:        key,
 				Value:      event.Content,

--- a/config_center/zookeeper/listener_test.go
+++ b/config_center/zookeeper/listener_test.go
@@ -18,6 +18,7 @@
 package zookeeper
 
 import (
+	"sync"
 	"testing"
 )
 
@@ -34,11 +35,25 @@ func (r *recListener) Process(e *config_center.ConfigChangeEvent) {
 	r.events = append(r.events, e)
 }
 
+// safeCountingListener is a ConfigurationListener safe for concurrent Process.
+type safeCountingListener struct {
+	mu  sync.Mutex
+	cnt int
+}
+
+func (s *safeCountingListener) Process(*config_center.ConfigChangeEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cnt++
+}
+
 func TestCacheListenerDataChange(t *testing.T) {
 	l := &CacheListener{rootPath: "/dubbo/config"}
 	path := "/dubbo/config/group/app"
 	rec := &recListener{}
-	l.keyListeners.Store(path, map[config_center.ConfigurationListener]struct{}{rec: {}})
+	set := newListenerSet()
+	set.add(rec)
+	l.keyListeners.Store(path, set)
 
 	ok := l.DataChange(remoting.Event{Path: path, Action: remoting.EventTypeUpdate, Content: "val"})
 	if !ok {
@@ -53,7 +68,9 @@ func TestCacheListenerDataChangeEmptyContent(t *testing.T) {
 	l := &CacheListener{rootPath: "/dubbo/config"}
 	path := "/dubbo/config/group/app"
 	rec := &recListener{}
-	l.keyListeners.Store(path, map[config_center.ConfigurationListener]struct{}{rec: {}})
+	set := newListenerSet()
+	set.add(rec)
+	l.keyListeners.Store(path, set)
 
 	ok := l.DataChange(remoting.Event{Path: path, Action: remoting.EventTypeAdd})
 	if !ok {
@@ -76,11 +93,37 @@ func TestCacheListenerRemoveListener(t *testing.T) {
 	l := &CacheListener{}
 	key := "k"
 	rec := &recListener{}
-	l.keyListeners.Store(key, map[config_center.ConfigurationListener]struct{}{rec: {}})
+	set := newListenerSet()
+	set.add(rec)
+	l.keyListeners.Store(key, set)
 	l.RemoveListener(key, rec)
-	if m, ok := l.keyListeners.Load(key); ok {
-		if _, exists := m.(map[config_center.ConfigurationListener]struct{})[rec]; exists {
-			t.Fatalf("listener should be removed")
+	if s, ok := l.keyListeners.Load(key); ok {
+		if got := len(s.(*listenerSet).snapshot()); got != 0 {
+			t.Fatalf("listener should be removed, got %d", got)
+		}
+	}
+}
+
+// TestListenerSetConcurrency verifies the mutex-guarded listenerSet is race-free
+// under concurrent add/remove/snapshot (DataChange's read path). Run with -race.
+// Regression for #3536 (inner map had no lock -> fatal concurrent map read+write).
+func TestListenerSetConcurrency(t *testing.T) {
+	s := newListenerSet()
+	a := &safeCountingListener{}
+	b := &safeCountingListener{}
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(4)
+		go func() { defer wg.Done(); s.add(a) }()
+		go func() { defer wg.Done(); s.remove(a) }()
+		go func() { defer wg.Done(); s.add(b) }()
+		go func() { defer wg.Done(); _ = s.snapshot() }()
+	}
+	wg.Wait()
+	// snapshot must only ever reference the registered listeners and not panic.
+	for _, l := range s.snapshot() {
+		if l != a && l != b {
+			t.Fatalf("unexpected listener %v", l)
 		}
 	}
 }


### PR DESCRIPTION
## What

Two bugs in the Zookeeper config_center listener: `RemoveListener` was a silent no-op (key mismatch → leak), and the inner listener map had no lock (fatal concurrent map read+write).

## Why

**1. Key mismatch (leak).** `AddListener` stored under the qualified key (`buildPath(rootPath, namespace/key)`), but `RemoveListener` passed the **raw** caller key, so `CacheListener.RemoveListener` did `keyListeners.Load(rawKey)` → never matched → listener never deleted. Every router `RemoveListener` call (condition/script/affinity routers) was a no-op; stale listeners kept receiving `DataChange` after unsubscribe.

```go
// config_center/zookeeper/impl.go (before)
func (c *zookeeperDynamicConfiguration) AddListener(key string, ...) {
    key = strings.Join([]string{c.GetURL().GetParam(constant.ConfigNamespaceKey, ...), key}, "/")
    qualifiedKey := buildPath(c.rootPath, key)
    c.cacheListener.AddListener(qualifiedKey, listener)   // stored qualified
}
func (c *zookeeperDynamicConfiguration) RemoveListener(key string, ...) {
    c.cacheListener.RemoveListener(key, listener)           // looked up RAW -> no-op
}
```

**2. Inner map race (fatal).** `keyListeners` is a `sync.Map` whose value is a plain `map[ConfigurationListener]struct{}` with no mutex (unlike `metadata/report/zookeeper`'s locked `ListenerSet`). `AddListener`/`RemoveListener` (router goroutines) write/delete the inner map; `DataChange` (zk event goroutine) ranges it → `fatal error: concurrent map read and map write`.

## Fix

- Add a `qualifyKey(key)` helper used by **both** `AddListener` and `RemoveListener` so the keys cannot drift.
- Replace the inner `map` value with a mutex-guarded `listenerSet` (`add`/`remove`/`snapshot`); `DataChange` snapshots under the lock and dispatches `Process` outside it.

## Tests

- `TestZookeeperDynamicConfigurationQualifyKey`: `qualifyKey` produces the same key for Add/Remove (with and without an explicit namespace).
- `TestListenerSetConcurrency`: 100 rounds of concurrent `add`/`remove`/`snapshot` under `-race`.
- Updated existing `CacheListener` tests for the new `listenerSet` value type.

`config_center/zookeeper` passes under `-race`.

Fixes #3539