### PR TITLE
fix(protocol/triple): SendHeader writes into ResponseHeader instead of RequestHeader

### DIFF
--- a/protocol/triple/triple_protocol/header.go
+++ b/protocol/triple/triple_protocol/header.go
@@ -309,6 +309,6 @@ func SendHeader(ctx context.Context, header http.Header) error {
 	if !ok {
 		return errorf(CodeInternal, "triple: handler outgoing context not found; SendHeader must be called within a Triple handler")
 	}
-	mergeHeaders(conn.RequestHeader(), header)
+	mergeHeaders(conn.ResponseHeader(), header)
 	return conn.Send(nil)
 }

--- a/protocol/triple/triple_protocol/header_test.go
+++ b/protocol/triple/triple_protocol/header_test.go
@@ -165,26 +165,29 @@ func TestAppendToOutgoingContextPanicsOnOddKV(t *testing.T) {
 	})
 }
 
-// mockHandlerConn is a minimal StreamingHandlerConn for testing SetHeader and
-// SetTrailer.
+// mockHandlerConn is a minimal StreamingHandlerConn for testing SetHeader,
+// SendHeader and SetTrailer.
 type mockHandlerConn struct {
 	responseHdr  http.Header
 	responseTrlr http.Header
+	requestHdr   http.Header
+	sendCalls    int
 }
 
 func newMockHandlerConn() *mockHandlerConn {
 	return &mockHandlerConn{
 		responseHdr:  make(http.Header),
 		responseTrlr: make(http.Header),
+		requestHdr:   make(http.Header),
 	}
 }
 
 func (m *mockHandlerConn) Spec() Spec                    { return Spec{} }
 func (m *mockHandlerConn) Peer() Peer                    { return Peer{} }
 func (m *mockHandlerConn) Receive(any) error             { return nil }
-func (m *mockHandlerConn) RequestHeader() http.Header    { return nil }
+func (m *mockHandlerConn) RequestHeader() http.Header    { return m.requestHdr }
 func (m *mockHandlerConn) ExportableHeader() http.Header { return nil }
-func (m *mockHandlerConn) Send(any) error                { return nil }
+func (m *mockHandlerConn) Send(any) error                { m.sendCalls++; return nil }
 func (m *mockHandlerConn) ResponseHeader() http.Header   { return m.responseHdr }
 func (m *mockHandlerConn) ResponseTrailer() http.Header  { return m.responseTrlr }
 
@@ -208,6 +211,33 @@ func TestSetTrailer(t *testing.T) {
 	err := SetTrailer(ctx, http.Header{"X-Trailer": []string{"end"}})
 	assert.Nil(t, err)
 	assert.Equal(t, conn.responseTrlr.Get("X-Trailer"), "end")
+}
+
+// TestSendHeader verifies that SendHeader merges headers into the response
+// header buffer (not the request header) and triggers a flush via Send.
+func TestSendHeader(t *testing.T) {
+	t.Parallel()
+	conn := newMockHandlerConn()
+	ctx := context.WithValue(context.Background(), handlerOutgoingKey{}, conn)
+	err := SendHeader(ctx, http.Header{"X-Custom": []string{"value"}})
+	assert.Nil(t, err)
+	// Headers must land in the response header buffer.
+	assert.Equal(t, conn.responseHdr.Get("X-Custom"), "value")
+	// The request header must not be polluted.
+	assert.Equal(t, len(conn.requestHdr), 0)
+	// Send must be called exactly once to flush the headers.
+	assert.Equal(t, conn.sendCalls, 1)
+}
+
+// TestSendHeaderOutsideHandler verifies that SendHeader returns a CodeInternal
+// error when called outside a Triple handler context.
+func TestSendHeaderOutsideHandler(t *testing.T) {
+	t.Parallel()
+	err := SendHeader(context.Background(), http.Header{"X-Custom": []string{"value"}})
+	assert.NotNil(t, err)
+	tripleErr, ok := asError(err)
+	assert.True(t, ok)
+	assert.Equal(t, tripleErr.Code(), CodeInternal)
 }
 
 // TestSetHeaderOutsideHandler verifies that SetHeader returns a CodeInternal

--- a/protocol/triple/triple_protocol/triple_ext_test.go
+++ b/protocol/triple/triple_protocol/triple_ext_test.go
@@ -565,6 +565,44 @@ func TestSetHeaderAndSetTrailerInUnaryHandler(t *testing.T) {
 	assert.Equal(t, response.Trailer().Values(handlerTrailer), []string{trailerValue})
 }
 
+// TestSendHeaderInUnaryHandler verifies that SendHeader flushes response
+// headers over a real HTTP transport and that the response body stays
+// decodable. Unlike the mock in header_test.go, this exercises net/http's
+// WriteHeader snapshot semantics and the unary handler's double-Send path
+// (SendHeader's conn.Send(nil) followed by the framework's conn.Send(msg)),
+// guarding the regression fixed in #3667.
+func TestSendHeaderInUnaryHandler(t *testing.T) {
+	t.Parallel()
+
+	handler := triple.NewUnaryHandler(
+		"/connect.ping.v1.PingService/Ping",
+		func() any { return new(pingv1.PingRequest) },
+		func(ctx context.Context, req *triple.Request) (*triple.Response, error) {
+			if err := triple.SendHeader(ctx, http.Header{handlerHeader: []string{headerValue}}); err != nil {
+				return nil, err
+			}
+			msg := req.Msg.(*pingv1.PingRequest)
+			return triple.NewResponse(&pingv1.PingResponse{
+				Number: msg.Number,
+				Text:   msg.Text,
+			}), nil
+		},
+	)
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	client := pingv1connect.NewPingServiceClient(server.Client(), server.URL)
+	request := triple.NewRequest(&pingv1.PingRequest{Number: 42, Text: "hello"})
+	response := triple.NewResponse(&pingv1.PingResponse{})
+	err := client.Ping(context.Background(), request, response)
+	assert.Nil(t, err)
+	// The flushed response header must reach the client.
+	assert.Equal(t, response.Header().Values(handlerHeader), []string{headerValue})
+	// The response body must remain decodable after the header flush.
+	assert.Equal(t, response.Msg.(*pingv1.PingResponse).Number, int64(42))
+	assert.Equal(t, response.Msg.(*pingv1.PingResponse).Text, "hello")
+}
+
 func TestConcurrentStreams(t *testing.T) {
 	if testing.Short() {
 		t.Skipf("skipping %s test in short mode", t.Name())


### PR DESCRIPTION
## What & why

`SendHeader` is documented to "append response headers from a server handler and send them immediately" (same semantics as `SetHeader`, but flushed on the first `Send`). Its implementation merged the user-supplied headers into `conn.RequestHeader()` instead of `conn.ResponseHeader()`, so:

1. **Response headers were silently dropped** — `grpcHandlerConn.Send` only flushes `hc.responseHeader` into the response writer, so the user's headers never reached the client.
2. **Request headers were polluted** — the headers were merged into the shared inbound request header map, so subsequent `RequestHeader()` / `FromIncomingContext` reads observed headers the client never sent.

Align with the sibling `SetHeader` (`header.go:263`) by writing into `conn.ResponseHeader()`.

Closes #3667.

## Changes

- `protocol/triple/triple_protocol/header.go:312` — `conn.RequestHeader()` → `conn.ResponseHeader()`.
- `protocol/triple/triple_protocol/header_test.go` — upgrade `mockHandlerConn` to expose a real `RequestHeader` map and a `Send` call counter (the old `RequestHeader()` returned `nil`, which masked any pollution); add `TestSendHeader` (asserts headers land in `ResponseHeader()`, `RequestHeader()` is **not** mutated, and `Send` is called once) and `TestSendHeaderOutsideHandler` (asserts `CodeInternal`).
- `protocol/triple/triple_protocol/triple_ext_test.go` — add `TestSendHeaderInUnaryHandler`, an end-to-end test over a real `httptest` HTTP transport. The mock in `header_test.go` does not simulate `net/http`'s `WriteHeader` snapshot semantics, so it could not catch the "headers never reach the wire" failure mode. This test also covers the unary handler's double-`Send` path (`SendHeader`'s `conn.Send(nil)` followed by the framework's `conn.Send(msg)`) and verifies the response body stays decodable after the header flush.

## Verification

- Confirmed `TestSendHeader` (mock) and `TestSendHeaderInUnaryHandler` (e2e) both **FAIL** on the pre-fix code (`got: []` / `got: []`), proving the new tests reproduce the bug.
- After the one-line fix, both pass; the full `protocol/triple/triple_protocol` package test suite is green; `go vet` / `go build` clean.

## Notes

- Based on the latest `origin/develop` (a31acfb6).
- Scope is intentionally limited to the public `SendHeader` API. The compat layer's `compatHandlerStream.SendHeader` remains a documented no-op (handled by #3663) and is out of scope.
- A streaming e2e covering `grpcHandlerConn.Send`'s flush path would be a natural follow-up, but is left to a separate change to keep this fix focused.