### PR TITLE
fix(config): guard the global dynamicConfiguration with a RWMutex

### DIFF
--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -99,8 +99,8 @@ func (env *Environment) Configuration() *list.List {
 // SetDynamicConfiguration sets value for dynamicConfiguration
 func (env *Environment) SetDynamicConfiguration(dc config_center.DynamicConfiguration) {
 	env.dynamicMu.Lock()
+	defer env.dynamicMu.Unlock()
 	env.dynamicConfiguration = dc
-	env.dynamicMu.Unlock()
 }
 
 // GetDynamicConfiguration gets dynamicConfiguration

--- a/common/config/environment.go
+++ b/common/config/environment.go
@@ -38,6 +38,7 @@ type Environment struct {
 	// externalConfigs      sync.Map
 	externalConfigMap    sync.Map
 	appExternalConfigMap sync.Map
+	dynamicMu            sync.RWMutex
 	dynamicConfiguration config_center.DynamicConfiguration
 }
 
@@ -97,11 +98,15 @@ func (env *Environment) Configuration() *list.List {
 
 // SetDynamicConfiguration sets value for dynamicConfiguration
 func (env *Environment) SetDynamicConfiguration(dc config_center.DynamicConfiguration) {
+	env.dynamicMu.Lock()
 	env.dynamicConfiguration = dc
+	env.dynamicMu.Unlock()
 }
 
 // GetDynamicConfiguration gets dynamicConfiguration
 func (env *Environment) GetDynamicConfiguration() config_center.DynamicConfiguration {
+	env.dynamicMu.RLock()
+	defer env.dynamicMu.RUnlock()
 	return env.dynamicConfiguration
 }
 

--- a/common/config/environment_race_test.go
+++ b/common/config/environment_race_test.go
@@ -34,12 +34,20 @@ func TestDynamicConfigurationRace(t *testing.T) {
 	})
 
 	const iterations = 100000
+	start := make(chan struct{})
+	ready := make(chan struct{})
+
 	var wg sync.WaitGroup
 	wg.Go(func() { // reader goroutine mimics a lingering registry subscription goroutine
+		close(ready)
+		<-start
 		for range iterations {
 			_ = env.GetDynamicConfiguration()
 		}
 	})
+
+	<-ready
+	close(start)
 	for range iterations { // the test goroutine keeps writing
 		env.SetDynamicConfiguration(nil)
 	}

--- a/common/config/environment_race_test.go
+++ b/common/config/environment_race_test.go
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestDynamicConfigurationRace verifies that concurrent SetDynamicConfiguration
+// and GetDynamicConfiguration calls on the global Environment instance are
+// race-free. It mirrors the CI flaky race where a registry subscription
+// goroutine kept reading the field while a test goroutine wrote it.
+func TestDynamicConfigurationRace(t *testing.T) {
+	env := GetEnvInstance()
+	previous := env.GetDynamicConfiguration()
+	t.Cleanup(func() {
+		env.SetDynamicConfiguration(previous)
+	})
+
+	const iterations = 100000
+	var wg sync.WaitGroup
+	wg.Go(func() { // reader goroutine mimics a lingering registry subscription goroutine
+		for range iterations {
+			_ = env.GetDynamicConfiguration()
+		}
+	})
+	for range iterations { // the test goroutine keeps writing
+		env.SetDynamicConfiguration(nil)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
### Description
Fixes #3664 (task of #3614)

Fixes the data race on the global `Environment.dynamicConfiguration` in `common/config`, reported by the CI `-race` job on the `registry/directory` package.

The `Environment` singleton keeps `dynamicConfiguration` as a lock-free field. A test goroutine writes it via `SetDynamicConfiguration`, while subscription goroutines leaked from earlier `normalRegistryDir` tests keep reading it through `GetDynamicConfiguration` (tag `PriorityRouter.Notify`) — a data race under the Go memory model. The registry subscription goroutine blocks on `listener.Next()` and never exits, so it survives across tests and races with the writer of the next test.

### Changes

- Add a `dynamicMu sync.RWMutex` field to `Environment`
- `SetDynamicConfiguration` takes the write lock before storing
- `GetDynamicConfiguration` takes the read lock before loading
- The exported API and nil semantics are unchanged, so existing callers and tests are unaffected

### Test

Add `TestDynamicConfigurationRace` in `environment_race_test.go`:

| Test | Description |
| --- | --- |
| `TestDynamicConfigurationRace` | Drives 100k concurrent reads and writes on the global `Environment.dynamicConfiguration`: a reader goroutine mimics a lingering registry subscription goroutine calling `GetDynamicConfiguration`, while the test goroutine keeps calling `SetDynamicConfiguration`. Fails on the previous lock-free field under `-race` and passes with the `RWMutex` guard |

### Validation

- `go test -race -run TestDynamicConfigurationRace ./common/config/ -count=1` reports a `DATA RACE`  `dynamicConfiguration` before the fix, passes after it
- `-race` runs pass with no `DATA RACE` reported.

### Checklist
- [x] I confirm the target branch is `develop`
- [x] I have run `make fmt` to format my code
- [x] I have run `make test` to run local tests
- [x] I have added tests that prove my fix is effective or that my feature works
