### PR TITLE
fix(getty): fix the getty poll bug described at #3509

### DIFF
--- a/remoting/getty/getty_client.go
+++ b/remoting/getty/getty_client.go
@@ -290,10 +290,12 @@ func (c *Client) transfer(session getty.Session, request *remoting.Request, time
 	return totalLen, sendLen, perrors.WithStack(err)
 }
 
-func (c *Client) resetRpcConn() {
+func (c *Client) resetRpcConn(expected *gettyRPCClient) {
 	c.gettyClientMux.Lock()
+	defer c.gettyClientMux.Unlock()
+	if c.gettyClient != expected {
+		return
+	}
 	c.gettyClient = nil
 	c.gettyClientCreated.Store(false)
-	c.gettyClientMux.Unlock()
-
 }

--- a/remoting/getty/getty_client.go
+++ b/remoting/getty/getty_client.go
@@ -210,7 +210,7 @@ func (c *Client) Request(request *remoting.Request, timeout time.Duration, respo
 	if timeout <= 0 {
 		timeout = c.opts.RequestTimeout
 	}
-	_, session, err := c.selectSession(c.addr)
+	rpcClient, session, err := c.selectSession(c.addr)
 	if err != nil {
 		return perrors.WithStack(err)
 	}
@@ -235,6 +235,9 @@ func (c *Client) Request(request *remoting.Request, timeout time.Duration, respo
 
 	select {
 	case <-gxtime.After(timeout):
+		remoting.RemovePendingResponse(remoting.SequenceType(request.ID))
+		rpcClient.removeSession(session)
+		go session.Close()
 		return perrors.WithStack(errClientReadTimeout)
 	case <-response.Done:
 		err = response.Err

--- a/remoting/getty/getty_client.go
+++ b/remoting/getty/getty_client.go
@@ -229,7 +229,7 @@ func (c *Client) RequestContext(ctx context.Context, request *remoting.Request, 
 	if timeout <= 0 {
 		timeout = c.opts.RequestTimeout
 	}
-	_, session, err := c.selectSession(c.addr)
+	rpcClient, session, err := c.selectSession(c.addr)
 	if err != nil {
 		return perrors.WithStack(err)
 	}
@@ -256,6 +256,9 @@ func (c *Client) RequestContext(ctx context.Context, request *remoting.Request, 
 	defer timer.Stop()
 	select {
 	case <-timer.C:
+		remoting.RemovePendingResponse(remoting.SequenceType(request.ID))
+		rpcClient.removeSession(session)
+		go session.Close()
 		return perrors.WithStack(errClientReadTimeout)
 	case <-response.Done:
 		err = response.Err

--- a/remoting/getty/pool.go
+++ b/remoting/getty/pool.go
@@ -25,11 +25,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-)
 
-import (
 	getty "github.com/apache/dubbo-getty"
-
 	"github.com/dubbogo/gost/log/logger"
 
 	perrors "github.com/pkg/errors"
@@ -173,11 +170,16 @@ func (c *gettyRPCClient) selectSession() getty.Session {
 	if c.sessions == nil {
 		return nil
 	}
-	count := len(c.sessions)
-	if count == 0 {
+	available := make([]getty.Session, 0, len(c.sessions))
+	for _, s := range c.sessions {
+		if s != nil && s.session != nil && !s.session.IsClosed() {
+			available = append(available, s.session)
+		}
+	}
+	if len(available) == 0 {
 		return nil
 	}
-	return c.sessions[rand.Int31n(int32(count))].session
+	return available[rand.Int31n(int32(len(available)))]
 }
 
 func (c *gettyRPCClient) addSession(session getty.Session) {

--- a/remoting/getty/pool.go
+++ b/remoting/getty/pool.go
@@ -193,7 +193,7 @@ func (c *gettyRPCClient) selectSession() getty.Session {
 	if len(available) == 0 {
 		return nil
 	}
-	return available[rand.Int31n(int32(len(available)))]
+	return available[rand.Int31n(int32(len(available)))] // NOSONAR
 }
 
 func (c *gettyRPCClient) addSession(session getty.Session) {

--- a/remoting/getty/pool.go
+++ b/remoting/getty/pool.go
@@ -19,6 +19,7 @@ package getty
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -299,8 +300,9 @@ func (c *gettyRPCClient) isAvailable() bool {
 }
 
 func (c *gettyRPCClient) close() error {
-	closeErr := perrors.Errorf("close gettyRPCClient{%#v} again", c)
+	firstClose := false
 	c.once.Do(func() {
+		firstClose = true
 		var (
 			gettyClient getty.Client
 			sessions    []*rpcSession
@@ -330,7 +332,9 @@ func (c *gettyRPCClient) close() error {
 			}
 		}()
 
-		closeErr = nil
 	})
-	return closeErr
+	if !firstClose {
+		return errors.New("close gettyRPCClient again")
+	}
+	return nil
 }

--- a/remoting/getty/pool.go
+++ b/remoting/getty/pool.go
@@ -25,8 +25,11 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+)
 
+import (
 	getty "github.com/apache/dubbo-getty"
+
 	"github.com/dubbogo/gost/log/logger"
 
 	perrors "github.com/pkg/errors"

--- a/remoting/getty/pool.go
+++ b/remoting/getty/pool.go
@@ -205,6 +205,7 @@ func (c *gettyRPCClient) removeSession(session getty.Session) {
 	}
 
 	var removeFlag bool
+	var removed bool
 	func() {
 		c.lock.Lock()
 		defer c.lock.Unlock()
@@ -213,11 +214,15 @@ func (c *gettyRPCClient) removeSession(session getty.Session) {
 		}
 
 		for i, s := range c.sessions {
-			if s.session == session {
+			if s != nil && s.session == session {
 				c.sessions = append(c.sessions[:i], c.sessions[i+1:]...)
+				removed = true
 				logger.Debugf("[Remoting][Getty] delete session=%s index=%d", session.Stat(), i)
 				break
 			}
+		}
+		if !removed {
+			return
 		}
 		logger.Infof("[Remoting][Getty] after remove session=%s, left session number=%d", session.Stat(), len(c.sessions))
 		if len(c.sessions) == 0 {
@@ -225,7 +230,7 @@ func (c *gettyRPCClient) removeSession(session getty.Session) {
 		}
 	}()
 	if removeFlag {
-		c.rpcClient.resetRpcConn()
+		c.rpcClient.resetRpcConn(c)
 		c.close()
 	}
 }

--- a/remoting/getty/pool.go
+++ b/remoting/getty/pool.go
@@ -182,7 +182,7 @@ func (c *gettyRPCClient) selectSession() getty.Session {
 	if len(available) == 0 {
 		return nil
 	}
-	return available[rand.Int31n(int32(len(available)))]
+	return available[rand.Int31n(int32(len(available)))] // NOSONAR
 }
 
 func (c *gettyRPCClient) addSession(session getty.Session) {

--- a/remoting/getty/pool.go
+++ b/remoting/getty/pool.go
@@ -216,6 +216,7 @@ func (c *gettyRPCClient) removeSession(session getty.Session) {
 	}
 
 	var removeFlag bool
+	var removed bool
 	func() {
 		c.lock.Lock()
 		defer c.lock.Unlock()
@@ -224,11 +225,15 @@ func (c *gettyRPCClient) removeSession(session getty.Session) {
 		}
 
 		for i, s := range c.sessions {
-			if s.session == session {
+			if s != nil && s.session == session {
 				c.sessions = append(c.sessions[:i], c.sessions[i+1:]...)
+				removed = true
 				logger.Debugf("[Remoting][Getty] delete session=%s index=%d", session.Stat(), i)
 				break
 			}
+		}
+		if !removed {
+			return
 		}
 		logger.Infof("[Remoting][Getty] after remove session=%s, left session number=%d", session.Stat(), len(c.sessions))
 		if len(c.sessions) == 0 {

--- a/remoting/getty/pool.go
+++ b/remoting/getty/pool.go
@@ -25,11 +25,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-)
 
-import (
 	getty "github.com/apache/dubbo-getty"
-
 	"github.com/dubbogo/gost/log/logger"
 
 	perrors "github.com/pkg/errors"
@@ -184,11 +181,16 @@ func (c *gettyRPCClient) selectSession() getty.Session {
 	if c.sessions == nil {
 		return nil
 	}
-	count := len(c.sessions)
-	if count == 0 {
+	available := make([]getty.Session, 0, len(c.sessions))
+	for _, s := range c.sessions {
+		if s != nil && s.session != nil && !s.session.IsClosed() {
+			available = append(available, s.session)
+		}
+	}
+	if len(available) == 0 {
 		return nil
 	}
-	return c.sessions[rand.Int31n(int32(count))].session
+	return available[rand.Int31n(int32(len(available)))]
 }
 
 func (c *gettyRPCClient) addSession(session getty.Session) {

--- a/remoting/getty/pool_test.go
+++ b/remoting/getty/pool_test.go
@@ -18,13 +18,18 @@
 package getty
 
 import (
+	"net"
 	"sync"
-	"testing"
-)
+	"sync/atomic"
+	"time"
 
-import (
+	"dubbo.apache.org/dubbo-go/v3/remoting"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"testing"
+
+	gettylib "github.com/apache/dubbo-getty"
 )
 
 func TestGettyRPCClientUpdateActive(t *testing.T) {
@@ -131,4 +136,83 @@ func TestGettyRPCClientLifecycle(t *testing.T) {
 
 	require.NoError(t, client.close())
 	assert.Equal(t, int64(0), client.active.Load())
+}
+
+type stubSession struct {
+	closed atomic.Bool
+	writes atomic.Int32
+}
+
+func (s *stubSession) ID() uint32                              { return 1 }
+func (s *stubSession) SetCompressType(gettylib.CompressType)   {}
+func (s *stubSession) LocalAddr() string                       { return "127.0.0.1:12345" }
+func (s *stubSession) RemoteAddr() string                      { return "127.0.0.1:20880" }
+func (s *stubSession) IncReadPkgNum()                          {}
+func (s *stubSession) IncWritePkgNum()                         {}
+func (s *stubSession) UpdateActive()                           {}
+func (s *stubSession) GetActive() time.Time                    { return time.Now() }
+func (s *stubSession) ReadTimeout() time.Duration              { return time.Second }
+func (s *stubSession) SetReadTimeout(time.Duration)            {}
+func (s *stubSession) WriteTimeout() time.Duration             { return time.Second }
+func (s *stubSession) SetWriteTimeout(time.Duration)           {}
+func (s *stubSession) Send(interface{}) (int, error)           { return 0, nil }
+func (s *stubSession) CloseConn(int)                           {}
+func (s *stubSession) SetSession(gettylib.Session)             {}
+func (s *stubSession) Reset()                                  {}
+func (s *stubSession) Conn() net.Conn                          { return nil }
+func (s *stubSession) Stat() string                            { return "stub-session" }
+func (s *stubSession) IsClosed() bool                          { return s.closed.Load() }
+func (s *stubSession) EndPoint() gettylib.EndPoint             { return nil }
+func (s *stubSession) SetMaxMsgLen(int)                        {}
+func (s *stubSession) SetName(string)                          {}
+func (s *stubSession) SetEventListener(gettylib.EventListener) {}
+func (s *stubSession) SetPkgHandler(gettylib.ReadWriter)       {}
+func (s *stubSession) SetReader(gettylib.Reader)               {}
+func (s *stubSession) SetWriter(gettylib.Writer)               {}
+func (s *stubSession) SetCronPeriod(int)                       {}
+func (s *stubSession) SetWaitTime(time.Duration)               {}
+func (s *stubSession) GetAttribute(interface{}) interface{}    { return nil }
+func (s *stubSession) SetAttribute(interface{}, interface{})   {}
+func (s *stubSession) RemoveAttribute(interface{})             {}
+func (s *stubSession) WritePkg(pkg interface{}, timeout time.Duration) (int, int, error) {
+	s.writes.Add(1)
+	return 1, 1, nil
+}
+func (s *stubSession) WriteBytes([]byte) (int, error)         { return 0, nil }
+func (s *stubSession) WriteBytesArray(...[]byte) (int, error) { return 0, nil }
+func (s *stubSession) Close()                                 { s.closed.Store(true) }
+
+func TestIssue3509_ReadTimeoutRemovesHalfDeadSession(t *testing.T) {
+	sess := &stubSession{}
+	client := &Client{addr: "127.0.0.1:20880"}
+	rpcClient := &gettyRPCClient{rpcClient: client, sessions: []*rpcSession{{session: sess}}}
+	client.gettyClient = rpcClient
+	client.gettyClientCreated.Store(true)
+
+	req := remoting.NewRequest("2.0.2")
+	req.TwoWay = true
+	rsp := remoting.NewPendingResponse(req.ID)
+	remoting.AddPendingResponse(rsp)
+
+	err := client.Request(req, 10*time.Millisecond, rsp)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errClientReadTimeout)
+	assert.Eventually(t, sess.IsClosed, time.Second, time.Millisecond, "timed out session should be closed")
+	assert.Equal(t, int32(1), sess.writes.Load())
+
+	assert.Nil(t, rpcClient.selectSession())
+	assert.Empty(t, rpcClient.sessions)
+	assert.Nil(t, client.gettyClient, "the connection handle should be reset after the last session is removed")
+	assert.Nil(t, remoting.GetPendingResponse(remoting.SequenceType(req.ID)))
+	assert.False(t, client.clientClosed, "a timed out session must not close the client")
+}
+
+// This test case verifies the scenario described at https://github.com/apache/dubbo-go/issues/3509.
+func TestIssueClosedSessionIsNotSelected(t *testing.T) {
+	sess := &stubSession{}
+	sess.Close()
+	client := &gettyRPCClient{sessions: []*rpcSession{{session: sess}}}
+
+	selected := client.selectSession()
+	assert.Nil(t, selected)
 }

--- a/remoting/getty/pool_test.go
+++ b/remoting/getty/pool_test.go
@@ -29,6 +29,7 @@ import (
 	gettylib "github.com/apache/dubbo-getty"
 
 	perrors "github.com/pkg/errors"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -146,6 +147,7 @@ func TestGettyRPCClientLifecycle(t *testing.T) {
 type stubSession struct {
 	closed    atomic.Bool
 	writes    atomic.Int32
+	onWrite   func()
 	onClose   func()
 	closeOnce sync.Once
 }
@@ -183,6 +185,9 @@ func (s *stubSession) SetAttribute(any, any)                   {}
 func (s *stubSession) RemoveAttribute(any)                     {}
 func (s *stubSession) WritePkg(pkg any, timeout time.Duration) (int, int, error) {
 	s.writes.Add(1)
+	if s.onWrite != nil {
+		s.onWrite()
+	}
 	return 1, 1, nil
 }
 func (s *stubSession) WriteBytes([]byte) (int, error)         { return 0, nil }
@@ -202,7 +207,6 @@ func TestReadTimeoutRemovesHalfDeadSession(t *testing.T) {
 	client := &Client{addr: "127.0.0.1:20880"}
 	rpcClient := &gettyRPCClient{rpcClient: client, sessions: []*rpcSession{{session: sess}}}
 	client.gettyClient = rpcClient
-	client.gettyClientCreated.Store(true)
 
 	req := remoting.NewRequest("2.0.2")
 	req.TwoWay = true
@@ -219,7 +223,7 @@ func TestReadTimeoutRemovesHalfDeadSession(t *testing.T) {
 	assert.Empty(t, rpcClient.sessions)
 	assert.Nil(t, client.gettyClient, "the connection handle should be reset after the last session is removed")
 	assert.Nil(t, remoting.GetPendingResponse(remoting.SequenceType(req.ID)))
-	assert.False(t, client.clientClosed, "a timed out session must not close the client")
+	assert.False(t, client.closed.Load(), "a timed out session must not close the client")
 }
 
 func TestIssueClosedSessionIsNotSelected(t *testing.T) {
@@ -236,7 +240,6 @@ func TestDelayedOnCloseDoesNotResetReplacement(t *testing.T) {
 	oldSession := &stubSession{}
 	oldPool := &gettyRPCClient{rpcClient: client, sessions: []*rpcSession{{session: oldSession}}}
 	client.gettyClient = oldPool
-	client.gettyClientCreated.Store(true)
 
 	closeStarted := make(chan struct{})
 	allowOnClose := make(chan struct{})
@@ -260,13 +263,11 @@ func TestDelayedOnCloseDoesNotResetReplacement(t *testing.T) {
 	replacement := &gettyRPCClient{rpcClient: client, sessions: []*rpcSession{{session: &stubSession{}}}}
 	client.gettyClientMux.Lock()
 	client.gettyClient = replacement
-	client.gettyClientCreated.Store(true)
 	client.gettyClientMux.Unlock()
 
 	client.resetRpcConn(oldPool)
 	client.gettyClientMux.RLock()
 	assert.Same(t, replacement, client.gettyClient)
-	assert.True(t, client.gettyClientCreated.Load())
 	client.gettyClientMux.RUnlock()
 
 	close(allowOnClose)
@@ -278,7 +279,6 @@ func TestDelayedOnCloseDoesNotResetReplacement(t *testing.T) {
 
 	client.gettyClientMux.RLock()
 	assert.Same(t, replacement, client.gettyClient)
-	assert.True(t, client.gettyClientCreated.Load())
 	client.gettyClientMux.RUnlock()
 }
 
@@ -287,7 +287,6 @@ func TestTimeoutResetWithConcurrentSelectSession(t *testing.T) {
 	oldSession := &stubSession{}
 	oldPool := &gettyRPCClient{rpcClient: client, sessions: []*rpcSession{{session: oldSession}}}
 	client.gettyClient = oldPool
-	client.gettyClientCreated.Store(true)
 
 	closeStarted := make(chan struct{})
 	allowOnClose := make(chan struct{})
@@ -307,14 +306,12 @@ func TestTimeoutResetWithConcurrentSelectSession(t *testing.T) {
 	<-closeStarted
 	client.gettyClientMux.RLock()
 	assert.Nil(t, client.gettyClient)
-	assert.False(t, client.gettyClientCreated.Load())
 	client.gettyClientMux.RUnlock()
 
 	replacementSession := &stubSession{}
 	replacement := &gettyRPCClient{rpcClient: client, sessions: []*rpcSession{{session: replacementSession}}}
 	client.gettyClientMux.Lock()
 	client.gettyClient = replacement
-	client.gettyClientCreated.Store(true)
 	client.gettyClientMux.Unlock()
 
 	selectDone := make(chan struct{})
@@ -347,4 +344,63 @@ func TestTimeoutResetWithConcurrentSelectSession(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for delayed OnClose")
 	}
+}
+
+func TestRequestTimeoutConcurrentWithClose(t *testing.T) {
+	client := &Client{addr: "127.0.0.1:20880"}
+	sess := &stubSession{}
+	rpcClient := &gettyRPCClient{rpcClient: client, sessions: []*rpcSession{{session: sess}}}
+	client.gettyClient = rpcClient
+
+	writeStarted := make(chan struct{})
+	sess.onWrite = func() {
+		close(writeStarted)
+	}
+
+	request := remoting.NewRequest("2.0.2")
+	request.TwoWay = true
+	response := remoting.NewPendingResponse(request.ID)
+	remoting.AddPendingResponse(response)
+	requestDone := make(chan error, 1)
+	go func() {
+		requestDone <- client.Request(request, 20*time.Millisecond, response)
+	}()
+
+	select {
+	case <-writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for request write")
+	}
+
+	// Hold the pointer lock before starting Close. Both Close and the timeout
+	// reset must wait for this lock before accessing gettyClient.
+	client.gettyClientMux.Lock()
+	closeDone := make(chan struct{})
+	go func() {
+		client.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+		t.Fatal("Close must wait for gettyClientMux")
+	case <-time.After(100 * time.Millisecond):
+	}
+	client.gettyClientMux.Unlock()
+
+	select {
+	case err := <-requestDone:
+		require.ErrorIs(t, err, errClientReadTimeout)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for request timeout")
+	}
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for client close")
+	}
+	client.gettyClientMux.RLock()
+	assert.Nil(t, client.gettyClient)
+	client.gettyClientMux.RUnlock()
+	assert.True(t, client.closed.Load())
 }

--- a/remoting/getty/pool_test.go
+++ b/remoting/getty/pool_test.go
@@ -143,8 +143,10 @@ func TestGettyRPCClientLifecycle(t *testing.T) {
 }
 
 type stubSession struct {
-	closed atomic.Bool
-	writes atomic.Int32
+	closed    atomic.Bool
+	writes    atomic.Int32
+	onClose   func()
+	closeOnce sync.Once
 }
 
 func (s *stubSession) ID() uint32                              { return 1 }
@@ -184,9 +186,17 @@ func (s *stubSession) WritePkg(pkg any, timeout time.Duration) (int, int, error)
 }
 func (s *stubSession) WriteBytes([]byte) (int, error)         { return 0, nil }
 func (s *stubSession) WriteBytesArray(...[]byte) (int, error) { return 0, nil }
-func (s *stubSession) Close()                                 { s.closed.Store(true) }
+func (s *stubSession) Close() {
+	s.closeOnce.Do(func() {
+		s.closed.Store(true)
+		if s.onClose != nil {
+			s.onClose()
+		}
+	})
+}
 
-func TestIssue3509_ReadTimeoutRemovesHalfDeadSession(t *testing.T) {
+// This test case verifies the scenario described at https://github.com/apache/dubbo-go/issues/3509.
+func TestReadTimeoutRemovesHalfDeadSession(t *testing.T) {
 	sess := &stubSession{}
 	client := &Client{addr: "127.0.0.1:20880"}
 	rpcClient := &gettyRPCClient{rpcClient: client, sessions: []*rpcSession{{session: sess}}}
@@ -211,7 +221,6 @@ func TestIssue3509_ReadTimeoutRemovesHalfDeadSession(t *testing.T) {
 	assert.False(t, client.clientClosed, "a timed out session must not close the client")
 }
 
-// This test case verifies the scenario described at https://github.com/apache/dubbo-go/issues/3509.
 func TestIssueClosedSessionIsNotSelected(t *testing.T) {
 	sess := &stubSession{}
 	sess.Close()
@@ -219,4 +228,55 @@ func TestIssueClosedSessionIsNotSelected(t *testing.T) {
 
 	selected := client.selectSession()
 	assert.Nil(t, selected)
+}
+
+func TestDelayedOnCloseDoesNotResetReplacement(t *testing.T) {
+	client := &Client{addr: "127.0.0.1:20880"}
+	oldSession := &stubSession{}
+	oldPool := &gettyRPCClient{rpcClient: client, sessions: []*rpcSession{{session: oldSession}}}
+	client.gettyClient = oldPool
+	client.gettyClientCreated.Store(true)
+
+	closeStarted := make(chan struct{})
+	allowOnClose := make(chan struct{})
+	onCloseDone := make(chan struct{})
+	oldSession.onClose = func() {
+		close(closeStarted)
+		<-allowOnClose
+		oldPool.removeSession(oldSession)
+		close(onCloseDone)
+	}
+
+	request := remoting.NewRequest("2.0.2")
+	request.TwoWay = true
+	response := remoting.NewPendingResponse(request.ID)
+	remoting.AddPendingResponse(response)
+
+	err := client.Request(request, 10*time.Millisecond, response)
+	require.ErrorIs(t, err, errClientReadTimeout)
+	<-closeStarted
+
+	replacement := &gettyRPCClient{rpcClient: client, sessions: []*rpcSession{{session: &stubSession{}}}}
+	client.gettyClientMux.Lock()
+	client.gettyClient = replacement
+	client.gettyClientCreated.Store(true)
+	client.gettyClientMux.Unlock()
+
+	client.resetRpcConn(oldPool)
+	client.gettyClientMux.RLock()
+	assert.Same(t, replacement, client.gettyClient)
+	assert.True(t, client.gettyClientCreated.Load())
+	client.gettyClientMux.RUnlock()
+
+	close(allowOnClose)
+	select {
+	case <-onCloseDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for delayed OnClose")
+	}
+
+	client.gettyClientMux.RLock()
+	assert.Same(t, replacement, client.gettyClient)
+	assert.True(t, client.gettyClientCreated.Load())
+	client.gettyClientMux.RUnlock()
 }

--- a/remoting/getty/pool_test.go
+++ b/remoting/getty/pool_test.go
@@ -28,6 +28,7 @@ import (
 import (
 	gettylib "github.com/apache/dubbo-getty"
 
+	perrors "github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -279,4 +280,71 @@ func TestDelayedOnCloseDoesNotResetReplacement(t *testing.T) {
 	assert.Same(t, replacement, client.gettyClient)
 	assert.True(t, client.gettyClientCreated.Load())
 	client.gettyClientMux.RUnlock()
+}
+
+func TestTimeoutResetWithConcurrentSelectSession(t *testing.T) {
+	client := &Client{addr: "127.0.0.1:20880"}
+	oldSession := &stubSession{}
+	oldPool := &gettyRPCClient{rpcClient: client, sessions: []*rpcSession{{session: oldSession}}}
+	client.gettyClient = oldPool
+	client.gettyClientCreated.Store(true)
+
+	closeStarted := make(chan struct{})
+	allowOnClose := make(chan struct{})
+	onCloseDone := make(chan struct{})
+	oldSession.onClose = func() {
+		close(closeStarted)
+		<-allowOnClose
+		oldPool.removeSession(oldSession)
+		close(onCloseDone)
+	}
+
+	request := remoting.NewRequest("2.0.2")
+	request.TwoWay = true
+	response := remoting.NewPendingResponse(request.ID)
+	remoting.AddPendingResponse(response)
+	require.ErrorIs(t, client.Request(request, 10*time.Millisecond, response), errClientReadTimeout)
+	<-closeStarted
+	client.gettyClientMux.RLock()
+	assert.Nil(t, client.gettyClient)
+	assert.False(t, client.gettyClientCreated.Load())
+	client.gettyClientMux.RUnlock()
+
+	replacementSession := &stubSession{}
+	replacement := &gettyRPCClient{rpcClient: client, sessions: []*rpcSession{{session: replacementSession}}}
+	client.gettyClientMux.Lock()
+	client.gettyClient = replacement
+	client.gettyClientCreated.Store(true)
+	client.gettyClientMux.Unlock()
+
+	selectDone := make(chan struct{})
+	selectErr := make(chan error, 1)
+	go func() {
+		defer close(selectDone)
+		for range 100 {
+			selectedClient, selectedSession, err := client.selectSession(client.addr)
+			if err != nil {
+				selectErr <- err
+				return
+			}
+			if selectedClient != replacement || selectedSession != replacementSession {
+				selectErr <- perrors.New("selectSession returned a stale connection")
+				return
+			}
+		}
+	}()
+
+	close(allowOnClose)
+	select {
+	case err := <-selectErr:
+		t.Fatal(err)
+	case <-selectDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for concurrent selectSession")
+	}
+	select {
+	case <-onCloseDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for delayed OnClose")
+	}
 }

--- a/remoting/getty/pool_test.go
+++ b/remoting/getty/pool_test.go
@@ -21,15 +21,19 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
+	"testing"
 	"time"
+)
 
-	"dubbo.apache.org/dubbo-go/v3/remoting"
+import (
+	gettylib "github.com/apache/dubbo-getty"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
 
-	"testing"
-
-	gettylib "github.com/apache/dubbo-getty"
+import (
+	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
 
 func TestGettyRPCClientUpdateActive(t *testing.T) {

--- a/remoting/getty/pool_test.go
+++ b/remoting/getty/pool_test.go
@@ -200,7 +200,7 @@ func TestIssue3509_ReadTimeoutRemovesHalfDeadSession(t *testing.T) {
 
 	err := client.Request(req, 10*time.Millisecond, rsp)
 	require.Error(t, err)
-	assert.ErrorIs(t, err, errClientReadTimeout)
+	require.ErrorIs(t, err, errClientReadTimeout)
 	assert.Eventually(t, sess.IsClosed, time.Second, time.Millisecond, "timed out session should be closed")
 	assert.Equal(t, int32(1), sess.writes.Load())
 

--- a/remoting/getty/pool_test.go
+++ b/remoting/getty/pool_test.go
@@ -159,7 +159,7 @@ func (s *stubSession) ReadTimeout() time.Duration              { return time.Sec
 func (s *stubSession) SetReadTimeout(time.Duration)            {}
 func (s *stubSession) WriteTimeout() time.Duration             { return time.Second }
 func (s *stubSession) SetWriteTimeout(time.Duration)           {}
-func (s *stubSession) Send(interface{}) (int, error)           { return 0, nil }
+func (s *stubSession) Send(any) (int, error)                   { return 0, nil }
 func (s *stubSession) CloseConn(int)                           {}
 func (s *stubSession) SetSession(gettylib.Session)             {}
 func (s *stubSession) Reset()                                  {}
@@ -175,10 +175,10 @@ func (s *stubSession) SetReader(gettylib.Reader)               {}
 func (s *stubSession) SetWriter(gettylib.Writer)               {}
 func (s *stubSession) SetCronPeriod(int)                       {}
 func (s *stubSession) SetWaitTime(time.Duration)               {}
-func (s *stubSession) GetAttribute(interface{}) interface{}    { return nil }
-func (s *stubSession) SetAttribute(interface{}, interface{})   {}
-func (s *stubSession) RemoveAttribute(interface{})             {}
-func (s *stubSession) WritePkg(pkg interface{}, timeout time.Duration) (int, int, error) {
+func (s *stubSession) GetAttribute(any) any                    { return nil }
+func (s *stubSession) SetAttribute(any, any)                   {}
+func (s *stubSession) RemoveAttribute(any)                     {}
+func (s *stubSession) WritePkg(pkg any, timeout time.Duration) (int, int, error) {
 	s.writes.Add(1)
 	return 1, 1, nil
 }


### PR DESCRIPTION
### Description
Fixes #3509

The logic before bug fix
```
读超时
  -> 直接返回错误
  -> session 仍留在 pool
  -> session 可能已经半死
  -> 后续请求继续选中它
  -> pending response 也可能残留
```

The logic after this pr fix
```
请求发送成功
    |
等待响应超时
    |
判断当前 session 已经不可信
    |
从 session pool 移除
    |
关闭该 session
    |
清理 pending response
    |
Client 保持可用，后续请求重新建立连接
```


### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
