### PR TITLE
fix(protocol/triple): handle ParseDuration error for keepalive config

### DIFF
--- a/protocol/triple/dubbo3_invoker.go
+++ b/protocol/triple/dubbo3_invoker.go
@@ -111,9 +111,16 @@ func NewDubbo3Invoker(url *common.URL) (*DubboInvoker, error) {
 	tripleConfRaw, ok := url.GetAttribute(constant.TripleConfigKey)
 	if ok {
 		tripleConf := tripleConfRaw.(*global.TripleConfig)
-		// TODO: handle ParseDuration error
-		keepAliveInterval, _ = time.ParseDuration(tripleConf.KeepAliveInterval)
-		keepAliveTimeout, _ = time.ParseDuration(tripleConf.KeepAliveTimeout)
+		if parsedInterval, err := time.ParseDuration(tripleConf.KeepAliveInterval); err == nil {
+			keepAliveInterval = parsedInterval
+		} else if tripleConf.KeepAliveInterval != "" {
+			logger.Warnf("[Triple][Invoker] invalid keepAliveInterval %q, using default %v", tripleConf.KeepAliveInterval, keepAliveInterval)
+		}
+		if parsedTimeout, err := time.ParseDuration(tripleConf.KeepAliveTimeout); err == nil {
+			keepAliveTimeout = parsedTimeout
+		} else if tripleConf.KeepAliveTimeout != "" {
+			logger.Warnf("[Triple][Invoker] invalid keepAliveTimeout %q, using default %v", tripleConf.KeepAliveTimeout, keepAliveTimeout)
+		}
 	}
 
 	opts = append(opts, triConfig.WithGRPCKeepAliveTimeInterval(keepAliveInterval))


### PR DESCRIPTION
### Description

Fixes a bug in `Dubbo3Invoker` where `time.ParseDuration` errors for `KeepAliveInterval` and `KeepAliveTimeout` configuration were silently discarded. Invalid duration strings (e.g., `"30sec"`) would silently zero out the keepalive values, leading to hard-to-debug connection behavior.

Now the invoker checks the parse error, logs a warning with the invalid value, and falls back to the URL-param-derived default when parsing fails.

Fixes #3621

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [ ] I have added tests that prove my fix is effective or that my feature works
