### PR TITLE
docs(metadata): clarify ServiceInfo URL and parameter conversion

### DIFF
--- a/metadata/info/metadata_info.go
+++ b/metadata/info/metadata_info.go
@@ -268,6 +268,9 @@ type ServiceInfo struct {
 	URL        *common.URL `json:"-" hessian:"-"`
 }
 
+// NewServiceInfoWithURL builds a service-level metadata view from provider URL.
+// It copies the service identity and endpoint fields, retains only whitelisted service and
+// method parameters, and stores method parameters in the compact "<method>.<key>" form.
 func NewServiceInfoWithURL(url *common.URL) *ServiceInfo {
 	service := NewServiceInfo(url.Service(), url.Group(), url.Version(), url.Protocol, url.Path, nil)
 	service.Port, _ = strconv.Atoi(url.Port)
@@ -311,11 +314,19 @@ func (si *ServiceInfo) JavaClassName() string {
 	return "org.apache.dubbo.metadata.MetadataInfo$ServiceInfo"
 }
 
+// GetMethods returns the service method name corresponding to MethodsKey.
+// The comma-separated representation preserves the order found in the provider URL.
+// If the parameter is null, the current implementation returns a list of method names containing a single empty string.
 func (si *ServiceInfo) GetMethods() []string {
 	s := si.Params[constant.MethodsKey]
 	return strings.Split(s, ",")
 }
 
+// GetParams reconstructs URL query parameters from the serialized service metadata.
+// Method parameters are stored compactly as "<method>.<key>" in ServiceInfo and are expanded
+// to "methods.<method>.<key>" when the method is listed in MethodsKey. All other parameters
+// keep their original keys. The returned url.Values is newly allocated and can be used to
+// rebuild a consumer URL without modifying ServiceInfo.Params.
 func (si *ServiceInfo) GetParams() url.Values {
 	v := url.Values{}
 	methods := gxset.NewSet()


### PR DESCRIPTION
### Description
#3598 - Task 17

Improve the documentation for `ServiceInfo` metadata conversion:

- Explain how `NewServiceInfoWithURL` projects an exported provider URL into service-level metadata.
- Document parameter filtering and the compact representation of method-level parameters.
- Clarify how `GetMethods` decodes the serialized method list.
- Explain how `GetParams` restores method parameters for consumer URL reconstruction.
- Document that the original URL is retained only as a local runtime reference and is excluded from serialization.

This change only improves code comments and does not alter runtime behavior.

---

### Why?

## Change Description

Improve the comments related to `ServiceInfo` metadata conversion:

- Explain how `NewServiceInfoWithURL` converts a provider URL into service-level metadata.
- Explain service-parameter filtering and the compact format used for method-level parameters.
- Explain how `GetMethods` restores the method list.
- Explain how `GetParams` reconstructs the parameters required by the consumer URL.
- Clarify that the original URL is retained only as a local runtime reference and is excluded from serialization.

This change only adds code comments and does not alter runtime behavior.

## Why Are URL Parameters Extracted?

The extracted parameters are from the `MetadataService` URL, not from ordinary business service URLs.

The core reason is to solve the bootstrap problem:

```text
The consumer needs MetadataInfo to know which services the application provides.
The consumer needs to call MetadataService to obtain MetadataInfo.
The consumer needs the MetadataService URL to call MetadataService.
```

The MetadataService URL cannot exist only inside `MetadataInfo`, because the consumer would need to obtain metadata before knowing where to obtain that metadata. This creates a circular dependency.

The solution is to store the minimum information required to call MetadataService directly in `ServiceInstance.Metadata`.

## Overall Flow

```text
Provider
  ├─ Exports business service URLs
  ├─ Exports the MetadataService URL
  └─ Registers a ServiceInstance
       ├─ host / port
       ├─ dubbo.endpoints
       ├─ dubbo.metadata-service.url-params
       └─ dubbo.metadata.revision
              ↓
           Registry
              ↓
Consumer obtains ServiceInstance
              ↓
Rebuilds the MetadataService URL from url-params
              ↓
Calls MetadataService.GetMetadataInfo(revision)
              ↓
Obtains MetadataInfo
              ↓
Reads ServiceInfo from MetadataInfo.Services
              ↓
Combines ServiceInstance and ServiceInfo
              ↓
Builds the concrete business service URL
              ↓
Creates an Invoker and performs RPC calls
```

## Provider Side

In addition to business interfaces, the Provider exposes the built-in `MetadataService`. This is a control-plane service used by consumers to query metadata.

Its main operation is:

```text
GetMetadataInfo(revision)
```

Conceptually, the Provider may expose a URL such as:

```text
tri://10.0.0.8:20880/org.apache.dubbo.metadata.MetadataService
    ?serialization=hessian2
    &version=1.0.0
    &application=demo-provider
    &timestamp=1786000000
```

The registered service instance already contains:

```text
ServiceName = demo-provider
Host        = 10.0.0.8
```

Therefore, the customizer only needs to publish the additional parameters required to connect to MetadataService:

```json
{
  "protocol": "tri",
  "port": "20880",
  "serialization": "hessian2",
  "version": "1.0.0"
}
```

These parameters are stored under:

```text
dubbo.metadata-service.url-params
```

## Consumer Side

The consumer obtains the following information from `ServiceInstance`:

```text
Host        = 10.0.0.8
ServiceName = demo-provider
URL Params  = protocol, port, serialization, version
```

`buildStandardMetadataServiceURL` then adds the standard fields:

```text
Path      = org.apache.dubbo.metadata.MetadataService
Interface = org.apache.dubbo.metadata.MetadataService
Group     = demo-provider
```

The consumer reconstructs:

```text
tri://10.0.0.8:20880/org.apache.dubbo.metadata.MetadataService
```

It can then call MetadataService through RPC and fetch the complete `MetadataInfo`.

## Why Not Store the Full URL?

Many parts of the full URL do not need to be published:

- The host is already available in `ServiceInstance`.
- The MetadataService path and interface are fixed by convention.
- The group can be reconstructed from the application name.
- Parameters such as `timestamp` may change but do not affect connectivity.
- The Provider URL may contain local or unrelated configuration.
- Service instance metadata should remain small and stable.
- Publishing a common whitelist of parameters improves interoperability between Dubbo Java and Dubbo Go.

<details>
<summary>中文说明</summary>

### 变更说明

完善 `ServiceInfo` 元数据转换相关注释：

- 说明 `NewServiceInfoWithURL` 如何将 Provider URL 转换为服务级元数据。
- 解释服务参数筛选和方法级参数的紧凑存储格式。
- 说明 `GetMethods` 如何恢复方法列表。
- 说明 `GetParams` 如何还原消费者 URL 所需的方法参数。
- 明确原始 URL 仅作为本地运行时引用，不参与序列化。

本次变更仅补充代码注释，不改变运行时行为。

---

### 回答: 为什么 URL 需要被抽取？

这里抽取的是 MetadataService URL 的参数，不是普通业务服务 URL。

核心原因是解决一个“启动信息从哪里来”的问题：

```text
消费者需要 MetadataInfo，才能知道应用提供哪些业务服务
消费者需要调用 MetadataService，才能拿到 MetadataInfo
消费者需要 MetadataService URL，才能调用 MetadataService
```

因此不能把 MetadataService URL 只放在 `MetadataInfo` 里面，否则消费者必须先拿到 metadata，才能知道去哪里拿 metadata，形成循环依赖。

解决方式就是把调用 MetadataService 所需的最小信息，直接写进注册中心的 `ServiceInstance.Metadata`。

**Provider 侧**

Provider 除了暴露业务接口 也会暴露框架内置接口
假设 Provider 导出的 MetadataService URL 是：

```text
tri://10.0.0.8:20880/org.apache.dubbo.metadata.MetadataService
    ?serialization=hessian2
    &version=1.0.0
    &application=demo-provider
    &timestamp=1786000000
```

注册中心里的服务实例已经包含：

```text
ServiceName = demo-provider
Host        = 10.0.0.8
```

所以 customizer 只需要额外发布类似：

```json
{
  "protocol": "tri",
  "port": "20880",
  "serialization": "hessian2",
  "version": "1.0.0"
}
```

并存入：

```text
dubbo.metadata-service.url-params
```


**Consumer 侧**

消费者从 `ServiceInstance` 获得：

```text
Host        = 10.0.0.8
ServiceName = demo-provider
URL Params  = protocol、port、serialization、version
```

然后由 buildStandardMetadataServiceURL 补上约定字段：

```text
Path      = org.apache.dubbo.metadata.MetadataService
Interface = org.apache.dubbo.metadata.MetadataService
Group     = demo-provider
```

最终重建：

tri://10.0.0.8:20880/org.apache.dubbo.metadata.MetadataService
随后通过 RPC 拉取完整的 MetadataInfo。

为什么不直接保存完整 URL

完整 URL 中有很多信息不需要发布：

- host 已经存在于 ServiceInstance。
- MetadataService 的 path 和 interface 是固定值。
- group 可以由应用名重建。
- timestamp 等参数会变化，但不影响调用。
- Provider URL 可能包含本地配置或无关调用参数。
- 注册中心的实例元数据应该尽量小且稳定。
- 只发布统一白名单参数更利于 Dubbo Java 与 Dubbo Go 互通。


</details>

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
