### PR TITLE
perf(metadata): pipeline ZooKeeper revision reads

### DIFF
--- a/common/constant/default.go
+++ b/common/constant/default.go
@@ -95,6 +95,9 @@ const (
 const (
 	SimpleMetadataServiceName = "MetadataService"
 	DefaultRevision           = "N/A"
+
+	// ZookeeperListAppRevisionsMaxConcurrency bounds in-flight reads when listing application revisions.
+	ZookeeperListAppRevisionsMaxConcurrency = 16
 )
 
 const (

--- a/metadata/report/zookeeper/report.go
+++ b/metadata/report/zookeeper/report.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 )
 
 import (
@@ -89,6 +90,11 @@ type zookeeperMetadataReport struct {
 	url           *common.URL
 }
 
+// listAppRevisionsMaxConcurrency bounds the number of in-flight reads sent
+// over the ZooKeeper connection. ZooKeeper's Go client does not support read
+// operations in Multi, but concurrent requests are pipelined by the client.
+const listAppRevisionsMaxConcurrency = 16
+
 // URL returns the URL used to create this metadata report.
 func (m *zookeeperMetadataReport) URL() *common.URL {
 	return m.url
@@ -144,17 +150,42 @@ func (m *zookeeperMetadataReport) ListAppRevisions(application string) ([]report
 		}
 		return nil, err
 	}
+	revisions := make([]report.AppRevision, len(children))
+	found := make([]bool, len(children))
+	jobs := make(chan int, len(children))
+	for i := range children {
+		jobs <- i
+	}
+	close(jobs)
+
+	var workers sync.WaitGroup
+	workerCount := min(len(children), listAppRevisionsMaxConcurrency)
+	workers.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for i := range jobs {
+				revision := children[i]
+				path := parent + constant.PathSeparator + revision
+				data, _, getErr := m.client.Get(path)
+				if getErr != nil {
+					continue // skip if node disappeared between listing and reading
+				}
+				revisions[i] = report.AppRevision{
+					Revision:   revision,
+					ModifyTime: report.ParseMetadataLastUpdatedTime(data),
+				}
+				found[i] = true
+			}
+		}()
+	}
+	workers.Wait()
+
 	result := make([]report.AppRevision, 0, len(children))
-	for _, rev := range children {
-		path := parent + constant.PathSeparator + rev
-		data, _, err := m.client.Get(path)
-		if err != nil {
-			continue // skip if node disappeared between listing and reading
+	for i := range revisions {
+		if found[i] {
+			result = append(result, revisions[i])
 		}
-		result = append(result, report.AppRevision{
-			Revision:   rev,
-			ModifyTime: report.ParseMetadataLastUpdatedTime(data),
-		})
 	}
 	return result, nil
 }

--- a/metadata/report/zookeeper/report.go
+++ b/metadata/report/zookeeper/report.go
@@ -90,11 +90,6 @@ type zookeeperMetadataReport struct {
 	url           *common.URL
 }
 
-// listAppRevisionsMaxConcurrency bounds the number of in-flight reads sent
-// over the ZooKeeper connection. ZooKeeper's Go client does not support read
-// operations in Multi, but concurrent requests are pipelined by the client.
-const listAppRevisionsMaxConcurrency = 16
-
 // URL returns the URL used to create this metadata report.
 func (m *zookeeperMetadataReport) URL() *common.URL {
 	return m.url
@@ -159,7 +154,7 @@ func (m *zookeeperMetadataReport) ListAppRevisions(application string) ([]report
 	close(jobs)
 
 	var workers sync.WaitGroup
-	workerCount := min(len(children), listAppRevisionsMaxConcurrency)
+	workerCount := min(len(children), constant.ZookeeperListAppRevisionsMaxConcurrency)
 	workers.Add(workerCount)
 	for range workerCount {
 		go func() {

--- a/metadata/report/zookeeper/report_test.go
+++ b/metadata/report/zookeeper/report_test.go
@@ -290,7 +290,7 @@ func TestListAppRevisions(t *testing.T) {
 
 func TestListAppRevisionsPipelinesReadsWithBoundedConcurrency(t *testing.T) {
 	const extraRevisions = 5
-	revisionCount := listAppRevisionsMaxConcurrency + extraRevisions
+	revisionCount := constant.ZookeeperListAppRevisionsMaxConcurrency + extraRevisions
 	mc := newMockZkClient()
 	client := &concurrencyTrackingZkClient{
 		mockZkClient: mc,
@@ -313,7 +313,7 @@ func TestListAppRevisionsPipelinesReadsWithBoundedConcurrency(t *testing.T) {
 		done <- listResult{revisions: revisions, err: err}
 	}()
 
-	for range listAppRevisionsMaxConcurrency {
+	for range constant.ZookeeperListAppRevisionsMaxConcurrency {
 		select {
 		case <-client.entered:
 		case <-time.After(time.Second):
@@ -331,7 +331,7 @@ func TestListAppRevisionsPipelinesReadsWithBoundedConcurrency(t *testing.T) {
 	require.NoError(t, result.err)
 	require.Len(t, result.revisions, revisionCount)
 	client.mu.Lock()
-	assert.Equal(t, listAppRevisionsMaxConcurrency, client.maxActive)
+	assert.Equal(t, constant.ZookeeperListAppRevisionsMaxConcurrency, client.maxActive)
 	client.mu.Unlock()
 }
 

--- a/metadata/report/zookeeper/report_test.go
+++ b/metadata/report/zookeeper/report_test.go
@@ -299,7 +299,7 @@ func TestListAppRevisionsPipelinesReadsWithBoundedConcurrency(t *testing.T) {
 	}
 	for i := range revisionCount {
 		path := fmt.Sprintf("/dubbo/my-app/r%d", i)
-		mc.data[path] = []byte(fmt.Sprintf(`{"lastUpdatedTime":%d}`, i))
+		mc.data[path] = fmt.Appendf(nil, `{"lastUpdatedTime":%d}`, i)
 	}
 
 	r := &zookeeperMetadataReport{client: client, rootDir: "/dubbo/"}

--- a/metadata/report/zookeeper/report_test.go
+++ b/metadata/report/zookeeper/report_test.go
@@ -19,8 +19,11 @@ package zookeeper
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 import (
@@ -134,11 +137,41 @@ func (m *mockZkClient) Children(path string) ([]string, *zk.Stat, error) {
 }
 
 func (m *mockZkClient) Get(path string) ([]byte, *zk.Stat, error) {
+	if err, ok := m.errors["Get:"+path]; ok {
+		return nil, nil, err
+	}
 	v, ok := m.data[path]
 	if !ok {
 		return nil, nil, zk.ErrNoNode
 	}
 	return v, m.stats[path], nil
+}
+
+type concurrencyTrackingZkClient struct {
+	*mockZkClient
+	entered chan struct{}
+	release chan struct{}
+
+	mu        sync.Mutex
+	active    int
+	maxActive int
+}
+
+func (m *concurrencyTrackingZkClient) Get(path string) ([]byte, *zk.Stat, error) {
+	m.mu.Lock()
+	m.active++
+	if m.active > m.maxActive {
+		m.maxActive = m.active
+	}
+	m.mu.Unlock()
+
+	m.entered <- struct{}{}
+	<-m.release
+
+	m.mu.Lock()
+	m.active--
+	m.mu.Unlock()
+	return m.mockZkClient.Get(path)
 }
 
 // --- Helper ---
@@ -253,6 +286,65 @@ func TestListAppRevisions(t *testing.T) {
 	assert.Equal(t, int64(1000), names["r1"])
 	assert.Equal(t, int64(3000), names["r2"])
 	assert.Equal(t, int64(2000), names["r3"])
+}
+
+func TestListAppRevisionsPipelinesReadsWithBoundedConcurrency(t *testing.T) {
+	const extraRevisions = 5
+	revisionCount := listAppRevisionsMaxConcurrency + extraRevisions
+	mc := newMockZkClient()
+	client := &concurrencyTrackingZkClient{
+		mockZkClient: mc,
+		entered:      make(chan struct{}, revisionCount),
+		release:      make(chan struct{}),
+	}
+	for i := range revisionCount {
+		path := fmt.Sprintf("/dubbo/my-app/r%d", i)
+		mc.data[path] = []byte(fmt.Sprintf(`{"lastUpdatedTime":%d}`, i))
+	}
+
+	r := &zookeeperMetadataReport{client: client, rootDir: "/dubbo/"}
+	type listResult struct {
+		revisions []report.AppRevision
+		err       error
+	}
+	done := make(chan listResult, 1)
+	go func() {
+		revisions, err := r.ListAppRevisions("my-app")
+		done <- listResult{revisions: revisions, err: err}
+	}()
+
+	for range listAppRevisionsMaxConcurrency {
+		select {
+		case <-client.entered:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for concurrent ZooKeeper reads")
+		}
+	}
+	select {
+	case <-client.entered:
+		t.Fatal("ListAppRevisions exceeded its concurrency limit")
+	default:
+	}
+	close(client.release)
+
+	result := <-done
+	require.NoError(t, result.err)
+	require.Len(t, result.revisions, revisionCount)
+	client.mu.Lock()
+	assert.Equal(t, listAppRevisionsMaxConcurrency, client.maxActive)
+	client.mu.Unlock()
+}
+
+func TestListAppRevisionsSkipsRevisionRemovedDuringRead(t *testing.T) {
+	r, mc := newTestReportWithMock()
+	mc.data["/dubbo/my-app/r1"] = []byte(`{"lastUpdatedTime":1000}`)
+	mc.data["/dubbo/my-app/r2"] = []byte(`{"lastUpdatedTime":2000}`)
+	mc.errors["Get:/dubbo/my-app/r2"] = zk.ErrNoNode
+
+	revisions, err := r.ListAppRevisions("my-app")
+	require.NoError(t, err)
+	require.Len(t, revisions, 1)
+	assert.Equal(t, "r1", revisions[0].Revision)
 }
 
 func TestRegisterServiceAppMapping_NewKey(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

- Replaces the serial per-revision ZooKeeper Get loop with a bounded 16-worker read pipeline.
- Preserves child ordering and the existing behavior of skipping revisions removed between Children and Get.
- Documents why Multi is not used: the current dubbogo/go-zookeeper client only supports write/check operations in Multi.

ZooKeeper still requires one data request per child with the current client API, but concurrent calls are pipelined over the shared connection. This removes the N-times-RTT critical path while the concurrency cap avoids flooding ZooKeeper when an app has many revisions.

Closes #3571.

## Tests

- make check-fmt
- go test -race ./metadata/report/zookeeper
- go test ./metadata/report/...
- go test ./metadata/... ./registry/servicediscovery/...
- go test ./metadata/report/zookeeper -run TestListAppRevisions -count=50
- go vet ./metadata/report/zookeeper ./metadata/report/...

The new tests prove that reads overlap, never exceed the 16-request limit, return all revision timestamps, and continue to skip a revision that disappears during the read.

A full go test ./... run also reached the changed packages successfully. Its unrelated environment-dependent failures were filter/accesslog expecting /tmp on Windows, remoting/etcdv3 depending on local port 2379 state, and remoting/getty being unable to bind port 20060.