### PR TITLE
Feat: Add ZK config cache

### DIFF
--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -261,6 +261,7 @@ const (
 	ConfigSecretKey           = "config-center.secret"
 	ConfigBackupConfigKey     = "config-center.isBackupConfig"
 	ConfigBackupConfigPathKey = "config-center.backupConfigPath"
+	ConfigCacheTTLKey         = "config-center.cache-ttl"
 	ConfigRootPathParamKey    = "dubbo.config-center.root-path"
 )
 

--- a/config_center/zookeeper/config_cache.go
+++ b/config_center/zookeeper/config_cache.go
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zookeeper
+
+import (
+	"sync"
+	"time"
+)
+
+type configCacheEntry struct {
+	content   string
+	exists    bool
+	expiresAt time.Time
+}
+
+type configCache struct {
+	ttl time.Duration
+
+	stateLock  sync.RWMutex
+	entries    map[string]configCacheEntry
+	watches    map[string]bool
+	generation uint64
+
+	pathLocks sync.Map
+}
+
+func newConfigCache(ttl time.Duration) configCache {
+	return configCache{
+		ttl:     ttl,
+		entries: make(map[string]configCacheEntry),
+		watches: make(map[string]bool),
+	}
+}
+
+func (c *configCache) enabled() bool {
+	return c.ttl > 0
+}
+
+func (c *configCache) load(path string, loader func(bool) (configCacheEntry, bool, error)) (configCacheEntry, error) {
+	if !c.enabled() {
+		entry, _, err := loader(false)
+		return entry, err
+	}
+	if entry, ok := c.getFresh(path); ok {
+		return entry, nil
+	}
+
+	pathLock := c.pathLock(path)
+	pathLock.Lock()
+	defer pathLock.Unlock()
+
+	for {
+		if entry, ok := c.getFresh(path); ok {
+			return entry, nil
+		}
+
+		generation, watchActive := c.snapshot(path)
+		entry, nextWatchActive, err := loader(watchActive)
+		if err != nil {
+			if !c.storeWatchState(path, generation, nextWatchActive) {
+				continue
+			}
+			return configCacheEntry{}, err
+		}
+		if !c.storeLoad(path, generation, entry, nextWatchActive) {
+			continue
+		}
+		return entry, nil
+	}
+}
+
+func (c *configCache) store(path string, entry configCacheEntry) {
+	if !c.enabled() {
+		return
+	}
+	pathLock := c.pathLock(path)
+	pathLock.Lock()
+	defer pathLock.Unlock()
+
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+	c.storeEntryLocked(path, entry)
+}
+
+func (c *configCache) storeAtGeneration(path string, generation uint64, entry configCacheEntry) {
+	if !c.enabled() {
+		return
+	}
+	pathLock := c.pathLock(path)
+	pathLock.Lock()
+	defer pathLock.Unlock()
+
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+	if c.generation == generation {
+		c.storeEntryLocked(path, entry)
+	}
+}
+
+func (c *configCache) getFresh(path string) (configCacheEntry, bool) {
+	c.stateLock.RLock()
+	defer c.stateLock.RUnlock()
+
+	entry, ok := c.entries[path]
+	if !ok {
+		return configCacheEntry{}, false
+	}
+	return entry, entry.expiresAt.After(time.Now())
+}
+
+func (c *configCache) storeEntryLocked(path string, entry configCacheEntry) {
+	entry.expiresAt = time.Now().Add(c.ttl)
+	c.entries[path] = entry
+}
+
+func (c *configCache) snapshot(path string) (uint64, bool) {
+	c.stateLock.RLock()
+	defer c.stateLock.RUnlock()
+	return c.generation, c.watches[path]
+}
+
+func (c *configCache) isCurrentGeneration(generation uint64) bool {
+	c.stateLock.RLock()
+	defer c.stateLock.RUnlock()
+	return c.generation == generation
+}
+
+func (c *configCache) storeLoad(path string, generation uint64, entry configCacheEntry, watchActive bool) bool {
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+	if c.generation != generation {
+		return false
+	}
+
+	c.storeEntryLocked(path, entry)
+	c.setWatchActiveLocked(path, watchActive)
+	return true
+}
+
+func (c *configCache) storeWatchState(path string, generation uint64, watchActive bool) bool {
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+	if c.generation != generation {
+		return false
+	}
+	c.setWatchActiveLocked(path, watchActive)
+	return true
+}
+
+func (c *configCache) setWatchActive(path string, active bool) {
+	if !c.enabled() {
+		return
+	}
+	pathLock := c.pathLock(path)
+	pathLock.Lock()
+	defer pathLock.Unlock()
+
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+	c.setWatchActiveLocked(path, active)
+}
+
+func (c *configCache) setWatchActiveAtGeneration(path string, generation uint64, active bool) {
+	if !c.enabled() {
+		return
+	}
+	pathLock := c.pathLock(path)
+	pathLock.Lock()
+	defer pathLock.Unlock()
+	c.storeWatchState(path, generation, active)
+}
+
+func (c *configCache) setWatchActiveLocked(path string, active bool) {
+	if active {
+		c.watches[path] = true
+		return
+	}
+	delete(c.watches, path)
+}
+
+func (c *configCache) ensureWatch(path string, register func() error) error {
+	if !c.enabled() {
+		return register()
+	}
+	pathLock := c.pathLock(path)
+	pathLock.Lock()
+	defer pathLock.Unlock()
+
+	for {
+		generation, active := c.snapshot(path)
+		if active {
+			return nil
+		}
+		if err := register(); err != nil {
+			if !c.isCurrentGeneration(generation) {
+				continue
+			}
+			return err
+		}
+
+		c.stateLock.Lock()
+		if c.generation == generation {
+			c.watches[path] = true
+			c.stateLock.Unlock()
+			return nil
+		}
+		c.stateLock.Unlock()
+	}
+}
+
+func (c *configCache) reset() {
+	c.stateLock.Lock()
+	defer c.stateLock.Unlock()
+	c.generation++
+	c.entries = make(map[string]configCacheEntry)
+	c.watches = make(map[string]bool)
+}
+
+func (c *configCache) pathLock(path string) *sync.Mutex {
+	lock, _ := c.pathLocks.LoadOrStore(path, &sync.Mutex{})
+	return lock.(*sync.Mutex)
+}

--- a/config_center/zookeeper/config_cache_test.go
+++ b/config_center/zookeeper/config_cache_test.go
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package zookeeper
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigCacheLoadAndExpiry(t *testing.T) {
+	cache := newConfigCache(20 * time.Millisecond)
+	var loads atomic.Int32
+	var watchStates []bool
+	loader := func(watchActive bool) (configCacheEntry, bool, error) {
+		watchStates = append(watchStates, watchActive)
+		count := loads.Add(1)
+		return configCacheEntry{content: string(rune('0' + count)), exists: true}, true, nil
+	}
+
+	first, err := cache.load("/path", loader)
+	require.NoError(t, err)
+	second, err := cache.load("/path", loader)
+	require.NoError(t, err)
+	require.Equal(t, first.content, second.content)
+	require.Equal(t, int32(1), loads.Load())
+
+	require.Eventually(t, func() bool {
+		entry, loadErr := cache.load("/path", loader)
+		return loadErr == nil && entry.content == "2"
+	}, time.Second, 5*time.Millisecond)
+	require.Equal(t, int32(2), loads.Load())
+	require.Equal(t, []bool{false, true}, watchStates)
+
+	readErr := errors.New("read failed after watch registration")
+	_, err = cache.load("/error", func(bool) (configCacheEntry, bool, error) {
+		return configCacheEntry{}, true, readErr
+	})
+	require.ErrorIs(t, err, readErr)
+	_, watchActive := cache.snapshot("/error")
+	require.True(t, watchActive)
+}
+
+func TestConfigCacheWatchUpdateWinsOverLoad(t *testing.T) {
+	cache := newConfigCache(time.Minute)
+	loadStarted := make(chan struct{})
+	releaseLoad := make(chan struct{})
+	loadDone := make(chan struct{})
+	go func() {
+		defer close(loadDone)
+		_, _ = cache.load("/path", func(bool) (configCacheEntry, bool, error) {
+			close(loadStarted)
+			<-releaseLoad
+			return configCacheEntry{content: "old", exists: true}, true, nil
+		})
+	}()
+
+	<-loadStarted
+	updateDone := make(chan struct{})
+	go func() {
+		defer close(updateDone)
+		cache.store("/path", configCacheEntry{content: "new", exists: true})
+	}()
+	close(releaseLoad)
+	<-loadDone
+	<-updateDone
+
+	entry, ok := cache.getFresh("/path")
+	require.True(t, ok)
+	require.Equal(t, "new", entry.content)
+}
+
+func TestConfigCacheResetDiscardsInFlightLoad(t *testing.T) {
+	cache := newConfigCache(time.Minute)
+	cache.setWatchActive("/path", true)
+	loadStarted := make(chan struct{})
+	releaseLoad := make(chan struct{})
+	result := make(chan configCacheEntry, 1)
+	var loads atomic.Int32
+
+	go func() {
+		entry, _ := cache.load("/path", func(bool) (configCacheEntry, bool, error) {
+			if loads.Add(1) == 1 {
+				close(loadStarted)
+				<-releaseLoad
+				return configCacheEntry{content: "old", exists: true}, true, nil
+			}
+			return configCacheEntry{content: "new", exists: true}, true, nil
+		})
+		result <- entry
+	}()
+
+	<-loadStarted
+	cache.reset()
+	_, ok := cache.getFresh("/path")
+	require.False(t, ok)
+	_, watchActive := cache.snapshot("/path")
+	require.False(t, watchActive)
+	close(releaseLoad)
+
+	require.Equal(t, "new", (<-result).content)
+	require.Equal(t, int32(2), loads.Load())
+	entry, ok := cache.getFresh("/path")
+	require.True(t, ok)
+	require.Equal(t, "new", entry.content)
+}

--- a/config_center/zookeeper/impl.go
+++ b/config_center/zookeeper/impl.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"time"
 )
 
 import (
@@ -45,7 +46,8 @@ import (
 )
 
 const (
-	pathSeparator = "/"
+	pathSeparator         = "/"
+	defaultConfigCacheTTL = 30 * time.Second
 )
 
 type zookeeperDynamicConfiguration struct {
@@ -60,6 +62,7 @@ type zookeeperDynamicConfiguration struct {
 	// listenerLock  sync.Mutex
 	listener      *zookeeper.ZkEventListener
 	cacheListener *CacheListener
+	cache         configCache
 	parser        parser.ConfigurationParser
 
 	base64Enabled bool
@@ -67,9 +70,14 @@ type zookeeperDynamicConfiguration struct {
 
 func newZookeeperDynamicConfiguration(url *common.URL) (*zookeeperDynamicConfiguration, error) {
 	rootPath := url.GetParam(constant.ConfigRootPathParamKey, "/dubbo/config")
+	cacheTTL, err := parseConfigCacheTTL(url.GetParam(constant.ConfigCacheTTLKey, ""))
+	if err != nil {
+		return nil, err
+	}
 	c := &zookeeperDynamicConfiguration{
 		url:      url,
 		rootPath: rootPath,
+		cache:    newConfigCache(cacheTTL),
 	}
 	logger.Infof("[ConfigCenter][Zookeeper] new Zookeeper ConfigCenter with Configuration, zkConfig=%v url=%v", c, c.GetURL())
 	if v := url.GetParam("base64", ""); v != "" {
@@ -80,7 +88,7 @@ func newZookeeperDynamicConfiguration(url *common.URL) (*zookeeperDynamicConfigu
 		c.base64Enabled = base64Enabled
 	}
 
-	err := zookeeper.ValidateZookeeperClient(c, url.Location)
+	err = zookeeper.ValidateZookeeperClient(c, url.Location)
 	if err != nil {
 		logger.Errorf("[ConfigCenter][Zookeeper] zookeeper client start error, err=%v", err)
 		return nil, err
@@ -96,7 +104,7 @@ func newZookeeperDynamicConfiguration(url *common.URL) (*zookeeperDynamicConfigu
 
 	// Start listener
 	c.listener = zookeeper.NewZkEventListener(c.client)
-	c.cacheListener = NewCacheListener(c.rootPath, c.listener)
+	c.cacheListener = newCacheListener(c.rootPath, c.listener, &c.cache)
 	c.listener.ListenConfigurationEvent(c.rootPath, c.cacheListener)
 	return c, nil
 }
@@ -124,6 +132,28 @@ func (c *zookeeperDynamicConfiguration) RemoveListener(key string, listener conf
 }
 
 func (c *zookeeperDynamicConfiguration) GetProperties(key string, opts ...config_center.Option) (string, error) {
+	path := c.getPropertiesPath(key, opts...)
+	entry, err := c.cache.load(path, func(watchActive bool) (configCacheEntry, bool, error) {
+		return c.loadProperties(path, watchActive)
+	})
+	if err != nil {
+		return "", err
+	}
+	if !entry.exists {
+		return "", nil
+	}
+	if !c.base64Enabled {
+		return entry.content, nil
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(entry.content)
+	if err != nil {
+		return "", perrors.WithStack(err)
+	}
+	return string(decoded), nil
+}
+
+func (c *zookeeperDynamicConfiguration) getPropertiesPath(key string, opts ...config_center.Option) string {
 	tmpOpts := config_center.NewOptions(opts...)
 	/**
 	 * when group is not null, we are getting startup configs from Config Center, for example:
@@ -134,23 +164,63 @@ func (c *zookeeperDynamicConfiguration) GetProperties(key string, opts ...config
 	} else {
 		key = c.GetURL().GetParam(constant.ConfigNamespaceKey, config_center.DefaultGroup) + "/" + key
 	}
-	content, _, err := c.client.GetContent(c.rootPath + "/" + key)
-	if errors.Is(err, zk.ErrNoNode) {
-		logger.Warnf("[ConfigCenter][Zookeeper] query rule fail, key=%s err=%v", key, err)
-		return "", nil
-	}
-	if err != nil {
-		return "", perrors.WithStack(err)
-	}
-	if !c.base64Enabled {
-		return string(content), nil
+	return buildPath(c.rootPath, key)
+}
+
+func (c *zookeeperDynamicConfiguration) loadProperties(path string, watchActive bool) (configCacheEntry, bool, error) {
+	if !c.cache.enabled() || watchActive {
+		content, _, err := c.client.GetContent(path)
+		if errors.Is(err, zk.ErrNoNode) {
+			logger.Warnf("[ConfigCenter][Zookeeper] query rule fail, key=%s err=%v", path, err)
+			return configCacheEntry{exists: false}, watchActive, nil
+		}
+		if err != nil {
+			return configCacheEntry{}, watchActive, perrors.WithStack(err)
+		}
+		return configCacheEntry{content: string(content), exists: true}, watchActive, nil
 	}
 
-	decoded, err := base64.StdEncoding.DecodeString(string(content))
-	if err != nil {
-		return "", perrors.WithStack(err)
+	for {
+		content, _, _, err := c.client.Conn.GetW(path)
+		if err == nil {
+			return configCacheEntry{content: string(content), exists: true}, true, nil
+		}
+		if !errors.Is(err, zk.ErrNoNode) {
+			return configCacheEntry{}, false, perrors.WithStack(err)
+		}
+
+		exists, _, _, watchErr := c.client.Conn.ExistsW(path)
+		if watchErr != nil {
+			return configCacheEntry{}, false, perrors.WithStack(watchErr)
+		}
+		if !exists {
+			logger.Warnf("[ConfigCenter][Zookeeper] query rule fail, key=%s err=%v", path, err)
+			return configCacheEntry{exists: false}, true, nil
+		}
+
+		content, _, getErr := c.client.Conn.Get(path)
+		if errors.Is(getErr, zk.ErrNoNode) {
+			continue
+		}
+		if getErr != nil {
+			return configCacheEntry{}, true, perrors.WithStack(getErr)
+		}
+		return configCacheEntry{content: string(content), exists: true}, true, nil
 	}
-	return string(decoded), nil
+}
+
+func parseConfigCacheTTL(value string) (time.Duration, error) {
+	if value == "" {
+		return defaultConfigCacheTTL, nil
+	}
+	ttl, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, perrors.Wrapf(err, "invalid %s value %q", constant.ConfigCacheTTLKey, value)
+	}
+	if ttl < 0 {
+		return 0, perrors.Errorf("%s must not be negative", constant.ConfigCacheTTLKey)
+	}
+	return ttl, nil
 }
 
 // GetInternalProperty For zookeeper, getConfig and getConfigs have the same meaning.
@@ -274,6 +344,7 @@ func (c *zookeeperDynamicConfiguration) closeConfigs() {
 }
 
 func (c *zookeeperDynamicConfiguration) RestartCallBack() bool {
+	c.cache.reset()
 	return true
 }
 

--- a/config_center/zookeeper/impl_test.go
+++ b/config_center/zookeeper/impl_test.go
@@ -18,20 +18,18 @@
 package zookeeper
 
 import (
+	"encoding/base64"
 	"testing"
-)
+	"time"
 
-import (
 	"github.com/dubbogo/go-zookeeper/zk"
 
-	gxzookeeper "github.com/dubbogo/gost/database/kv/zk"
-
-	"github.com/stretchr/testify/require"
-)
-
-import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/config_center"
+	gxzookeeper "github.com/dubbogo/gost/database/kv/zk"
+	"github.com/stretchr/testify/require"
+
+	remotingzookeeper "dubbo.apache.org/dubbo-go/v3/remoting/zookeeper"
 )
 
 func TestBuildPath(t *testing.T) {
@@ -124,6 +122,133 @@ func TestGetPropertiesWithMockZk(t *testing.T) {
 	empty, err := cfg.GetProperties("missing", config_center.WithGroup("grp"))
 	require.NoError(t, err)
 	require.Empty(t, empty)
+}
+
+func TestLoadPropertiesRegistersWatchOnlyWhenInactive(t *testing.T) {
+	cluster, client, events, err := gxzookeeper.NewMockZookeeperClient("watch-selection", 5*time.Second)
+	if err != nil {
+		t.Skipf("skip mock zk setup: %v", err)
+	}
+	defer cluster.Stop()
+
+	cfg := &zookeeperDynamicConfiguration{
+		rootPath: "/dubbo/config",
+		client:   client,
+		url:      mustURL(t, "registry://127.0.0.1:2181"),
+		cache:    newConfigCache(time.Minute),
+	}
+	activePath := cfg.getPath("active", "group")
+	inactivePath := cfg.getPath("inactive", "group")
+	require.NoError(t, cfg.PublishConfig("active", "group", "v1"))
+	require.NoError(t, cfg.PublishConfig("inactive", "group", "v1"))
+
+	waitForEvent := func(path string, timeout time.Duration) bool {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		for {
+			select {
+			case event := <-events:
+				if event.Path == path && event.Type == zk.EventNodeDataChanged {
+					return true
+				}
+			case <-timer.C:
+				return false
+			}
+		}
+	}
+
+	_, watchActive, err := cfg.loadProperties(activePath, true)
+	require.NoError(t, err)
+	require.True(t, watchActive)
+	_, stat, err := client.GetContent(activePath)
+	require.NoError(t, err)
+	_, err = client.SetContent(activePath, []byte("v2"), stat.Version)
+	require.NoError(t, err)
+	require.False(t, waitForEvent(activePath, time.Second))
+
+	_, watchActive, err = cfg.loadProperties(inactivePath, false)
+	require.NoError(t, err)
+	require.True(t, watchActive)
+	_, stat, err = client.GetContent(inactivePath)
+	require.NoError(t, err)
+	_, err = client.SetContent(inactivePath, []byte("v2"), stat.Version)
+	require.NoError(t, err)
+	require.True(t, waitForEvent(inactivePath, time.Second))
+}
+
+func TestGetPropertiesCacheUpdatedByWatch(t *testing.T) {
+	cluster, client, _, err := gxzookeeper.NewMockZookeeperClient("cache-watch", 5*time.Second)
+	if err != nil {
+		t.Skipf("skip mock zk setup: %v", err)
+	}
+	defer cluster.Stop()
+	go (&gxzookeeper.DefaultHandler{}).HandleZkEvent(client)
+
+	cfg := &zookeeperDynamicConfiguration{
+		rootPath: "/dubbo/config",
+		client:   client,
+		done:     make(chan struct{}),
+		url:      mustURL(t, "registry://127.0.0.1:2181"),
+		cache:    newConfigCache(time.Minute),
+	}
+	cfg.listener = remotingzookeeper.NewZkEventListener(client)
+	cfg.cacheListener = newCacheListener(cfg.rootPath, cfg.listener, &cfg.cache)
+	cfg.listener.ListenConfigurationEvent(cfg.rootPath, cfg.cacheListener)
+	defer cfg.listener.Close()
+
+	require.NoError(t, cfg.PublishConfig("file.properties", "grp", "v1"))
+	value, err := cfg.GetProperties("file.properties", config_center.WithGroup("grp"))
+	require.NoError(t, err)
+	require.Equal(t, "v1", value)
+
+	// ListenConfigurationEvent registers asynchronously; wait before triggering the watch.
+	time.Sleep(50 * time.Millisecond)
+	_, stat, err := client.GetContent("/dubbo/config/grp/file.properties")
+	require.NoError(t, err)
+	_, err = client.SetContent("/dubbo/config/grp/file.properties", []byte("v2"), stat.Version)
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		value, getErr := cfg.GetProperties("file.properties", config_center.WithGroup("grp"))
+		return getErr == nil && value == "v2"
+	}, time.Second, 10*time.Millisecond)
+
+	require.NoError(t, cfg.RemoveConfig("file.properties", "grp"))
+	require.Eventually(t, func() bool {
+		entry, ok := cfg.cache.getFresh("/dubbo/config/grp/file.properties")
+		return ok && !entry.exists
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestGetPropertiesDecodesCachedBase64(t *testing.T) {
+	cfg := &zookeeperDynamicConfiguration{
+		rootPath:      "/dubbo/config",
+		url:           mustURL(t, "registry://127.0.0.1:2181"),
+		cache:         newConfigCache(time.Minute),
+		base64Enabled: true,
+	}
+	path := cfg.getPropertiesPath("key", config_center.WithGroup("group"))
+	cfg.cache.store(path, configCacheEntry{
+		content: base64.StdEncoding.EncodeToString([]byte("value")),
+		exists:  true,
+	})
+
+	value, err := cfg.GetProperties("key", config_center.WithGroup("group"))
+	require.NoError(t, err)
+	require.Equal(t, "value", value)
+}
+
+func TestRestartCallBackResetsCache(t *testing.T) {
+	cfg := &zookeeperDynamicConfiguration{cache: newConfigCache(time.Minute)}
+	path := "/dubbo/config/group/key"
+	cfg.cache.store(path, configCacheEntry{content: "value", exists: true})
+	cfg.cache.setWatchActive(path, true)
+
+	require.True(t, cfg.RestartCallBack())
+	_, ok := cfg.cache.getFresh(path)
+	require.False(t, ok)
+	_, watchActive := cfg.cache.snapshot(path)
+	require.False(t, watchActive)
 }
 
 func mustURL(t *testing.T, raw string) *common.URL {

--- a/config_center/zookeeper/listener.go
+++ b/config_center/zookeeper/listener.go
@@ -35,19 +35,34 @@ import (
 type CacheListener struct {
 	// key is zkNode Path and value is set of listeners
 	keyListeners    sync.Map
+	eventGeneration sync.Map
 	zkEventListener *zookeeper.ZkEventListener
 	rootPath        string
+	cache           *configCache
 }
 
 // NewCacheListener creates a new CacheListener
 func NewCacheListener(rootPath string, listener *zookeeper.ZkEventListener) *CacheListener {
-	return &CacheListener{zkEventListener: listener, rootPath: rootPath}
+	return newCacheListener(rootPath, listener, nil)
+}
+
+func newCacheListener(rootPath string, listener *zookeeper.ZkEventListener, cache *configCache) *CacheListener {
+	return &CacheListener{zkEventListener: listener, rootPath: rootPath, cache: cache}
 }
 
 // AddListener will add a listener if loaded
 func (l *CacheListener) AddListener(key string, listener config_center.ConfigurationListener) {
 	// FIXME do not use Client.ExistW, cause it has a bug(can not watch zk node that do not exist)
-	_, _, _, err := l.zkEventListener.Client.Conn.ExistsW(key)
+	register := func() error {
+		_, _, _, err := l.zkEventListener.Client.Conn.ExistsW(key)
+		return err
+	}
+	var err error
+	if l.cache == nil {
+		err = register()
+	} else {
+		err = l.cache.ensureWatch(key, register)
+	}
 	// reference from https://stackoverflow.com/questions/34018908/golang-why-dont-we-have-a-set-datastructure
 	// make a map[your type]struct{} like set in java
 	if err != nil {
@@ -60,6 +75,24 @@ func (l *CacheListener) AddListener(key string, listener config_center.Configura
 	}
 }
 
+// WatchStateChanged updates the cache's concrete-path watch state.
+func (l *CacheListener) WatchStateChanged(path string, active bool) {
+	if l.cache == nil {
+		return
+	}
+	if !active {
+		generation, _ := l.cache.snapshot(path)
+		l.eventGeneration.Store(path, generation)
+		l.cache.setWatchActiveAtGeneration(path, generation, false)
+		return
+	}
+	if generation, ok := l.eventGeneration.Load(path); ok {
+		l.cache.setWatchActiveAtGeneration(path, generation.(uint64), true)
+		return
+	}
+	l.cache.setWatchActive(path, true)
+}
+
 // RemoveListener will delete a listener if loaded
 func (l *CacheListener) RemoveListener(key string, listener config_center.ConfigurationListener) {
 	listeners, loaded := l.keyListeners.Load(key)
@@ -70,6 +103,18 @@ func (l *CacheListener) RemoveListener(key string, listener config_center.Config
 
 // DataChange changes all listeners' event
 func (l *CacheListener) DataChange(event remoting.Event) bool {
+	if l.cache != nil {
+		entry := configCacheEntry{content: event.Content, exists: true}
+		if event.Action == remoting.EventTypeDel {
+			entry = configCacheEntry{exists: false}
+		}
+		if generation, ok := l.eventGeneration.LoadAndDelete(event.Path); ok {
+			l.cache.storeAtGeneration(event.Path, generation.(uint64), entry)
+		} else {
+			l.cache.store(event.Path, entry)
+		}
+	}
+
 	changeType := event.Action
 	if event.Content == "" {
 		changeType = remoting.EventTypeDel

--- a/config_center/zookeeper/listener_test.go
+++ b/config_center/zookeeper/listener_test.go
@@ -19,9 +19,12 @@ package zookeeper
 
 import (
 	"testing"
+	"time"
 )
 
 import (
+	"github.com/stretchr/testify/require"
+
 	"dubbo.apache.org/dubbo-go/v3/config_center"
 	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
@@ -50,7 +53,8 @@ func TestCacheListenerDataChange(t *testing.T) {
 }
 
 func TestCacheListenerDataChangeEmptyContent(t *testing.T) {
-	l := &CacheListener{rootPath: "/dubbo/config"}
+	cache := newConfigCache(time.Minute)
+	l := &CacheListener{rootPath: "/dubbo/config", cache: &cache}
 	path := "/dubbo/config/group/app"
 	rec := &recListener{}
 	l.keyListeners.Store(path, map[config_center.ConfigurationListener]struct{}{rec: {}})
@@ -61,6 +65,48 @@ func TestCacheListenerDataChangeEmptyContent(t *testing.T) {
 	}
 	if len(rec.events) != 1 || rec.events[0].ConfigType != remoting.EventTypeDel {
 		t.Fatalf("unexpected events %+v", rec.events)
+	}
+	entry, ok := cache.getFresh(path)
+	if !ok || !entry.exists || entry.content != "" {
+		t.Fatalf("empty configuration should be cached as existing: %+v", entry)
+	}
+
+	l.DataChange(remoting.Event{Path: path, Action: remoting.EventTypeDel})
+	entry, ok = cache.getFresh(path)
+	if !ok || entry.exists {
+		t.Fatalf("deleted configuration should be cached as missing: %+v", entry)
+	}
+}
+
+func TestCacheListenerIgnoresEventAcrossReset(t *testing.T) {
+	cache := newConfigCache(time.Minute)
+	l := &CacheListener{rootPath: "/dubbo/config", cache: &cache}
+	path := "/dubbo/config/group/app"
+	pathLock := cache.pathLock(path)
+	pathLock.Lock()
+	watchStateDone := make(chan struct{})
+	go func() {
+		l.WatchStateChanged(path, false)
+		close(watchStateDone)
+	}()
+	require.Eventually(t, func() bool {
+		_, ok := l.eventGeneration.Load(path)
+		return ok
+	}, time.Second, time.Millisecond)
+
+	cache.reset()
+	pathLock.Unlock()
+	<-watchStateDone
+	l.WatchStateChanged(path, true)
+	l.DataChange(remoting.Event{Path: path, Action: remoting.EventTypeUpdate, Content: "old"})
+
+	_, ok := cache.getFresh(path)
+	if ok {
+		t.Fatal("event started before reset should not repopulate cache")
+	}
+	_, watchActive := cache.snapshot(path)
+	if watchActive {
+		t.Fatal("event started before reset should not reactivate watch state")
 	}
 }
 

--- a/remoting/zookeeper/listener.go
+++ b/remoting/zookeeper/listener.go
@@ -56,6 +56,10 @@ type ZkEventListener struct {
 	exit        chan struct{}
 }
 
+type configurationWatchStateListener interface {
+	WatchStateChanged(path string, active bool)
+}
+
 // NewZkEventListener returns a EventListener instance
 func NewZkEventListener(client *gxzookeeper.ZookeeperClient) *ZkEventListener {
 	return &ZkEventListener{
@@ -86,25 +90,37 @@ func (l *ZkEventListener) ListenConfigurationEvent(zkPath string, listener remot
 	go func(zkPath string, listener remoting.DataListener) {
 		var eventChan = make(chan zk.Event, 16)
 		l.Client.RegisterEvent(zkPath, eventChan)
+		watchStateListener, tracksWatchState := listener.(configurationWatchStateListener)
 		for {
 			select {
 			case event := <-eventChan:
 				logger.Infof("[Remoting][Zookeeper]Receive configuration change event:%#v", event)
-				if event.Type == zk.EventNodeChildrenChanged || event.Type == zk.EventNotWatching {
+				if event.Type == zk.EventNotWatching {
+					if tracksWatchState {
+						watchStateListener.WatchStateChanged(event.Path, false)
+					}
 					continue
 				}
+				if event.Type == zk.EventNodeChildrenChanged {
+					continue
+				}
+				if tracksWatchState {
+					watchStateListener.WatchStateChanged(event.Path, false)
+				}
 				// 1. Re-set watcher for the zk node
-				_, _, _, err := l.Client.Conn.ExistsW(event.Path)
+				exists, _, _, err := l.Client.Conn.ExistsW(event.Path)
 				if err != nil {
 					logger.Warnf("[Remoting][Zookeeper]Re-set watcher error, err=%v", err)
 					continue
 				}
+				if tracksWatchState {
+					watchStateListener.WatchStateChanged(event.Path, true)
+				}
 
-				action := remoting.EventTypeAdd
+				action := remoting.EventTypeDel
 				var content string
-				if event.Type == zk.EventNodeDeleted {
-					action = remoting.EventTypeDel
-				} else {
+				if exists {
+					action = remoting.EventTypeAdd
 					// 2. Try to get new configuration value of the zk node
 					// Notice: The order of step 1 and step 2 cannot be swapped, if you get value(with timestamp t1)
 					// before re-set the watcher(with timestamp t2), and some one change the data of the zk node after


### PR DESCRIPTION
**What this PR does**:

This PR adds a read-through cache for the ZooKeeper Config Center to reduce repeated ZooKeeper reads from `GetProperties` and `GetInternalProperty`. The existing `CacheListener` updates or invalidates the cache when configuration change events are received.

Main changes:

1. Add a configuration cache. Cache keys use the full ZooKeeper path, including the group and namespace.
2. Add the `config-center.cache-ttl` configuration:
   - The default value is `30s`;
   - Setting it to `0` disables the cache;
   - Negative values and invalid duration formats are rejected.
3. Distinguish between:
   - An existing node with empty content;
   - A node that does not exist.
4. Read from ZooKeeper on a cache miss, selecting the read method based on the watch state:
   - Use ordinary `Get` when the watch is active;
   - Use `GetW` to read the data and register a data watch when the watch is inactive;
   - Use `ExistsW` to watch for node creation when the node does not exist.
5. Let `CacheListener` update the cache when add, update, and delete events are received:
   - Add/update events write the latest content to the cache and refresh the TTL;
   - Delete events cache the node as absent and refresh the TTL.
6. Add an `active` state to track whether the watch for a specific configuration path is still valid, preventing duplicate watch registration during TTL refreshes.
7. Clear the configuration cache and reset all watch states to inactive after a ZooKeeper reconnect. A generation counter prevents reads already in progress and old watch events from repopulating the cache after reconnection.
8. Fix group/option path handling in `AddListener` and `RemoveListener so that the read path, listener path, and listener removal path remain consistent.
9. Preserve the existing Base64 configuration behavior. Base64 decoding is still performed when a value is read from the cache.

This PR also adds tests covering cache behavior, TTL, watch-based updates, deletion, reconnect handling, generation isolation, and Base64 reads.

**Design options**:

This PR evaluated the following three approaches:

1. TTL-only caching

   Advantages:

   - Simple to implement;
   - Does not require maintaining watch state for individual configuration paths;
   - TTL limits the maximum cache lifetime.

   Disadvantages:

   - Configuration changes are not reflected in the cache immediately;
   - Old values may be returned until the TTL expires;
   - ZooKeeper still needs to be accessed periodically;
   - It cannot make use of the existing `CacheListener` change notifications.

2. Watch-driven caching only

   Advantages:

   - Cache updates can be applied promptly after configuration changes;
   - Under normal conditions, repeated ZooKeeper reads can be minimized.

   Disadvantages:

   - ZooKeeper watches are one-shot and must be continuously re-registered;
   - Watch registration failures, event content read-back failures, and reconnect scenarios are more complex;
   - If an event is missed or the watch state becomes unreliable, stale values may remain in the cache for an indefinite period;
   - Node absence, node creation, deletion, and rapid recreation must all be handled.

3. TTL plus watch-driven caching

   Advantages:

   - Normal configuration changes update the cache promptly through watch events;
   - TTL provides a fallback when watch registration fails, event content read-back fails, or the client reconnects;
   - Ordinary `Get` is used when the watch is active, avoiding duplicate watch registration;
   - `GetW`/`ExistsW` are used to re-establish the watch when it is inactive;
   - It is more responsive than the TTL-only approach and more resilient than the watch-only approach.

   Disadvantages:

   - The implementation needs to maintain both cache TTLs and per-path watch state;
   - Watch consumption, reconnects, and concurrent reads require additional lifecycle handling;
   - The implementation is more complex than the TTL-only approach.

The TTL plus watch-driven approach was selected because it satisfies all of the following goals:

- Reduce repeated ZooKeeper reads;
- Reflect configuration changes in the cache promptly;
- Fall back to ZooKeeper through TTL when the watch becomes invalid or fails;
- Reduce the risk of stale cache data after reconnects or event-processing failures.

**`active` state design**:

ZooKeeper watches are one-shot. After a configuration change is received, the existing watch is consumed. The cache therefore needs to know whether a valid watch still exists for each concrete configuration path.

- `active=true`: The path has a valid watch. When the TTL expires, ordinary `Get` is used to refresh the content without registering another watch.
- `active=false`: The path does not have a valid watch. When the TTL expires, `GetW` is used to read the content and register a new data watch. If the node does not exist, `ExistsW` is used to watch for its creation.

This state prevents duplicate watch registration during TTL refreshes and ensures that watches are re-established after they are consumed.

**Reconnect handling**:

After a ZooKeeper reconnect, the cache content and local watch state established before the reconnect can no longer be treated as reliable. The reconnect callback therefore:

1. Clears all configuration cache entries;
2. Resets all concrete-path watch states to inactive;
3. Increments the generation counter;
4. Discards reads that started before the reconnect and old watch events, preventing old data from being written back into the cache after the reconnect.

The next configuration read after reconnecting accesses ZooKeeper again and re-establishes the watch based on the current node state.

**Which issue(s) this PR fixes**:

Fixes #3572

**Does this PR introduce a user-facing change?**:

```
None
```

This PR adds the following user-configurable option:

```text
config-center.cache-ttl
```