### PR TITLE
build: migrate direct YAML usage to v4

### DIFF
--- a/cluster/router/affinity/router.go
+++ b/cluster/router/affinity/router.go
@@ -26,7 +26,7 @@ import (
 import (
 	"github.com/dubbogo/gost/log/logger"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 import (

--- a/cluster/router/condition/dynamic_router.go
+++ b/cluster/router/condition/dynamic_router.go
@@ -27,7 +27,7 @@ import (
 import (
 	"github.com/dubbogo/gost/log/logger"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 import (

--- a/cluster/router/condition/route.go
+++ b/cluster/router/condition/route.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 import (

--- a/cluster/router/script/router.go
+++ b/cluster/router/script/router.go
@@ -25,7 +25,7 @@ import (
 import (
 	"github.com/dubbogo/gost/log/logger"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 import (

--- a/cluster/router/tag/router.go
+++ b/cluster/router/tag/router.go
@@ -26,7 +26,7 @@ import (
 import (
 	"github.com/dubbogo/gost/log/logger"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 import (

--- a/config_center/apollo/impl.go
+++ b/config_center/apollo/impl.go
@@ -34,7 +34,7 @@ import (
 
 	perrors "github.com/pkg/errors"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 import (

--- a/config_center/apollo/listener.go
+++ b/config_center/apollo/listener.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/dubbogo/gost/log/logger"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 import (

--- a/config_center/mock_dynamic_config.go
+++ b/config_center/mock_dynamic_config.go
@@ -25,7 +25,7 @@ import (
 import (
 	gxset "github.com/dubbogo/gost/container/set"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 import (

--- a/config_center/parser/configuration_parser.go
+++ b/config_center/parser/configuration_parser.go
@@ -29,7 +29,7 @@ import (
 
 	perrors "github.com/pkg/errors"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	google.golang.org/grpc v1.64.1
 	google.golang.org/protobuf v1.34.2
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v4 v4.0.0-rc.6
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1424,3 +1424,5 @@ sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
+go.yaml.in/yaml/v4 v4.0.0-rc.6 h1:1h7H1ohdUh93/FyE4YaDa1Zh64K6VVbjF4K6WUxMtH4=
+go.yaml.in/yaml/v4 v4.0.0-rc.6/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=

--- a/protocol/grpc/client.go
+++ b/protocol/grpc/client.go
@@ -38,7 +38,7 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 import (

--- a/protocol/rest/config/reader/rest_config_reader.go
+++ b/protocol/rest/config/reader/rest_config_reader.go
@@ -28,7 +28,7 @@ import (
 
 	perrors "github.com/pkg/errors"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 import (

--- a/protocol/triple/openapi/encoder.go
+++ b/protocol/triple/openapi/encoder.go
@@ -23,7 +23,7 @@ import (
 )
 
 import (
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 import (

--- a/remoting/getty/getty_client.go
+++ b/remoting/getty/getty_client.go
@@ -34,7 +34,7 @@ import (
 
 	"go.uber.org/atomic"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 import (

--- a/remoting/getty/getty_server.go
+++ b/remoting/getty/getty_server.go
@@ -31,7 +31,7 @@ import (
 
 	perrors "github.com/pkg/errors"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 import (

--- a/tools/protoc-gen-triple-openapi/go.mod
+++ b/tools/protoc-gen-triple-openapi/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang/protobuf v1.5.0
 	github.com/pb33f/libopenapi v0.23.0
 	google.golang.org/protobuf v1.36.6
-	gopkg.in/yaml.v3 v3.0.1
+	go.yaml.in/yaml/v4 v4.0.0-rc.6
 )
 
 require (

--- a/tools/protoc-gen-triple-openapi/go.sum
+++ b/tools/protoc-gen-triple-openapi/go.sum
@@ -33,5 +33,5 @@ google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+go.yaml.in/yaml/v4 v4.0.0-rc.6 h1:1h7H1ohdUh93/FyE4YaDa1Zh64K6VVbjF4K6WUxMtH4=
+go.yaml.in/yaml/v4 v4.0.0-rc.6/go.mod h1:aZqd9kCMsGL7AuUv/m/PvWLdg5sjJsZ4oHDEnfPPfY0=

--- a/tools/protoc-gen-triple-openapi/internal/converter/convert.go
+++ b/tools/protoc-gen-triple-openapi/internal/converter/convert.go
@@ -39,7 +39,7 @@ import (
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/pluginpb"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 import (

--- a/tools/protoc-gen-triple-openapi/internal/converter/schema/util.go
+++ b/tools/protoc-gen-triple-openapi/internal/converter/schema/util.go
@@ -27,7 +27,7 @@ import (
 
 	"google.golang.org/protobuf/reflect/protoreflect"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v4"
 )
 
 func messageToSchema(tt protoreflect.MessageDescriptor) (string, *base.Schema) {


### PR DESCRIPTION
## Summary\n- migrate direct YAML imports in the main module and the Triple OpenAPI tool to go.yaml.in/yaml/v4\n- update both module manifests and checksums\n- leave generated CLI templates and nested tool modules that only carry transitive YAML entries unchanged\n\n## Validation\n- git diff --check\n- verified no direct gopkg.in/yaml.v3 imports remain in the main module or Triple OpenAPI tool\n\nThe Go toolchain is not installed in this Windows checkout, so go test ./..., go test for the focused packages, and gofmt remain CI-only validation. The v4 module checksums were taken from the Go checksum database.