### PR TITLE
refactor: converge protocol and triple configuration models

### DIFF
--- a/dubbo_test.go
+++ b/dubbo_test.go
@@ -314,7 +314,24 @@ func TestInstanceInitAddsDefaultGlobalProtocolWhenEmpty(t *testing.T) {
 	require.NotNil(t, tri)
 	assert.Equal(t, constant.TriProtocol, tri.Name)
 	assert.Equal(t, constant.DefaultTripleProtocolPort, tri.Port)
-	assert.Equal(t, "4mib", tri.MaxServerRecvMsgSize)
+	require.NotNil(t, tri.TripleConfig)
+	assert.Equal(t, "4mib", tri.TripleConfig.MaxServerRecvMsgSize)
+}
+
+func TestInstanceInitDefaultsExplicitTripleConfig(t *testing.T) {
+	ins, err := NewInstance(func(opts *InstanceOptions) {
+		opts.Protocols = map[string]*global.ProtocolConfig{
+			constant.TriProtocol: {
+				TripleConfig: &global.TripleConfig{},
+			},
+		}
+	})
+	require.NoError(t, err)
+
+	tri := ins.insOpts.Protocols[constant.TriProtocol]
+	require.NotNil(t, tri)
+	require.NotNil(t, tri.TripleConfig)
+	assert.Equal(t, "4mib", tri.TripleConfig.MaxServerRecvMsgSize)
 }
 
 func TestInstanceInitTranslatesGlobalRegistryAddress(t *testing.T) {

--- a/dubbo_test.go
+++ b/dubbo_test.go
@@ -25,6 +25,8 @@ import (
 import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"gopkg.in/yaml.v3"
 )
 
 import (
@@ -332,6 +334,95 @@ func TestInstanceInitDefaultsExplicitTripleConfig(t *testing.T) {
 	require.NotNil(t, tri)
 	require.NotNil(t, tri.TripleConfig)
 	assert.Equal(t, "4mib", tri.TripleConfig.MaxServerRecvMsgSize)
+}
+
+func TestInstanceInitMigratesDeprecatedProtocolMessageSizes(t *testing.T) {
+	tests := []struct {
+		name           string
+		protocol       *global.ProtocolConfig
+		wantLegacySend string
+		wantLegacyRecv string
+		wantNestedSend string
+		wantNestedRecv string
+	}{
+		{
+			name: "deprecated values populate empty nested values",
+			protocol: &global.ProtocolConfig{
+				MaxServerSendMsgSize: "2mib",
+				MaxServerRecvMsgSize: "3mib",
+				TripleConfig:         &global.TripleConfig{},
+			},
+			wantLegacySend: "2mib",
+			wantLegacyRecv: "3mib",
+			wantNestedSend: "2mib",
+			wantNestedRecv: "3mib",
+		},
+		{
+			name: "nested values take precedence",
+			protocol: &global.ProtocolConfig{
+				MaxServerSendMsgSize: "2mib",
+				MaxServerRecvMsgSize: "3mib",
+				TripleConfig: &global.TripleConfig{
+					MaxServerSendMsgSize: "5mib",
+					MaxServerRecvMsgSize: "6mib",
+				},
+			},
+			wantLegacySend: "2mib",
+			wantLegacyRecv: "3mib",
+			wantNestedSend: "5mib",
+			wantNestedRecv: "6mib",
+		},
+		{
+			name:           "empty values use defaults",
+			protocol:       &global.ProtocolConfig{},
+			wantLegacyRecv: "4mib",
+			wantNestedRecv: "4mib",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ins, err := NewInstance(func(opts *InstanceOptions) {
+				opts.Protocols = map[string]*global.ProtocolConfig{
+					constant.TriProtocol: tt.protocol,
+				}
+			})
+			require.NoError(t, err)
+
+			tri := ins.insOpts.Protocols[constant.TriProtocol]
+			require.NotNil(t, tri)
+			require.NotNil(t, tri.TripleConfig)
+			assert.Equal(t, tt.wantLegacySend, tri.MaxServerSendMsgSize)
+			assert.Equal(t, tt.wantLegacyRecv, tri.MaxServerRecvMsgSize)
+			assert.Equal(t, tt.wantNestedSend, tri.TripleConfig.MaxServerSendMsgSize)
+			assert.Equal(t, tt.wantNestedRecv, tri.TripleConfig.MaxServerRecvMsgSize)
+		})
+	}
+}
+
+func TestInstanceInitMigratesDeprecatedProtocolMessageSizesFromYAML(t *testing.T) {
+	var protocols map[string]*global.ProtocolConfig
+	err := yaml.Unmarshal([]byte(`
+tri:
+  name: tri
+  max-server-send-msg-size: 2mib
+  max-server-recv-msg-size: 3mib
+  triple: {}
+`), &protocols)
+	require.NoError(t, err)
+
+	ins, err := NewInstance(func(opts *InstanceOptions) {
+		opts.Protocols = protocols
+	})
+	require.NoError(t, err)
+
+	tri := ins.insOpts.Protocols[constant.TriProtocol]
+	require.NotNil(t, tri)
+	require.NotNil(t, tri.TripleConfig)
+	assert.Equal(t, "2mib", tri.MaxServerSendMsgSize)
+	assert.Equal(t, "3mib", tri.MaxServerRecvMsgSize)
+	assert.Equal(t, "2mib", tri.TripleConfig.MaxServerSendMsgSize)
+	assert.Equal(t, "3mib", tri.TripleConfig.MaxServerRecvMsgSize)
 }
 
 func TestInstanceInitTranslatesGlobalRegistryAddress(t *testing.T) {

--- a/global/config_test.go
+++ b/global/config_test.go
@@ -998,11 +998,9 @@ func TestRouterConfigFields(t *testing.T) {
 func TestProtocolConfigClone(t *testing.T) {
 	t.Run("clone_full_protocol_config", func(t *testing.T) {
 		proto := &ProtocolConfig{
-			Name:                 "tri",
-			Ip:                   "localhost",
-			Port:                 "20880",
-			MaxServerSendMsgSize: "1mb",
-			MaxServerRecvMsgSize: "4mb",
+			Name: "tri",
+			Ip:   "localhost",
+			Port: "20880",
 			TripleConfig: &TripleConfig{
 				MaxServerSendMsgSize: "2mb",
 				MaxServerRecvMsgSize: "4mb",
@@ -1021,11 +1019,11 @@ func TestProtocolConfigClone(t *testing.T) {
 		assert.Equal(t, proto.Name, cloned.Name)
 		assert.Equal(t, proto.Ip, cloned.Ip)
 		assert.Equal(t, proto.Port, cloned.Port)
-		assert.Equal(t, proto.MaxServerSendMsgSize, cloned.MaxServerSendMsgSize)
-		assert.Equal(t, proto.MaxServerRecvMsgSize, cloned.MaxServerRecvMsgSize)
 		assert.NotSame(t, proto, cloned)
 		assert.NotSame(t, proto.TripleConfig, cloned.TripleConfig)
 		assert.NotNil(t, cloned.TripleConfig)
+		assert.Equal(t, "2mb", cloned.TripleConfig.MaxServerSendMsgSize)
+		assert.Equal(t, "4mb", cloned.TripleConfig.MaxServerRecvMsgSize)
 	})
 
 	t.Run("clone_nil_protocol_config", func(t *testing.T) {
@@ -1044,20 +1042,18 @@ func TestProtocolConfigClone(t *testing.T) {
 		assert.Equal(t, "dubbo", cloned.Name)
 	})
 
-	t.Run("clone_protocol_config_preserves_all_fields", func(t *testing.T) {
+	t.Run("clone_protocol_config_preserves_protocol_fields", func(t *testing.T) {
 		proto := &ProtocolConfig{
-			Name:                 "http",
-			Ip:                   "localhost",
-			Port:                 "8080",
-			MaxServerSendMsgSize: "10mb",
-			MaxServerRecvMsgSize: "10mb",
+			Name:   "http",
+			Ip:     "localhost",
+			Port:   "8080",
+			Params: map[string]string{"key": "value"},
 		}
 		cloned := proto.Clone()
 		assert.Equal(t, "http", cloned.Name)
 		assert.Equal(t, "localhost", cloned.Ip)
 		assert.Equal(t, "8080", cloned.Port)
-		assert.Equal(t, "10mb", cloned.MaxServerSendMsgSize)
-		assert.Equal(t, "10mb", cloned.MaxServerRecvMsgSize)
+		assert.Equal(t, proto.Params, cloned.Params)
 	})
 }
 
@@ -1075,6 +1071,14 @@ func TestDefaultProtocolConfig(t *testing.T) {
 
 // TestProtocolConfigFields tests individual fields of ProtocolConfig
 func TestProtocolConfigFields(t *testing.T) {
+	t.Run("triple_fields_are_nested", func(t *testing.T) {
+		protocolType := reflect.TypeOf(ProtocolConfig{})
+		_, hasSendSize := protocolType.FieldByName("MaxServerSendMsgSize")
+		_, hasRecvSize := protocolType.FieldByName("MaxServerRecvMsgSize")
+		assert.False(t, hasSendSize)
+		assert.False(t, hasRecvSize)
+	})
+
 	t.Run("protocol_config_name", func(t *testing.T) {
 		proto := &ProtocolConfig{Name: "dubbo"}
 		assert.Equal(t, "dubbo", proto.Name)
@@ -1158,7 +1162,10 @@ func TestDefaultTripleConfig(t *testing.T) {
 	t.Run("default_triple_config", func(t *testing.T) {
 		triple := DefaultTripleConfig()
 		assert.NotNil(t, triple)
+		assert.Equal(t, "4mib", triple.MaxServerRecvMsgSize)
 		assert.NotNil(t, triple.Http3)
+		assert.NotNil(t, triple.Cors)
+		assert.NotNil(t, triple.OpenAPI)
 	})
 }
 

--- a/global/config_test.go
+++ b/global/config_test.go
@@ -1072,7 +1072,7 @@ func TestDefaultProtocolConfig(t *testing.T) {
 // TestProtocolConfigFields tests individual fields of ProtocolConfig
 func TestProtocolConfigFields(t *testing.T) {
 	t.Run("triple_fields_are_nested", func(t *testing.T) {
-		protocolType := reflect.TypeOf(ProtocolConfig{})
+		protocolType := reflect.TypeFor[ProtocolConfig]()
 		_, hasSendSize := protocolType.FieldByName("MaxServerSendMsgSize")
 		_, hasRecvSize := protocolType.FieldByName("MaxServerRecvMsgSize")
 		assert.False(t, hasSendSize)

--- a/global/config_test.go
+++ b/global/config_test.go
@@ -998,9 +998,11 @@ func TestRouterConfigFields(t *testing.T) {
 func TestProtocolConfigClone(t *testing.T) {
 	t.Run("clone_full_protocol_config", func(t *testing.T) {
 		proto := &ProtocolConfig{
-			Name: "tri",
-			Ip:   "localhost",
-			Port: "20880",
+			Name:                 "tri",
+			Ip:                   "localhost",
+			Port:                 "20880",
+			MaxServerSendMsgSize: "1mb",
+			MaxServerRecvMsgSize: "3mb",
 			TripleConfig: &TripleConfig{
 				MaxServerSendMsgSize: "2mb",
 				MaxServerRecvMsgSize: "4mb",
@@ -1019,6 +1021,8 @@ func TestProtocolConfigClone(t *testing.T) {
 		assert.Equal(t, proto.Name, cloned.Name)
 		assert.Equal(t, proto.Ip, cloned.Ip)
 		assert.Equal(t, proto.Port, cloned.Port)
+		assert.Equal(t, proto.MaxServerSendMsgSize, cloned.MaxServerSendMsgSize)
+		assert.Equal(t, proto.MaxServerRecvMsgSize, cloned.MaxServerRecvMsgSize)
 		assert.NotSame(t, proto, cloned)
 		assert.NotSame(t, proto.TripleConfig, cloned.TripleConfig)
 		assert.NotNil(t, cloned.TripleConfig)
@@ -1044,16 +1048,20 @@ func TestProtocolConfigClone(t *testing.T) {
 
 	t.Run("clone_protocol_config_preserves_protocol_fields", func(t *testing.T) {
 		proto := &ProtocolConfig{
-			Name:   "http",
-			Ip:     "localhost",
-			Port:   "8080",
-			Params: map[string]string{"key": "value"},
+			Name:                 "http",
+			Ip:                   "localhost",
+			Port:                 "8080",
+			Params:               map[string]string{"key": "value"},
+			MaxServerSendMsgSize: "10mb",
+			MaxServerRecvMsgSize: "10mb",
 		}
 		cloned := proto.Clone()
 		assert.Equal(t, "http", cloned.Name)
 		assert.Equal(t, "localhost", cloned.Ip)
 		assert.Equal(t, "8080", cloned.Port)
 		assert.Equal(t, proto.Params, cloned.Params)
+		assert.Equal(t, "10mb", cloned.MaxServerSendMsgSize)
+		assert.Equal(t, "10mb", cloned.MaxServerRecvMsgSize)
 	})
 }
 
@@ -1071,12 +1079,19 @@ func TestDefaultProtocolConfig(t *testing.T) {
 
 // TestProtocolConfigFields tests individual fields of ProtocolConfig
 func TestProtocolConfigFields(t *testing.T) {
-	t.Run("triple_fields_are_nested", func(t *testing.T) {
+	t.Run("deprecated_triple_fields_remain_available_in_v3", func(t *testing.T) {
 		protocolType := reflect.TypeFor[ProtocolConfig]()
 		_, hasSendSize := protocolType.FieldByName("MaxServerSendMsgSize")
 		_, hasRecvSize := protocolType.FieldByName("MaxServerRecvMsgSize")
-		assert.False(t, hasSendSize)
-		assert.False(t, hasRecvSize)
+		assert.True(t, hasSendSize)
+		assert.True(t, hasRecvSize)
+
+		proto := ProtocolConfig{
+			MaxServerSendMsgSize: "1mib",
+			MaxServerRecvMsgSize: "2mib",
+		}
+		assert.Equal(t, "1mib", proto.MaxServerSendMsgSize)
+		assert.Equal(t, "2mib", proto.MaxServerRecvMsgSize)
 	})
 
 	t.Run("protocol_config_name", func(t *testing.T) {

--- a/global/protocol_config.go
+++ b/global/protocol_config.go
@@ -32,20 +32,6 @@ type ProtocolConfig struct {
 
 	// TripleConfig holds the Triple protocol configuration.
 	TripleConfig *TripleConfig `yaml:"triple" json:"triple,omitempty" property:"triple"`
-
-	// TODO: remove MaxServerSendMsgSize and MaxServerRecvMsgSize when version 4.0.0
-	//
-	// MaxServerSendMsgSize defines the max size of server send message, 1mb=1000kb=1000000b 1mib=1024kb=1048576b.
-	// more detail to see https://pkg.go.dev/github.com/dustin/go-humanize#pkg-constants
-	//
-	// Deprecated: use "ClientProtocolConfig.TripleConfig.MaxServerSendMsgSize" or in config tag "protocol_config/triple/max-server-send-msg-size" instead
-	MaxServerSendMsgSize string `yaml:"max-server-send-msg-size" json:"max-server-send-msg-size,omitempty"`
-	// TODO: remove MaxServerSendMsgSize and MaxServerRecvMsgSize when version 4.0.0
-	//
-	// MaxServerRecvMsgSize defines the max size of server receive message.
-	//
-	// Deprecated: use "ClientProtocolConfig.TripleConfig.MaxServerRecvMsgSize" or in config tag "protocol_config/triple/max-server-recv-msg-size" instead
-	MaxServerRecvMsgSize string `default:"4mib" yaml:"max-server-recv-msg-size" json:"max-server-recv-msg-size,omitempty"`
 }
 
 // DefaultProtocolConfig returns a default ProtocolConfig instance.
@@ -64,12 +50,10 @@ func (c *ProtocolConfig) Clone() *ProtocolConfig {
 	}
 
 	return &ProtocolConfig{
-		Name:                 c.Name,
-		Ip:                   c.Ip,
-		Port:                 c.Port,
-		Params:               c.Params,
-		TripleConfig:         c.TripleConfig.Clone(),
-		MaxServerSendMsgSize: c.MaxServerSendMsgSize,
-		MaxServerRecvMsgSize: c.MaxServerRecvMsgSize,
+		Name:         c.Name,
+		Ip:           c.Ip,
+		Port:         c.Port,
+		Params:       c.Params,
+		TripleConfig: c.TripleConfig.Clone(),
 	}
 }

--- a/global/protocol_config.go
+++ b/global/protocol_config.go
@@ -32,6 +32,20 @@ type ProtocolConfig struct {
 
 	// TripleConfig holds the Triple protocol configuration.
 	TripleConfig *TripleConfig `yaml:"triple" json:"triple,omitempty" property:"triple"`
+
+	// TODO: remove MaxServerSendMsgSize and MaxServerRecvMsgSize when version 4.0.0
+	//
+	// MaxServerSendMsgSize defines the max size of server send message, 1mb=1000kb=1000000b 1mib=1024kb=1048576b.
+	// more detail to see https://pkg.go.dev/github.com/dustin/go-humanize#pkg-constants
+	//
+	// Deprecated: use TripleConfig.MaxServerSendMsgSize or the "triple/max-server-send-msg-size" config key instead.
+	MaxServerSendMsgSize string `yaml:"max-server-send-msg-size" json:"max-server-send-msg-size,omitempty"`
+	// TODO: remove MaxServerSendMsgSize and MaxServerRecvMsgSize when version 4.0.0
+	//
+	// MaxServerRecvMsgSize defines the max size of server receive message.
+	//
+	// Deprecated: use TripleConfig.MaxServerRecvMsgSize or the "triple/max-server-recv-msg-size" config key instead.
+	MaxServerRecvMsgSize string `default:"4mib" yaml:"max-server-recv-msg-size" json:"max-server-recv-msg-size,omitempty"`
 }
 
 // DefaultProtocolConfig returns a default ProtocolConfig instance.
@@ -50,10 +64,12 @@ func (c *ProtocolConfig) Clone() *ProtocolConfig {
 	}
 
 	return &ProtocolConfig{
-		Name:         c.Name,
-		Ip:           c.Ip,
-		Port:         c.Port,
-		Params:       c.Params,
-		TripleConfig: c.TripleConfig.Clone(),
+		Name:                 c.Name,
+		Ip:                   c.Ip,
+		Port:                 c.Port,
+		Params:               c.Params,
+		TripleConfig:         c.TripleConfig.Clone(),
+		MaxServerSendMsgSize: c.MaxServerSendMsgSize,
+		MaxServerRecvMsgSize: c.MaxServerRecvMsgSize,
 	}
 }

--- a/global/triple_config.go
+++ b/global/triple_config.go
@@ -28,7 +28,7 @@ type TripleConfig struct {
 	// more detail to see https://pkg.go.dev/github.com/dustin/go-humanize#pkg-constants
 	MaxServerSendMsgSize string `yaml:"max-server-send-msg-size" json:"max-server-send-msg-size,omitempty"`
 	// MaxServerRecvMsgSize defines the max size of server receive message.
-	MaxServerRecvMsgSize string `yaml:"max-server-recv-msg-size" json:"max-server-recv-msg-size,omitempty"`
+	MaxServerRecvMsgSize string `default:"4mib" yaml:"max-server-recv-msg-size" json:"max-server-recv-msg-size,omitempty"`
 	// Http3 holds the HTTP/3 transport configuration.
 	Http3 *Http3Config `yaml:"http3" json:"http3,omitempty"`
 	// Cors configures CORS for Triple protocol handlers.
@@ -48,9 +48,10 @@ type TripleConfig struct {
 // DefaultTripleConfig returns a default TripleConfig instance.
 func DefaultTripleConfig() *TripleConfig {
 	return &TripleConfig{
-		Http3:   DefaultHttp3Config(),
-		Cors:    DefaultCorsConfig(),
-		OpenAPI: DefaultOpenAPIConfig(),
+		MaxServerRecvMsgSize: "4mib",
+		Http3:                DefaultHttp3Config(),
+		Cors:                 DefaultCorsConfig(),
+		OpenAPI:              DefaultOpenAPIConfig(),
 	}
 }
 

--- a/instance_options_init.go
+++ b/instance_options_init.go
@@ -140,6 +140,11 @@ func (rc *InstanceOptions) initGlobalProtocols() error {
 }
 
 func initGlobalProtocol(protocolConfig *global.ProtocolConfig) error {
+	legacySendMsgSize := protocolConfig.MaxServerSendMsgSize
+	legacyRecvMsgSize := protocolConfig.MaxServerRecvMsgSize
+	nestedSendMsgSizeSet := protocolConfig.TripleConfig != nil && protocolConfig.TripleConfig.MaxServerSendMsgSize != ""
+	nestedRecvMsgSizeSet := protocolConfig.TripleConfig != nil && protocolConfig.TripleConfig.MaxServerRecvMsgSize != ""
+
 	if err := defaults.Set(protocolConfig); err != nil {
 		return err
 	}
@@ -162,6 +167,15 @@ func initGlobalProtocol(protocolConfig *global.ProtocolConfig) error {
 			protocolConfig.TripleConfig.OpenAPI = global.DefaultOpenAPIConfig()
 		}
 		protocolConfig.TripleConfig.OpenAPI.Init()
+	}
+
+	// Keep v3 configurations source-compatible while converging on TripleConfig.
+	// A non-empty nested value wins; otherwise migrate the deprecated value.
+	if !nestedSendMsgSizeSet && legacySendMsgSize != "" {
+		protocolConfig.TripleConfig.MaxServerSendMsgSize = legacySendMsgSize
+	}
+	if !nestedRecvMsgSizeSet && legacyRecvMsgSize != "" {
+		protocolConfig.TripleConfig.MaxServerRecvMsgSize = legacyRecvMsgSize
 	}
 	return commonCfg.Verify(protocolConfig)
 }

--- a/server/action.go
+++ b/server/action.go
@@ -184,10 +184,17 @@ func (svcOpts *ServiceOptions) Export() error {
 			isIDL = svcOpts.IDLMode
 		}
 
-		var maxServerSendMsgSize, maxServerRecvMsgSize string
+		// Keep accepting the deprecated protocol-level fields through v3. Nested
+		// Triple values take precedence when both forms are configured.
+		maxServerSendMsgSize := protocolConf.MaxServerSendMsgSize
+		maxServerRecvMsgSize := protocolConf.MaxServerRecvMsgSize
 		if protocolConf.TripleConfig != nil {
-			maxServerSendMsgSize = protocolConf.TripleConfig.MaxServerSendMsgSize
-			maxServerRecvMsgSize = protocolConf.TripleConfig.MaxServerRecvMsgSize
+			if protocolConf.TripleConfig.MaxServerSendMsgSize != "" {
+				maxServerSendMsgSize = protocolConf.TripleConfig.MaxServerSendMsgSize
+			}
+			if protocolConf.TripleConfig.MaxServerRecvMsgSize != "" {
+				maxServerRecvMsgSize = protocolConf.TripleConfig.MaxServerRecvMsgSize
+			}
 		}
 
 		ivkURL := common.NewURLWithOptions(

--- a/server/action.go
+++ b/server/action.go
@@ -184,6 +184,12 @@ func (svcOpts *ServiceOptions) Export() error {
 			isIDL = svcOpts.IDLMode
 		}
 
+		var maxServerSendMsgSize, maxServerRecvMsgSize string
+		if protocolConf.TripleConfig != nil {
+			maxServerSendMsgSize = protocolConf.TripleConfig.MaxServerSendMsgSize
+			maxServerRecvMsgSize = protocolConf.TripleConfig.MaxServerRecvMsgSize
+		}
+
 		ivkURL := common.NewURLWithOptions(
 			common.WithPath(svcConf.Interface),
 			common.WithProtocol(protocolConf.Name),
@@ -201,11 +207,9 @@ func (svcOpts *ServiceOptions) Export() error {
 			common.WithToken(svcConf.Token),
 			common.WithParamsValue(constant.MetadataTypeKey, svcOpts.metadataType),
 
-			// fix https://github.com/apache/dubbo-go/issues/2176
-			// TODO: remove MaxServerSendMsgSize value and MaxServerRecvMsgSize value when version 4.0.0
-			// use TripleConfig to transport arguments
-			common.WithParamsValue(constant.MaxServerSendMsgSize, protocolConf.MaxServerSendMsgSize),
-			common.WithParamsValue(constant.MaxServerRecvMsgSize, protocolConf.MaxServerRecvMsgSize),
+			// Preserve the legacy URL parameters for downstream protocol compatibility.
+			common.WithParamsValue(constant.MaxServerSendMsgSize, maxServerSendMsgSize),
+			common.WithParamsValue(constant.MaxServerRecvMsgSize, maxServerRecvMsgSize),
 
 			// TODO: remove IDL value when version 4.0.0
 			common.WithParamsValue(constant.IDLMode, isIDL),

--- a/server/inst_test.go
+++ b/server/inst_test.go
@@ -42,8 +42,9 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	_ "dubbo.apache.org/dubbo-go/v3/filter/echo"
 	_ "dubbo.apache.org/dubbo-go/v3/filter/graceful_shutdown"
+	"dubbo.apache.org/dubbo-go/v3/global"
 	"dubbo.apache.org/dubbo-go/v3/protocol"
-	_ "dubbo.apache.org/dubbo-go/v3/protocol/triple"
+	"dubbo.apache.org/dubbo-go/v3/protocol/triple"
 	tri "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol"
 	_ "dubbo.apache.org/dubbo-go/v3/proxy/proxy_factory"
 	dubboserver "dubbo.apache.org/dubbo-go/v3/server"
@@ -62,6 +63,10 @@ func (s *NewConfigAPIService) Reference() string {
 
 func (s *NewConfigAPIService) SayHello(context.Context, *emptypb.Empty) (*wrapperspb.StringValue, error) {
 	return wrapperspb.String(newConfigAPIHelloBody), nil
+}
+
+func (s *NewConfigAPIService) Echo(_ context.Context, req *wrapperspb.BytesValue) (*wrapperspb.BytesValue, error) {
+	return wrapperspb.Bytes(req.Value), nil
 }
 
 type newConfigAPITestSetup struct {
@@ -87,6 +92,11 @@ func TestCfgAPI_Export(t *testing.T) {
 
 	svcOpts := registerAndExportNewConfigAPIService(t, setup.srv)
 	require.NotNil(t, svcOpts)
+
+	urls := svcOpts.GetExportedUrls()
+	require.Len(t, urls, 1)
+	assert.Empty(t, urls[0].GetParam(constant.MaxServerSendMsgSize, ""))
+	assert.Equal(t, "4mib", urls[0].GetParam(constant.MaxServerRecvMsgSize, ""))
 }
 
 // TestCfgAPI_Call verifies the end-to-end
@@ -99,7 +109,107 @@ func TestCfgAPI_Call(t *testing.T) {
 	assertNewConfigAPIUnaryHello(t, conn)
 }
 
-func setupNewConfigAPITest(t *testing.T) *newConfigAPITestSetup {
+func TestCfgAPITripleMessageSizePropagation(t *testing.T) {
+	setup := setupNewConfigAPITest(
+		t,
+		triple.WithMaxServerSendMsgSize("8kib"),
+		triple.WithMaxServerRecvMsgSize("1kib"),
+	)
+	svcOpts := registerAndExportNewConfigAPIService(t, setup.srv)
+
+	urls := svcOpts.GetExportedUrls()
+	require.Len(t, urls, 1)
+	assert.Equal(t, "8kib", urls[0].GetParam(constant.MaxServerSendMsgSize, ""))
+	assert.Equal(t, "1kib", urls[0].GetParam(constant.MaxServerRecvMsgSize, ""))
+
+	conn := dialNewConfigAPIConnection(t, setup.ins, setup.port)
+	assertNewConfigAPIUnaryHello(t, conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	smallResponse := new(wrapperspb.BytesValue)
+	err := conn.CallUnary(ctx, []any{wrapperspb.Bytes(make([]byte, 512))}, smallResponse, "Echo")
+	require.NoError(t, err)
+	assert.Len(t, smallResponse.Value, 512)
+
+	largeResponse := new(wrapperspb.BytesValue)
+	err = conn.CallUnary(ctx, []any{wrapperspb.Bytes(make([]byte, 4*1024))}, largeResponse, "Echo")
+	require.Error(t, err)
+}
+
+func TestCfgAPIExportedMessageSizeCompatibility(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol *global.ProtocolConfig
+		wantSend string
+		wantRecv string
+	}{
+		{
+			name: "deprecated values fill empty nested values",
+			protocol: &global.ProtocolConfig{
+				MaxServerSendMsgSize: "2mib",
+				MaxServerRecvMsgSize: "3mib",
+				TripleConfig:         &global.TripleConfig{},
+			},
+			wantSend: "2mib",
+			wantRecv: "3mib",
+		},
+		{
+			name: "nested values take precedence",
+			protocol: &global.ProtocolConfig{
+				MaxServerSendMsgSize: "2mib",
+				MaxServerRecvMsgSize: "3mib",
+				TripleConfig: &global.TripleConfig{
+					MaxServerSendMsgSize: "5mib",
+					MaxServerRecvMsgSize: "6mib",
+				},
+			},
+			wantSend: "5mib",
+			wantRecv: "6mib",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port := freePortForNewConfigAPITest(t)
+			tt.protocol.Name = constant.TriProtocol
+			tt.protocol.Ip = "127.0.0.1"
+			tt.protocol.Port = strconv.Itoa(port)
+
+			ins, err := dubbo.NewInstance(
+				dubbo.WithName("message-size-compatibility"),
+				func(opts *dubbo.InstanceOptions) {
+					opts.Protocols = map[string]*global.ProtocolConfig{
+						constant.TriProtocol: tt.protocol,
+					}
+				},
+			)
+			require.NoError(t, err)
+
+			srv, err := ins.NewServer()
+			require.NoError(t, err)
+			svcOpts := registerAndExportNewConfigAPIService(t, srv)
+
+			urls := svcOpts.GetExportedUrls()
+			require.Len(t, urls, 1)
+			assert.Equal(t, tt.wantSend, urls[0].GetParam(constant.MaxServerSendMsgSize, ""))
+			assert.Equal(t, tt.wantRecv, urls[0].GetParam(constant.MaxServerRecvMsgSize, ""))
+		})
+	}
+}
+
+func TestDeprecatedProtocolConfigMessageSizeFieldsCompileForExternalConsumers(t *testing.T) {
+	config := global.ProtocolConfig{
+		MaxServerSendMsgSize: "2mib",
+		MaxServerRecvMsgSize: "3mib",
+	}
+
+	assert.Equal(t, "2mib", config.MaxServerSendMsgSize)
+	assert.Equal(t, "3mib", config.MaxServerRecvMsgSize)
+}
+
+func setupNewConfigAPITest(t *testing.T, tripleOpts ...triple.Option) *newConfigAPITestSetup {
 	t.Helper()
 
 	port := freePortForNewConfigAPITest(t)
@@ -107,7 +217,7 @@ func setupNewConfigAPITest(t *testing.T) *newConfigAPITestSetup {
 	ins, err := dubbo.NewInstance(
 		dubbo.WithName("new-config-api-integration"),
 		dubbo.WithProtocol(
-			protocol.WithTriple(),
+			protocol.WithTriple(tripleOpts...),
 			protocol.WithIp("127.0.0.1"),
 			protocol.WithPort(port),
 		),
@@ -141,6 +251,21 @@ func registerAndExportNewConfigAPIService(t *testing.T, srv *dubboserver.Server)
 				MethodFunc: func(ctx context.Context, args []any, handler any) (any, error) {
 					req := args[0].(*emptypb.Empty)
 					res, callErr := handler.(*NewConfigAPIService).SayHello(ctx, req)
+					if callErr != nil {
+						return nil, callErr
+					}
+					return tri.NewResponse(res), nil
+				},
+			},
+			{
+				Name: "Echo",
+				Type: constant.CallUnary,
+				ReqInitFunc: func() any {
+					return &wrapperspb.BytesValue{}
+				},
+				MethodFunc: func(ctx context.Context, args []any, handler any) (any, error) {
+					req := args[0].(*wrapperspb.BytesValue)
+					res, callErr := handler.(*NewConfigAPIService).Echo(ctx, req)
 					if callErr != nil {
 						return nil, callErr
 					}
@@ -181,7 +306,7 @@ func dialNewConfigAPIConnection(t *testing.T, ins *dubbo.Instance, port int) *cl
 		newConfigAPIServiceName,
 		&client.ClientInfo{
 			InterfaceName: newConfigAPIServiceName,
-			MethodNames:   []string{"SayHello"},
+			MethodNames:   []string{"SayHello", "Echo"},
 		},
 		client.WithClusterAvailable(),
 		client.WithProtocolTriple(),

--- a/tools/dubbo-go-schema/dubbo-go.json
+++ b/tools/dubbo-go-schema/dubbo-go.json
@@ -161,9 +161,7 @@
           "type": "object",
           "additionalProperties": true
         },
-        "triple": { "$ref": "#/definitions/triple" },
-        "max-server-send-msg-size": { "type": "string" },
-        "max-server-recv-msg-size": { "type": "string", "default": "4mib" }
+        "triple": { "$ref": "#/definitions/triple" }
       }
     },
     "triple": {
@@ -171,7 +169,7 @@
       "additionalProperties": false,
       "properties": {
         "max-server-send-msg-size": { "type": "string" },
-        "max-server-recv-msg-size": { "type": "string" },
+        "max-server-recv-msg-size": { "type": "string", "default": "4mib" },
         "keep-alive-interval": { "$ref": "#/definitions/duration" },
         "keep-alive-timeout": { "$ref": "#/definitions/duration" },
         "http3": { "$ref": "#/definitions/http3" },

--- a/tools/dubbo-go-schema/dubbo-go.json
+++ b/tools/dubbo-go-schema/dubbo-go.json
@@ -161,7 +161,9 @@
           "type": "object",
           "additionalProperties": true
         },
-        "triple": { "$ref": "#/definitions/triple" }
+        "triple": { "$ref": "#/definitions/triple" },
+        "max-server-send-msg-size": { "type": "string" },
+        "max-server-recv-msg-size": { "type": "string", "default": "4mib" }
       }
     },
     "triple": {


### PR DESCRIPTION
### Description

Related to #3598, task 5.

Triple server message-size limits currently have two configuration sources:
deprecated top-level fields in `ProtocolConfig` and the corresponding fields
under `TripleConfig`. `server/action.go` historically forwarded the
protocol-level values as URL parameters, while the Triple server later applied
the nested configuration.

This change:

- makes `TripleConfig` the runtime source of truth for Triple message-size
  settings;
- moves the `4mib` receive-size default to `TripleConfig`;
- preserves the deprecated `ProtocolConfig` fields throughout v3 for source
  and YAML compatibility;
- migrates non-empty legacy values into empty nested fields, while explicit
  nested values take precedence;
- continues populating the legacy URL parameters for downstream protocol
  compatibility;
- updates the JSON Schema and regression tests.

### Compatibility

The two deprecated exported fields remain available in v3 and are still cloned
and accepted from legacy YAML. Existing code using
`ProtocolConfig.MaxServerSendMsgSize` or
`ProtocolConfig.MaxServerRecvMsgSize` therefore continues to compile.

When both legacy and nested values are configured, the non-empty
`TripleConfig` value wins. The deprecated fields remain scheduled for removal
in v4.

### Validation

Validated after rebasing onto the latest `develop` branch:

```text
go test . ./global ./server ./protocol/triple -count=1
go test ./... -count=1
jq empty tools/dubbo-go-schema/dubbo-go.json
git diff --check upstream/develop...HEAD
```

All checks pass.

### Checklist

- [x] The target branch is `develop`.
- [x] The branch is rebased onto the latest `develop`.
- [x] Code has passed focused and full-repository tests.
- [x] Tests cover defaults, cloning, legacy YAML migration, value precedence,
      exported URL parameters, and the real Triple server message-size path.
