### PR TITLE
chore(triple): clean up draft TODOs and unify comment style

### DIFF
--- a/protocol/triple/client.go
+++ b/protocol/triple/client.go
@@ -63,9 +63,6 @@ type clientManager struct {
 	healthClient *tri.Client
 }
 
-// TODO: code a triple client between clientManager and triple_protocol client
-// TODO: write a NewClient for triple client
-
 func (cm *clientManager) callUnary(ctx context.Context, method string, req, resp any, responseHeader, responseTrailer *http.Header) error {
 	triReq := tri.NewRequest(req)
 	triResp := tri.NewResponse(resp)
@@ -115,7 +112,7 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 	var cliOpts []tri.ClientOption
 	var isIDL bool
 
-	// set serialization
+	// Set serialization
 	serialization := url.GetParam(constant.SerializationKey, constant.ProtobufSerialization)
 	switch serialization {
 	case constant.ProtobufSerialization:
@@ -131,18 +128,18 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 		panic(fmt.Sprintf("Unsupported serialization: %s", serialization))
 	}
 
-	// set timeout
+	// Set timeout
 	timeout := url.GetParamDuration(constant.TimeoutKey, "")
 	cliOpts = append(cliOpts, tri.WithTimeout(timeout))
 
-	// set service group and version
+	// Set service group and version
 	group := url.GetParam(constant.GroupKey, "")
 	version := url.GetParam(constant.VersionKey, "")
 	cliOpts = append(cliOpts, tri.WithGroup(group), tri.WithVersion(version))
 
-	// todo(DMwangnima): support opentracing
+	// TODO(DMwangnima): support OpenTracing
 
-	// handle tls
+	// Handle TLS
 	var (
 		tlsFlag bool
 		tlsConf *global.TLSConfig
@@ -175,7 +172,7 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 		tripleConf = tripleConfRaw.(*global.TripleConfig)
 	}
 
-	// handle keepalive options
+	// Handle keepalive options
 	cliKeepAliveOpts, keepAliveInterval, keepAliveTimeout, genKeepAliveOptsErr := genKeepAliveOptions(url, tripleConf)
 	if genKeepAliveOptsErr != nil {
 		logger.Errorf("[Triple][Client] genKeepAliveOpts failed, err=%v", genKeepAliveOptsErr)
@@ -183,7 +180,7 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 	}
 	cliOpts = append(cliOpts, cliKeepAliveOpts...)
 
-	// handle http transport of triple protocol
+	// Handle HTTP transport of triple protocol
 	var transport http.RoundTripper
 
 	var callProtocol string
@@ -196,7 +193,7 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 
 	switch callProtocol {
 	// This case might be for backward compatibility,
-	// it's not useful for the Triple protocol, HTTP/1 lacks trailer functionality.
+	// It's not useful for the Triple protocol, HTTP/1 lacks trailer functionality.
 	// Triple protocol only supports HTTP/2 and HTTP/3.
 	case constant.CallHTTP:
 		transport = &http.Transport{
@@ -204,7 +201,8 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 		}
 		cliOpts = append(cliOpts, tri.WithTriple())
 	case constant.CallHTTP2:
-		// TODO: Enrich the http2 transport config for triple protocol.
+		// HTTP/2 transport only configures keepalive (ReadIdleTimeout/PingTimeout) and TLS;
+		// All other knobs keep the http2.Transport defaults.
 		if tlsFlag {
 			transport = &http2.Transport{
 				TLSClientConfig: cfg,
@@ -229,7 +227,8 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 			return nil, fmt.Errorf("TRIPLE http3 client must have TLS config, but TLS config is nil")
 		}
 
-		// TODO: Enrich the http3 transport config for triple protocol.
+		// HTTP/3 transport maps keepalive to quic-go's KeepAlivePeriod and MaxIdleTimeout;
+		// All other QUIC knobs keep the quic.Config defaults.
 		transport = &http3.Transport{
 			TLSClientConfig: cfg,
 			QUICConfig: &quic.Config{
@@ -300,7 +299,7 @@ func (cm *clientManager) callHealthWatch(ctx context.Context, service string) (*
 func genKeepAliveOptions(url *common.URL, tripleConf *global.TripleConfig) ([]tri.ClientOption, time.Duration, time.Duration, error) {
 	var cliKeepAliveOpts []tri.ClientOption
 
-	// set max send and recv msg size
+	// Set max send and recv msg size
 	maxCallRecvMsgSize := constant.DefaultMaxCallRecvMsgSize
 	if recvMsgSize, err := humanize.ParseBytes(url.GetParam(constant.MaxCallRecvMsgSize, "")); err == nil && recvMsgSize > 0 {
 		maxCallRecvMsgSize = int(recvMsgSize)
@@ -312,8 +311,8 @@ func genKeepAliveOptions(url *common.URL, tripleConf *global.TripleConfig) ([]tr
 	}
 	cliKeepAliveOpts = append(cliKeepAliveOpts, tri.WithSendMaxBytes(maxCallSendMsgSize))
 
-	// set keepalive interval and keepalive timeout
-	// Compatibility: read legacy URL keepalive parameters.
+	// Set keepalive interval and keepalive timeout
+	// Compatibility: read the legacy URL keepalive parameters.
 	// TODO: remove KeepAliveInterval and KeepAliveTimeout in version 4.0.0.
 	keepAliveInterval := url.GetParamDuration(constant.KeepAliveInterval, constant.DefaultKeepAliveInterval)
 	keepAliveTimeout := url.GetParamDuration(constant.KeepAliveTimeout, constant.DefaultKeepAliveTimeout)

--- a/protocol/triple/server.go
+++ b/protocol/triple/server.go
@@ -119,10 +119,6 @@ func resolveServerTransport(url *common.URL) (*transportSettings, error) {
 		callProtocol = constant.CallHTTP2AndHTTP3
 	}
 
-	// todo: support opentracing interceptor
-
-	// TODO: move tls config to handleService
-
 	rawTLSConfig, err := resolveRawTLSConfig(url)
 	if err != nil {
 		return nil, err
@@ -248,7 +244,7 @@ func (s *Server) registerServiceHandlers(invoker base.Invoker, info *common.Serv
 	url := invoker.GetURL()
 
 	// IDLMode means that this will only be set when
-	// the new triple is started in non-IDL mode.
+	// The new triple is started in non-IDL mode.
 	// TODO: remove IDLMode when config package is removed
 	IDLMode := url.GetParam(constant.IDLMode, "")
 
@@ -258,7 +254,7 @@ func (s *Server) registerServiceHandlers(invoker base.Invoker, info *common.Serv
 	}
 
 	intfName := url.Interface()
-	//OpenAPI group
+	// OpenAPI group
 	var openapiGroup string
 	if g, ok := url.GetAttribute(constant.OpenAPIMetaKeyOpenAPIGroup); ok {
 		if gs, ok := g.(string); ok && gs != "" {
@@ -267,11 +263,11 @@ func (s *Server) registerServiceHandlers(invoker base.Invoker, info *common.Serv
 	}
 
 	if info != nil {
-		// new triple idl mode
+		// New triple IDL mode
 		s.handleServiceWithInfo(intfName, invoker, info, hanOpts...)
 		s.saveServiceInfo(intfName, info, openapiGroup, url.Group(), url.Version())
 	} else if IDLMode == constant.NONIDL {
-		// new triple non-idl mode
+		// New triple non-IDL mode
 		reflectInfo := createServiceInfoWithReflection(service)
 		s.handleServiceWithInfo(intfName, invoker, reflectInfo, hanOpts...)
 		s.saveServiceInfo(intfName, reflectInfo, openapiGroup, url.Group(), url.Version())
@@ -426,7 +422,7 @@ func getHanOpts(url *common.URL, tripleConf *global.TripleConfig) (hanOpts []tri
 		hanOpts = append(hanOpts, tri.WithSendMaxBytes(maxServerSendMsgSize))
 	}
 
-	// todo:// open tracing
+	// TODO: support OpenTracing
 
 	// CORS configuration
 	if tripleConf.Cors != nil && len(tripleConf.Cors.AllowOrigins) > 0 {
@@ -443,7 +439,7 @@ func getHanOpts(url *common.URL, tripleConf *global.TripleConfig) (hanOpts []tri
 	return hanOpts
 }
 
-// *Important*, this function is responsible for being compatible with old triple-gen code and non-idl code
+// *Important*, this function is responsible for being compatible with old triple-gen code and non-IDL code
 // compatHandleService registers handler based on ServiceConfig and provider service.
 func (s *Server) compatHandleService(url *common.URL, interfaceName string, group, version string, opts ...tri.HandlerOption) {
 	var providerServices map[string]*global.ServiceConfig
@@ -483,7 +479,7 @@ func (s *Server) compatHandleService(url *common.URL, interfaceName string, grou
 			continue
 		}
 		s.compatSaveServiceInfo(ds.XXX_ServiceDesc())
-		// inject invoker, it has all invocation logics
+		// Inject invoker, it has all invocation logics
 		ds.XXX_SetProxyImpl(invoker)
 		s.compatRegisterHandler(interfaceName, ds, opts...)
 	}
@@ -491,18 +487,18 @@ func (s *Server) compatHandleService(url *common.URL, interfaceName string, grou
 
 func (s *Server) compatRegisterHandler(interfaceName string, svc dubbo3.Dubbo3GrpcService, opts ...tri.HandlerOption) {
 	desc := svc.XXX_ServiceDesc()
-	// init unary handlers
+	// Init unary handlers
 	for _, method := range desc.Methods {
-		// please refer to protocol/triple/internal/proto/triple_gen/greettriple for procedure examples
-		// error could be ignored because base is empty string
+		// Please refer to protocol/triple/internal/proto/triple_gen/greettriple for procedure examples
+		// Error could be ignored because base is empty string
 		procedure := joinProcedure(interfaceName, method.MethodName)
 		_ = s.triServer.RegisterCompatUnaryHandler(procedure, method.MethodName, svc, tri.MethodHandler(method.Handler), opts...)
 	}
 
-	// init stream handlers
+	// Init stream handlers
 	for _, stream := range desc.Streams {
-		// please refer to protocol/triple/internal/proto/triple_gen/greettriple for procedure examples
-		// error could be ignored because base is empty string
+		// Please refer to protocol/triple/internal/proto/triple_gen/greettriple for procedure examples
+		// Error could be ignored because base is empty string
 		procedure := joinProcedure(interfaceName, stream.StreamName)
 		var typ tri.StreamType
 		switch {
@@ -549,12 +545,12 @@ func (s *Server) registerUnaryMethodHandler(procedure string, m common.MethodInf
 		func(ctx context.Context, req *tri.Request) (*tri.Response, error) {
 			args := extractUnaryInvocationArgs(req.Msg)
 			attachments := generateAttachments(req.Header())
-			// inject attachments
+			// Inject attachments
 			ctx = context.WithValue(ctx, constant.AttachmentKey, attachments)
 			invo := invocation.NewRPCInvocation(m.Name, args, attachments)
 			res := invoker.Invoke(ctx, invo)
-			// todo(DMwangnima): modify InfoInvoker to get a unified processing logic
-			// please refer to server/InfoInvoker.Invoke()
+			// TODO(DMwangnima): modify InfoInvoker to get a unified processing logic
+			// Please refer to server/InfoInvoker.Invoke()
 			triResp := wrapTripleResponse(res.Result())
 			appendTripleOutgoingAttachments(ctx, res.Attachments())
 			return triResp, res.Error()
@@ -569,7 +565,7 @@ func (s *Server) registerClientStreamMethodHandler(procedure string, m common.Me
 		func(ctx context.Context, stream *tri.ClientStream) (*tri.Response, error) {
 			args := []any{m.StreamInitFunc(stream)}
 			attachments := generateAttachments(stream.RequestHeader())
-			// inject attachments
+			// Inject attachments
 			ctx = context.WithValue(ctx, constant.AttachmentKey, attachments)
 			invo := invocation.NewRPCInvocation(m.Name, args, attachments)
 			res := invoker.Invoke(ctx, invo)
@@ -586,7 +582,7 @@ func (s *Server) registerServerStreamMethodHandler(procedure string, m common.Me
 		func(ctx context.Context, req *tri.Request, stream *tri.ServerStream) error {
 			args := []any{req.Msg, m.StreamInitFunc(stream)}
 			attachments := generateAttachments(req.Header())
-			// inject attachments
+			// Inject attachments
 			ctx = context.WithValue(ctx, constant.AttachmentKey, attachments)
 			invo := invocation.NewRPCInvocation(m.Name, args, attachments)
 			res := invoker.Invoke(ctx, invo)
@@ -602,7 +598,7 @@ func (s *Server) registerBidiStreamMethodHandler(procedure string, m common.Meth
 		func(ctx context.Context, stream *tri.BidiStream) error {
 			args := []any{m.StreamInitFunc(stream)}
 			attachments := generateAttachments(stream.RequestHeader())
-			// inject attachments
+			// Inject attachments
 			ctx = context.WithValue(ctx, constant.AttachmentKey, attachments)
 			invo := invocation.NewRPCInvocation(m.Name, args, attachments)
 			res := invoker.Invoke(ctx, invo)
@@ -615,15 +611,15 @@ func (s *Server) registerBidiStreamMethodHandler(procedure string, m common.Meth
 func extractUnaryInvocationArgs(msg any) []any {
 	if argsRaw, ok := msg.([]any); ok {
 		args := make([]any, 0, len(argsRaw))
-		// non-idl mode, req.Msg consists of many arguments
+		// Non-IDL mode, req.Msg consists of many arguments
 		for _, argRaw := range argsRaw {
-			// refer to createServiceInfoWithReflection, in ReqInitFunc, argRaw is a pointer to real arg.
-			// so we have to invoke Elem to get the real arg.
+			// Refer to createServiceInfoWithReflection, in ReqInitFunc, argRaw is a pointer to real arg.
+			// So we have to invoke Elem to get the real arg.
 			args = append(args, reflect.ValueOf(argRaw).Elem().Interface())
 		}
 		return args
 	}
-	// triple idl mode and old triple idl mode
+	// Triple IDL mode and old triple IDL mode
 	return []any{msg}
 }
 
@@ -631,7 +627,7 @@ func wrapTripleResponse(result any) *tri.Response {
 	if existingResp, ok := result.(*tri.Response); ok {
 		return existingResp
 	}
-	// please refer to proxy/proxy_factory/ProxyInvoker.Invoke
+	// Please refer to proxy/proxy_factory/ProxyInvoker.Invoke
 	return tri.NewResponse([]any{result})
 }
 
@@ -673,7 +669,7 @@ func (s *Server) saveServiceInfo(interfaceName string, info *common.ServiceInfo,
 	ret.Metadata = info
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// todo(DMwangnima): using interfaceName is not enough, we need to consider group and version
+	// TODO(DMwangnima): using interfaceName is not enough, we need to consider group and version
 	s.services[interfaceName] = ret
 
 	if s.triServer != nil {
@@ -729,7 +725,7 @@ func (s *Server) GracefulStop() {
 	}
 }
 
-// createServiceInfoWithReflection is for non-idl scenario.
+// createServiceInfoWithReflection is for non-IDL scenario.
 // It makes use of reflection to extract method parameters information and create ServiceInfo.
 // As a result, Server could use this ServiceInfo to register.
 func createServiceInfoWithReflection(svc common.RPCService) *common.ServiceInfo {
@@ -761,7 +757,7 @@ func createServiceInfoWithReflection(svc common.RPCService) *common.ServiceInfo 
 // buildMethodInfoWithReflection creates MethodInfo for a single method using reflection.
 func buildMethodInfoWithReflection(methodType reflect.Method) *common.MethodInfo {
 	paramsNum := methodType.Type.NumIn()
-	// the first param is receiver itself, the second param is ctx
+	// The first param is receiver itself, the second param is ctx
 	if paramsNum < 2 {
 		logger.Fatalf("[Triple][Server] triple does not support %s method that does not have any parameter", methodType.Name)
 		return nil
@@ -775,7 +771,7 @@ func buildMethodInfoWithReflection(methodType reflect.Method) *common.MethodInfo
 
 	// Extract return types for OpenAPI schema generation.
 	// Only record response.type when the signature is a reliable unary shape:
-	// exactly 2 return values where the second implements error.
+	// Exactly 2 return values where the second implements error.
 	// This avoids:
 	//   - methods returning only error getting a synthetic response type
 	//   - non-standard signatures producing misleading OpenAPI schemas
@@ -802,7 +798,7 @@ func buildMethodInfoWithReflection(methodType reflect.Method) *common.MethodInfo
 	method := methodType
 	return &common.MethodInfo{
 		Name: methodType.Name,
-		Type: constant.CallUnary, // only support Unary invocation now
+		Type: constant.CallUnary, // Only support Unary invocation now
 		Meta: meta,
 		ReqInitFunc: func() any {
 			params := make([]any, len(paramsTypes))
@@ -824,9 +820,9 @@ func buildGenericMethodInfo() common.MethodInfo {
 		Type: constant.CallUnary,
 		ReqInitFunc: func() any {
 			return []any{
-				func(s string) *string { return &s }(""), // methodName *string
-				&[]string{},                              // types *[]string
-				&[]hessian.Object{},                      // args *[]hessian.Object
+				func(s string) *string { return &s }(""), // MethodName *string
+				&[]string{},                              // Types *[]string
+				&[]hessian.Object{},                      // Args *[]hessian.Object
 			}
 		},
 	}

--- a/protocol/triple/triple_protocol/handler.go
+++ b/protocol/triple/triple_protocol/handler.go
@@ -35,7 +35,7 @@ const (
 // standard library's [compress/gzip].
 type Handler struct {
 	spec Spec
-	// key is group/version
+	// Key is group/version
 	implementations  map[string]StreamingHandlerFunc
 	protocolHandlers []protocolHandler
 	allowMethod      string      // Allow header
@@ -74,7 +74,7 @@ func generateUnaryHandlerFunc(
 ) StreamingHandlerFunc {
 	// Wrap the strongly-typed implementation so we can apply interceptors.
 	untyped := UnaryHandlerFunc(func(ctx context.Context, request AnyRequest) (AnyResponse, error) {
-		// verify err
+		// Verify err
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
@@ -90,30 +90,30 @@ func generateUnaryHandlerFunc(
 		}
 		return res, err
 	})
-	// todo: modify server func
+	// TODO: modify server func
 	if interceptor != nil {
 		untyped = interceptor.WrapUnaryHandler(untyped)
 	}
-	// receive and send
-	// conn should be responsible for marshal and unmarshal
+	// Receive and send
+	// Conn should be responsible for marshal and unmarshal
 	// Given a stream, how should we call the unary function?
 	implementation := func(ctx context.Context, conn StreamingHandlerConn) error {
 		req := reqInitFunc()
 		if err := conn.Receive(req); err != nil {
 			return err
 		}
-		// wrap the specific msg
+		// Wrap the specific msg
 		request := NewRequest(req)
 		request.spec = conn.Spec()
 		request.peer = conn.Peer()
 		request.header = conn.RequestHeader()
-		// embed header in context so that user logic could process them via FromIncomingContext
+		// Embed header in context so that user logic could process them via FromIncomingContext
 		ctx = newIncomingContext(ctx, conn.RequestHeader())
 		ctx = context.WithValue(ctx, handlerOutgoingKey{}, conn)
 
 		response, err := untyped(ctx, request)
 
-		//Write the server-side return-attachment-data in the tailer to send to the caller
+		// Write the server-side return-attachment-data in the trailer to send to the caller
 		if data := ExtractFromOutgoingContext(ctx); data != nil {
 			mergeHeaders(conn.ResponseTrailer(), data)
 		}
@@ -122,7 +122,7 @@ func generateUnaryHandlerFunc(
 			return err
 		}
 
-		// merge headers
+		// Merge headers
 		mergeHeaders(conn.ResponseHeader(), response.Header())
 		mergeHeaders(conn.ResponseTrailer(), response.Trailer())
 		return conn.Send(response.Any())
@@ -161,7 +161,7 @@ func generateClientStreamHandlerFunc(
 ) StreamingHandlerFunc {
 	implementation := func(ctx context.Context, conn StreamingHandlerConn) error {
 		stream := &ClientStream{conn: conn}
-		// embed header in context so that user logic could process them via FromIncomingContext
+		// Embed header in context so that user logic could process them via FromIncomingContext
 		ctx = newIncomingContext(ctx, conn.RequestHeader())
 		res, err := streamFunc(ctx, stream)
 
@@ -224,7 +224,7 @@ func generateServerStreamHandlerFunc(
 		if err := conn.Receive(req); err != nil {
 			return err
 		}
-		// embed header in context so that user logic could process them via FromIncomingContext
+		// Embed header in context so that user logic could process them via FromIncomingContext
 		ctx = newIncomingContext(ctx, conn.RequestHeader())
 		err := streamFunc(
 			ctx,
@@ -280,7 +280,7 @@ func generateBidiStreamHandlerFunc(
 	interceptor Interceptor,
 ) StreamingHandlerFunc {
 	implementation := func(ctx context.Context, conn StreamingHandlerConn) error {
-		// embed header in context so that user logic could process them via FromIncomingContext
+		// Embed header in context so that user logic could process them via FromIncomingContext
 		ctx = newIncomingContext(ctx, conn.RequestHeader())
 		err := streamFunc(ctx, &BidiStream{conn: conn})
 		if err != nil {
@@ -325,7 +325,7 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 		}
 	}
 
-	// inspect headers
+	// Inspect headers
 	var protocolHandlers []protocolHandler
 	for _, handler := range h.protocolHandlers {
 		if _, ok := handler.Methods()[request.Method]; ok {
@@ -341,7 +341,7 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 
 	contentType := canonicalizeContentType(getHeaderCanonical(request.Header, headerContentType))
 
-	// inspect contentType
+	// Inspect contentType
 	// Find our implementation of the RPC protocol in use.
 	var protocolHdl protocolHandler
 	for _, handler := range protocolHandlers {
@@ -358,7 +358,7 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 
 	// Establish a stream and serve the RPC.
 	setHeaderCanonical(request.Header, headerContentType, contentType)
-	// process context
+	// Process context
 	ctx, cancel, timeoutErr := protocolHdl.SetTimeout(request) //nolint: contextcheck
 	if timeoutErr != nil {
 		ctx = request.Context()
@@ -366,7 +366,7 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 	if cancel != nil {
 		defer cancel()
 	}
-	// create stream
+	// Create stream
 	connCloser, ok := protocolHdl.NewConn(
 		responseWriter,
 		request.WithContext(ctx),
@@ -381,10 +381,10 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 		return
 	}
 
-	// invoke implementation
+	// Invoke implementation
 	svcGroup := request.Header.Get(tripleServiceGroup)
 	svcVersion := request.Header.Get(tripleServiceVersion)
-	// todo(DMwangnima): inspect ok
+	// TODO(DMwangnima): inspect ok
 	implementation, ok := h.implementations[getIdentifier(svcGroup, svcVersion)]
 	if !ok {
 		_ = connCloser.Close(errorf(CodeUnimplemented, "no implementation found for service group %s and service version %s", svcGroup, svcVersion))
@@ -441,7 +441,7 @@ func (c *handlerConfig) newSpec(streamType StreamType) Spec {
 }
 
 func (c *handlerConfig) newProtocolHandlers(streamType StreamType) []protocolHandler {
-	// initialize protocol
+	// Initialize protocol
 	var protocols []protocol
 	if streamType == StreamTypeUnary {
 		protocols = append(protocols, &protocolTriple{})
@@ -449,9 +449,9 @@ func (c *handlerConfig) newProtocolHandlers(streamType StreamType) []protocolHan
 	if c.HandleGRPC {
 		protocols = append(protocols, &protocolGRPC{})
 	}
-	// protocol -> protocolHandler
+	// Protocol -> protocolHandler
 	handlers := make([]protocolHandler, 0, len(protocols))
-	// initialize codec and compressor
+	// Initialize codec and compressor
 	compressors := newReadOnlyCompressionPools(
 		c.CompressionPools,
 		c.CompressionNames,
@@ -464,7 +464,7 @@ func (c *handlerConfig) newProtocolHandlers(streamType StreamType) []protocolHan
 			Codecs:            codecs,
 			CompressionPools:  compressors,
 			FallbackCodecName: c.FallbackCodecName,
-			// config content
+			// Config content
 			CompressMinBytes:            c.CompressMinBytes,
 			BufferPool:                  c.BufferPool,
 			ReadMaxBytes:                c.ReadMaxBytes,


### PR DESCRIPTION
### Description
Fixes #3598 (task 24)
Unify the comment style in the Triple mainline( protocol/triple/client.go ,  protocol/triple/server.go ,
protocol/triple/triple_protocol/handler.go ). This is a comment-only change with no behavior impact.
### Changes
- Remove stale and duplicate draft TODOs: two dangling client TODOs
  (already implemented), a duplicated opentracing TODO, and a TODO
  referencing the non-existent handleService.
- Fix a malformed TODO: // todo:// open tracing -> // TODO: support OpenTracing.
- Rewrite the "Enrich http2/http3 transport config" TODOs into real transport config descriptions.
- Comment capitalization: capitalize the first letter of inline comments
(including end-of-line comments) across the three files.
- TODO capitalization: normalize todo to all-caps TODO with a colon,
  keeping author tags (e.g. TODO(DMwangnima):).
- Term capitalization: idl -> IDL, tls -> TLS, opentracing -> OpenTracing.
- Comment formatting fixes: missing space after //,
  tailer -> trailer typo, and consistent Compatibility: notes.
### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [ ] I have added tests that prove my fix is effective or that my feature works
