### PR TITLE
fix(config_center/apollo): guard apolloListener map with RWMutex

### DIFF
--- a/config_center/apollo/listener.go
+++ b/config_center/apollo/listener.go
@@ -18,6 +18,10 @@
 package apollo
 
 import (
+	"sync"
+)
+
+import (
 	"github.com/apolloconfig/agollo/v4/storage"
 
 	"github.com/dubbogo/gost/log/logger"
@@ -31,6 +35,7 @@ import (
 )
 
 type apolloListener struct {
+	mu        sync.RWMutex
 	listeners map[config_center.ConfigurationListener]struct{}
 }
 
@@ -53,7 +58,17 @@ func (a *apolloListener) OnNewestChange(changeEvent *storage.FullChangeEvent) {
 		return
 	}
 	content := string(b)
-	for listener := range a.listeners {
+	// Snapshot under the lock and dispatch outside it: OnNewestChange runs on
+	// agollo's long-poll goroutine while AddListener/RemoveListener run on router
+	// goroutines. The previous unlocked range was a fatal concurrent map read+write.
+	// See #3541.
+	a.mu.RLock()
+	snapshot := make([]config_center.ConfigurationListener, 0, len(a.listeners))
+	for l := range a.listeners {
+		snapshot = append(snapshot, l)
+	}
+	a.mu.RUnlock()
+	for _, listener := range snapshot {
 		listener.Process(&config_center.ConfigChangeEvent{
 			ConfigType: remoting.EventTypeUpdate,
 			Key:        changeEvent.Namespace,
@@ -64,6 +79,8 @@ func (a *apolloListener) OnNewestChange(changeEvent *storage.FullChangeEvent) {
 
 // AddListener adds a listener for apollo
 func (a *apolloListener) AddListener(l config_center.ConfigurationListener) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	if _, ok := a.listeners[l]; !ok {
 		a.listeners[l] = struct{}{}
 	}
@@ -71,10 +88,14 @@ func (a *apolloListener) AddListener(l config_center.ConfigurationListener) {
 
 // RemoveListener removes listeners of apollo
 func (a *apolloListener) RemoveListener(l config_center.ConfigurationListener) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
 	delete(a.listeners, l)
 }
 
 // IsEmpty Check if listeners is empty
 func (a *apolloListener) IsEmpty() bool {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
 	return len(a.listeners) == 0
 }

--- a/config_center/apollo/listener_test.go
+++ b/config_center/apollo/listener_test.go
@@ -18,6 +18,7 @@
 package apollo
 
 import (
+	"sync"
 	"testing"
 )
 
@@ -69,4 +70,41 @@ func TestApolloListener(t *testing.T) {
 	if !l.IsEmpty() {
 		t.Fatalf("listener should be empty after remove")
 	}
+}
+
+// safeRecordingListener is a ConfigurationListener safe for concurrent Process.
+type safeRecordingListener struct {
+	mu  sync.Mutex
+	cnt int
+}
+
+func (s *safeRecordingListener) Process(*config_center.ConfigChangeEvent) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cnt++
+}
+
+// TestApolloListenerConcurrency verifies the mutex-guarded listener set is
+// race-free under concurrent OnNewestChange (agollo goroutine) vs Add/Remove
+// (router goroutines). Run with -race. Regression for #3541 (unlocked map ->
+// fatal concurrent map read+write).
+func TestApolloListenerConcurrency(t *testing.T) {
+	l := newApolloListener()
+	a := &safeRecordingListener{}
+	b := &safeRecordingListener{}
+	change := &storage.FullChangeEvent{
+		Changes: map[string]any{"k": "v"},
+	}
+	change.Namespace = "application"
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(4)
+		go func() { defer wg.Done(); l.AddListener(a) }()
+		go func() { defer wg.Done(); l.RemoveListener(a) }()
+		go func() { defer wg.Done(); l.AddListener(b) }()
+		go func() { defer wg.Done(); l.OnNewestChange(change) }()
+	}
+	wg.Wait()
+	// no panic, no race; IsEmpty reads under the lock without racing writers.
+	_ = l.IsEmpty()
 }


### PR DESCRIPTION
## What

`apolloListener.listeners` was a plain `map` with no mutex; `OnNewestChange` ranges it on agollo's long-poll goroutine while `AddListener`/`RemoveListener` mutate it on router goroutines — a fatal concurrent map read+write. Same class as the zk config_center `CacheListener` fix (#3539/#3540).

## Why

```go
// config_center/apollo/listener.go (before)
type apolloListener struct {
    listeners map[config_center.ConfigurationListener]struct{}   // no lock
}
func (a *apolloListener) OnNewestChange(...) {
    for listener := range a.listeners { listener.Process(...) }   // agollo goroutine
}
func (a *apolloListener) AddListener(l ...)  { a.listeners[l] = struct{}{} }   // router goroutine
func (a *apolloListener) RemoveListener(l ...) { delete(a.listeners, l) }      // router goroutine
func (a *apolloListener) IsEmpty() bool        { return len(a.listeners) == 0 } // router goroutine
```

A config push from Apollo arriving while a router subscribes/unsubscribes (or `IsEmpty` runs inside `RemoveListener`'s `RemoveChangeListener` decision) → `fatal error: concurrent map read and map write`.

## Fix

Add a `sync.RWMutex` to `apolloListener`. `AddListener`/`RemoveListener` take the write lock; `IsEmpty` takes the read lock; `OnNewestChange` snapshots the set under the read lock and dispatches `Process` outside it (so a slow consumer cannot block agollo's long-poll goroutine).

## Tests

Added `TestApolloListenerConcurrency`: 100 rounds of concurrent `OnNewestChange` vs `Add`/`Remove`, passing under `-race`. `config_center/apollo` passes under `-race`.

Fixes #3542