### PR TITLE
fix(triple): preserve CodeBizError over the Triple unary transport

### DIFF
--- a/protocol/triple/triple_protocol/protocol_triple.go
+++ b/protocol/triple/triple_protocol/protocol_triple.go
@@ -691,7 +691,7 @@ func (e *tripleWireError) asError() *Error {
 	if e == nil {
 		return nil
 	}
-	if e.Code < minCode || e.Code > maxCode {
+	if (e.Code < minCode || e.Code > maxCode) && e.Code != CodeBizError {
 		e.Code = CodeUnknown
 	}
 	err := NewWireError(e.Code, errors.New(e.Message))

--- a/protocol/triple/triple_protocol/triple_ext_test.go
+++ b/protocol/triple/triple_protocol/triple_ext_test.go
@@ -710,6 +710,44 @@ func TestContextError(t *testing.T) {
 	assert.False(t, triple.IsWireError(err))
 }
 
+func TestBizErrorCodePreservedAcrossProtocols(t *testing.T) {
+	t.Parallel()
+
+	handler := triple.NewUnaryHandler(
+		"/connect.ping.v1.PingService/Ping",
+		func() any { return new(pingv1.PingRequest) },
+		func(ctx context.Context, req *triple.Request) (*triple.Response, error) {
+			return nil, triple.NewError(triple.CodeBizError, errors.New(errorMessage))
+		},
+	)
+	assertBizError := func(t *testing.T, server *httptest.Server, opts ...triple.ClientOption) { //nolint:thelper
+		client := pingv1connect.NewPingServiceClient(server.Client(), server.URL, opts...)
+		request := triple.NewRequest(&pingv1.PingRequest{Number: 42})
+		response := triple.NewResponse(&pingv1.PingResponse{})
+		err := client.Ping(context.Background(), request, response)
+		assert.NotNil(t, err)
+		var tripleErr *triple.Error
+		assert.True(t, errors.As(err, &tripleErr))
+		assert.Equal(t, tripleErr.Code(), triple.CodeBizError)
+	}
+
+	t.Run("triple", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewServer(handler)
+		t.Cleanup(server.Close)
+		assertBizError(t, server, triple.WithTriple())
+	})
+
+	t.Run("grpc", func(t *testing.T) {
+		t.Parallel()
+		server := httptest.NewUnstartedServer(handler)
+		server.EnableHTTP2 = true
+		server.StartTLS()
+		t.Cleanup(server.Close)
+		assertBizError(t, server)
+	})
+}
+
 func TestGRPCMarshalStatusError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
### Description
Fixes #3654

Over the Triple (non-gRPC) unary transport, a server-returned `CodeBizError` (17) reaches the client as `CodeUnknown` (2); the gRPC transport in the same package preserves it. Downstream, `failover.isBizError` stops recognizing business errors and retries them (default up to 3 attempts, so non-idempotent calls run repeatedly), and `metrics/rpc` counts them as unknown.

**Root cause.** `tripleWireError.asError()` (`protocol_triple.go:694`) clamps any code outside `[minCode, maxCode]` = `[1,16]` to `CodeUnknown`. That clamp comes from connect-go, which only defines codes 1..16; `CodeBizError = 17` is a dubbo-go extension and `maxCode` was never updated. `code.go` deliberately supports such codes — the `UnmarshalText` branch commented *"Ensure that non-canonical codes round-trip through MarshalText and UnmarshalText"* keeps out-of-range codes for exactly this reason. `asError()` then discards what `UnmarshalText` just preserved.

**Fix.** Exempt `CodeBizError` from the clamp (one line), plus `TestBizErrorCodePreservedAcrossProtocols`: a real `httptest` server whose handler returns `NewError(CodeBizError, ...)`, asserting the client-visible code over both transports. Before the fix the `triple` subtest fails (`got: unknown, want: code_17`) while `grpc` passes; after, both pass.

<details>
<summary>Why not raise <code>maxCode</code> to <code>CodeBizError</code> instead</summary>

That breaks the round-trip. The `UnmarshalText` fallback only keeps codes *outside* `[minCode, maxCode]`:

```go
if err == nil && (code < uint64(minCode) || code > uint64(maxCode)) {
	*c = Code(code)
	return nil
}
```

With `maxCode = CodeBizError`, the string `code_17` no longer satisfies that condition and falls through to `invalid code %q`. Making it work needs a canonical string for `CodeBizError` in both `String()` and `UnmarshalText`, which changes the wire representation of the code. The clamp exemption keeps the existing wire format and touches one line.
</details>

<details>
<summary>Test output (before / after)</summary>

Before the fix — only `protocol_triple.go` reverted, test unchanged:

```
$ go test ./protocol/triple/triple_protocol/ -run TestBizErrorCodePreservedAcrossProtocols -v
=== NAME  TestBizErrorCodePreservedAcrossProtocols/triple
    triple_ext_test.go:772:
        assertion:	assert.Equal
        got:	unknown
        want:	code_17
--- FAIL: TestBizErrorCodePreservedAcrossProtocols (0.00s)
    --- FAIL: TestBizErrorCodePreservedAcrossProtocols/triple (0.01s)
    --- PASS: TestBizErrorCodePreservedAcrossProtocols/grpc (0.01s)
FAIL	dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol	4.304s
```

After:

```
--- PASS: TestBizErrorCodePreservedAcrossProtocols (0.00s)
    --- PASS: TestBizErrorCodePreservedAcrossProtocols/triple (0.00s)
    --- PASS: TestBizErrorCodePreservedAcrossProtocols/grpc (0.02s)
ok  	dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol	0.970s
```

Existing tests, including the packages that consume the code:

```
$ go test ./protocol/triple/... ./cluster/cluster/failover/... ./metrics/rpc/...
ok  	dubbo.apache.org/dubbo-go/v3/cluster/cluster/failover	1.675s
ok  	dubbo.apache.org/dubbo-go/v3/metrics/rpc	2.234s
ok  	dubbo.apache.org/dubbo-go/v3/protocol/triple	5.790s
ok  	dubbo.apache.org/dubbo-go/v3/protocol/triple/health	1.687s
ok  	dubbo.apache.org/dubbo-go/v3/protocol/triple/openapi	2.138s
ok  	dubbo.apache.org/dubbo-go/v3/protocol/triple/reflection	2.667s
ok  	dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol	18.123s
```

`go vet ./protocol/triple/triple_protocol/...` and `gofmt -l` are both clean.

Not run locally: the full `make test` and the integration suite (they need ZooKeeper / Nacos / etcd / Docker, which I don't have set up), and golangci-lint. Leaving those to CI.
</details>

### Checklist
- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works

_Assisted-by: Cursor (Claude Opus 5). Reproduced, reviewed and tested locally by the author._

