### PR TITLE
fix(configurator): align v3 rule version and empty match

### DIFF
--- a/common/constant/key.go
+++ b/common/constant/key.go
@@ -234,6 +234,7 @@ const (
 	MethodKey              = "method"
 	MethodKeys             = "methods"
 	RuleKey                = "rule"
+	RuleConfigVersionKey   = "configVersion"
 	RuntimeKey             = "runtime"
 	BackupKey              = "backup"
 	RoutersCategory        = "routers"

--- a/config_center/configurator/override.go
+++ b/config_center/configurator/override.go
@@ -56,7 +56,7 @@ func (c *overrideConfigurator) Configure(url *common.URL) {
 	}
 
 	// branch for version 2.7.x
-	apiVersion := c.configuratorUrl.GetParam(constant.ConfigVersionKey, "")
+	apiVersion := c.configuratorUrl.GetParam(constant.RuleConfigVersionKey, "")
 	if len(apiVersion) != 0 {
 		var host string
 		currentSide := url.GetParam(constant.SideKey, "")
@@ -153,7 +153,7 @@ func getConditionKeys() *gxset.HashSet {
 	conditionKeys.Add(constant.VersionKey)
 	conditionKeys.Add(constant.ApplicationKey)
 	conditionKeys.Add(constant.SideKey)
-	conditionKeys.Add(constant.ConfigVersionKey)
+	conditionKeys.Add(constant.RuleConfigVersionKey)
 	conditionKeys.Add(constant.CompatibleConfigKey)
 	return conditionKeys
 }

--- a/config_center/configurator/override.go
+++ b/config_center/configurator/override.go
@@ -55,8 +55,11 @@ func (c *overrideConfigurator) Configure(url *common.URL) {
 		return
 	}
 
-	// branch for version 2.7.x
+	// Prefer the rule-level key for versioned rules (2.7.x and v3), while retaining the legacy key as a fallback.
 	apiVersion := c.configuratorUrl.GetParam(constant.RuleConfigVersionKey, "")
+	if len(apiVersion) == 0 {
+		apiVersion = c.configuratorUrl.GetParam(constant.ConfigVersionKey, "")
+	}
 	if len(apiVersion) != 0 {
 		var host string
 		currentSide := url.GetParam(constant.SideKey, "")
@@ -154,6 +157,7 @@ func getConditionKeys() *gxset.HashSet {
 	conditionKeys.Add(constant.ApplicationKey)
 	conditionKeys.Add(constant.SideKey)
 	conditionKeys.Add(constant.RuleConfigVersionKey)
+	conditionKeys.Add(constant.ConfigVersionKey)
 	conditionKeys.Add(constant.CompatibleConfigKey)
 	return conditionKeys
 }

--- a/config_center/configurator/override_test.go
+++ b/config_center/configurator/override_test.go
@@ -30,6 +30,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
+	"dubbo.apache.org/dubbo-go/v3/config_center/parser"
 )
 
 const (
@@ -84,4 +85,20 @@ func TestConfigureVersion2p7(t *testing.T) {
 	require.NoError(t, err)
 	configurator.Configure(providerUrl)
 	assert.Equal(t, failfast, providerUrl.GetParam(constant.ClusterKey, ""))
+}
+
+func TestConfigureV3UsesRuleConfigVersion(t *testing.T) {
+	url, err := common.NewURL("override://0.0.0.0:0/*?configVersion=v3.0&side=consumer&loadbalance=roundrobin")
+	require.NoError(t, err)
+	url.SetAttribute(constant.MatchCondition, &parser.ConditionMatch{
+		App: &common.ListStringMatch{Oneof: []common.StringMatch{{Exact: "another-consumer"}}},
+	})
+	configurator := extension.GetConfigurator(defaults, url)
+
+	consumerURL, err := common.NewURL("consumer://127.0.0.1/org.apache.dubbo.quickstart.GreeterDynamic?side=consumer&loadbalance=random")
+	require.NoError(t, err)
+	configurator.Configure(consumerURL)
+
+	assert.Equal(t, "random", consumerURL.GetParam(constant.LoadbalanceKey, ""))
+	assert.Empty(t, consumerURL.GetParam(constant.RuleConfigVersionKey, ""))
 }

--- a/config_center/configurator/override_test.go
+++ b/config_center/configurator/override_test.go
@@ -102,3 +102,50 @@ func TestConfigureV3UsesRuleConfigVersion(t *testing.T) {
 	assert.Equal(t, "random", consumerURL.GetParam(constant.LoadbalanceKey, ""))
 	assert.Empty(t, consumerURL.GetParam(constant.RuleConfigVersionKey, ""))
 }
+
+func TestConfigureV3UsesLegacyConfigVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		configuratorURL string
+		matchApp        string
+		wantBalance     string
+	}{
+		{
+			name:            "mismatched condition does not configure",
+			configuratorURL: "override://0.0.0.0:0/*?config-center.configVersion=v3.0&side=consumer&loadbalance=roundrobin",
+			matchApp:        "another-consumer",
+			wantBalance:     "random",
+		},
+		{
+			name:            "matched condition configures without leaking legacy key",
+			configuratorURL: "override://0.0.0.0:0/*?config-center.configVersion=v3.0&side=consumer&loadbalance=roundrobin",
+			matchApp:        "demo-consumer",
+			wantBalance:     "roundrobin",
+		},
+		{
+			name:            "rule key takes precedence over legacy key",
+			configuratorURL: "override://0.0.0.0:0/*?configVersion=v3.0&config-center.configVersion=2.7.1&side=consumer&loadbalance=roundrobin",
+			matchApp:        "another-consumer",
+			wantBalance:     "random",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			url, err := common.NewURL(tt.configuratorURL)
+			require.NoError(t, err)
+			url.SetAttribute(constant.MatchCondition, &parser.ConditionMatch{
+				App: &common.ListStringMatch{Oneof: []common.StringMatch{{Exact: tt.matchApp}}},
+			})
+			configurator := extension.GetConfigurator(defaults, url)
+
+			consumerURL, err := common.NewURL("consumer://127.0.0.1/org.apache.dubbo.quickstart.GreeterDynamic?application=demo-consumer&side=consumer&loadbalance=random")
+			require.NoError(t, err)
+			configurator.Configure(consumerURL)
+
+			assert.Equal(t, tt.wantBalance, consumerURL.GetParam(constant.LoadbalanceKey, ""))
+			assert.Empty(t, consumerURL.GetParam(constant.RuleConfigVersionKey, ""))
+			assert.Empty(t, consumerURL.GetParam(constant.ConfigVersionKey, ""))
+		})
+	}
+}

--- a/config_center/parser/configuration_parser.go
+++ b/config_center/parser/configuration_parser.go
@@ -82,16 +82,19 @@ type ConditionMatch struct {
 }
 
 func (c *ConditionMatch) IsMatch(host string, url *common.URL) bool {
-	if !c.Address.IsMatch(host) {
+	if c == nil {
+		return true
+	}
+	if c.Address != nil && !c.Address.IsMatch(host) {
 		return false
 	}
-	if !c.ProviderAddress.IsMatch(url.Location) {
+	if c.ProviderAddress != nil && !c.ProviderAddress.IsMatch(url.Location) {
 		return false
 	}
-	if !c.Service.IsMatch(url.ServiceKey()) {
+	if c.Service != nil && !c.Service.IsMatch(url.ServiceKey()) {
 		return false
 	}
-	if !c.App.IsMatch(url.GetParam(constant.ApplicationKey, "")) {
+	if c.App != nil && !c.App.IsMatch(url.GetParam(constant.ApplicationKey, "")) {
 		return false
 	}
 	if c.Param != nil {
@@ -165,7 +168,7 @@ func serviceItemToUrls(item ConfigItem, config ConfiguratorConfig) ([]*common.UR
 		urlStr = urlStr + getEnabledString(item, config)
 		urlStr = urlStr + "&category="
 		urlStr = urlStr + constant.DynamicConfiguratorsCategory
-		urlStr = urlStr + "&configVersion="
+		urlStr = urlStr + "&" + constant.RuleConfigVersionKey + "="
 		urlStr = urlStr + config.ConfigVersion
 		apps := item.Applications
 		if len(apps) > 0 {
@@ -221,7 +224,7 @@ func appItemToUrls(item ConfigItem, config ConfiguratorConfig) ([]*common.URL, e
 			urlStr = urlStr + getEnabledString(item, config)
 			urlStr = urlStr + "&category="
 			urlStr = urlStr + constant.AppDynamicConfiguratorsCategory
-			urlStr = urlStr + "&configVersion="
+			urlStr = urlStr + "&" + constant.RuleConfigVersionKey + "="
 			urlStr = urlStr + config.ConfigVersion
 			url, err := common.NewURL(urlStr)
 			if err != nil {

--- a/config_center/parser/configuration_parser_test.go
+++ b/config_center/parser/configuration_parser_test.go
@@ -26,6 +26,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+)
+
 func TestDefaultConfigurationParserParser(t *testing.T) {
 	parser := &DefaultConfigurationParser{}
 	m, err := parser.Parse("dubbo.registry.address=172.0.0.1\ndubbo.registry.name=test")
@@ -85,8 +90,57 @@ configs:
 	assert.Equal(t, "*", urls[0].Service())
 	assert.Equal(t, "app-key", urls[0].GetParam("application", ""))
 	assert.Equal(t, "dynamicconfigurators", urls[0].GetParam("category", ""))
-	assert.Equal(t, "3.0.0", urls[0].GetParam("configVersion", ""))
+	assert.Equal(t, "3.0.0", urls[0].GetParam(constant.RuleConfigVersionKey, ""))
 	assert.Equal(t, "false", urls[0].GetParam("enabled", ""))
+}
+
+func TestConditionMatchIsMatch(t *testing.T) {
+	url, err := common.NewURL("dubbo://127.0.0.1:20880/org.apache.dubbo.quickstart.GreeterDynamic?application=demo-provider&env=prod&group=demo&version=1.0.0")
+	require.NoError(t, err)
+
+	const host = "10.0.0.1"
+	listMatch := func(value string) *common.ListStringMatch {
+		return &common.ListStringMatch{Oneof: []common.StringMatch{{Exact: value}}}
+	}
+	paramMatch := func(value string) []*common.ParamMatch {
+		return []*common.ParamMatch{{Key: "env", Value: common.StringMatch{Exact: value}}}
+	}
+
+	tests := []struct {
+		name  string
+		match *ConditionMatch
+		want  bool
+	}{
+		{name: "nil matches all", match: nil, want: true},
+		{name: "empty matches all", match: &ConditionMatch{}, want: true},
+		{name: "address matches", match: &ConditionMatch{Address: &common.AddressMatch{Exact: host}}, want: true},
+		{name: "address rejects", match: &ConditionMatch{Address: &common.AddressMatch{Exact: "10.0.0.2"}}, want: false},
+		{name: "provider address matches", match: &ConditionMatch{ProviderAddress: &common.AddressMatch{Exact: url.Location}}, want: true},
+		{name: "provider address rejects", match: &ConditionMatch{ProviderAddress: &common.AddressMatch{Exact: "127.0.0.2:20880"}}, want: false},
+		{name: "service matches", match: &ConditionMatch{Service: listMatch(url.ServiceKey())}, want: true},
+		{name: "service rejects", match: &ConditionMatch{Service: listMatch("demo/another.Service:1.0.0")}, want: false},
+		{name: "application matches", match: &ConditionMatch{App: listMatch("demo-provider")}, want: true},
+		{name: "application rejects", match: &ConditionMatch{App: listMatch("another-provider")}, want: false},
+		{name: "parameter matches", match: &ConditionMatch{Param: paramMatch("prod")}, want: true},
+		{name: "parameter rejects", match: &ConditionMatch{Param: paramMatch("staging")}, want: false},
+		{
+			name: "all configured dimensions match",
+			match: &ConditionMatch{
+				Address:         &common.AddressMatch{Exact: host},
+				ProviderAddress: &common.AddressMatch{Exact: url.Location},
+				Service:         listMatch(url.ServiceKey()),
+				App:             listMatch("demo-provider"),
+				Param:           paramMatch("prod"),
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, tt.match.IsMatch(host, url))
+		})
+	}
 }
 
 func TestDefaultConfigurationParserServiceItemToUrls_ParserToUrls(t *testing.T) {


### PR DESCRIPTION
Fixes #3661

## Background

Dubbo Admin publishes v3 dynamic configuration with the rule-level YAML field `configVersion` and optional `configs[].match` constraints. Dubbo-Go parses that YAML into configurator URLs before `overrideConfigurator` decides which matching semantics to use and applies parameters to consumer or provider URLs.

The Dynamic Config E2E exposed two runtime problems in this path. A rule could be present in Admin and ZooKeeper while the consumer either followed the deprecated configurator path or failed when evaluating an empty match. This made a persistence-only check insufficient and could produce a false-positive E2E result.

## Root cause

1. The configurator read the wrong version key.

   `ConfigVersionKey` belongs to the config-center component parameter namespace and currently resolves to `config-center.configVersion`. The dynamic rule schema and `DefaultConfigurationParser`, however, use `configVersion`. The constant originally also contained `configVersion`, but it was namespaced together with other config-center component keys in a historical registry-parameter cleanup. `overrideConfigurator` kept reusing it, so standard v3 rule URLs had no version from the configurator's perspective and fell into the deprecated pre-2.7 path.

2. Empty or partial v3 matches dereferenced nil fields.

   An omitted match or the valid YAML form `match: {}` leaves `ConditionMatch` or its optional fields nil. `ConditionMatch.IsMatch` called every matcher unconditionally, so the real v3 path could panic before applying the configured parameters. A partially specified match had the same problem for every omitted dimension.

## Why both fixes are necessary

The version-key fix is required to ensure a standard Admin v3 rule actually executes the v3 configurator path instead of accidentally succeeding through deprecated behavior. Once that dispatch is corrected, empty-match handling is required for the default match-all rule emitted by Admin and for partial match constraints.

Without both changes, the Dynamic Config E2E cannot prove the intended chain:

Admin rule -> config center data -> v3 parser/configurator -> final URL parameters -> observable invocation behavior.

These are runtime contract fixes, not test-only accommodations. The E2E uses load-balancing behavior for its assertion and does not require any CallOption semantic changes.

## Changes

- Add `constant.RuleConfigVersionKey` for the rule-level `configVersion` field, keeping it separate from config-center component keys.
- Use the rule constant consistently when parser-generated URLs are built, when configurator versions are read, and when metadata keys are excluded from applied parameters.
- Treat an absent or empty `ConditionMatch` as match-all and evaluate only explicitly configured match dimensions.
- Add regression coverage for rule-version dispatch, empty match behavior, parser output, and v3 configuration application.

## Testing

```text
go test ./config_center/parser ./config_center/configurator ./cluster/router/condition
```