### PR TITLE
fix: correct inverted guard in WithRegistryIDs/WithProtocolIDs

### DIFF
--- a/server/options.go
+++ b/server/options.go
@@ -619,7 +619,7 @@ func WithInterface(interfaceName string) ServiceOption {
 // todo(DMwangnima): think about a more ideal configuration style
 func WithRegistryIDs(registryIDs []string) ServiceOption {
 	return func(cfg *ServiceOptions) {
-		if len(registryIDs) <= 0 {
+		if len(registryIDs) > 0 {
 			cfg.Service.RegistryIDs = registryIDs
 		}
 	}
@@ -635,7 +635,7 @@ func WithFilter(filter string) ServiceOption {
 // todo(DMwangnima): think about a more ideal configuration style
 func WithProtocolIDs(protocolIDs []string) ServiceOption {
 	return func(cfg *ServiceOptions) {
-		if len(protocolIDs) <= 0 {
+		if len(protocolIDs) > 0 {
 			cfg.Service.ProtocolIDs = protocolIDs
 		}
 	}

--- a/server/options_test.go
+++ b/server/options_test.go
@@ -614,7 +614,7 @@ func TestWithRegistryIDs(t *testing.T) {
 	registryIDs := []string{"registry1"}
 	opt := WithRegistryIDs(registryIDs)
 	opt(opts)
-	assert.NotEqual(t, registryIDs, opts.Service.RegistryIDs)
+	assert.Equal(t, registryIDs, opts.Service.RegistryIDs)
 }
 
 // Test WithFilter
@@ -1060,5 +1060,5 @@ func TestWithProtocolIDs(t *testing.T) {
 	protocolIDs := []string{"dubbo"}
 	opt := WithProtocolIDs(protocolIDs)
 	opt(opts)
-	assert.NotEqual(t, protocolIDs, opts.Service.ProtocolIDs)
+	assert.Equal(t, protocolIDs, opts.Service.ProtocolIDs)
 }


### PR DESCRIPTION
### Description
Fixes # (issue)
The root cause of the bug is an inverted guard condition. When a user use RegistryIDs/ProtocolIDs, a non-empty value should be written to the field; however, due to the inverted guard condition, the assignment is skipped whenever the user provides a value (i.e., len(IDs) > 0), causing it to be silently dropped. The test file： when a non-empty value is passed, the assertion should be that the field equals the input (assert.Equal), not that it differs (assert.NotEqual).

Refs https://github.com/apache/dubbo-go/issues/3598 (task1)

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
