### PR TITLE
fix(protocolwrapper): skip unknown filter names instead of nil-deref panic

### DIFF
--- a/protocol/protocolwrapper/protocol_filter_wrapper.go
+++ b/protocol/protocolwrapper/protocol_filter_wrapper.go
@@ -87,7 +87,15 @@ func BuildInvokerChain(invoker base.Invoker, key string) base.Invoker {
 	// The order of filters is from left to right, so loading from right to left
 	next := invoker
 	for _, filterName := range slices.Backward(filterNames) {
-		flt, _ := extension.GetFilter(strings.TrimSpace(filterName))
+		name := strings.TrimSpace(filterName)
+		flt, ok := extension.GetFilter(name)
+		if !ok {
+			// An unregistered filter name (typo / unimported) would otherwise build a
+			// nil-filter FilterInvoker that nil-derefs on every Invoke. Skip it and
+			// log so misconfiguration is visible instead of crashing at runtime.
+			logger.Errorf("[Protocol][Wrapper] filter %q is not registered, skip it", name)
+			continue
+		}
 		fi := &FilterInvoker{next: next, invoker: invoker, filter: flt}
 		next = fi
 	}

--- a/protocol/protocolwrapper/protocol_filter_wrapper_test.go
+++ b/protocol/protocolwrapper/protocol_filter_wrapper_test.go
@@ -35,6 +35,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/filter"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
+	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
 	"dubbo.apache.org/dubbo-go/v3/protocol/result"
 )
 
@@ -89,4 +90,25 @@ func (ef *mockEchoFilter) OnResponse(ctx context.Context, result result.Result, 
 
 func newFilter() filter.Filter {
 	return &mockEchoFilter{}
+}
+
+// TestBuildInvokerChainSkipsUnknownFilter verifies that an unregistered filter
+// name (typo / unimported) is skipped rather than producing a nil-filter
+// FilterInvoker that nil-derefs at invoke time. Regression for #3547.
+func TestBuildInvokerChainSkipsUnknownFilter(t *testing.T) {
+	u := common.NewURLWithOptions(
+		common.WithParams(url.Values{}),
+		common.WithParamsValue(constant.ServiceFilterKey, mockFilterKey+",unknownFilterName"))
+	invoker := base.NewBaseInvoker(u)
+	chain := BuildInvokerChain(invoker, constant.ServiceFilterKey)
+
+	// top of the chain is the registered mockEcho FilterInvoker (unknown skipped)
+	_, ok := chain.(*FilterInvoker)
+	assert.True(t, ok)
+
+	// A non-echo method forces mockEcho to call next.Invoke; on the old code path
+	// the unknown filter produced a nil-filter FilterInvoker that nil-derefs here.
+	assert.NotPanics(t, func() {
+		_ = chain.Invoke(context.Background(), invocation.NewRPCInvocation("someMethod", nil, nil))
+	})
 }


### PR DESCRIPTION
## What

`BuildInvokerChain` discarded the `bool` from `extension.GetFilter`, so an unregistered filter name (typo / unimported) produced a `FilterInvoker` with a nil `filter` that nil-derefs on the first `Invoke`.

## Why

```go
// protocol/protocolwrapper/protocol_filter_wrapper.go BuildInvokerChain (before)
for _, filterName := range slices.Backward(filterNames) {
    flt, _ := extension.GetFilter(strings.TrimSpace(filterName))   // bool discarded
    fi := &FilterInvoker{next: next, invoker: invoker, filter: flt} // flt == nil if name unknown
    next = fi
}

func (fi *FilterInvoker) Invoke(ctx, invocation) result.Result {
    result := fi.filter.Invoke(ctx, fi.next, invocation)   // nil interface deref -> panic
    return fi.filter.OnResponse(ctx, result, fi.invoker, invocation)
}
```

`extension.GetFilter` returns `(nil, false)` for an unknown name; the `bool` is the intended signal and was thrown away. Setup succeeds; the first request panics instead of failing at boot.

## Fix

Check the `bool` from `GetFilter`; on `!ok`, log an error and `continue` (skip that filter, wrap the rest):

```go
flt, ok := extension.GetFilter(name)
if !ok {
    logger.Errorf("[Protocol][Wrapper] filter %q is not registered, skip it", name)
    continue
}
```

## Tests

Added `TestBuildInvokerChainSkipsUnknownFilter`: a chain with `mockEcho,unknownFilterName`; a non-echo invocation forces `mockEcho` to call `next.Invoke` (which on the old code reached the nil-filter `FilterInvoker` and panicked). Verified to **fail (panic)** on the old code and **pass** on the fixed code. `protocol/protocolwrapper` passes under `-race`.

Fixes #3548