### PR TITLE
feat: expose Triple response metadata for GenericService

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -157,7 +157,23 @@ func (cli *Client) NewService(service any, opts ...ReferenceOption) (*Connection
 //	if err != nil {
 //	    panic(err)
 //	}
-//	result, err := genericService.Invoke(ctx, "QueryUser", []string{"org.apache.dubbo.samples.User"}, []hessian.Object{user})
+//	var trailers http.Header
+//	result, err := genericService.InvokeWithOptions(
+//	    ctx,
+//	    "QueryUser",
+//	    []string{"org.apache.dubbo.samples.User"},
+//	    []hessian.Object{user},
+//	    client.WithResponseTrailer(&trailers),
+//	)
+//	var typed User
+//	err = genericService.InvokeWithType(
+//	    ctx,
+//	    "QueryUser",
+//	    []string{"org.apache.dubbo.samples.User"},
+//	    []hessian.Object{user},
+//	    &typed,
+//	    client.WithResponseTrailer(&trailers),
+//	)
 func (cli *Client) NewGenericService(referenceStr string, opts ...ReferenceOption) (*generic.GenericService, error) {
 	finalOpts := []ReferenceOption{
 		WithIDL(constant.NONIDL),

--- a/client/options.go
+++ b/client/options.go
@@ -1016,15 +1016,13 @@ func SetClientRouters(routers []*global.RouterConfig) ClientOption {
 	}
 }
 
-// todo: need to be consistent with MethodConfig
-type CallOptions struct {
-	RequestTimeout  string
-	Retries         string
-	ResponseHeader  *http.Header
-	ResponseTrailer *http.Header
-}
+// CallOptions is kept as an alias for compatibility. The shared definition lives
+// in protocol/base so GenericService and the reflective proxy can reuse it.
+type CallOptions = base.CallOptions
 
-type CallOption func(*CallOptions)
+// CallOption is kept as an alias for compatibility. The shared definition lives
+// in protocol/base so GenericService and the reflective proxy can reuse it.
+type CallOption = base.CallOption
 
 func newDefaultCallOptions() *CallOptions {
 	return &CallOptions{}

--- a/filter/generic/filter.go
+++ b/filter/generic/filter.go
@@ -60,6 +60,14 @@ func newGenericFilter() filter.Filter {
 	return instance
 }
 
+func copyResponseMetadataAttributes(from, to base.Invocation) {
+	for _, key := range [...]string{constant.ResponseHeaderKey, constant.ResponseTrailerKey} {
+		if value, ok := from.GetAttribute(key); ok {
+			to.SetAttribute(key, value)
+		}
+	}
+}
+
 // Invoke turns the parameters to map for generic method
 func (f *genericFilter) Invoke(ctx context.Context, invoker base.Invoker, inv base.Invocation) result.Result {
 	configuredGeneric := invoker.GetURL().GetParam(constant.GenericKey, "")
@@ -124,6 +132,7 @@ func (f *genericFilter) Invoke(ctx context.Context, invoker base.Invoker, inv ba
 		} else {
 			newIvc.SetAttribute(constant.CallTypeKey, constant.CallUnary)
 		}
+		copyResponseMetadataAttributes(inv, newIvc)
 
 		return invoker.Invoke(ctx, newIvc)
 	} else if isMakingAGenericCall(invoker, inv) {
@@ -151,6 +160,7 @@ func (f *genericFilter) Invoke(ctx context.Context, invoker base.Invoker, inv ba
 		} else {
 			newIvc.SetAttribute(constant.CallTypeKey, constant.CallUnary)
 		}
+		copyResponseMetadataAttributes(inv, newIvc)
 
 		return invoker.Invoke(ctx, newIvc)
 	}

--- a/filter/generic/filter_test.go
+++ b/filter/generic/filter_test.go
@@ -19,6 +19,7 @@ package generic
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 	"testing"
 )
@@ -94,6 +95,10 @@ func TestFilter_InvokeWithGenericCall(t *testing.T) {
 		[]string{"java.lang.String"},
 		[]string{"arg1"},
 	}, make(map[string]any))
+	var responseHeader http.Header
+	var responseTrailer http.Header
+	genericInvocation.SetAttribute(constant.ResponseHeaderKey, &responseHeader)
+	genericInvocation.SetAttribute(constant.ResponseTrailerKey, &responseTrailer)
 
 	mockInvoker := mock.NewMockInvoker(ctrl)
 	mockInvoker.EXPECT().GetURL().Return(invokeUrl).Times(3)
@@ -105,6 +110,12 @@ func TestFilter_InvokeWithGenericCall(t *testing.T) {
 			assert.Equal(t, "java.lang.String", args[1].([]string)[0])
 			assert.Equal(t, "arg1", args[2].([]string)[0])
 			assert.Equal(t, constant.GenericSerializationDefault, invocation.GetAttachmentWithDefaultValue(constant.GenericKey, ""))
+			gotHeader, ok := invocation.GetAttribute(constant.ResponseHeaderKey)
+			require.True(t, ok)
+			require.Same(t, &responseHeader, gotHeader)
+			gotTrailer, ok := invocation.GetAttribute(constant.ResponseTrailerKey)
+			require.True(t, ok)
+			require.Same(t, &responseTrailer, gotTrailer)
 			return &result.RPCResult{}
 		})
 
@@ -575,4 +586,38 @@ func TestFilter_OnResponse_DeserializationError(t *testing.T) {
 		// The result should still be the original map
 		assert.Equal(t, mapResult, newRes.Result())
 	})
+}
+
+func TestFilter_InvokePreservesResponseMetadataAttributes(t *testing.T) {
+	invokeURL := common.NewURLWithOptions(
+		common.WithParams(url.Values{}),
+		common.WithParamsValue(constant.GenericKey, constant.GenericSerializationDefault),
+	)
+	filter := &genericFilter{}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	var responseHeader http.Header
+	var responseTrailer http.Header
+	inv := invocation.NewRPCInvocation("echo", []any{"hello"}, nil)
+	inv.SetAttribute(constant.ResponseHeaderKey, &responseHeader)
+	inv.SetAttribute(constant.ResponseTrailerKey, &responseTrailer)
+
+	mockInvoker := mock.NewMockInvoker(ctrl)
+	mockInvoker.EXPECT().GetURL().Return(invokeURL).Times(2)
+	mockInvoker.EXPECT().Invoke(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, transformed base.Invocation) result.Result {
+			gotHeader, ok := transformed.GetAttribute(constant.ResponseHeaderKey)
+			require.True(t, ok)
+			require.Same(t, &responseHeader, gotHeader)
+			gotTrailer, ok := transformed.GetAttribute(constant.ResponseTrailerKey)
+			require.True(t, ok)
+			require.Same(t, &responseTrailer, gotTrailer)
+			return &result.RPCResult{}
+		},
+	).Times(1)
+
+	invokeResult := filter.Invoke(context.Background(), mockInvoker, inv)
+	require.NoError(t, invokeResult.Error())
 }

--- a/filter/generic/service.go
+++ b/filter/generic/service.go
@@ -19,6 +19,7 @@ package generic
 
 import (
 	"context"
+	"errors"
 	"reflect"
 )
 
@@ -28,12 +29,17 @@ import (
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/filter/generic/generalizer"
+	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 )
 
 // GenericService uses for generic invoke for service call
 type GenericService struct {
-	Invoke       func(ctx context.Context, methodName string, types []string, args []hessian.Object) (any, error) `dubbo:"$invoke"`
-	referenceStr string
+	// Invoke is the legacy generic call entry point. Use InvokeWithOptions when
+	// per-call options such as response metadata targets are required.
+	Invoke func(ctx context.Context, methodName string, types []string, args []hessian.Object) (any, error) `dubbo:"$invoke"`
+	// InvokeWithOptions is the options-aware generic call entry point.
+	InvokeWithOptions func(ctx context.Context, methodName string, types []string, args []hessian.Object, opts ...base.CallOption) (any, error) `dubbo:"$invoke"`
+	referenceStr      string
 }
 
 // NewGenericService returns a GenericService instance
@@ -47,7 +53,8 @@ func (s *GenericService) Reference() string {
 }
 
 // InvokeWithType invokes the remote method and deserializes the result into the reply struct.
-// The reply parameter must be a non-nil pointer to the target type.
+// The reply parameter must be a non-nil pointer to the target type. Optional call options
+// are forwarded through the options-aware generic call path.
 //
 // Note: This method uses MapGeneralizer for deserialization, which means it only supports
 // the default map-based generic serialization (generic=true). If you are using other
@@ -62,34 +69,50 @@ func (s *GenericService) Reference() string {
 //	    return err
 //	}
 //	fmt.Println(user.Name, user.Age)
-func (s *GenericService) InvokeWithType(ctx context.Context, methodName string, types []string, args []hessian.Object, reply any) error {
-	// Validate the reply pointer
+func (s *GenericService) InvokeWithType(ctx context.Context, methodName string, types []string, args []hessian.Object, reply any, opts ...base.CallOption) error {
+	if len(opts) > 0 {
+		return s.invokeWithTypeOptions(ctx, methodName, types, args, reply, opts...)
+	}
+	return s.invokeWithType(ctx, methodName, types, args, reply, func(ctx context.Context, methodName string, types []string, args []hessian.Object) (any, error) {
+		return s.Invoke(ctx, methodName, types, args)
+	})
+}
+
+// InvokeWithTypeOptions is the explicit options-named form of InvokeWithType.
+// The reply parameter must be a non-nil pointer. It returns an initialization error
+// if the service was not implemented with the options-aware proxy path.
+func (s *GenericService) InvokeWithTypeOptions(ctx context.Context, methodName string, types []string, args []hessian.Object, reply any, opts ...base.CallOption) error {
+	return s.invokeWithTypeOptions(ctx, methodName, types, args, reply, opts...)
+}
+
+func (s *GenericService) invokeWithTypeOptions(ctx context.Context, methodName string, types []string, args []hessian.Object, reply any, opts ...base.CallOption) error {
+	if s.InvokeWithOptions == nil {
+		return errors.New("generic invoke with options is not initialized")
+	}
+	return s.invokeWithType(ctx, methodName, types, args, reply, func(ctx context.Context, methodName string, types []string, args []hessian.Object) (any, error) {
+		return s.InvokeWithOptions(ctx, methodName, types, args, opts...)
+	})
+}
+
+func (s *GenericService) invokeWithType(ctx context.Context, methodName string, types []string, args []hessian.Object, reply any, invoke func(context.Context, string, []string, []hessian.Object) (any, error)) error {
 	replyValue, err := validateReplyPointer(reply)
 	if err != nil {
 		return err
 	}
 
-	// Call the underlying Invoke method
-	result, err := s.Invoke(ctx, methodName, types, args)
+	result, err := invoke(ctx, methodName, types, args)
 	if err != nil {
 		return err
 	}
-
 	if result == nil {
 		return nil
 	}
 
-	// Get the element type that the pointer points to
-	replyType := replyValue.Elem().Type()
-
-	// Use MapGeneralizer to realize the map result to the target struct
 	g := generalizer.GetMapGeneralizer()
-	realized, err := realizeResult(result, replyType, g)
+	realized, err := realizeResult(result, replyValue.Elem().Type(), g)
 	if err != nil {
 		return err
 	}
-
-	// Set the realized value to reply
 	if realized != nil {
 		replyValue.Elem().Set(reflect.ValueOf(realized))
 	}

--- a/filter/generic/service_options_test.go
+++ b/filter/generic/service_options_test.go
@@ -1,0 +1,134 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package generic_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+)
+
+import (
+	hessian "github.com/apache/dubbo-go-hessian2"
+
+	"github.com/stretchr/testify/require"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/client"
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/filter/generic"
+	"dubbo.apache.org/dubbo-go/v3/protocol/base"
+	"dubbo.apache.org/dubbo-go/v3/protocol/result"
+	"dubbo.apache.org/dubbo-go/v3/proxy"
+)
+
+func TestGenericServiceInvokeWithTypeCopiesCallOption(t *testing.T) {
+	service := generic.NewGenericService("TestService")
+	var gotTrailer *http.Header
+	service.InvokeWithOptions = func(_ context.Context, _ string, _ []string, _ []hessian.Object, opts ...client.CallOption) (any, error) {
+		options := &client.CallOptions{}
+		for _, opt := range opts {
+			opt(options)
+		}
+		gotTrailer = options.ResponseTrailer
+		return map[string]any{
+			"name": "testUser",
+			"age":  25,
+		}, nil
+	}
+
+	var trailers http.Header
+	var user struct {
+		Name string
+		Age  int
+	}
+	err := service.InvokeWithType(
+		context.Background(),
+		"getUser",
+		[]string{"java.lang.String"},
+		[]hessian.Object{"123"},
+		&user,
+		client.WithResponseTrailer(&trailers),
+	)
+
+	require.NoError(t, err)
+	require.Same(t, &trailers, gotTrailer)
+	require.Equal(t, "testUser", user.Name)
+	require.Equal(t, 25, user.Age)
+}
+
+type genericOptionsInvoker struct {
+	base.BaseInvoker
+	invocation base.Invocation
+}
+
+func (i *genericOptionsInvoker) Invoke(_ context.Context, inv base.Invocation) result.Result {
+	i.invocation = inv
+	if reply, ok := inv.Reply().(*any); ok {
+		*reply = map[string]any{
+			"name": "testUser",
+			"age":  25,
+		}
+	}
+	return &result.RPCResult{}
+}
+
+func TestGenericServiceInvokeWithTypeOptionsThroughProxy(t *testing.T) {
+	invoker := &genericOptionsInvoker{BaseInvoker: *base.NewBaseInvoker(&common.URL{})}
+	service := generic.NewGenericService("TestService")
+	proxy.NewProxy(invoker, nil, nil).Implement(service)
+
+	var responseHeader http.Header
+	var responseTrailer http.Header
+	var user struct {
+		Name string
+		Age  int
+	}
+	err := service.InvokeWithTypeOptions(
+		context.Background(),
+		"getUser",
+		[]string{"java.lang.String"},
+		[]hessian.Object{"123"},
+		&user,
+		client.WithCallRequestTimeout(time.Second),
+		client.WithResponseHeader(&responseHeader),
+		client.WithResponseTrailer(&responseTrailer),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "testUser", user.Name)
+	require.Equal(t, 25, user.Age)
+	require.Equal(t, []any{
+		"getUser",
+		[]string{"java.lang.String"},
+		[]hessian.Object{"123"},
+	}, invoker.invocation.Arguments())
+
+	timeout, ok := invoker.invocation.GetAttachment(constant.TimeoutKey)
+	require.True(t, ok)
+	require.Equal(t, "1s", timeout)
+	header, ok := invoker.invocation.GetAttribute(constant.ResponseHeaderKey)
+	require.True(t, ok)
+	require.Same(t, &responseHeader, header)
+	trailer, ok := invoker.invocation.GetAttribute(constant.ResponseTrailerKey)
+	require.True(t, ok)
+	require.Same(t, &responseTrailer, trailer)
+}

--- a/protocol/base/call_options.go
+++ b/protocol/base/call_options.go
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base
+
+import (
+	"net/http"
+)
+
+// CallOptions contains per-invocation options shared by client and proxy paths.
+type CallOptions struct {
+	RequestTimeout  string
+	Retries         string
+	ResponseHeader  *http.Header
+	ResponseTrailer *http.Header
+}
+
+// CallOption configures one RPC invocation.
+type CallOption func(*CallOptions)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -121,7 +121,7 @@ func DefaultProxyImplementFunc(p *Proxy, v common.RPCService) {
 
 	valueOfElem := valueOf.Elem()
 
-	makeDubboCallProxy := func(methodName string, outs []reflect.Type) func(in []reflect.Value) []reflect.Value {
+	makeDubboCallProxy := func(methodName string, outs []reflect.Type, hasCallOptions bool) func(in []reflect.Value) []reflect.Value {
 		return func(in []reflect.Value) []reflect.Value {
 			var (
 				err            error
@@ -159,6 +159,15 @@ func DefaultProxyImplementFunc(p *Proxy, v common.RPCService) {
 				}
 			}
 
+			callOptions := &base.CallOptions{}
+			if hasCallOptions {
+				optionValues := in[end-1]
+				end--
+				for i := 0; i < optionValues.Len(); i++ {
+					optionValues.Index(i).Interface().(base.CallOption)(callOptions)
+				}
+			}
+
 			if end-start <= 0 {
 				inIArr = []any{}
 				inVArr = []reflect.Value{}
@@ -181,6 +190,17 @@ func DefaultProxyImplementFunc(p *Proxy, v common.RPCService) {
 				invocation.WithCallBack(p.callback), invocation.WithParameterValues(inVArr))
 			if !replyEmptyFlag {
 				inv.SetReply(reply.Interface())
+			}
+
+			if hasCallOptions {
+				inv.SetAttachment(constant.TimeoutKey, callOptions.RequestTimeout)
+				inv.SetAttachment(constant.RetriesKey, callOptions.Retries)
+				if callOptions.ResponseHeader != nil {
+					inv.SetAttribute(constant.ResponseHeaderKey, callOptions.ResponseHeader)
+				}
+				if callOptions.ResponseTrailer != nil {
+					inv.SetAttribute(constant.ResponseTrailerKey, callOptions.ResponseTrailer)
+				}
 			}
 
 			for k, value := range p.attachments {
@@ -231,7 +251,7 @@ func DefaultProxyImplementFunc(p *Proxy, v common.RPCService) {
 	}
 }
 
-func refectAndMakeObjectFunc(valueOfElem reflect.Value, makeDubboCallProxy func(methodName string, outs []reflect.Type) func(in []reflect.Value) []reflect.Value) error {
+func refectAndMakeObjectFunc(valueOfElem reflect.Value, makeDubboCallProxy func(methodName string, outs []reflect.Type, hasCallOptions bool) func(in []reflect.Value) []reflect.Value) error {
 	typeOf := valueOfElem.Type()
 	// check incoming interface, incoming interface's elem must be a struct.
 	if typeOf.Kind() != reflect.Struct {
@@ -266,7 +286,8 @@ func refectAndMakeObjectFunc(valueOfElem reflect.Value, makeDubboCallProxy func(
 			}
 
 			// do method proxy here:
-			f.Set(reflect.MakeFunc(f.Type(), makeDubboCallProxy(methodName, funcOuts)))
+			hasCallOptions := t.Type.IsVariadic() && t.Type.In(t.Type.NumIn()-1).Elem() == reflect.TypeFor[base.CallOption]()
+			f.Set(reflect.MakeFunc(f.Type(), makeDubboCallProxy(methodName, funcOuts, hasCallOptions)))
 			logger.Debugf("[Proxy] set method [%s]", methodName)
 		} else if f.IsValid() && f.CanSet() {
 			// for struct combination

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -20,11 +20,14 @@ package proxy
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"reflect"
 	"testing"
 )
 
 import (
+	hessian "github.com/apache/dubbo-go-hessian2"
+
 	perrors "github.com/pkg/errors"
 
 	"github.com/stretchr/testify/assert"
@@ -48,6 +51,14 @@ type TestService struct {
 	MethodFive  func() error
 	MethodSix   func(context.Context, string) (any, error)
 	Echo        func(any, *any) error
+}
+
+type TestServiceWithCallOptions struct {
+	Invoke func(context.Context, string, []string, []hessian.Object, ...base.CallOption) (any, error) `dubbo:"$invoke"`
+}
+
+type TestServiceWithVariadic struct {
+	Echo func(...any) (any, error)
 }
 
 func (s *TestService) Reference() string {
@@ -158,4 +169,71 @@ func (bi *TestProxyInvoker) Invoke(_ context.Context, inv base.Invocation) resul
 	return &result.RPCResult{
 		Rest: inv.Arguments(),
 	}
+}
+
+type callOptionsProxyInvoker struct {
+	base.BaseInvoker
+	invocation base.Invocation
+}
+
+func (i *callOptionsProxyInvoker) Invoke(_ context.Context, inv base.Invocation) result.Result {
+	i.invocation = inv
+	if reply, ok := inv.Reply().(*any); ok {
+		*reply = "ok"
+	}
+	return &result.RPCResult{}
+}
+
+func TestProxyImplementWithCallOptions(t *testing.T) {
+	invoker := &callOptionsProxyInvoker{BaseInvoker: *base.NewBaseInvoker(&common.URL{})}
+	service := &TestServiceWithCallOptions{}
+	p := NewProxy(invoker, nil, nil)
+	p.Implement(service)
+
+	var responseHeader http.Header
+	var responseTrailer http.Header
+	resultValue, err := service.Invoke(
+		context.Background(),
+		"echo",
+		[]string{"java.lang.String"},
+		[]hessian.Object{"hello"},
+		func(options *base.CallOptions) {
+			options.RequestTimeout = "1s"
+			options.Retries = "2"
+			options.ResponseHeader = &responseHeader
+			options.ResponseTrailer = &responseTrailer
+		},
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "ok", resultValue)
+	require.Equal(t, []any{
+		"echo",
+		[]string{"java.lang.String"},
+		[]hessian.Object{"hello"},
+	}, invoker.invocation.Arguments())
+
+	timeout, ok := invoker.invocation.GetAttachment(constant.TimeoutKey)
+	require.True(t, ok)
+	require.Equal(t, "1s", timeout)
+	retries, ok := invoker.invocation.GetAttachment(constant.RetriesKey)
+	require.True(t, ok)
+	require.Equal(t, "2", retries)
+
+	trailer, ok := invoker.invocation.GetAttribute(constant.ResponseTrailerKey)
+	require.True(t, ok)
+	require.Same(t, &responseTrailer, trailer)
+}
+
+func TestProxyImplementKeepsOrdinaryVariadicArguments(t *testing.T) {
+	invoker := &callOptionsProxyInvoker{BaseInvoker: *base.NewBaseInvoker(&common.URL{})}
+	service := &TestServiceWithVariadic{}
+	p := NewProxy(invoker, nil, nil)
+	p.Implement(service)
+
+	resultValue, err := service.Echo("one", "two")
+
+	require.NoError(t, err)
+	require.Equal(t, "ok", resultValue)
+	require.Equal(t, []any{"one", "two"}, invoker.invocation.Arguments())
 }


### PR DESCRIPTION
## 关联 Issue

Related #3445

## 一、问题背景

Dubbo-go 当前已经支持通过 Triple unary 调用传递和读取 response headers/trailers。

对于生成式 Triple client，可以通过 call options 获取 provider 返回的 response metadata：

```go
var trailers http.Header

resp, err := service.Greet(
    ctx,
    request,
    client.WithResponseTrailer(&trailers),
)
```

但是，GenericService 的调用路径没有提供等价能力。

GenericService 主要用于 non-IDL 泛化调用，当前典型调用方式如下：

```go
result, err := genericService.Invoke(
    ctx,
    "echo",
    []string{"java.lang.String"},
    []hessian.Object{"hello"},
)
```

当 provider 通过 result attachments 将数据写入 Triple response trailers 后，generic consumer 无法向底层 Triple unary client 提供 response trailer 的目标 `http.Header`，因此无法读取 provider 返回的 response attachments。

期望的数据流是：

```text
provider result attachments
    -> Triple response trailers
    -> Triple client response metadata
    -> GenericService 调用方提供的 http.Header
```

## 二、根因分析

### 1. GenericService.Invoke 没有 per-call options

`GenericService.Invoke` 原本是一个公开的函数类型字段：

```go
type GenericService struct {
    Invoke func(
        ctx context.Context,
        methodName string,
        types []string,
        args []hessian.Object,
    ) (any, error) `dubbo:"$invoke"`
}
```

该字段没有 `opts ...CallOption` 参数，因此调用方无法传入：

```go
client.WithResponseHeader(&headers)
client.WithResponseTrailer(&trailers)
```

### 2. Invoke 是公开函数类型字段，不能直接改变签名

如果直接把 `Invoke` 改成带 `opts ...client.CallOption` 的函数类型，已有用户对 `Invoke` 字段的直接赋值会发生源码不兼容。

同时，Go 不支持同名重载，因此无法同时保留旧的四参数函数类型字段，并让同一个字段接受带 options 的调用。

### 3. CallOption 定义在 client 包会造成依赖方向问题

proxy 和 generic filter 都需要识别并传递 call options。如果它们直接依赖 `client.CallOption`，会引入不必要的包依赖，甚至可能形成 import cycle。call option 类型需要放在更底层、与 client 无关的共享包中。

### 4. Proxy 反射调用必须区分 options 和普通业务参数

GenericService 的调用通过 proxy 反射生成。proxy 需要从反射参数中识别并移除 `opts ...base.CallOption`，但不能通过“最后一个参数是 variadic”这种宽泛规则判断，否则普通业务方法的 variadic 参数也可能被错误剥离。

### 5. Generic filter 会重建 Invocation

generic filter 在 `$invoke` 调用过程中会重建 Invocation，将原始业务参数转换为 generic 调用需要的形式。如果重建时不复制 response metadata attributes，之前由 proxy 写入的 response header/trailer 目标就会丢失，底层 Triple client 最终无法回写用户提供的 `http.Header`。

## 三、解决方案

本次修改采用兼容优先的最小方案：

1. 将 `CallOptions` / `CallOption` 下沉到 `protocol/base`。
2. 在 `client` 包保留类型别名，兼容已有 `client.CallOption` 使用方式。
3. 保留原有 `GenericService.Invoke` 字段和调用方式。
4. 新增 `InvokeWithOptions` 作为带 options 的 generic 调用入口。
5. 扩展 `InvokeWithType`，支持可选的 `...base.CallOption`。
6. 保留显式命名的 `InvokeWithTypeOptions` API。
7. proxy 仅精确识别 `...base.CallOption`，避免影响普通业务 variadic 参数。
8. 通过 Invocation attachments/attributes 复用现有 Triple client 的 metadata 传递路径。
9. generic filter 重建 Invocation 时，只复制 response header/trailer 两类必要 attributes。

## 四、具体实现

### 1. 增加共享 CallOption 类型

新增：

```text
protocol/base/call_options.go
```

定义：

```go
type CallOptions struct {
    RequestTimeout  string
    Retries         string
    ResponseHeader  *http.Header
    ResponseTrailer *http.Header
}

type CallOption func(*CallOptions)
```

`CallOptions` 同时承载 request timeout、retries、response header 目标和 response trailer 目标。

### 2. 保留 client 包的兼容 API

`client/options.go` 中保留：

```go
type CallOptions = base.CallOptions
type CallOption = base.CallOption
```

因此以下已有写法继续有效：

```go
client.WithResponseHeader(&headers)
client.WithResponseTrailer(&trailers)
client.WithCallRequestTimeout(time.Second)
```

proxy 和 generic filter 只依赖 `protocol/base`，不反向依赖 `client`。

### 3. 新增 GenericService options 调用入口

`GenericService` 保留旧字段：

```go
Invoke func(
    ctx context.Context,
    methodName string,
    types []string,
    args []hessian.Object,
) (any, error)
```

同时新增：

```go
InvokeWithOptions func(
    ctx context.Context,
    methodName string,
    types []string,
    args []hessian.Object,
    opts ...base.CallOption,
) (any, error)
```

带 options 的泛化调用示例：

```go
var headers http.Header
var trailers http.Header

result, err := genericService.InvokeWithOptions(
    ctx,
    "echo",
    []string{"java.lang.String"},
    []hessian.Object{"hello"},
    client.WithResponseHeader(&headers),
    client.WithResponseTrailer(&trailers),
)
```

### 4. 扩展 InvokeWithType

`InvokeWithType` 现在支持可选 options：

```go
func (s *GenericService) InvokeWithType(
    ctx context.Context,
    methodName string,
    types []string,
    args []hessian.Object,
    reply any,
    opts ...base.CallOption,
) error
```

示例：

```go
var trailers http.Header
var user User

err := genericService.InvokeWithType(
    ctx,
    "getUser",
    []string{"java.lang.String"},
    []hessian.Object{"123"},
    &user,
    client.WithResponseTrailer(&trailers),
)
```

同时保留显式 options 命名形式：

```go
err := genericService.InvokeWithTypeOptions(
    ctx,
    "getUser",
    []string{"java.lang.String"},
    []hessian.Object{"123"},
    &user,
    client.WithResponseTrailer(&trailers),
)
```

### 5. Proxy 传递 Invocation metadata

修改：

```text
proxy/proxy.go
```

proxy 只在方法满足以下条件时处理 call options：

```go
method.IsVariadic()
method.LastParameterElementType == reflect.TypeFor[base.CallOption]()
```

处理过程：

1. 从最后一个 variadic 参数中取出 `[]base.CallOption`；
2. 执行每个 option，生成 `CallOptions`；
3. 不将 options 放入业务参数；
4. 将 request timeout/retries 写入 Invocation attachments；
5. 将 response header/trailer 目标写入 Invocation attributes。

对应 attributes：

```go
constant.ResponseHeaderKey
constant.ResponseTrailerKey
```

普通业务 variadic 方法不会进入这条逻辑，原有参数语义保持不变。

### 6. Generic filter 保留 response metadata attributes

修改：

```text
filter/generic/filter.go
```

generic filter 在重建 Invocation 时，复制：

```go
constant.ResponseHeaderKey
constant.ResponseTrailerKey
```

只复制这两类 response metadata attributes，不复制全部内部 attributes，避免将不必要的 Invocation 状态泄漏到新的调用对象中。

该逻辑覆盖 generic filter 中两条会重建 Invocation 的路径。

### 复用现有 Triple response metadata 路径

本次没有修改 Triple invoker 底层 response metadata 读取逻辑。

调用链如下：

```text
client.WithResponseTrailer(&trailers)
    -> proxy 解析 CallOption
    -> Invocation.ResponseTrailerKey
    -> generic filter 重建 Invocation 并保留 attribute
    -> Triple unary call
    -> 读取 response trailers
    -> 写回 trailers
```

response header 的流程相同。

## 五、API 兼容性说明

原有 `Invoke` 调用保持不变：

```go
result, err := genericService.Invoke(
    ctx,
    "echo",
    types,
    args,
)
```

由于 `Invoke` 是公开的非 variadic 函数类型字段，无法在不破坏已有字段赋值代码的情况下支持以下形式：

```go
genericService.Invoke(ctx, method, types, args, opts...)
```

因此本次使用：

```go
genericService.InvokeWithOptions(...)
```

作为兼容入口。

`InvokeWithType` 是公开方法，普通的五参数直接调用仍然有效：

```go
err := genericService.InvokeWithType(
    ctx,
    method,
    types,
    args,
    &reply,
)
```

新增调用可以直接追加 options：

```go
err := genericService.InvokeWithType(
    ctx,
    method,
    types,
    args,
    &reply,
    client.WithResponseTrailer(&trailers),
)
```

如果 GenericService 仅手动初始化了旧的 `Invoke` 字段，没有通过 `proxy.Implement` 等方式初始化 options-aware 调用字段，options API 会返回明确的初始化错误。

## 六、测试与验证

已通过：

```text
go test -count=1 ./protocol/base ./client ./proxy ./filter/generic
Go test: 278 passed in 4 packages
```

```text
go test -race -count=1 ./proxy ./filter/generic
Go test: 73 passed in 2 packages
```

```text
go test -count=1 ./protocol/triple -run 'Response|Trailer'
Go test: 3 passed in 1 packages
```

```text
cd tools/dubbogo-cli && go test -count=1 ./...
Go test: 12 passed in 15 packages
```

其他验证：

```text
make fmt
通过
```

```text
make lint
0 issues.
```

```text
git diff --check
通过
```

`make test` 的 root module 测试除既有 Triple 外部 timeout 测试外均通过，但以下测试仍受当前环境/外部服务行为影响：

```text
protocol/triple/TestClientInvokeWithTimeout/without_TLS
unexpected EOF

protocol/triple/TestClientInvokeWithTimeout/with_TLS
no Grpc-Status trailer
```

这两个失败发生在现有外部 Triple timeout 测试路径，与本次 GenericService response metadata 修改路径无关。
