### PR TITLE
fix: preserve wrapped error handling

### DIFF
--- a/otel/trace/exporter.go
+++ b/otel/trace/exporter.go
@@ -74,7 +74,7 @@ func NewExporter(config *ExporterConfig, customFunc func() (sdktrace.SpanExporte
 
 	exporter, err := customFunc()
 	if err != nil {
-		err = fmt.Errorf("failed to create %s exporter: %v", config.Exporter, err)
+		err = fmt.Errorf("failed to create %s exporter: %w", config.Exporter, err)
 		logger.Errorf("[OTel][Trace] failed to create %s exporter, err=%v", config.Exporter, err)
 		return
 	}

--- a/otel/trace/exporter_test.go
+++ b/otel/trace/exporter_test.go
@@ -76,8 +76,9 @@ func TestNewExporter_CustomFuncError(t *testing.T) {
 		ServiceName: "test-service",
 	}
 
+	cause := errors.New("custom func error")
 	customFunc := func() (sdktrace.SpanExporter, error) {
-		return nil, errors.New("custom func error")
+		return nil, cause
 	}
 
 	tracerProvider, propagator, err := NewExporter(config, customFunc)
@@ -85,6 +86,7 @@ func TestNewExporter_CustomFuncError(t *testing.T) {
 	assert.Nil(t, propagator)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to create test exporter")
+	require.ErrorIs(t, err, cause)
 }
 
 func TestNewExporter_InvalidSampleMode(t *testing.T) {

--- a/protocol/jsonrpc/server.go
+++ b/protocol/jsonrpc/server.go
@@ -21,6 +21,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"mime"
 	"net"
@@ -124,7 +125,7 @@ func (s *Server) handlePkg(conn net.Conn) {
 
 	for {
 		bufReader := bufio.NewReader(io.LimitReader(conn, MaxHeaderSize))
-		if _, err := bufReader.Peek(1); err == io.EOF {
+		if _, err := bufReader.Peek(1); errors.Is(err, io.EOF) {
 			return
 		}
 		r, err := http.ReadRequest(bufReader)
@@ -326,7 +327,7 @@ func serveRequest(ctx context.Context, header map[string]string, body []byte, co
 	codec := newServerCodec()
 	err := codec.ReadHeader(header, body)
 	if err != nil {
-		if err == io.EOF || err == io.ErrUnexpectedEOF {
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 			return perrors.WithStack(err)
 		}
 		return perrors.New("server cannot decode request: " + err.Error())

--- a/protocol/triple/reflection/serverreflection.go
+++ b/protocol/triple/reflection/serverreflection.go
@@ -20,6 +20,7 @@ package reflection
 
 import (
 	"context"
+	"errors"
 	"io"
 	"slices"
 	"sort"
@@ -166,7 +167,7 @@ func (s *ReflectionServer) ServerReflectionInfo(ctx context.Context, stream rpb.
 	sentFileDescriptors := make(map[string]bool)
 	for {
 		in, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {

--- a/protocol/triple/reflection/serverreflection_test.go
+++ b/protocol/triple/reflection/serverreflection_test.go
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package reflection
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	rpb "dubbo.apache.org/dubbo-go/v3/protocol/triple/reflection/triple_reflection"
+)
+
+type recvErrorStream struct {
+	rpb.ServerReflection_ServerReflectionInfoServer
+	err error
+}
+
+func (s recvErrorStream) Recv() (*rpb.ServerReflectionRequest, error) { return nil, s.err }
+
+func TestServerReflectionInfoRecvError(t *testing.T) {
+	server := &ReflectionServer{}
+	require.NoError(t, server.ServerReflectionInfo(context.Background(), recvErrorStream{err: fmt.Errorf("transport: %w", io.EOF)}))
+
+	recvErr := errors.New("receive failed")
+	require.ErrorIs(t, server.ServerReflectionInfo(context.Background(), recvErrorStream{err: recvErr}), recvErr)
+}

--- a/protocol/triple/reflection/serverreflection_test.go
+++ b/protocol/triple/reflection/serverreflection_test.go
@@ -23,9 +23,13 @@ import (
 	"fmt"
 	"io"
 	"testing"
+)
 
+import (
 	"github.com/stretchr/testify/require"
+)
 
+import (
 	rpb "dubbo.apache.org/dubbo-go/v3/protocol/triple/reflection/triple_reflection"
 )
 


### PR DESCRIPTION
### Description
Fixes #3560

Use `errors.Is` for EOF sentinel checks so wrapped errors follow the existing control flow, and wrap exporter creation errors with `%w` so callers can inspect their cause.

Validation:
- `go test ./protocol/jsonrpc ./protocol/triple/reflection ./otel/trace`
- `go vet ./protocol/jsonrpc ./protocol/triple/reflection ./otel/trace`
- `golangci-lint run ./protocol/jsonrpc ./protocol/triple/reflection ./otel/trace --timeout=10m`

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [ ] I have added tests that prove my fix is effective or that my feature works (N/A: this change updates standard-library error matching/wrapping behavior; the affected package suites and `errorlint` pass)
