### PR TITLE
fix:cache manager race #3569

### DIFF
--- a/registry/servicediscovery/store/cache_manager.go
+++ b/registry/servicediscovery/store/cache_manager.go
@@ -35,9 +35,10 @@ type CacheManager struct {
 	cacheFile    string        // The file path where the cache is stored
 	dumpInterval time.Duration // The duration after which the cache dump
 	stop         chan struct{} // Channel used to stop the cache expiration routine
+	done         chan struct{} // Channel closed after the cache expiration routine stops
 	cache        *lru.Cache    // The LRU cache implementation
 	lock         sync.Mutex
-	enableDump   bool
+	stopOnce     sync.Once
 }
 
 type Item struct {
@@ -53,7 +54,7 @@ func NewCacheManager(name, cacheFile string, dumpInterval time.Duration, maxCach
 		cacheFile:    cacheFile,
 		dumpInterval: dumpInterval,
 		stop:         make(chan struct{}),
-		enableDump:   enableDump,
+		done:         make(chan struct{}),
 	}
 	cache, err := lru.New(maxCacheSize)
 	if err != nil {
@@ -70,6 +71,8 @@ func NewCacheManager(name, cacheFile string, dumpInterval time.Duration, maxCach
 
 	if enableDump {
 		cm.runDumpTask()
+	} else {
+		close(cm.done)
 	}
 
 	return cm, nil
@@ -77,29 +80,54 @@ func NewCacheManager(name, cacheFile string, dumpInterval time.Duration, maxCach
 
 // Get retrieves the value associated with the given key from the cache.
 func (cm *CacheManager) Get(key string) (any, bool) {
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
 	return cm.cache.Get(key)
 }
 
 // Set sets the value associated with the given key in the cache.
 func (cm *CacheManager) Set(key string, value any) {
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
 	cm.cache.Add(key, value)
 }
 
 // Delete removes the value associated with the given key from the cache.
 func (cm *CacheManager) Delete(key string) {
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
 	cm.cache.Remove(key)
 }
 
 // GetAll returns all the key-value pairs in the cache.
 func (cm *CacheManager) GetAll() map[string]any {
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
+
+	return cm.getAllLocked()
+}
+
+func (cm *CacheManager) getAllLocked() map[string]any {
 	keys := cm.cache.Keys()
 
-	result := make(map[string]any)
+	result := make(map[string]any, len(keys))
 	for _, k := range keys {
-		result[k.(string)], _ = cm.cache.Get(k)
+		key, ok := k.(string)
+		if !ok {
+			continue
+		}
+		if value, ok := cm.cache.Get(k); ok {
+			result[key] = value
+		}
 	}
 
 	return result
+}
+
+func (cm *CacheManager) len() int {
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
+	return cm.cache.Len()
 }
 
 // loadCache loads the cache from the cache file.
@@ -120,7 +148,7 @@ func (cm *CacheManager) loadCache() error {
 			return err
 		}
 		// Add the loaded keys to the front of the LRU list
-		cm.cache.Add(it.Key, it.Value)
+		cm.Set(it.Key, it.Value)
 	}
 
 	return cf.Close()
@@ -128,10 +156,6 @@ func (cm *CacheManager) loadCache() error {
 
 // dumpCache dumps the cache to the cache file.
 func (cm *CacheManager) dumpCache() error {
-
-	cm.lock.Lock()
-	defer cm.lock.Unlock()
-
 	items := cm.GetAll()
 
 	file, err := os.Create(cm.cacheFile)
@@ -157,6 +181,10 @@ func (cm *CacheManager) dumpCache() error {
 func (cm *CacheManager) runDumpTask() {
 	go func() {
 		ticker := time.NewTicker(cm.dumpInterval)
+		defer func() {
+			ticker.Stop()
+			close(cm.done)
+		}()
 		for {
 			select {
 			case <-ticker.C:
@@ -165,10 +193,9 @@ func (cm *CacheManager) runDumpTask() {
 					// Handle error
 					logger.Warnf("[Registry][ServiceDiscovery] failed to dump cache, err=%v", err)
 				} else {
-					logger.Infof("[Registry][ServiceDiscovery] dumping [%s] caches, latest entries=%d", cm.name, cm.cache.Len())
+					logger.Infof("[Registry][ServiceDiscovery] dumping [%s] caches, latest entries=%d", cm.name, cm.len())
 				}
 			case <-cm.stop:
-				ticker.Stop()
 				return
 			}
 		}
@@ -176,18 +203,19 @@ func (cm *CacheManager) runDumpTask() {
 }
 
 func (cm *CacheManager) StopDump() {
-	cm.lock.Lock()
-	defer cm.lock.Unlock()
-	if cm.enableDump {
-		cm.stop <- struct{}{} // Stop the cache dump routine
-		cm.enableDump = false
-	}
+	cm.stopOnce.Do(func() {
+		close(cm.stop)
+	})
+	<-cm.done
 }
 
 // destroy stops the cache dump routine, clears the cache and removes the cache file.
 func (cm *CacheManager) destroy() {
-	cm.StopDump()    // Stop the cache dump routine
+	cm.StopDump() // Stop the cache dump routine
+
+	cm.lock.Lock()
 	cm.cache.Purge() // Clear the cache
+	cm.lock.Unlock()
 
 	// Delete the cache file if it exists
 	if _, err := os.Stat(cm.cacheFile); err == nil {

--- a/registry/servicediscovery/store/cache_manager_test.go
+++ b/registry/servicediscovery/store/cache_manager_test.go
@@ -19,6 +19,7 @@ package store
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"sync"
 	"testing"
@@ -155,7 +156,8 @@ func TestMetaInfoCacheManager(t *testing.T) {
 }
 
 func TestCacheManagerConcurrentAccess(t *testing.T) {
-	cm, err := NewCacheManager("raceTest", filepath.Join(t.TempDir(), "race_cache"), time.Millisecond, 32, true)
+	cacheFile := filepath.Join(t.TempDir(), "race_cache")
+	cm, err := NewCacheManager("raceTest", cacheFile, time.Millisecond, 32, true)
 	if err != nil {
 		t.Fatalf("failed to create cache manager: %v", err)
 	}
@@ -180,4 +182,83 @@ func TestCacheManagerConcurrentAccess(t *testing.T) {
 		}(i)
 	}
 	wg.Wait()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		info, statErr := os.Stat(cacheFile)
+		if statErr == nil && info.Size() > 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("cache dump was not created: %v", statErr)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	cm.StopDump()
+
+	loaded, err := NewCacheManager("raceTestReloaded", cacheFile, time.Hour, 32, false)
+	if err != nil {
+		t.Fatalf("failed to reload cache manager: %v", err)
+	}
+	defer loaded.destroy()
+
+	items := loaded.GetAll()
+	if len(items) == 0 {
+		t.Fatal("reloaded cache dump contained no entries")
+	}
+	for key, value := range items {
+		if value == nil {
+			t.Fatalf("reloaded cache entry %q contained a nil value", key)
+		}
+		if _, ok := value.(string); !ok {
+			t.Fatalf("reloaded cache entry %q had unexpected type %T", key, value)
+		}
+	}
+}
+
+func TestCacheManagerConcurrentStopDump(t *testing.T) {
+	tests := []struct {
+		name       string
+		enableDump bool
+	}{
+		{name: "enabled", enableDump: true},
+		{name: "disabled", enableDump: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cm, err := NewCacheManager("stopTest", filepath.Join(t.TempDir(), "stop_cache"), time.Hour, 8, tt.enableDump)
+			if err != nil {
+				t.Fatalf("failed to create cache manager: %v", err)
+			}
+			defer cm.destroy()
+
+			const callers = 64
+			start := make(chan struct{})
+			var wg sync.WaitGroup
+			for i := 0; i < callers; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-start
+					cm.StopDump()
+				}()
+			}
+			close(start)
+
+			done := make(chan struct{})
+			go func() {
+				wg.Wait()
+				close(done)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("concurrent StopDump calls did not complete")
+			}
+
+			cm.StopDump()
+		})
+	}
 }

--- a/registry/servicediscovery/store/cache_manager_test.go
+++ b/registry/servicediscovery/store/cache_manager_test.go
@@ -18,6 +18,9 @@
 package store
 
 import (
+	"fmt"
+	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 )
@@ -149,4 +152,32 @@ func TestMetaInfoCacheManager(t *testing.T) {
 	cm3.destroy()
 	cm2.destroy()
 	cm.destroy() // clear cache file
+}
+
+func TestCacheManagerConcurrentAccess(t *testing.T) {
+	cm, err := NewCacheManager("raceTest", filepath.Join(t.TempDir(), "race_cache"), time.Millisecond, 32, true)
+	if err != nil {
+		t.Fatalf("failed to create cache manager: %v", err)
+	}
+	defer cm.destroy()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for j := 0; j < 500; j++ {
+				key := fmt.Sprintf("key-%d", j%64)
+				cm.Set(key, fmt.Sprintf("value-%d-%d", worker, j))
+				cm.Get(key)
+				if j%3 == 0 {
+					cm.Delete(fmt.Sprintf("key-%d", (j+worker)%64))
+				}
+				if j%7 == 0 {
+					cm.GetAll()
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
 }

--- a/registry/servicediscovery/store/cache_manager_test.go
+++ b/registry/servicediscovery/store/cache_manager_test.go
@@ -164,11 +164,11 @@ func TestCacheManagerConcurrentAccess(t *testing.T) {
 	defer cm.destroy()
 
 	var wg sync.WaitGroup
-	for i := 0; i < 16; i++ {
+	for i := range 16 {
 		wg.Add(1)
 		go func(worker int) {
 			defer wg.Done()
-			for j := 0; j < 500; j++ {
+			for j := range 500 {
 				key := fmt.Sprintf("key-%d", j%64)
 				cm.Set(key, fmt.Sprintf("value-%d-%d", worker, j))
 				cm.Get(key)
@@ -236,13 +236,11 @@ func TestCacheManagerConcurrentStopDump(t *testing.T) {
 			const callers = 64
 			start := make(chan struct{})
 			var wg sync.WaitGroup
-			for i := 0; i < callers; i++ {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
+			for range callers {
+				wg.Go(func() {
 					<-start
 					cm.StopDump()
-				}()
+				})
 			}
 			close(start)
 


### PR DESCRIPTION
### 说明

Fixes #3569

本 PR 保证服务发现 `CacheManager` 在并发更新期间生成一致的缓存快照，并使定时落盘任务能够可靠、幂等地停止。

### 问题分析

进一步检查发现，项目通过 `*lru.Cache` 使用 `github.com/hashicorp/golang-lru v0.5.4`。该类型本身是并发安全的，其 `Get`、`Add`、`Remove`、`Keys`、`Len` 和 `Purge` 均有内部锁保护。

实际问题发生在复合操作层面：

1. `GetAll` 先通过 `Keys()` 获取键快照。
2. 另一个 goroutine 可能在此时删除其中一个键。
3. 后续 `Get(key)` 返回 `(nil, false)`。
4. 原实现忽略了布尔返回值，将 `nil` 写入结果。
5. `dumpCache` 调用 `gob.Register(nil)`，最终触发 panic。

因此，可复现的问题是缓存快照不具备原子性，并在定时落盘时引发崩溃，而不是底层 LRU 双向链表发生了无锁数据竞争。

原 `StopDump` 还会在持有 `CacheManager.lock` 时向无缓冲通道发送停止信号。如果落盘 goroutine 正在等待同一把锁，停止流程存在死锁窗口。

### 修改内容

- 使用同一把互斥锁保护所有 `CacheManager` 缓存操作。
- 保证 `GetAll` 相对于 `Get`、`Set` 和 `Delete` 是原子快照。
- 忽略已经不存在的键，避免将 `nil` 写入落盘数据。
- 缓存加载统一通过加锁后的 `Set` 方法执行。
- 文件写入前先生成一致的缓存快照。
- 使用 `sync.Once` 保证 `StopDump` 可以安全重复调用。
- 使用 `done` 通道等待落盘 goroutine 完全退出。
- goroutine 退出时停止 ticker 并关闭 `done`。
- 增加并发访问、落盘重载和并发停止回归测试。

### 回归测试设计

`TestCacheManagerConcurrentAccess` 启动 16 个 goroutine。每个 goroutine 执行 500 轮并发 `Set`、`Get`、`Delete` 和 `GetAll`，同时启用 1ms 周期的定时落盘任务。

每轮测试包含：

- 8,000 次 `Set`
- 8,000 次 `Get`
- 2,672 次 `Delete`
- 1,152 次 `GetAll`

并发操作结束后，测试还会：

- 等待定时落盘文件生成；
- 停止落盘 goroutine；
- 从落盘文件重新加载缓存；
- 验证缓存可正常解码、值不为 nil 且类型正确。

`TestCacheManagerConcurrentStopDump` 分别覆盖开启和关闭落盘两种模式，每种模式由 64 个 goroutine 同时调用 `StopDump`，并验证重复停止不会阻塞或死锁。

### 自测报告

测试环境：Go 1.25.5、Windows/AMD64、`CGO_ENABLED=1`、32 个逻辑处理器。

| 测试命令 | 结果 |
| --- | --- |
| `go test -count=1 ./registry/servicediscovery/store` | 通过，9.337s |
| `go test -race -count=1 ./registry/servicediscovery/store` | 通过，10.810s |
| 目标回归测试 `-count=20` | 通过，2.239s |
| 目标回归测试 `-race -count=20` | 通过，4.412s |
| `go test -count=1 ./registry/servicediscovery/...` | 全部通过 |
| `go vet ./registry/servicediscovery/...` | 通过，无诊断信息 |
| store 包语句覆盖率 | 90.2% |

20 轮 race 回归共执行 396,480 次缓存读写及快照操作，并执行 2,560 次并发 `StopDump` 调用。

### 覆盖率明细

- `Get`、`Set`、`Delete`、`GetAll`、`StopDump`、`destroy`：100%
- `runDumpTask`：90.9%
- `getAllLocked`：88.9%
- `loadCache`：84.6%
- `dumpCache`：83.3%
- `NewCacheManager`：83.3%
- 总语句覆盖率：90.2%

### 性能测试

32 线程环境下，每项执行 5 次 1 秒 benchmark，取中位数：

| 操作 | 修改前 | 修改后 | 变化 |
| --- | ---: | ---: | ---: |
| 并行 `Get` | 103.2 ns/op | 121.0 ns/op | +17.2% |
| 混合读写 | 114.2 ns/op | 125.0 ns/op | +9.5% |
| 并行 `GetAll` | 16.179 μs/op | 5.207 μs/op | -67.8% |

由于底层缓存本身也有锁，外层互斥锁会增加单次操作开销；但原子 `GetAll` 的性能明显提升，内存分配由 10,520 B / 12 allocs 降至约 6,104 B / 5 allocs。

### 已知但不属于本 PR 的问题

- `go test -race ./registry/servicediscovery/...` 会在既有的 `TestServiceDiscoveryRegistryUnRegister_Concurrent` 中报告竞态。该测试明确无锁修改 `sdReg.instances`，在基线提交上同样失败，与本 PR 无关。store 范围的 race 测试全部通过。
- 显式调用 `Set(key, nil)` 仍可能在 `gob.Register(nil)` 处 panic。生产元数据路径会拒绝 nil，建议单独处理。
- 缓存文件仍直接写入最终路径，没有使用临时文件加原子重命名。本 PR 未修改该既有行为。

### 检查清单

- [x] 确认目标分支为 `develop`
- [x] 代码已通过本地测试
- [x] 已添加能够证明修复有效的回归测试
