### PR TITLE
fix(filter, protocol, registry, config_center): guard unsafe type assertions

### DIFF
--- a/config_center/apollo/impl.go
+++ b/config_center/apollo/impl.go
@@ -118,7 +118,11 @@ func (c *apolloConfiguration) GetInternalProperty(key string, opts ...cc.Option)
 	if err != nil {
 		return "", perrors.Wrap(err, "get config value failed")
 	}
-	return value.(string), nil
+	stringValue, ok := value.(string)
+	if !ok {
+		return "", perrors.Errorf("apollo config value for key %q is not a string: %T", key, value)
+	}
+	return stringValue, nil
 }
 
 func (c *apolloConfiguration) GetRule(key string, opts ...cc.Option) (string, error) {

--- a/config_center/apollo/impl_test.go
+++ b/config_center/apollo/impl_test.go
@@ -68,7 +68,7 @@ const (
 	"homepageUrl": "http://localhost:8080"
 }]`
 
-	mockConfigCacheRes = `{"content":"dubbo:\n  application:\n     name: \"demo-server\"\n     version: \"2.0\"\n"}`
+	mockConfigCacheRes = `{"content":"dubbo:\n  application:\n     name: \"demo-server\"\n     version: \"2.0\"\n     retries: 3\n"}`
 
 	mockConfigCacheJsonRes = `{
     "content": "{\n    \"dubbo\": {\n        \"application\": {\n            \"name\": \"demo-server\",\n            \"version\": \"2.0\"\n        },\n        \"otel\": {\n            \"trace\": {\n                \"enable\": true,\n                \"sample-ratio\": 1.123\n            }\n        }\n    }\n}"
@@ -80,7 +80,7 @@ var mockConfigRes = `{
 	"cluster": "default",
 	"namespaceName": "mockDubbogo.yaml",
 	"configurations":{
-		"content":"dubbo:\n  application:\n     name: \"demo-server\"\n     version: \"2.0\"\n"
+		"content":"dubbo:\n  application:\n     name: \"demo-server\"\n     version: \"2.0\"\n     retries: 3\n"
     },
 	"releaseKey": "20191104105242-0f13805d89f834a4"
 }`
@@ -179,6 +179,20 @@ func TestGetConfigItem(t *testing.T) {
 	appName, err := configuration.GetInternalProperty(constant.ApplicationConfigPrefix + ".name")
 	require.NoError(t, err)
 	assert.Equal(t, "demo-server", appName)
+}
+
+func TestGetConfigItemReturnsErrorForNonStringValue(t *testing.T) {
+	configuration := initMockApollo(t)
+
+	var (
+		value string
+		err   error
+	)
+	require.NotPanics(t, func() {
+		value, err = configuration.GetInternalProperty(constant.ApplicationConfigPrefix + ".retries")
+	})
+	require.Error(t, err)
+	assert.Empty(t, value)
 }
 
 func initMockApollo(t *testing.T) *apolloConfiguration {

--- a/filter/accesslog/filter.go
+++ b/filter/accesslog/filter.go
@@ -136,30 +136,24 @@ func (f *Filter) logIntoChannel(accessLogData Data) {
 func (f *Filter) buildAccessLogData(_ base.Invoker, invocation base.Invocation) map[string]string {
 	dataMap := make(map[string]string, 16)
 	attachments := invocation.Attachments()
-	itf := attachments[constant.InterfaceKey]
-	if itf == nil || len(itf.(string)) == 0 {
-		itf = attachments[constant.PathKey]
+	itf, ok := stringAttachment(attachments, constant.InterfaceKey)
+	if !ok || len(itf) == 0 {
+		itf, _ = stringAttachment(attachments, constant.PathKey)
 	}
-	if itf != nil {
-		dataMap[constant.InterfaceKey] = itf.(string)
+	if itf != "" {
+		dataMap[constant.InterfaceKey] = itf
 	}
-	if v, ok := attachments[constant.MethodKey]; ok && v != nil {
-		dataMap[constant.MethodKey] = v.(string)
-	}
-	if v, ok := attachments[constant.VersionKey]; ok && v != nil {
-		dataMap[constant.VersionKey] = v.(string)
-	}
-	if v, ok := attachments[constant.GroupKey]; ok && v != nil {
-		dataMap[constant.GroupKey] = v.(string)
-	}
-	if v, ok := attachments[constant.TimestampKey]; ok && v != nil {
-		dataMap[constant.TimestampKey] = v.(string)
-	}
-	if v, ok := attachments[constant.LocalAddr]; ok && v != nil {
-		dataMap[constant.LocalAddr] = v.(string)
-	}
-	if v, ok := attachments[constant.RemoteAddr]; ok && v != nil {
-		dataMap[constant.RemoteAddr] = v.(string)
+	for _, key := range []string{
+		constant.MethodKey,
+		constant.VersionKey,
+		constant.GroupKey,
+		constant.TimestampKey,
+		constant.LocalAddr,
+		constant.RemoteAddr,
+	} {
+		if value, ok := stringAttachment(attachments, key); ok {
+			dataMap[key] = value
+		}
 	}
 
 	if len(invocation.Arguments()) > 0 {
@@ -182,6 +176,19 @@ func (f *Filter) buildAccessLogData(_ base.Invoker, invocation base.Invocation) 
 	}
 
 	return dataMap
+}
+
+func stringAttachment(attachments map[string]any, key string) (string, bool) {
+	value, exists := attachments[key]
+	if !exists || value == nil {
+		return "", false
+	}
+	stringValue, ok := value.(string)
+	if !ok {
+		logger.Warnf("[Filter][AccessLog] attachment %q has unexpected type %T and will be omitted", key, value)
+		return "", false
+	}
+	return stringValue, true
 }
 
 // OnResponse do nothing

--- a/filter/accesslog/filter.go
+++ b/filter/accesslog/filter.go
@@ -185,7 +185,7 @@ func stringAttachment(attachments map[string]any, key string) (string, bool) {
 	}
 	stringValue, ok := value.(string)
 	if !ok {
-		logger.Warnf("[Filter][AccessLog] attachment %q has unexpected type %T and will be omitted", key, value)
+		logger.Debugf("[Filter][AccessLog] attachment %q has unexpected type %T and will be omitted", key, value)
 		return "", false
 	}
 	return stringValue, true

--- a/filter/accesslog/filter_test.go
+++ b/filter/accesslog/filter_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/mock/gomock"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 import (
@@ -81,4 +82,30 @@ func TestFilterOnResponse(t *testing.T) {
 	filter := &Filter{}
 	response := filter.OnResponse(context.TODO(), rpcResult, nil, nil)
 	assert.Equal(t, rpcResult, response)
+}
+
+func TestBuildAccessLogDataSkipsNonStringAttachments(t *testing.T) {
+	attachments := map[string]any{
+		constant.InterfaceKey: 42,
+		constant.PathKey:      "fallback.Service",
+		constant.MethodKey:    true,
+		constant.VersionKey:   1,
+		constant.GroupKey:     []string{"group"},
+		constant.TimestampKey: 1234567890,
+		constant.LocalAddr:    struct{}{},
+		constant.RemoteAddr:   nil,
+	}
+	inv := invocation.NewRPCInvocation("MethodName", nil, attachments)
+
+	var data map[string]string
+	require.NotPanics(t, func() {
+		data = (&Filter{}).buildAccessLogData(nil, inv)
+	})
+	assert.Equal(t, "fallback.Service", data[constant.InterfaceKey])
+	assert.NotContains(t, data, constant.MethodKey)
+	assert.NotContains(t, data, constant.VersionKey)
+	assert.NotContains(t, data, constant.GroupKey)
+	assert.NotContains(t, data, constant.TimestampKey)
+	assert.NotContains(t, data, constant.LocalAddr)
+	assert.NotContains(t, data, constant.RemoteAddr)
 }

--- a/protocol/dubbo/dubbo_codec.go
+++ b/protocol/dubbo/dubbo_codec.go
@@ -144,10 +144,14 @@ func (c *DubboCodec) EncodeResponse(response *remoting.Response) (*bytes.Buffer,
 		},
 	}
 	if !response.IsHeartbeat() {
+		rpcResult, err := rpcResultFromResponse(response.Result)
+		if err != nil {
+			return nil, err
+		}
 		resp.Body = &impl.ResponsePayload{
-			RspObj:      response.Result.(result.RPCResult).Rest,
-			Exception:   response.Result.(result.RPCResult).Err,
-			Attachments: response.Result.(result.RPCResult).Attrs,
+			RspObj:      rpcResult.Rest,
+			Exception:   rpcResult.Err,
+			Attachments: rpcResult.Attrs,
 		}
 	}
 
@@ -159,6 +163,20 @@ func (c *DubboCodec) EncodeResponse(response *remoting.Response) (*bytes.Buffer,
 	}
 
 	return bytes.NewBuffer(pkg), nil
+}
+
+func rpcResultFromResponse(value any) (result.RPCResult, error) {
+	switch rpcResult := value.(type) {
+	case result.RPCResult:
+		return rpcResult, nil
+	case *result.RPCResult:
+		if rpcResult == nil {
+			return result.RPCResult{}, perrors.New("dubbo response result is a nil *result.RPCResult")
+		}
+		return *rpcResult, nil
+	default:
+		return result.RPCResult{}, perrors.Errorf("dubbo response result has unexpected type %T", value)
+	}
 }
 
 // Decode data, including request and response.

--- a/protocol/dubbo/dubbo_codec_test.go
+++ b/protocol/dubbo/dubbo_codec_test.go
@@ -26,6 +26,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+import (
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/protocol/result"
+	"dubbo.apache.org/dubbo-go/v3/remoting"
+)
+
 // TestIsRequest tests isRequest with various bit patterns
 func TestIsRequest(t *testing.T) {
 	codec := &DubboCodec{}
@@ -99,6 +105,28 @@ func TestCodecType(t *testing.T) {
 	assert.NotNil(t, codec.EncodeResponse)
 	assert.NotNil(t, codec.Decode)
 	assert.NotNil(t, codec.encodeHeartbeatRequest)
+}
+
+func TestEncodeResponseAcceptsRPCResultPointer(t *testing.T) {
+	response := remoting.NewResponse(1, "2.0.2")
+	response.SerialID = constant.SHessian2
+	response.Result = &result.RPCResult{}
+
+	require.NotPanics(t, func() {
+		_, err := (&DubboCodec{}).EncodeResponse(response)
+		require.NoError(t, err)
+	})
+}
+
+func TestEncodeResponseRejectsUnexpectedResultType(t *testing.T) {
+	response := remoting.NewResponse(1, "2.0.2")
+	response.SerialID = constant.SHessian2
+	response.Result = "not-an-rpc-result"
+
+	require.NotPanics(t, func() {
+		_, err := (&DubboCodec{}).EncodeResponse(response)
+		require.Error(t, err)
+	})
 }
 
 // TestIsRequestEdgeCases tests isRequest with edge case bit patterns

--- a/registry/directory/directory.go
+++ b/registry/directory/directory.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"reflect"
 	"sync"
 	"time"
 )
@@ -502,6 +503,16 @@ func cloneServiceEvents(events []*registry.ServiceEvent) []*registry.ServiceEven
 }
 
 func (dir *RegistryDirectory) toGroupInvokers() []protocolbase.Invoker {
+	groupInvokersMap := dir.groupInvokersFromCache()
+	if len(groupInvokersMap) == 1 {
+		for _, invokers := range groupInvokersMap {
+			return invokers
+		}
+	}
+	return dir.joinGroupInvokers(groupInvokersMap)
+}
+
+func (dir *RegistryDirectory) groupInvokersFromCache() map[string][]protocolbase.Invoker {
 	groupInvokersMap := make(map[string][]protocolbase.Invoker)
 
 	dir.cacheInvokersMap.Range(func(key, value any) bool {
@@ -514,36 +525,30 @@ func (dir *RegistryDirectory) toGroupInvokers() []protocolbase.Invoker {
 		groupInvokersMap[group] = append(groupInvokersMap[group], invoker)
 		return true
 	})
+	return groupInvokersMap
+}
 
+func (dir *RegistryDirectory) joinGroupInvokers(groupInvokersMap map[string][]protocolbase.Invoker) []protocolbase.Invoker {
 	groupInvokersList := make([]protocolbase.Invoker, 0, len(groupInvokersMap))
-	if len(groupInvokersMap) == 1 {
-		// len is 1 it means no group setting ,so do not need cluster again
-		for _, invokers := range groupInvokersMap {
-			groupInvokersList = invokers
+	for _, invokers := range groupInvokersMap {
+		staticDir := static.NewDirectory(invokers)
+		clusterKey := dir.GetURL().SubURL.GetParam(constant.ClusterKey, constant.DefaultCluster)
+		cluster, err := extension.GetCluster(clusterKey)
+		if err != nil {
+			logger.Errorf("[Registry][Directory] directory get cluster %s error, err=%w, will skip this group",
+				clusterKey, err)
+			continue
 		}
-	} else {
-		for _, invokers := range groupInvokersMap {
-			staticDir := static.NewDirectory(invokers)
-			clusterKey := dir.GetURL().SubURL.GetParam(constant.ClusterKey, constant.DefaultCluster)
-			cluster, err := extension.GetCluster(clusterKey)
-			if err != nil {
-				logger.Errorf("[Registry][Directory] directory get cluster %s error, err=%w, will skip this group",
-					clusterKey, err)
-				continue
-			}
-			if cluster == nil {
-				logger.Errorf("[Registry][Directory] directory cluster is nil for key %s, will skip this group", clusterKey)
-				continue
-			}
-			err = staticDir.BuildRouterChain(invokers, dir.GetURL())
-			if err != nil {
-				logger.Errorf("[Registry][Directory] buildRouterChain error, err=%v", err)
-				continue
-			}
-			groupInvokersList = append(groupInvokersList, cluster.Join(staticDir))
+		if cluster == nil {
+			logger.Errorf("[Registry][Directory] directory cluster is nil for key %s, will skip this group", clusterKey)
+			continue
 		}
+		if err = staticDir.BuildRouterChain(invokers, dir.GetURL()); err != nil {
+			logger.Errorf("[Registry][Directory] buildRouterChain error, err=%v", err)
+			continue
+		}
+		groupInvokersList = append(groupInvokersList, cluster.Join(staticDir))
 	}
-
 	return groupInvokersList
 }
 
@@ -749,11 +754,24 @@ func (dir *RegistryDirectory) doCacheInvoker(newUrl *common.URL, event *registry
 
 func cachedInvoker(key, value any) (protocolbase.Invoker, bool) {
 	invoker, ok := value.(protocolbase.Invoker)
-	if !ok || invoker == nil {
+	if !ok || isNilInvoker(invoker) {
 		logger.Errorf("[Registry][Directory] cached invoker has unexpected type %T for key %v", value, key)
 		return nil, false
 	}
 	return invoker, true
+}
+
+func isNilInvoker(invoker protocolbase.Invoker) bool {
+	if invoker == nil {
+		return true
+	}
+	value := reflect.ValueOf(invoker)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 // List selected protocol invokers from the directory

--- a/registry/directory/directory.go
+++ b/registry/directory/directory.go
@@ -346,9 +346,15 @@ func (dir *RegistryDirectory) refreshAllInvokers(events []*registry.ServiceEvent
 		defer dir.registerLock.Unlock()
 		// get need clear invokers from original invoker list
 		dir.cacheInvokersMap.Range(func(k, v any) bool {
-			if !dir.eventMatched(k.(string), providerEvents) {
+			key, ok := k.(string)
+			if !ok {
+				logger.Errorf("[Registry][Directory] cached invoker has unexpected key type %T", k)
+				dir.cacheInvokersMap.Delete(k)
+				return true
+			}
+			if !dir.eventMatched(key, providerEvents) {
 				// delete unused invoker from cache
-				if invoker := dir.uncacheInvokerWithKey(k.(string)); invoker != nil {
+				if invoker := dir.uncacheInvokerWithKey(key); invoker != nil {
 					oldInvokers = append(oldInvokers, invoker)
 				}
 			}
@@ -499,7 +505,11 @@ func (dir *RegistryDirectory) toGroupInvokers() []protocolbase.Invoker {
 	groupInvokersMap := make(map[string][]protocolbase.Invoker)
 
 	dir.cacheInvokersMap.Range(func(key, value any) bool {
-		invoker := value.(protocolbase.Invoker)
+		invoker, ok := cachedInvoker(key, value)
+		if !ok {
+			dir.cacheInvokersMap.Delete(key)
+			return true
+		}
 		group := invoker.GetURL().GetParam(constant.GroupKey, "")
 		groupInvokersMap[group] = append(groupInvokersMap[group], invoker)
 		return true
@@ -541,8 +551,19 @@ func (dir *RegistryDirectory) uncacheInvokerWithClusterID(clusterID string) []pr
 	logger.Debugf("[Registry][Directory] all service will be deleted in cache invokers with clusterID=%s", clusterID)
 	invokerKeys := make([]string, 0)
 	dir.cacheInvokersMap.Range(func(key, cacheInvoker any) bool {
-		if cacheInvoker.(protocolbase.Invoker).GetURL().GetParam(constant.MeshClusterIDKey, "") == clusterID {
-			invokerKeys = append(invokerKeys, key.(string))
+		invoker, ok := cachedInvoker(key, cacheInvoker)
+		if !ok {
+			dir.cacheInvokersMap.Delete(key)
+			return true
+		}
+		keyString, ok := key.(string)
+		if !ok {
+			logger.Errorf("[Registry][Directory] cached invoker has unexpected key type %T", key)
+			dir.cacheInvokersMap.Delete(key)
+			return true
+		}
+		if invoker.GetURL().GetParam(constant.MeshClusterIDKey, "") == clusterID {
+			invokerKeys = append(invokerKeys, keyString)
 		}
 		return true
 	})
@@ -568,7 +589,11 @@ func (dir *RegistryDirectory) uncacheInvokerWithKey(key string) protocolbase.Inv
 	protocolbase.RemoveUrlKeyUnhealthyStatus(key)
 	if cacheInvoker, ok := dir.cacheInvokersMap.Load(key); ok {
 		dir.cacheInvokersMap.Delete(key)
-		return cacheInvoker.(protocolbase.Invoker)
+		invoker, valid := cachedInvoker(key, cacheInvoker)
+		if !valid {
+			return nil
+		}
+		return invoker
 	}
 	return nil
 }
@@ -586,7 +611,7 @@ func (dir *RegistryDirectory) RemoveClosingInstance(instanceKey string) bool {
 		defer dir.registerLock.Unlock()
 
 		if cacheInvoker, ok := dir.cacheInvokersMap.Load(instanceKey); ok {
-			removed = cacheInvoker.(protocolbase.Invoker)
+			removed, _ = cachedInvoker(instanceKey, cacheInvoker)
 		}
 		dir.markClosingTombstone(instanceKey, removed, "closing-event")
 		removed = dir.uncacheInvokerWithKey(instanceKey)
@@ -686,7 +711,15 @@ func (dir *RegistryDirectory) doCacheInvoker(newUrl *common.URL, event *registry
 		logger.Infof("[Registry][Directory] skip rebuilding closing instance due to tombstone, instance key: %s", key)
 		return nil, true
 	}
-	if cacheInvoker, ok := dir.cacheInvokersMap.Load(key); !ok {
+	cacheInvoker, ok := dir.cacheInvokersMap.Load(key)
+	var existingInvoker protocolbase.Invoker
+	if ok {
+		existingInvoker, ok = cachedInvoker(key, cacheInvoker)
+		if !ok {
+			dir.cacheInvokersMap.Delete(key)
+		}
+	}
+	if !ok {
 		logger.Debugf("[Registry][Directory] service will be added in cache invokers, url=%s", newUrl)
 		newInvoker := extension.GetProtocol(protocolwrapper.FILTER).Refer(newUrl)
 		if newInvoker != nil {
@@ -698,20 +731,29 @@ func (dir *RegistryDirectory) doCacheInvoker(newUrl *common.URL, event *registry
 		metrics.Publish(metricsRegistry.NewDirectoryEvent(metricsRegistry.NumValidTotal))
 		// if cached invoker has the same URL with the new URL, then no need to re-refer, and no need to destroy
 		// the old invoker.
-		if common.GetCompareURLEqualFunc()(newUrl, cacheInvoker.(protocolbase.Invoker).GetURL()) {
+		if common.GetCompareURLEqualFunc()(newUrl, existingInvoker.GetURL()) {
 			return nil, true
 		}
 
-		logger.Debugf("[Registry][Directory] service will be updated in cache invokers, newUrl=%s oldUrl=%s", newUrl, cacheInvoker.(protocolbase.Invoker).GetURL())
+		logger.Debugf("[Registry][Directory] service will be updated in cache invokers, newUrl=%s oldUrl=%s", newUrl, existingInvoker.GetURL())
 		newInvoker := extension.GetProtocol(protocolwrapper.FILTER).Refer(newUrl)
 		if newInvoker != nil {
 			dir.cacheInvokersMap.Store(key, newInvoker)
-			return cacheInvoker.(protocolbase.Invoker), true
+			return existingInvoker, true
 		} else {
 			logger.Warnf("[Registry][Directory] service will be updated in cache invokers fail, result is null, url=%s", newUrl.String())
 		}
 	}
 	return nil, false
+}
+
+func cachedInvoker(key, value any) (protocolbase.Invoker, bool) {
+	invoker, ok := value.(protocolbase.Invoker)
+	if !ok || invoker == nil {
+		logger.Errorf("[Registry][Directory] cached invoker has unexpected type %T for key %v", value, key)
+		return nil, false
+	}
+	return invoker, true
 }
 
 // List selected protocol invokers from the directory

--- a/registry/directory/directory_test.go
+++ b/registry/directory/directory_test.go
@@ -66,6 +66,38 @@ func TestSubscribe_InvalidUrl(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestUnexpectedCachedInvokerTypeDoesNotPanic(t *testing.T) {
+	registryDirectory, _ := normalRegistryDir()
+	const key = "unexpected-invoker-type"
+
+	t.Run("grouping", func(t *testing.T) {
+		registryDirectory.cacheInvokersMap.Store(key, "not-an-invoker")
+		require.NotPanics(t, func() {
+			registryDirectory.toGroupInvokers()
+		})
+		_, exists := registryDirectory.cacheInvokersMap.Load(key)
+		assert.False(t, exists)
+	})
+
+	t.Run("uncache", func(t *testing.T) {
+		registryDirectory.cacheInvokersMap.Store(key, "not-an-invoker")
+		var invoker protocolbase.Invoker
+		require.NotPanics(t, func() {
+			invoker = registryDirectory.uncacheInvokerWithKey(key)
+		})
+		assert.Nil(t, invoker)
+	})
+
+	t.Run("remove closing instance", func(t *testing.T) {
+		registryDirectory.cacheInvokersMap.Store(key, "not-an-invoker")
+		var removed bool
+		require.NotPanics(t, func() {
+			removed = registryDirectory.RemoveClosingInstance(key)
+		})
+		assert.False(t, removed)
+	})
+}
+
 func TestNewRegistryDirectoryResolvesApplicationAttribute(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/registry/directory/directory_test.go
+++ b/registry/directory/directory_test.go
@@ -148,6 +148,19 @@ func TestNewRegistryDirectoryResolvesApplicationAttribute(t *testing.T) {
 	}
 }
 
+func TestTypedNilCachedInvokerDoesNotPanic(t *testing.T) {
+	registryDirectory, _ := normalRegistryDir()
+	const key = "typed-nil-invoker"
+	var typedNil *protocolbase.BaseInvoker
+	registryDirectory.cacheInvokersMap.Store(key, typedNil)
+
+	require.NotPanics(t, func() {
+		registryDirectory.toGroupInvokers()
+	})
+	_, exists := registryDirectory.cacheInvokersMap.Load(key)
+	assert.False(t, exists)
+}
+
 func TestNewRegistryDirectoryCopiesRegistriesAttributeFromSubURL(t *testing.T) {
 	registryURL, subURL := newRegistryDirectoryAttributeTestURL(t)
 	registries := map[string]*global.RegistryConfig{

--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -19,6 +19,7 @@ package protocol
 
 import (
 	"context"
+	"reflect"
 	"strings"
 	"sync"
 	"time"
@@ -87,7 +88,11 @@ func (proto *registryProtocol) getRegistry(registryUrl *common.URL) registry.Reg
 		cacheKey = cacheKey + "?" + constant.NacosNamespaceID + "=" + namespace
 	}
 	if actualReg, loaded := proto.registries.Load(cacheKey); loaded {
-		return cachedRegistry(actualReg, cacheKey)
+		reg, ok := cachedRegistry(actualReg, cacheKey)
+		if !ok {
+			proto.registries.Delete(cacheKey)
+		}
+		return reg
 	}
 
 	reg, err := extension.GetRegistry(registryUrl.Protocol, registryUrl)
@@ -95,17 +100,38 @@ func (proto *registryProtocol) getRegistry(registryUrl *common.URL) registry.Reg
 		logger.Errorf("[Registry] registry cannot connect successfully, err=%s", err.Error())
 		panic(err)
 	}
-	actualReg, _ := proto.registries.LoadOrStore(cacheKey, reg)
-	return cachedRegistry(actualReg, cacheKey)
-}
-
-func cachedRegistry(value any, cacheKey string) registry.Registry {
-	reg, ok := value.(registry.Registry)
-	if !ok || reg == nil {
-		logger.Errorf("[Registry] cached registry has unexpected type %T for key %s", value, cacheKey)
+	reg, ok := cachedRegistry(reg, cacheKey)
+	if !ok {
 		return nil
 	}
-	return reg
+	actualReg, _ := proto.registries.LoadOrStore(cacheKey, reg)
+	cachedReg, ok := cachedRegistry(actualReg, cacheKey)
+	if !ok {
+		proto.registries.Delete(cacheKey)
+	}
+	return cachedReg
+}
+
+func cachedRegistry(value any, cacheKey string) (registry.Registry, bool) {
+	reg, ok := value.(registry.Registry)
+	if !ok || isNilRegistry(reg) {
+		logger.Errorf("[Registry] cached registry has unexpected type %T for key %s", value, cacheKey)
+		return nil, false
+	}
+	return reg, true
+}
+
+func isNilRegistry(reg registry.Registry) bool {
+	if reg == nil {
+		return true
+	}
+	value := reflect.ValueOf(reg)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice, reflect.UnsafePointer:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 func getCacheKey(invoker base.Invoker) string {
@@ -185,9 +211,11 @@ func shutdownFromAttribute(url *common.URL) (*global.ShutdownConfig, bool) {
 // GetRegistries returns all underlying registry instances.
 func (proto *registryProtocol) GetRegistries() []registry.Registry {
 	var rs []registry.Registry
-	proto.registries.Range(func(_, v any) bool {
-		if r, ok := v.(registry.Registry); ok {
+	proto.registries.Range(func(key, v any) bool {
+		if r, ok := v.(registry.Registry); ok && !isNilRegistry(r) {
 			rs = append(rs, r)
+		} else {
+			proto.registries.Delete(key)
 		}
 		return true
 	})

--- a/registry/protocol/protocol.go
+++ b/registry/protocol/protocol.go
@@ -86,15 +86,26 @@ func (proto *registryProtocol) getRegistry(registryUrl *common.URL) registry.Reg
 	if namespace != "" {
 		cacheKey = cacheKey + "?" + constant.NacosNamespaceID + "=" + namespace
 	}
-	actualReg, _ := proto.registries.LoadOrStore(cacheKey, func() any {
-		reg, err := extension.GetRegistry(registryUrl.Protocol, registryUrl)
-		if err != nil {
-			logger.Errorf("[Registry] registry cannot connect successfully, err=%s", err.Error())
-			panic(err)
-		}
-		return reg
-	}())
-	return actualReg.(registry.Registry)
+	if actualReg, loaded := proto.registries.Load(cacheKey); loaded {
+		return cachedRegistry(actualReg, cacheKey)
+	}
+
+	reg, err := extension.GetRegistry(registryUrl.Protocol, registryUrl)
+	if err != nil {
+		logger.Errorf("[Registry] registry cannot connect successfully, err=%s", err.Error())
+		panic(err)
+	}
+	actualReg, _ := proto.registries.LoadOrStore(cacheKey, reg)
+	return cachedRegistry(actualReg, cacheKey)
+}
+
+func cachedRegistry(value any, cacheKey string) registry.Registry {
+	reg, ok := value.(registry.Registry)
+	if !ok || reg == nil {
+		logger.Errorf("[Registry] cached registry has unexpected type %T for key %s", value, cacheKey)
+		return nil
+	}
+	return reg
 }
 
 func getCacheKey(invoker base.Invoker) string {
@@ -192,6 +203,10 @@ func (proto *registryProtocol) Refer(url *common.URL) base.Invoker {
 	}
 
 	reg := proto.getRegistry(url)
+	if reg == nil {
+		logger.Errorf("[Registry] consumer service %v has no valid registry, and will return nil invoker", serviceUrl.String())
+		return nil
+	}
 
 	// new registry directory for store service url from registry
 	dic, err := extension.GetDirectoryInstance(registryUrl, reg)
@@ -255,6 +270,10 @@ func (proto *registryProtocol) Export(originInvoker base.Invoker) base.Exporter 
 	if len(registryUrl.Protocol) > 0 {
 		// url to registry
 		reg := proto.getRegistry(registryUrl)
+		if reg == nil {
+			logger.Errorf("[Registry] provider service %v has no valid registry, and will return nil exporter", providerUrl.String())
+			return nil
+		}
 		registeredProviderUrl := getUrlToRegistry(providerUrl, registryUrl)
 
 		err := reg.Register(registeredProviderUrl)
@@ -496,10 +515,14 @@ func (proto *registryProtocol) Destroy() {
 		// the work for unexport should be finished in protocol.UnExport(), see also config.destroyProviderProtocols().
 		exporter := value.(*exporterChangeableWrapper)
 		reg := proto.getRegistry(getRegistryUrl(exporter.originInvoker))
-		if err := reg.UnRegister(exporter.registerUrl); err != nil {
-			logger.Warnf("[Registry] unRegister consumer url failed, url=%s err=%v", exporter.registerUrl.String(), err)
+		if reg == nil {
+			logger.Warnf("[Registry] skip unregister because no valid registry was found, url=%s", exporter.registerUrl.String())
+		} else {
+			if err := reg.UnRegister(exporter.registerUrl); err != nil {
+				logger.Warnf("[Registry] unRegister consumer url failed, url=%s err=%v", exporter.registerUrl.String(), err)
+			}
+			proto.unsubscribeOverrideListener(reg, exporter.subscribeUrl)
 		}
-		proto.unsubscribeOverrideListener(reg, exporter.subscribeUrl)
 		proto.serviceConfigurationListeners.Delete(getProviderUrl(exporter.originInvoker).ServiceKey())
 
 		// close all protocol server after consumerUpdateWait + stepTimeout(max time wait during
@@ -559,6 +582,10 @@ func (proto *registryProtocol) UnregisterRegistries() {
 	proto.bounds.Range(func(_, value any) bool {
 		exporter := value.(*exporterChangeableWrapper)
 		reg := proto.getRegistry(getRegistryUrl(exporter.originInvoker))
+		if reg == nil {
+			logger.Warnf("[Registry] skip unregister because no valid registry was found, url=%s", exporter.registerUrl.String())
+			return true
+		}
 		if err := reg.UnRegister(exporter.registerUrl); err != nil {
 			logger.Warnf("[Registry] unRegister consumer url failed, url=%s err=%v", exporter.registerUrl.String(), err)
 		}

--- a/registry/protocol/protocol_test.go
+++ b/registry/protocol/protocol_test.go
@@ -79,6 +79,19 @@ func referNormal(t *testing.T, regProtocol *registryProtocol) {
 	assert.Equal(t, invoker.GetURL().String(), url.String())
 }
 
+func TestGetRegistryReturnsNilForUnexpectedCachedType(t *testing.T) {
+	regProtocol := newRegistryProtocol()
+	registryURL, err := common.NewURL("mock://127.0.0.1:1111")
+	require.NoError(t, err)
+	regProtocol.registries.Store(registryURL.PrimitiveURL, "not-a-registry")
+
+	var actual registry.Registry
+	require.NotPanics(t, func() {
+		actual = regProtocol.getRegistry(registryURL)
+	})
+	assert.Nil(t, actual)
+}
+
 func TestRefer(t *testing.T) {
 	regProtocol := newRegistryProtocol()
 	referNormal(t, regProtocol)

--- a/registry/protocol/protocol_test.go
+++ b/registry/protocol/protocol_test.go
@@ -79,17 +79,46 @@ func referNormal(t *testing.T, regProtocol *registryProtocol) {
 	assert.Equal(t, invoker.GetURL().String(), url.String())
 }
 
-func TestGetRegistryReturnsNilForUnexpectedCachedType(t *testing.T) {
-	regProtocol := newRegistryProtocol()
-	registryURL, err := common.NewURL("mock://127.0.0.1:1111")
-	require.NoError(t, err)
-	regProtocol.registries.Store(registryURL.PrimitiveURL, "not-a-registry")
+func TestGetRegistryRejectsInvalidCachedValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		value any
+	}{
+		{name: "unexpected type", value: "not-a-registry"},
+		{name: "typed nil", value: (*registry.MockRegistry)(nil)},
+	}
 
-	var actual registry.Registry
-	require.NotPanics(t, func() {
-		actual = regProtocol.getRegistry(registryURL)
-	})
-	assert.Nil(t, actual)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			regProtocol := newRegistryProtocol()
+			registryURL, err := common.NewURL("mock://127.0.0.1:1111")
+			require.NoError(t, err)
+			extension.SetRegistry("mock", registry.NewMockRegistry)
+			regProtocol.registries.Store(registryURL.PrimitiveURL, tt.value)
+
+			var actual registry.Registry
+			require.NotPanics(t, func() {
+				actual = regProtocol.getRegistry(registryURL)
+			})
+			assert.Nil(t, actual)
+			_, exists := regProtocol.registries.Load(registryURL.PrimitiveURL)
+			assert.False(t, exists)
+			assert.Empty(t, regProtocol.GetRegistries())
+
+			actual = regProtocol.getRegistry(registryURL)
+			assert.NotNil(t, actual)
+		})
+	}
+}
+
+func TestGetRegistriesSkipsTypedNil(t *testing.T) {
+	regProtocol := newRegistryProtocol()
+	var typedNil *registry.MockRegistry
+	regProtocol.registries.Store("typed-nil", typedNil)
+
+	assert.Empty(t, regProtocol.GetRegistries())
+	_, exists := regProtocol.registries.Load("typed-nil")
+	assert.False(t, exists)
 }
 
 func TestRefer(t *testing.T) {


### PR DESCRIPTION
### Description

Fixes #3554

This change removes panic-prone type assertions from the affected Apollo, registry, directory, Dubbo codec, and accesslog paths.

本次修改修复了 Apollo、registry、directory、Dubbo codec 和 accesslog 路径中可能导致 panic 的不安全类型断言问题。

- Validate Apollo configuration values before converting them to strings.  
  在转换 Apollo 配置值为字符串前增加类型校验。

- Safely handle unexpected registry and invoker cache values.  
  安全处理 registry 和 invoker 缓存中的异常类型。

- Avoid eager registry creation on cache hits.  
  避免缓存命中时重复创建 registry。

- Support both `result.RPCResult` and `*result.RPCResult` in Dubbo response encoding.  
  Dubbo 响应编码同时支持 `result.RPCResult` 和 `*result.RPCResult`。

- Return an error for unsupported response result types.  
  对不支持的响应结果类型返回错误。

- Skip invalid accesslog attachments and fall back from `interface` to `path`.  
  跳过非法的 accesslog attachment，并在 `interface` 无效时回退到 `path`。

- Add regression tests covering all affected locations.  
  为所有受影响位置补充回归测试。

### Checklist

- [x] I confirm the target branch is `develop`  
- [x] Code has passed local testing  
- [x] I have added tests that prove my fix is effective or that my feature works  