### PR TITLE
fix(router): preserve v3.0 condition flags

### DIFF
--- a/cluster/router/condition/dynamic_router.go
+++ b/cluster/router/condition/dynamic_router.go
@@ -293,7 +293,7 @@ func generateConditionsRoute(rawConfig string) (stateRouters, bool, bool, error)
 		return nil, false, false, err
 	}
 
-	force, enable := *routerConfig.Enabled, *routerConfig.Force
+	force, enable := *routerConfig.Force, *routerConfig.Enabled
 	if !enable {
 		return nil, false, false, nil
 	}

--- a/cluster/router/condition/router_test.go
+++ b/cluster/router/condition/router_test.go
@@ -187,6 +187,74 @@ func TestDynamicRouterSetStaticConfig(t *testing.T) {
 	})
 }
 
+func TestGenerateConditionsRoutePreservesExplicitBooleans(t *testing.T) {
+	raw := `conditions:
+- method=SayHello => application=router-rule-e2e-condition-provider-hangzhou
+configVersion: v3.0
+enabled: true
+force: false
+key: org.apache.dubbo.quickstart.Greeter:1.0.0:demo
+priority: 1
+runtime: true
+scope: service
+`
+
+	routers, force, enabled, err := generateConditionsRoute(raw)
+	require.NoError(t, err)
+	assert.False(t, force)
+	assert.True(t, enabled)
+	assert.Len(t, routers, 1)
+}
+
+func TestDynamicRouterSwitchesFromV31ToV30(t *testing.T) {
+	providerHangzhou, err := common.NewURL(
+		"dubbo://127.0.0.1:20000/org.apache.dubbo.quickstart.Greeter" +
+			"?application=router-rule-e2e-condition-provider-hangzhou&group=demo&version=1.0.0",
+	)
+	require.NoError(t, err)
+	providerShanghai, err := common.NewURL(
+		"dubbo://127.0.0.1:20001/org.apache.dubbo.quickstart.Greeter" +
+			"?application=router-rule-e2e-condition-provider-shanghai&group=demo&version=1.0.0",
+	)
+	require.NoError(t, err)
+	consumer, err := common.NewURL(
+		"consumer://127.0.0.1/org.apache.dubbo.quickstart.Greeter?group=demo&version=1.0.0",
+	)
+	require.NoError(t, err)
+	invokers := []base.Invoker{base.NewBaseInvoker(providerHangzhou), base.NewBaseInvoker(providerShanghai)}
+
+	d := &DynamicRouter{}
+	d.Process(&config_center.ConfigChangeEvent{
+		Value: `configVersion: v3.1
+enabled: true
+force: false
+conditions:
+  - from:
+      match: method=SayHello
+    to:
+      - match: application=router-rule-e2e-condition-provider-shanghai
+        weight: 100
+`,
+		ConfigType: remoting.EventTypeUpdate,
+	})
+	got := d.Route(invokers, consumer, invocation.NewRPCInvocation("SayHello", nil, nil))
+	require.Len(t, got, 1)
+	assert.Equal(t, "router-rule-e2e-condition-provider-shanghai", got[0].GetURL().GetParam("application", ""))
+
+	d.Process(&config_center.ConfigChangeEvent{
+		Value: `configVersion: v3.0
+enabled: true
+force: false
+conditions:
+  - method=SayHello => application=router-rule-e2e-condition-provider-hangzhou
+`,
+		ConfigType: remoting.EventTypeUpdate,
+	})
+	got = d.Route(invokers, consumer, invocation.NewRPCInvocation("SayHello", nil, nil))
+	require.Len(t, got, 1)
+	assert.Equal(t, "router-rule-e2e-condition-provider-hangzhou", got[0].GetURL().GetParam("application", ""))
+}
+
 func TestScopedStaticConfigSetters(t *testing.T) {
 	t.Run("service router only accepts service scope", func(t *testing.T) {
 		router := NewServiceRouter()


### PR DESCRIPTION
### What this PR does

Fixes the v3.0 condition-router parser assigning `enabled` and `force` in reverse order.

Before this change, the common combination below disabled the router at runtime:

```yaml
enabled: true
force: false
```

The parser interpreted it as `enable=false` and `force=true`, so `DynamicRouter.Route` returned the original invoker list without applying the condition.

### Changes

- assign `RouterConfig.Force` to `force` and `RouterConfig.Enabled` to `enable`;
- add regression coverage for asymmetric v3.0 boolean flags;
- verify that a runtime update from v3.1 to v3.0 replaces the active router and applies the v3.0 destination condition.

### Testing

```text
go test ./cluster/router/condition -count=1
ok dubbo.apache.org/dubbo-go/v3/cluster/router/condition
```

Fixes #3656