### PR TITLE
fix(protocol/triple): return standard errors in SetHeader, SetTrailer, SendHeader

### DIFF
--- a/protocol/triple/triple_protocol/header.go
+++ b/protocol/triple/triple_protocol/header.go
@@ -295,7 +295,7 @@ func SetTrailer(ctx context.Context, trailer http.Header) error {
 func SendHeader(ctx context.Context, header http.Header) error {
 	conn, ok := ctx.Value(handlerOutgoingKey{}).(StreamingHandlerConn)
 	if !ok {
-		return errorf(CodeInternal, "triple: handler outgoing context not found, ensure this is called from within a Triple handler")
+		return errorf(CodeInternal, "triple: handler outgoing context not found; SendHeader must be called within a Triple handler")
 	}
 	mergeHeaders(conn.RequestHeader(), header)
 	return conn.Send(nil)

--- a/protocol/triple/triple_protocol/header.go
+++ b/protocol/triple/triple_protocol/header.go
@@ -249,7 +249,7 @@ func FromIncomingContext(ctx context.Context) (http.Header, bool) {
 func SetHeader(ctx context.Context, header http.Header) error {
 	conn, ok := ctx.Value(handlerOutgoingKey{}).(StreamingHandlerConn)
 	if !ok {
-		return errorf(CodeInternal, "triple: handler outgoing context not found, ensure this is called from within a Triple handler")
+		return errorf(CodeInternal, "triple: handler outgoing context not found; SetHeader must be called within a Triple handler")
 	}
 	mergeHeaders(conn.ResponseHeader(), header)
 	return nil

--- a/protocol/triple/triple_protocol/header.go
+++ b/protocol/triple/triple_protocol/header.go
@@ -271,7 +271,7 @@ func SetHeader(ctx context.Context, header http.Header) error {
 func SetTrailer(ctx context.Context, trailer http.Header) error {
 	conn, ok := ctx.Value(handlerOutgoingKey{}).(StreamingHandlerConn)
 	if !ok {
-		return errorf(CodeInternal, "triple: handler outgoing context not found, ensure this is called from within a Triple handler")
+		return errorf(CodeInternal, "triple: handler outgoing context not found; SetTrailer must be called within a Triple handler")
 	}
 	mergeHeaders(conn.ResponseTrailer(), trailer)
 	return nil

--- a/protocol/triple/triple_protocol/header.go
+++ b/protocol/triple/triple_protocol/header.go
@@ -249,8 +249,7 @@ func FromIncomingContext(ctx context.Context) (http.Header, bool) {
 func SetHeader(ctx context.Context, header http.Header) error {
 	conn, ok := ctx.Value(handlerOutgoingKey{}).(StreamingHandlerConn)
 	if !ok {
-		// todo(DMwangnima): return standard error
-		return fmt.Errorf("triple: failed to fetch the connection from the context %v", ctx)
+		return errorf(CodeInternal, "triple: handler outgoing context not found, ensure this is called from within a Triple handler")
 	}
 	mergeHeaders(conn.ResponseHeader(), header)
 	return nil
@@ -272,8 +271,7 @@ func SetHeader(ctx context.Context, header http.Header) error {
 func SetTrailer(ctx context.Context, trailer http.Header) error {
 	conn, ok := ctx.Value(handlerOutgoingKey{}).(StreamingHandlerConn)
 	if !ok {
-		// todo(DMwangnima): return standard error
-		return fmt.Errorf("triple: failed to fetch the connection from the context %v", ctx)
+		return errorf(CodeInternal, "triple: handler outgoing context not found, ensure this is called from within a Triple handler")
 	}
 	mergeHeaders(conn.ResponseTrailer(), trailer)
 	return nil
@@ -297,8 +295,7 @@ func SetTrailer(ctx context.Context, trailer http.Header) error {
 func SendHeader(ctx context.Context, header http.Header) error {
 	conn, ok := ctx.Value(handlerOutgoingKey{}).(StreamingHandlerConn)
 	if !ok {
-		// todo(DMwangnima): return standard error
-		return fmt.Errorf("triple: failed to fetch the connection from the context %v", ctx)
+		return errorf(CodeInternal, "triple: handler outgoing context not found, ensure this is called from within a Triple handler")
 	}
 	mergeHeaders(conn.RequestHeader(), header)
 	return conn.Send(nil)


### PR DESCRIPTION
## Description

Replaces ad-hoc `fmt.Errorf` error returns with standard `*Error` values using `errorf(CodeInternal, ...)` in three functions:

- `SetHeader` (line 252)
- `SetTrailer` (line 275)
- `SendHeader` (line 300)

This ensures callers can use `errors.As` to inspect the error code and that errors are properly transmitted over the wire with the correct gRPC/Triple status code.

## Special notes for your reviewer:

- No behavior change for existing callers — the error message is still descriptive
- The error code `CodeInternal` is the appropriate classification for a missing handler context
- All existing tests pass

## Checklist:

- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] `go vet ./protocol/triple/triple_protocol/...` passes
