### PR TITLE
chore(global): global config formatting

### DIFF
--- a/global/client_protocol_config.go
+++ b/global/client_protocol_config.go
@@ -21,11 +21,12 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 )
 
-// ClientProtocolConfig represents the config of client's protocol
+// ClientProtocolConfig represents the config of client's protocol.
 type ClientProtocolConfig struct {
 	// TODO: maybe we could use this field
 	Name string `yaml:"name" json:"name,omitempty" property:"name"`
 
+	// TripleConfig holds the Triple protocol configuration.
 	TripleConfig *TripleConfig `yaml:"triple" json:"triple,omitempty" property:"triple"`
 }
 

--- a/global/http3_config.go
+++ b/global/http3_config.go
@@ -17,15 +17,14 @@
 
 package global
 
-// Http3Config represents the config of http3
+// Http3Config represents the config of http3 protocol.
 type Http3Config struct {
-	// Whether to enable HTTP/3 support.
+	// Enable defines whether to enable HTTP/3 support.
 	// When set to true, both HTTP/2 and HTTP/3 servers will be started simultaneously.
 	// When set to false, only HTTP/2 server will be started.
 	// The default value is false.
 	Enable bool `yaml:"enable" json:"enable,omitempty"`
-
-	// Whether to enable HTTP/3 negotiation.
+	// Negotiation defines whether to enable HTTP/3 negotiation.
 	// If set to true, HTTP/2 alt-svc negotiation will be enabled,
 	// allowing clients to negotiate between HTTP/2 and HTTP/3.
 	// If set to false, HTTP/2 alt-svc negotiation will be skipped,
@@ -36,13 +35,10 @@ type Http3Config struct {
 
 	// KeepAlivePeriod defines how often to send keep-alive packets.
 	KeepAlivePeriod string `yaml:"keep-alive-period" json:"keep-alive-period,omitempty"`
-
 	// MaxIdleTimeout defines the maximum idle timeout for QUIC connections.
 	MaxIdleTimeout string `yaml:"max-idle-timeout" json:"max-idle-timeout,omitempty"`
-
 	// MaxIncomingStreams defines the maximum number of concurrent bidirectional streams.
 	MaxIncomingStreams int64 `yaml:"max-incoming-streams" json:"max-incoming-streams,omitempty"`
-
 	// MaxIncomingUniStreams defines the maximum number of concurrent unidirectional streams.
 	MaxIncomingUniStreams int64 `yaml:"max-incoming-uni-streams" json:"max-incoming-uni-streams,omitempty"`
 }

--- a/global/protocol_config.go
+++ b/global/protocol_config.go
@@ -21,7 +21,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 )
 
-// ProtocolConfig is protocol configuration
+// ProtocolConfig represents the config of protocol.
 type ProtocolConfig struct {
 	Name string `yaml:"name" json:"name,omitempty" property:"name"`
 	Ip   string `yaml:"ip"  json:"ip,omitempty" property:"ip"`
@@ -30,18 +30,19 @@ type ProtocolConfig struct {
 	// TODO: maybe Params is useless, find a ideal way to config dubbo protocol, ref: TripleConfig.
 	Params any `yaml:"params" json:"params,omitempty" property:"params"`
 
+	// TripleConfig holds the Triple protocol configuration.
 	TripleConfig *TripleConfig `yaml:"triple" json:"triple,omitempty" property:"triple"`
 
 	// TODO: remove MaxServerSendMsgSize and MaxServerRecvMsgSize when version 4.0.0
 	//
-	// MaxServerSendMsgSize max size of server send message, 1mb=1000kb=1000000b 1mib=1024kb=1048576b.
+	// MaxServerSendMsgSize defines the max size of server send message, 1mb=1000kb=1000000b 1mib=1024kb=1048576b.
 	// more detail to see https://pkg.go.dev/github.com/dustin/go-humanize#pkg-constants
 	//
 	// Deprecated: use "ClientProtocolConfig.TripleConfig.MaxServerSendMsgSize" or in config tag "protocol_config/triple/max-server-send-msg-size" instead
 	MaxServerSendMsgSize string `yaml:"max-server-send-msg-size" json:"max-server-send-msg-size,omitempty"`
 	// TODO: remove MaxServerSendMsgSize and MaxServerRecvMsgSize when version 4.0.0
 	//
-	// MaxServerRecvMsgSize max size of server receive message
+	// MaxServerRecvMsgSize defines the max size of server receive message.
 	//
 	// Deprecated: use "ClientProtocolConfig.TripleConfig.MaxServerRecvMsgSize" or in config tag "protocol_config/triple/max-server-recv-msg-size" instead
 	MaxServerRecvMsgSize string `default:"4mib" yaml:"max-server-recv-msg-size" json:"max-server-recv-msg-size,omitempty"`

--- a/global/triple_config.go
+++ b/global/triple_config.go
@@ -19,33 +19,30 @@ package global
 
 // TODO: Find an ideal way to separate the triple config of server and client.
 
-// TripleConfig represents the config of triple protocol
+// TripleConfig represents the config of triple protocol.
 type TripleConfig struct {
 	//
 	// for server
 	//
-
-	// MaxServerSendMsgSize max size of server send message, 1mb=1000kb=1000000b 1mib=1024kb=1048576b.
+	// MaxServerSendMsgSize defines the max size of server send message, 1mb=1000kb=1000000b 1mib=1024kb=1048576b.
 	// more detail to see https://pkg.go.dev/github.com/dustin/go-humanize#pkg-constants
 	MaxServerSendMsgSize string `yaml:"max-server-send-msg-size" json:"max-server-send-msg-size,omitempty"`
-	// MaxServerRecvMsgSize max size of server receive message
+	// MaxServerRecvMsgSize defines the max size of server receive message.
 	MaxServerRecvMsgSize string `yaml:"max-server-recv-msg-size" json:"max-server-recv-msg-size,omitempty"`
-
-	// the config of http3 transport
+	// Http3 holds the HTTP/3 transport configuration.
 	Http3 *Http3Config `yaml:"http3" json:"http3,omitempty"`
-
-	// Cors configures CORS for Triple protocol handlers
+	// Cors configures CORS for Triple protocol handlers.
 	Cors *CorsConfig `yaml:"cors" json:"cors,omitempty"`
-
-	// OpenAPI configures OpenAPI documentation generation
+	// OpenAPI configures OpenAPI documentation generation.
 	OpenAPI *OpenAPIConfig `yaml:"openapi" json:"openapi,omitempty"`
 
 	//
 	// for client
 	//
-
+	// KeepAliveInterval defines the duration of keep alive interval.
 	KeepAliveInterval string `yaml:"keep-alive-interval" json:"keep-alive-interval,omitempty" property:"keep-alive-interval"`
-	KeepAliveTimeout  string `yaml:"keep-alive-timeout" json:"keep-alive-timeout,omitempty" property:"keep-alive-timeout"`
+	// KeepAliveTimeout defines the duration of keep alive timeout.
+	KeepAliveTimeout string `yaml:"keep-alive-timeout" json:"keep-alive-timeout,omitempty" property:"keep-alive-timeout"`
 }
 
 // DefaultTripleConfig returns a default TripleConfig instance.


### PR DESCRIPTION
### Description
Fixes # (issue)
For this PR, I consider the field ordering of the config structs already reasonable and left it unchanged. Changes made:

1. Rewrote incomplete sentences into complete sentences. For example, `// MaxServerRecvMsgSize max size of server receive message` was changed to `// MaxServerRecvMsgSize defines the max size of server receive message.`

2. Unified the type-comment style to `// XConfig represents`. For example, `// TripleConfig represents the config of triple protocol.`

3. Supplemented some missing comments.

4. Added periods to complete sentences.

5. Adjusted some blank lines to make the grouping more obvious. 

Refs https://github.com/apache/dubbo-go/issues/3598 (task19)
### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [ ] I have added tests that prove my fix is effective or that my feature works
