### PR TITLE
fix(jsonrpc): cancel timeout context per request instead of deferring in loop

### DIFF
--- a/protocol/jsonrpc/server.go
+++ b/protocol/jsonrpc/server.go
@@ -170,25 +170,32 @@ func (s *Server) handlePkg(conn net.Conn) {
 			ctx = context.WithValue(ctx, constant.TracingRemoteSpanCtx, spanCtx)
 		}
 
+		var cancel context.CancelFunc
 		if len(reqHeader["Timeout"]) > 0 {
 			timeout, err := time.ParseDuration(reqHeader["Timeout"])
 			if err == nil {
 				httpTimeout = timeout
-				var cancel context.CancelFunc
 				ctx, cancel = context.WithTimeout(ctx, httpTimeout)
-				defer cancel()
 			}
 			delete(reqHeader, "Timeout")
 		}
 		setTimeout(conn, httpTimeout)
 
-		if err := serveRequest(ctx, reqHeader, reqBody, conn); err != nil {
-			if errRsp := sendErrorResp(r.Header, []byte(perrors.WithStack(err).Error())); errRsp != nil {
+		// Cancel the timeout context after serving this request. A defer here
+		// would only fire when handlePkg returns (i.e. when the connection
+		// closes), accumulating one deferred cancel + retained context per
+		// keep-alive request for the connection's lifetime. See #3546.
+		serveErr := serveRequest(ctx, reqHeader, reqBody, conn)
+		if cancel != nil {
+			cancel()
+		}
+		if serveErr != nil {
+			if errRsp := sendErrorResp(r.Header, []byte(perrors.WithStack(serveErr).Error())); errRsp != nil {
 				logger.Warnf("[Jsonrpc][Server] sendErrorResp failed, header=%v, err=%v, send_err=%v",
-					r.Header, perrors.WithStack(err), errRsp)
+					r.Header, perrors.WithStack(serveErr), errRsp)
 			}
 
-			logger.Infof("[Jsonrpc][Server] unexpected error serving request, closing socket, err=%v", err)
+			logger.Infof("[Jsonrpc][Server] unexpected error serving request, closing socket, err=%v", serveErr)
 			return
 		}
 	}


### PR DESCRIPTION
## What

`handlePkg` serves many keep-alive requests in a `for` loop; each request with a `Timeout` header created a `context.WithTimeout` whose `cancel` was `defer`d **inside the loop**, so defers (and the retained contexts/timers) accumulated for the connection's lifetime — a slow memory leak under sustained keep-alive traffic.

## Why

```go
// protocol/jsonrpc/server.go handlePkg, per request in the for-loop (before)
if len(reqHeader["Timeout"]) > 0 {
    timeout, err := time.ParseDuration(reqHeader["Timeout"])
    if err == nil {
        httpTimeout = timeout
        var cancel context.CancelFunc
        ctx, cancel = context.WithTimeout(ctx, httpTimeout)
        defer cancel()   // <-- defer inside a loop, in a long-lived fn
    }
    delete(reqHeader, "Timeout")
}
```

`defer` only runs when `handlePkg` returns (connection close), so each keep-alive request with a `Timeout` header accumulates one deferred `cancel` + retained context/timer. A persistent connection sending many timed requests grows the defer chain unbounded → slow memory growth / eventual OOM. The `ctx` is also not cancelled promptly after `serveRequest` returns.

## Fix

Call `cancel` explicitly after `serveRequest` returns (declared outside the `if`):

```go
var cancel context.CancelFunc
if len(reqHeader["Timeout"]) > 0 {
    timeout, err := time.ParseDuration(reqHeader["Timeout"])
    if err == nil { httpTimeout = timeout; ctx, cancel = context.WithTimeout(ctx, httpTimeout) }
    delete(reqHeader, "Timeout")
}
setTimeout(conn, httpTimeout)
serveErr := serveRequest(ctx, reqHeader, reqBody, conn)
if cancel != nil { cancel() }
if serveErr != nil { ...; return }
```

## Tests

Existing jsonrpc tests pass (the request-serving behavior is unchanged; the fix is a scoped cancel-vs-defer change). A direct leak assertion isn't added because defer accumulation isn't observable without a heap-profile harness; the change is obviously correct (defer-in-loop → explicit call) and behavior-preserving.

Fixes #3546