### PR TITLE
fix(registry/etcdv3): guard dataListener.interestedURL with RWMutex

### DIFF
--- a/registry/etcdv3/listener.go
+++ b/registry/etcdv3/listener.go
@@ -38,6 +38,7 @@ import (
 )
 
 type dataListener struct {
+	mu            sync.RWMutex
 	interestedURL []*common.URL
 	listener      config_center.ConfigurationListener
 }
@@ -49,6 +50,8 @@ func NewRegistryDataListener(listener config_center.ConfigurationListener) *data
 
 // AddInterestedURL adds a registration @url to listen
 func (l *dataListener) AddInterestedURL(url *common.URL) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
 	l.interestedURL = append(l.interestedURL, url)
 }
 
@@ -66,7 +69,13 @@ func (l *dataListener) DataChange(eventType remoting.Event) bool {
 		return false
 	}
 
-	if slices.ContainsFunc(l.interestedURL, serviceURL.URLEqual) {
+	// AddInterestedURL appends from the consumer subscribe path while DataChange
+	// runs on the etcd watch goroutine; guard the slice read under RLock and
+	// dispatch Process outside the lock. See #3544.
+	l.mu.RLock()
+	matched := slices.ContainsFunc(l.interestedURL, serviceURL.URLEqual)
+	l.mu.RUnlock()
+	if matched {
 		l.listener.Process(
 			&config_center.ConfigChangeEvent{
 				Key:        eventType.Path,

--- a/registry/etcdv3/listener_test.go
+++ b/registry/etcdv3/listener_test.go
@@ -18,12 +18,53 @@
 package etcdv3
 
 import (
+	"sync"
+	"testing"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/config_center"
+	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
 
 type MockDataListener struct{}
 
 func (*MockDataListener) Process(configType *config_center.ConfigChangeEvent) {}
+
+// safeMockListener is a ConfigurationListener safe for concurrent Process.
+type safeMockListener struct {
+	mu  sync.Mutex
+	cnt int
+}
+
+func (m *safeMockListener) Process(*config_center.ConfigChangeEvent) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cnt++
+}
+
+// Test_dataListener_ConcurrentAddAndDataChange verifies the RWMutex guarding
+// interestedURL makes concurrent AddInterestedURL (subscribe path) and DataChange
+// (etcd watch goroutine) race-free. Run with -race. Regression for #3544.
+func Test_dataListener_ConcurrentAddAndDataChange(t *testing.T) {
+	rawURL := "dubbo://127.0.0.1:20880/com.test.Foo"
+	u, err := common.NewURL(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l := &dataListener{listener: &safeMockListener{}, interestedURL: []*common.URL{u}}
+	event := remoting.Event{Path: "/providers/" + rawURL, Action: remoting.EventTypeAdd}
+
+	var wg sync.WaitGroup
+	for range 100 {
+		wg.Add(2)
+		go func() { defer wg.Done(); l.AddInterestedURL(u) }()
+		go func() { defer wg.Done(); l.DataChange(event) }()
+	}
+	wg.Wait()
+	// No panic, no race; DataChange matched at least once (u is always present).
+}
 
 /*
 func Test_dataListener_DataChange(t *testing.T) {


### PR DESCRIPTION
## What

`dataListener.interestedURL` was a plain slice with no lock; `AddInterestedURL` appends from the `DoSubscribe` path while `DataChange` reads it (`slices.ContainsFunc`) on the etcd watch goroutine, racing the slice header.

## Why

```go
// registry/etcdv3/listener.go (before)
type dataListener struct {
    interestedURL []*common.URL   // no lock
    listener      config_center.ConfigurationListener
}
func (l *dataListener) AddInterestedURL(url *common.URL) {
    l.interestedURL = append(l.interestedURL, url)   // DoSubscribe path
}
func (l *dataListener) DataChange(eventType remoting.Event) bool {
    ...
    if slices.ContainsFunc(l.interestedURL, serviceURL.URLEqual) {  // etcd watch goroutine
        l.listener.Process(...)
    }
}
```

Two near-simultaneous `DoSubscribe` calls, or a subscribe concurrent with an incoming etcd watch event, race on the slice header → torn reads, missed event matching. `go test -race` flags it.

## Fix

Add a `sync.RWMutex` to `dataListener`. `AddInterestedURL` takes the write lock; `DataChange` does the `ContainsFunc` check under `RLock`, releases it, then dispatches `Process` outside the lock.

## Tests

Added `Test_dataListener_ConcurrentAddAndDataChange`: 100 rounds of concurrent `AddInterestedURL` vs `DataChange`, passing under `-race`. `registry/etcdv3` passes under `-race`.

Fixes #3544