### PR TITLE
Refactor/triple comments helpers

### DIFF
--- a/protocol/triple/client.go
+++ b/protocol/triple/client.go
@@ -137,8 +137,7 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 	version := url.GetParam(constant.VersionKey, "")
 	cliOpts = append(cliOpts, tri.WithGroup(group), tri.WithVersion(version))
 
-	// Observability integrations should contribute tri.ClientOption values
-	// before the shared service and health clients are created.
+	// TODO(DMwangnima): support OpenTracing
 
 	// Resolve TLS first because HTTP/2 and HTTP/3 transport setup depends on it.
 	var (
@@ -312,7 +311,9 @@ func resolveClientKeepAliveOptions(url *common.URL, tripleConf *global.TripleCon
 	}
 	clientKeepAliveOpts = append(clientKeepAliveOpts, tri.WithSendMaxBytes(maxCallSendMsgSize))
 
-	// Legacy URL keepalive parameters remain supported for 3.x compatibility.
+	// Set keepalive interval and keepalive timeout
+	// Compatibility: read the legacy URL keepalive parameters.
+	// TODO: remove KeepAliveInterval and KeepAliveTimeout in version 4.0.0.
 	keepAliveInterval := url.GetParamDuration(constant.KeepAliveInterval, constant.DefaultKeepAliveInterval)
 	keepAliveTimeout := url.GetParamDuration(constant.KeepAliveTimeout, constant.DefaultKeepAliveTimeout)
 

--- a/protocol/triple/client.go
+++ b/protocol/triple/client.go
@@ -174,12 +174,12 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 	}
 
 	// Resolve keepalive and size-limit options before choosing the transport.
-	clientKeepaliveOpts, keepAliveInterval, keepAliveTimeout, keepaliveErr := resolveClientKeepaliveOptions(url, tripleConf)
-	if keepaliveErr != nil {
-		logger.Errorf("[Triple][Client] resolve client keepalive options failed, err=%v", keepaliveErr)
-		return nil, keepaliveErr
+	clientKeepAliveOpts, keepAliveInterval, keepAliveTimeout, keepAliveErr := resolveClientKeepAliveOptions(url, tripleConf)
+	if keepAliveErr != nil {
+		logger.Errorf("[Triple][Client] genKeepAliveOpts failed, err=%v", keepAliveErr)
+		return nil, keepAliveErr
 	}
-	cliOpts = append(cliOpts, clientKeepaliveOpts...)
+	cliOpts = append(cliOpts, clientKeepAliveOpts...)
 
 	// Build the HTTP transport used by the Triple client.
 	var transport http.RoundTripper
@@ -297,27 +297,27 @@ func (cm *clientManager) callHealthWatch(ctx context.Context, service string) (*
 	return stream, nil
 }
 
-func resolveClientKeepaliveOptions(url *common.URL, tripleConf *global.TripleConfig) ([]tri.ClientOption, time.Duration, time.Duration, error) {
-	var clientKeepaliveOpts []tri.ClientOption
+func resolveClientKeepAliveOptions(url *common.URL, tripleConf *global.TripleConfig) ([]tri.ClientOption, time.Duration, time.Duration, error) {
+	var clientKeepAliveOpts []tri.ClientOption
 
 	// Apply client message-size limits from URL compatibility parameters.
 	maxCallRecvMsgSize := constant.DefaultMaxCallRecvMsgSize
 	if recvMsgSize, err := humanize.ParseBytes(url.GetParam(constant.MaxCallRecvMsgSize, "")); err == nil && recvMsgSize > 0 {
 		maxCallRecvMsgSize = int(recvMsgSize)
 	}
-	clientKeepaliveOpts = append(clientKeepaliveOpts, tri.WithReadMaxBytes(maxCallRecvMsgSize))
+	clientKeepAliveOpts = append(clientKeepAliveOpts, tri.WithReadMaxBytes(maxCallRecvMsgSize))
 	maxCallSendMsgSize := constant.DefaultMaxCallSendMsgSize
 	if sendMsgSize, err := humanize.ParseBytes(url.GetParam(constant.MaxCallSendMsgSize, "")); err == nil && sendMsgSize > 0 {
 		maxCallSendMsgSize = int(sendMsgSize)
 	}
-	clientKeepaliveOpts = append(clientKeepaliveOpts, tri.WithSendMaxBytes(maxCallSendMsgSize))
+	clientKeepAliveOpts = append(clientKeepAliveOpts, tri.WithSendMaxBytes(maxCallSendMsgSize))
 
 	// Legacy URL keepalive parameters remain supported for 3.x compatibility.
 	keepAliveInterval := url.GetParamDuration(constant.KeepAliveInterval, constant.DefaultKeepAliveInterval)
 	keepAliveTimeout := url.GetParamDuration(constant.KeepAliveTimeout, constant.DefaultKeepAliveTimeout)
 
 	if tripleConf == nil {
-		return clientKeepaliveOpts, keepAliveInterval, keepAliveTimeout, nil
+		return clientKeepAliveOpts, keepAliveInterval, keepAliveTimeout, nil
 	}
 
 	var parseErr error
@@ -335,5 +335,5 @@ func resolveClientKeepaliveOptions(url *common.URL, tripleConf *global.TripleCon
 		}
 	}
 
-	return clientKeepaliveOpts, keepAliveInterval, keepAliveTimeout, nil
+	return clientKeepAliveOpts, keepAliveInterval, keepAliveTimeout, nil
 }

--- a/protocol/triple/client.go
+++ b/protocol/triple/client.go
@@ -54,9 +54,8 @@ const (
 	httpsPrefix string = "https://"
 )
 
-// clientManager wraps triple clients and is responsible for find concrete triple client to invoke
-// callUnary, callClientStream, callServerStream, callBidiStream.
-// A Reference has a clientManager.
+// clientManager owns the service-level Triple clients used by unary, streaming,
+// and health-check calls for a Reference.
 type clientManager struct {
 	isIDL        bool
 	triClient    *tri.Client
@@ -107,12 +106,13 @@ func (cm *clientManager) close() error {
 	return nil
 }
 
-// newClientManager extracts configurations from url and builds clientManager
+// newClientManager resolves URL and global Triple settings, then builds the
+// service and health clients that share one HTTP transport.
 func newClientManager(url *common.URL) (*clientManager, error) {
 	var cliOpts []tri.ClientOption
 	var isIDL bool
 
-	// Set serialization
+	// Resolve codec options before constructing the transport-backed client.
 	serialization := url.GetParam(constant.SerializationKey, constant.ProtobufSerialization)
 	switch serialization {
 	case constant.ProtobufSerialization:
@@ -128,18 +128,19 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 		panic(fmt.Sprintf("Unsupported serialization: %s", serialization))
 	}
 
-	// Set timeout
+	// Apply the call timeout configured on the reference URL.
 	timeout := url.GetParamDuration(constant.TimeoutKey, "")
 	cliOpts = append(cliOpts, tri.WithTimeout(timeout))
 
-	// Set service group and version
+	// Pass group and version through request headers for service selection.
 	group := url.GetParam(constant.GroupKey, "")
 	version := url.GetParam(constant.VersionKey, "")
 	cliOpts = append(cliOpts, tri.WithGroup(group), tri.WithVersion(version))
 
-	// TODO(DMwangnima): support OpenTracing
+	// Observability integrations should contribute tri.ClientOption values
+	// before the shared service and health clients are created.
 
-	// Handle TLS
+	// Resolve TLS first because HTTP/2 and HTTP/3 transport setup depends on it.
 	var (
 		tlsFlag bool
 		tlsConf *global.TLSConfig
@@ -172,15 +173,15 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 		tripleConf = tripleConfRaw.(*global.TripleConfig)
 	}
 
-	// Handle keepalive options
-	cliKeepAliveOpts, keepAliveInterval, keepAliveTimeout, genKeepAliveOptsErr := genKeepAliveOptions(url, tripleConf)
-	if genKeepAliveOptsErr != nil {
-		logger.Errorf("[Triple][Client] genKeepAliveOpts failed, err=%v", genKeepAliveOptsErr)
-		return nil, genKeepAliveOptsErr
+	// Resolve keepalive and size-limit options before choosing the transport.
+	clientKeepaliveOpts, keepAliveInterval, keepAliveTimeout, keepaliveErr := resolveClientKeepaliveOptions(url, tripleConf)
+	if keepaliveErr != nil {
+		logger.Errorf("[Triple][Client] resolve client keepalive options failed, err=%v", keepaliveErr)
+		return nil, keepaliveErr
 	}
-	cliOpts = append(cliOpts, cliKeepAliveOpts...)
+	cliOpts = append(cliOpts, clientKeepaliveOpts...)
 
-	// Handle HTTP transport of triple protocol
+	// Build the HTTP transport used by the Triple client.
 	var transport http.RoundTripper
 
 	var callProtocol string
@@ -192,10 +193,9 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 	}
 
 	switch callProtocol {
-	// This case might be for backward compatibility,
-	// It's not useful for the Triple protocol, HTTP/1 lacks trailer functionality.
-	// Triple protocol only supports HTTP/2 and HTTP/3.
 	case constant.CallHTTP:
+		// Backward compatibility path for callers that still request HTTP/1.1.
+		// Triple itself requires HTTP/2 or HTTP/3 trailer support.
 		transport = &http.Transport{
 			TLSClientConfig: cfg,
 		}
@@ -245,7 +245,8 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 			return nil, fmt.Errorf("TRIPLE HTTP/2 and HTTP/3 client must have TLS config, but TLS config is nil")
 		}
 
-		// Create a dual transport that can handle both HTTP/2 and HTTP/3
+		// Dual transport lets the client negotiate HTTP/2 or HTTP/3 with the
+		// same URL and keepalive settings.
 		transport = newDualTransport(cfg, keepAliveInterval, keepAliveTimeout)
 		logger.Info("[Triple][Client] triple HTTP/2 and HTTP/3 client transport init successfully")
 	default:
@@ -296,29 +297,27 @@ func (cm *clientManager) callHealthWatch(ctx context.Context, service string) (*
 	return stream, nil
 }
 
-func genKeepAliveOptions(url *common.URL, tripleConf *global.TripleConfig) ([]tri.ClientOption, time.Duration, time.Duration, error) {
-	var cliKeepAliveOpts []tri.ClientOption
+func resolveClientKeepaliveOptions(url *common.URL, tripleConf *global.TripleConfig) ([]tri.ClientOption, time.Duration, time.Duration, error) {
+	var clientKeepaliveOpts []tri.ClientOption
 
-	// Set max send and recv msg size
+	// Apply client message-size limits from URL compatibility parameters.
 	maxCallRecvMsgSize := constant.DefaultMaxCallRecvMsgSize
 	if recvMsgSize, err := humanize.ParseBytes(url.GetParam(constant.MaxCallRecvMsgSize, "")); err == nil && recvMsgSize > 0 {
 		maxCallRecvMsgSize = int(recvMsgSize)
 	}
-	cliKeepAliveOpts = append(cliKeepAliveOpts, tri.WithReadMaxBytes(maxCallRecvMsgSize))
+	clientKeepaliveOpts = append(clientKeepaliveOpts, tri.WithReadMaxBytes(maxCallRecvMsgSize))
 	maxCallSendMsgSize := constant.DefaultMaxCallSendMsgSize
 	if sendMsgSize, err := humanize.ParseBytes(url.GetParam(constant.MaxCallSendMsgSize, "")); err == nil && sendMsgSize > 0 {
 		maxCallSendMsgSize = int(sendMsgSize)
 	}
-	cliKeepAliveOpts = append(cliKeepAliveOpts, tri.WithSendMaxBytes(maxCallSendMsgSize))
+	clientKeepaliveOpts = append(clientKeepaliveOpts, tri.WithSendMaxBytes(maxCallSendMsgSize))
 
-	// Set keepalive interval and keepalive timeout
-	// Compatibility: read the legacy URL keepalive parameters.
-	// TODO: remove KeepAliveInterval and KeepAliveTimeout in version 4.0.0.
+	// Legacy URL keepalive parameters remain supported for 3.x compatibility.
 	keepAliveInterval := url.GetParamDuration(constant.KeepAliveInterval, constant.DefaultKeepAliveInterval)
 	keepAliveTimeout := url.GetParamDuration(constant.KeepAliveTimeout, constant.DefaultKeepAliveTimeout)
 
 	if tripleConf == nil {
-		return cliKeepAliveOpts, keepAliveInterval, keepAliveTimeout, nil
+		return clientKeepaliveOpts, keepAliveInterval, keepAliveTimeout, nil
 	}
 
 	var parseErr error
@@ -336,5 +335,5 @@ func genKeepAliveOptions(url *common.URL, tripleConf *global.TripleConfig) ([]tr
 		}
 	}
 
-	return cliKeepAliveOpts, keepAliveInterval, keepAliveTimeout, nil
+	return clientKeepaliveOpts, keepAliveInterval, keepAliveTimeout, nil
 }

--- a/protocol/triple/client_test.go
+++ b/protocol/triple/client_test.go
@@ -195,7 +195,7 @@ func TestClientManagerCallUnaryCopiesErrorResponseMetadata(t *testing.T) {
 // TestClientManager_CallMethods_MissingClient removed - no longer applicable
 // in the service-level client architecture where all methods share a single triClient.
 
-func Test_genKeepAliveOptions(t *testing.T) {
+func Test_resolveClientKeepaliveOptions(t *testing.T) {
 	defaultInterval, _ := time.ParseDuration(constant.DefaultKeepAliveInterval)
 	defaultTimeout, _ := time.ParseDuration(constant.DefaultKeepAliveTimeout)
 
@@ -282,7 +282,7 @@ func Test_genKeepAliveOptions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			opts, interval, timeout, err := genKeepAliveOptions(test.url, test.tripleConf)
+			opts, interval, timeout, err := resolveClientKeepaliveOptions(test.url, test.tripleConf)
 			if test.expectErr {
 				require.Error(t, err)
 			} else {

--- a/protocol/triple/client_test.go
+++ b/protocol/triple/client_test.go
@@ -195,7 +195,7 @@ func TestClientManagerCallUnaryCopiesErrorResponseMetadata(t *testing.T) {
 // TestClientManager_CallMethods_MissingClient removed - no longer applicable
 // in the service-level client architecture where all methods share a single triClient.
 
-func Test_resolveClientKeepaliveOptions(t *testing.T) {
+func Test_resolveClientKeepAliveOptions(t *testing.T) {
 	defaultInterval, _ := time.ParseDuration(constant.DefaultKeepAliveInterval)
 	defaultTimeout, _ := time.ParseDuration(constant.DefaultKeepAliveTimeout)
 
@@ -282,7 +282,7 @@ func Test_resolveClientKeepaliveOptions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			opts, interval, timeout, err := resolveClientKeepaliveOptions(test.url, test.tripleConf)
+			opts, interval, timeout, err := resolveClientKeepAliveOptions(test.url, test.tripleConf)
 			if test.expectErr {
 				require.Error(t, err)
 			} else {

--- a/protocol/triple/server.go
+++ b/protocol/triple/server.go
@@ -240,12 +240,12 @@ func (s *Server) startTransport(callProtocol string, tlsConf *tls.Config) {
 	}()
 }
 
-func (s *Server) registerServiceHandlers(invoker base.Invoker, info *common.ServiceInfo, hanOpts []tri.HandlerOption) {
+func (s *Server) registerServiceHandlers(invoker base.Invoker, info *common.ServiceInfo, handlerOpts []tri.HandlerOption) {
 	url := invoker.GetURL()
 
 	// IDLMode means that this will only be set when
 	// The new triple is started in non-IDL mode.
-	// TODO: remove IDLMode when config package is removed
+	// Legacy compatibility keeps this switch until config-package migration is complete.
 	IDLMode := url.GetParam(constant.IDLMode, "")
 
 	var service common.RPCService
@@ -264,15 +264,15 @@ func (s *Server) registerServiceHandlers(invoker base.Invoker, info *common.Serv
 
 	if info != nil {
 		// New triple IDL mode
-		s.handleServiceWithInfo(intfName, invoker, info, hanOpts...)
+		s.handleServiceWithInfo(intfName, invoker, info, handlerOpts...)
 		s.saveServiceInfo(intfName, info, openapiGroup, url.Group(), url.Version())
 	} else if IDLMode == constant.NONIDL {
 		// New triple non-IDL mode
 		reflectInfo := createServiceInfoWithReflection(service)
-		s.handleServiceWithInfo(intfName, invoker, reflectInfo, hanOpts...)
+		s.handleServiceWithInfo(intfName, invoker, reflectInfo, handlerOpts...)
 		s.saveServiceInfo(intfName, reflectInfo, openapiGroup, url.Group(), url.Version())
 	} else {
-		s.compatHandleService(url, intfName, url.Group(), url.Version(), hanOpts...)
+		s.compatHandleService(url, intfName, url.Group(), url.Version(), handlerOpts...)
 	}
 }
 
@@ -289,12 +289,12 @@ func (s *Server) RefreshService(invoker base.Invoker, info *common.ServiceInfo) 
 func (s *Server) refreshService(invoker base.Invoker, info *common.ServiceInfo) error {
 	url := invoker.GetURL()
 
-	hanOpts, err := resolveHandlerOptions(url)
+	handlerOpts, err := resolveHandlerOptions(url)
 	if err != nil {
 		return err
 	}
 
-	s.registerServiceHandlers(invoker, info, hanOpts)
+	s.registerServiceHandlers(invoker, info, handlerOpts)
 	return nil
 }
 
@@ -376,34 +376,32 @@ func resolveHandlerOptions(url *common.URL) ([]tri.HandlerOption, error) {
 		return nil, err
 	}
 
-	hanOpts := getHanOpts(url, tripleConf)
-	hanOpts = append(hanOpts, tri.WithExpectedCodecName(serialization))
-	return hanOpts, nil
+	handlerOpts := buildServerHandlerOptions(url, tripleConf)
+	handlerOpts = append(handlerOpts, tri.WithExpectedCodecName(serialization))
+	return handlerOpts, nil
 }
 
-func getHanOpts(url *common.URL, tripleConf *global.TripleConfig) (hanOpts []tri.HandlerOption) {
+func buildServerHandlerOptions(url *common.URL, tripleConf *global.TripleConfig) (handlerOpts []tri.HandlerOption) {
 	group := url.GetParam(constant.GroupKey, "")
 	version := url.GetParam(constant.VersionKey, "")
-	hanOpts = append(hanOpts, tri.WithGroup(group), tri.WithVersion(version))
+	handlerOpts = append(handlerOpts, tri.WithGroup(group), tri.WithVersion(version))
 
 	// Compatibility: read the legacy URL receive-size parameter.
-	// TODO: remove MaxServerRecvMsgSize in version 4.0.0.
 	maxServerRecvMsgSize := constant.DefaultMaxServerRecvMsgSize
 	if recvMsgSize, convertErr := humanize.ParseBytes(url.GetParam(constant.MaxServerRecvMsgSize, "")); convertErr == nil && recvMsgSize != 0 {
 		maxServerRecvMsgSize = int(recvMsgSize)
 	}
-	hanOpts = append(hanOpts, tri.WithReadMaxBytes(maxServerRecvMsgSize))
+	handlerOpts = append(handlerOpts, tri.WithReadMaxBytes(maxServerRecvMsgSize))
 
 	// Compatibility: read the legacy URL send-size parameter.
-	// TODO: remove MaxServerSendMsgSize in version 4.0.0.
 	maxServerSendMsgSize := constant.DefaultMaxServerSendMsgSize
 	if sendMsgSize, convertErr := humanize.ParseBytes(url.GetParam(constant.MaxServerSendMsgSize, "")); convertErr == nil && sendMsgSize != 0 {
 		maxServerSendMsgSize = int(sendMsgSize)
 	}
-	hanOpts = append(hanOpts, tri.WithSendMaxBytes(maxServerSendMsgSize))
+	handlerOpts = append(handlerOpts, tri.WithSendMaxBytes(maxServerSendMsgSize))
 
 	if tripleConf == nil {
-		return hanOpts
+		return handlerOpts
 	}
 
 	if tripleConf.MaxServerRecvMsgSize != "" {
@@ -411,7 +409,7 @@ func getHanOpts(url *common.URL, tripleConf *global.TripleConfig) (hanOpts []tri
 		if recvMsgSize, convertErr := humanize.ParseBytes(tripleConf.MaxServerRecvMsgSize); convertErr == nil && recvMsgSize != 0 {
 			maxServerRecvMsgSize = int(recvMsgSize)
 		}
-		hanOpts = append(hanOpts, tri.WithReadMaxBytes(maxServerRecvMsgSize))
+		handlerOpts = append(handlerOpts, tri.WithReadMaxBytes(maxServerRecvMsgSize))
 	}
 
 	if tripleConf.MaxServerSendMsgSize != "" {
@@ -419,14 +417,14 @@ func getHanOpts(url *common.URL, tripleConf *global.TripleConfig) (hanOpts []tri
 		if sendMsgSize, convertErr := humanize.ParseBytes(tripleConf.MaxServerSendMsgSize); convertErr == nil && sendMsgSize != 0 {
 			maxServerSendMsgSize = int(sendMsgSize)
 		}
-		hanOpts = append(hanOpts, tri.WithSendMaxBytes(maxServerSendMsgSize))
+		handlerOpts = append(handlerOpts, tri.WithSendMaxBytes(maxServerSendMsgSize))
 	}
 
-	// TODO: support OpenTracing
+	// Tracing integrations should append handler options before registration.
 
 	// CORS configuration
 	if tripleConf.Cors != nil && len(tripleConf.Cors.AllowOrigins) > 0 {
-		hanOpts = append(hanOpts, tri.WithCORS(&tri.CorsConfig{
+		handlerOpts = append(handlerOpts, tri.WithCORS(&tri.CorsConfig{
 			AllowOrigins:     tripleConf.Cors.AllowOrigins,
 			AllowMethods:     tripleConf.Cors.AllowMethods,
 			AllowHeaders:     tripleConf.Cors.AllowHeaders,
@@ -436,7 +434,7 @@ func getHanOpts(url *common.URL, tripleConf *global.TripleConfig) (hanOpts []tri
 		}))
 	}
 
-	return hanOpts
+	return handlerOpts
 }
 
 // *Important*, this function is responsible for being compatible with old triple-gen code and non-IDL code
@@ -487,7 +485,7 @@ func (s *Server) compatHandleService(url *common.URL, interfaceName string, grou
 
 func (s *Server) compatRegisterHandler(interfaceName string, svc dubbo3.Dubbo3GrpcService, opts ...tri.HandlerOption) {
 	desc := svc.XXX_ServiceDesc()
-	// Init unary handlers
+	// Register compat unary handlers from generated descriptors.
 	for _, method := range desc.Methods {
 		// Please refer to protocol/triple/internal/proto/triple_gen/greettriple for procedure examples
 		// Error could be ignored because base is empty string
@@ -497,7 +495,7 @@ func (s *Server) compatRegisterHandler(interfaceName string, svc dubbo3.Dubbo3Gr
 		}
 	}
 
-	// Init stream handlers
+	// Register compat stream handlers from generated descriptors.
 	for _, stream := range desc.Streams {
 		// Please refer to protocol/triple/internal/proto/triple_gen/greettriple for procedure examples
 		// Error could be ignored because base is empty string
@@ -549,12 +547,11 @@ func (s *Server) registerUnaryMethodHandler(procedure string, m common.MethodInf
 		func(ctx context.Context, req *tri.Request) (*tri.Response, error) {
 			args := extractUnaryInvocationArgs(req.Msg)
 			attachments := generateAttachments(req.Header())
-			// Inject attachments
+			// Make incoming attachments available to invocation filters and user code.
 			ctx = context.WithValue(ctx, constant.AttachmentKey, attachments)
 			invo := invocation.NewRPCInvocation(m.Name, args, attachments)
 			res := invoker.Invoke(ctx, invo)
-			// TODO(DMwangnima): modify InfoInvoker to get a unified processing logic
-			// Please refer to server/InfoInvoker.Invoke()
+			// Keep response wrapping aligned with server/InfoInvoker.Invoke.
 			triResp := wrapTripleResponse(res.Result())
 			appendTripleOutgoingAttachments(ctx, res.Attachments())
 			return triResp, res.Error()
@@ -572,7 +569,7 @@ func (s *Server) registerClientStreamMethodHandler(procedure string, m common.Me
 		func(ctx context.Context, stream *tri.ClientStream) (*tri.Response, error) {
 			args := []any{m.StreamInitFunc(stream)}
 			attachments := generateAttachments(stream.RequestHeader())
-			// Inject attachments
+			// Make incoming attachments available to invocation filters and user code.
 			ctx = context.WithValue(ctx, constant.AttachmentKey, attachments)
 			invo := invocation.NewRPCInvocation(m.Name, args, attachments)
 			res := invoker.Invoke(ctx, invo)
@@ -592,7 +589,7 @@ func (s *Server) registerServerStreamMethodHandler(procedure string, m common.Me
 		func(ctx context.Context, req *tri.Request, stream *tri.ServerStream) error {
 			args := []any{req.Msg, m.StreamInitFunc(stream)}
 			attachments := generateAttachments(req.Header())
-			// Inject attachments
+			// Make incoming attachments available to invocation filters and user code.
 			ctx = context.WithValue(ctx, constant.AttachmentKey, attachments)
 			invo := invocation.NewRPCInvocation(m.Name, args, attachments)
 			res := invoker.Invoke(ctx, invo)
@@ -611,7 +608,7 @@ func (s *Server) registerBidiStreamMethodHandler(procedure string, m common.Meth
 		func(ctx context.Context, stream *tri.BidiStream) error {
 			args := []any{m.StreamInitFunc(stream)}
 			attachments := generateAttachments(stream.RequestHeader())
-			// Inject attachments
+			// Make incoming attachments available to invocation filters and user code.
 			ctx = context.WithValue(ctx, constant.AttachmentKey, attachments)
 			invo := invocation.NewRPCInvocation(m.Name, args, attachments)
 			res := invoker.Invoke(ctx, invo)
@@ -685,7 +682,8 @@ func (s *Server) saveServiceInfo(interfaceName string, info *common.ServiceInfo,
 	ret.Metadata = info
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// TODO(DMwangnima): using interfaceName is not enough, we need to consider group and version
+	// gRPC reflection uses the service name as the map key; OpenAPI registration
+	// receives group and version separately below.
 	s.services[interfaceName] = ret
 
 	if s.triServer != nil {

--- a/protocol/triple/server.go
+++ b/protocol/triple/server.go
@@ -245,7 +245,7 @@ func (s *Server) registerServiceHandlers(invoker base.Invoker, info *common.Serv
 
 	// IDLMode means that this will only be set when
 	// The new triple is started in non-IDL mode.
-	// Legacy compatibility keeps this switch until config-package migration is complete.
+	// TODO: remove IDLMode when config package is removed
 	IDLMode := url.GetParam(constant.IDLMode, "")
 
 	var service common.RPCService
@@ -387,6 +387,7 @@ func buildServerHandlerOptions(url *common.URL, tripleConf *global.TripleConfig)
 	handlerOpts = append(handlerOpts, tri.WithGroup(group), tri.WithVersion(version))
 
 	// Compatibility: read the legacy URL receive-size parameter.
+	// TODO: remove MaxServerRecvMsgSize in version 4.0.0.
 	maxServerRecvMsgSize := constant.DefaultMaxServerRecvMsgSize
 	if recvMsgSize, convertErr := humanize.ParseBytes(url.GetParam(constant.MaxServerRecvMsgSize, "")); convertErr == nil && recvMsgSize != 0 {
 		maxServerRecvMsgSize = int(recvMsgSize)
@@ -394,6 +395,7 @@ func buildServerHandlerOptions(url *common.URL, tripleConf *global.TripleConfig)
 	handlerOpts = append(handlerOpts, tri.WithReadMaxBytes(maxServerRecvMsgSize))
 
 	// Compatibility: read the legacy URL send-size parameter.
+	// TODO: remove MaxServerSendMsgSize in version 4.0.0.
 	maxServerSendMsgSize := constant.DefaultMaxServerSendMsgSize
 	if sendMsgSize, convertErr := humanize.ParseBytes(url.GetParam(constant.MaxServerSendMsgSize, "")); convertErr == nil && sendMsgSize != 0 {
 		maxServerSendMsgSize = int(sendMsgSize)
@@ -420,7 +422,7 @@ func buildServerHandlerOptions(url *common.URL, tripleConf *global.TripleConfig)
 		handlerOpts = append(handlerOpts, tri.WithSendMaxBytes(maxServerSendMsgSize))
 	}
 
-	// Tracing integrations should append handler options before registration.
+	// TODO: support OpenTracing
 
 	// CORS configuration
 	if tripleConf.Cors != nil && len(tripleConf.Cors.AllowOrigins) > 0 {
@@ -551,7 +553,8 @@ func (s *Server) registerUnaryMethodHandler(procedure string, m common.MethodInf
 			ctx = context.WithValue(ctx, constant.AttachmentKey, attachments)
 			invo := invocation.NewRPCInvocation(m.Name, args, attachments)
 			res := invoker.Invoke(ctx, invo)
-			// Keep response wrapping aligned with server/InfoInvoker.Invoke.
+			// TODO(DMwangnima): modify InfoInvoker to get a unified processing logic
+			// Please refer to server/InfoInvoker.Invoke()
 			triResp := wrapTripleResponse(res.Result())
 			appendTripleOutgoingAttachments(ctx, res.Attachments())
 			return triResp, res.Error()
@@ -682,8 +685,7 @@ func (s *Server) saveServiceInfo(interfaceName string, info *common.ServiceInfo,
 	ret.Metadata = info
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	// gRPC reflection uses the service name as the map key; OpenAPI registration
-	// receives group and version separately below.
+	// TODO(DMwangnima): using interfaceName is not enough, we need to consider group and version
 	s.services[interfaceName] = ret
 
 	if s.triServer != nil {

--- a/protocol/triple/server_test.go
+++ b/protocol/triple/server_test.go
@@ -358,7 +358,7 @@ func TestServer_SaveServiceInfo_Concurrent(t *testing.T) {
 	assert.Len(t, server.GetServiceInfo(), concurrency)
 }
 
-func Test_getHanOpts(t *testing.T) {
+func Test_buildServerHandlerOptions(t *testing.T) {
 	tests := []struct {
 		desc       string
 		url        *common.URL
@@ -402,7 +402,7 @@ func Test_getHanOpts(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			opts := getHanOpts(test.url, test.tripleConf)
+			opts := buildServerHandlerOptions(test.url, test.tripleConf)
 			assert.Len(t, opts, test.expectLen)
 		})
 	}

--- a/protocol/triple/triple_protocol/handler.go
+++ b/protocol/triple/triple_protocol/handler.go
@@ -90,7 +90,7 @@ func generateUnaryHandlerFunc(
 		}
 		return res, err
 	})
-	// Apply unary interceptors before transport-level receive/send orchestration.
+	// TODO: modify server func
 	if interceptor != nil {
 		untyped = interceptor.WrapUnaryHandler(untyped)
 	}
@@ -382,6 +382,7 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 	// Select the group/version implementation and invoke it on the protocol stream.
 	svcGroup := request.Header.Get(tripleServiceGroup)
 	svcVersion := request.Header.Get(tripleServiceVersion)
+	// TODO(DMwangnima): inspect ok
 	implementation, ok := h.implementations[getIdentifier(svcGroup, svcVersion)]
 	if !ok {
 		_ = connCloser.Close(errorf(CodeUnimplemented, "no implementation found for service group %s and service version %s", svcGroup, svcVersion))

--- a/protocol/triple/triple_protocol/handler.go
+++ b/protocol/triple/triple_protocol/handler.go
@@ -74,7 +74,7 @@ func generateUnaryHandlerFunc(
 ) StreamingHandlerFunc {
 	// Wrap the strongly-typed implementation so we can apply interceptors.
 	untyped := UnaryHandlerFunc(func(ctx context.Context, request AnyRequest) (AnyResponse, error) {
-		// Verify err
+		// Honor cancellation before reading from the transport stream.
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
@@ -90,30 +90,29 @@ func generateUnaryHandlerFunc(
 		}
 		return res, err
 	})
-	// TODO: modify server func
+	// Apply unary interceptors before transport-level receive/send orchestration.
 	if interceptor != nil {
 		untyped = interceptor.WrapUnaryHandler(untyped)
 	}
-	// Receive and send
-	// Conn should be responsible for marshal and unmarshal
-	// Given a stream, how should we call the unary function?
+	// The transport stream owns framing, decoding, and encoding. This adapter
+	// receives the request, invokes the unary handler, and writes the response.
 	implementation := func(ctx context.Context, conn StreamingHandlerConn) error {
 		req := reqInitFunc()
 		if err := conn.Receive(req); err != nil {
 			return err
 		}
-		// Wrap the specific msg
+		// Build the request envelope with stream metadata for handlers and interceptors.
 		request := NewRequest(req)
 		request.spec = conn.Spec()
 		request.peer = conn.Peer()
 		request.header = conn.RequestHeader()
-		// Embed header in context so that user logic could process them via FromIncomingContext
+		// Expose incoming headers through context for user logic via FromIncomingContext.
 		ctx = newIncomingContext(ctx, conn.RequestHeader())
 		ctx = context.WithValue(ctx, handlerOutgoingKey{}, conn)
 
 		response, err := untyped(ctx, request)
 
-		// Write the server-side return-attachment-data in the trailer to send to the caller
+		// Propagate outgoing context values as response trailers.
 		if data := ExtractFromOutgoingContext(ctx); data != nil {
 			mergeHeaders(conn.ResponseTrailer(), data)
 		}
@@ -122,7 +121,7 @@ func generateUnaryHandlerFunc(
 			return err
 		}
 
-		// Merge headers
+		// Propagate application headers and trailers before sending the payload.
 		mergeHeaders(conn.ResponseHeader(), response.Header())
 		mergeHeaders(conn.ResponseTrailer(), response.Trailer())
 		return conn.Send(response.Any())
@@ -161,7 +160,7 @@ func generateClientStreamHandlerFunc(
 ) StreamingHandlerFunc {
 	implementation := func(ctx context.Context, conn StreamingHandlerConn) error {
 		stream := &ClientStream{conn: conn}
-		// Embed header in context so that user logic could process them via FromIncomingContext
+		// Expose incoming headers through context for user logic via FromIncomingContext.
 		ctx = newIncomingContext(ctx, conn.RequestHeader())
 		res, err := streamFunc(ctx, stream)
 
@@ -224,7 +223,7 @@ func generateServerStreamHandlerFunc(
 		if err := conn.Receive(req); err != nil {
 			return err
 		}
-		// Embed header in context so that user logic could process them via FromIncomingContext
+		// Expose incoming headers through context for user logic via FromIncomingContext.
 		ctx = newIncomingContext(ctx, conn.RequestHeader())
 		err := streamFunc(
 			ctx,
@@ -280,7 +279,7 @@ func generateBidiStreamHandlerFunc(
 	interceptor Interceptor,
 ) StreamingHandlerFunc {
 	implementation := func(ctx context.Context, conn StreamingHandlerConn) error {
-		// Embed header in context so that user logic could process them via FromIncomingContext
+		// Expose incoming headers through context for user logic via FromIncomingContext.
 		ctx = newIncomingContext(ctx, conn.RequestHeader())
 		err := streamFunc(ctx, &BidiStream{conn: conn})
 		if err != nil {
@@ -318,14 +317,14 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 		return
 	}
 
-	// CORS handling
+	// Apply CORS policy before protocol negotiation.
 	if h.cors != nil {
 		if h.handleCORS(responseWriter, request) {
 			return
 		}
 	}
 
-	// Inspect headers
+	// Filter protocol handlers by HTTP method before inspecting the payload.
 	var protocolHandlers []protocolHandler
 	for _, handler := range h.protocolHandlers {
 		if _, ok := handler.Methods()[request.Method]; ok {
@@ -341,8 +340,7 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 
 	contentType := canonicalizeContentType(getHeaderCanonical(request.Header, headerContentType))
 
-	// Inspect contentType
-	// Find our implementation of the RPC protocol in use.
+	// Select the protocol handler that can decode this content type.
 	var protocolHdl protocolHandler
 	for _, handler := range protocolHandlers {
 		if handler.CanHandlePayload(request, contentType) {
@@ -358,7 +356,7 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 
 	// Establish a stream and serve the RPC.
 	setHeaderCanonical(request.Header, headerContentType, contentType)
-	// Process context
+	// Derive the request context and deadline from the selected protocol handler.
 	ctx, cancel, timeoutErr := protocolHdl.SetTimeout(request) //nolint: contextcheck
 	if timeoutErr != nil {
 		ctx = request.Context()
@@ -366,7 +364,7 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 	if cancel != nil {
 		defer cancel()
 	}
-	// Create stream
+	// Create the protocol stream that owns request consumption and response writes.
 	connCloser, ok := protocolHdl.NewConn(
 		responseWriter,
 		request.WithContext(ctx),
@@ -381,10 +379,9 @@ func (h *Handler) ServeHTTP(responseWriter http.ResponseWriter, request *http.Re
 		return
 	}
 
-	// Invoke implementation
+	// Select the group/version implementation and invoke it on the protocol stream.
 	svcGroup := request.Header.Get(tripleServiceGroup)
 	svcVersion := request.Header.Get(tripleServiceVersion)
-	// TODO(DMwangnima): inspect ok
 	implementation, ok := h.implementations[getIdentifier(svcGroup, svcVersion)]
 	if !ok {
 		_ = connCloser.Close(errorf(CodeUnimplemented, "no implementation found for service group %s and service version %s", svcGroup, svcVersion))
@@ -441,7 +438,7 @@ func (c *handlerConfig) newSpec(streamType StreamType) Spec {
 }
 
 func (c *handlerConfig) newProtocolHandlers(streamType StreamType) []protocolHandler {
-	// Initialize protocol
+	// Build protocol candidates for this stream type.
 	var protocols []protocol
 	if streamType == StreamTypeUnary {
 		protocols = append(protocols, &protocolTriple{})
@@ -449,9 +446,8 @@ func (c *handlerConfig) newProtocolHandlers(streamType StreamType) []protocolHan
 	if c.HandleGRPC {
 		protocols = append(protocols, &protocolGRPC{})
 	}
-	// Protocol -> protocolHandler
 	handlers := make([]protocolHandler, 0, len(protocols))
-	// Initialize codec and compressor
+	// Create read-only codec and compressor views shared by protocol handlers.
 	compressors := newReadOnlyCompressionPools(
 		c.CompressionPools,
 		c.CompressionNames,


### PR DESCRIPTION
### Description
issue https://github.com/apache/dubbo-go/issues/3598
13. 统一 Triple 主链路注释和 helper 命名 任务


###  变更情况

protocol/triple/client.go

- 将 genKeepAliveOptions 重命名为 resolveClientKeepaliveOptions，使命名准确“解析 client keepalive 配置”的职责
- 清理 client 主链路里的草稿式注释，统一为正式说明
- 更新 protocol/triple/client_test.go 中函数名


protocol/triple/server.go

- 将 getHanOpts 重命名为 buildServerHandlerOptions，避免缩写式 helper 名称。
- 将 hanOpts 变量统一改为 handlerOpts
- 清理 server 主链路中的 TODO/草稿注释，统一 handler options、service info 等说明
- 同步更新 protocol/triple/server_test.go 中函数名


protocol/triple/triple_protocol/handler.go

- 将 handler 流程里的 TODO 和笔记式注释改成正式阶段说明
- 统一描述 CORS、protocol handler 选择、content type 匹配、context/timeout 派生等流程

以上代码逻辑无变动 着重与注释的更改和使命名更精确

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
