### PR TITLE
fix(triple): filter http.ErrServerClosed in single-protocol server shutdown

### DIFF
--- a/protocol/triple/triple_protocol/server.go
+++ b/protocol/triple/triple_protocol/server.go
@@ -215,8 +215,10 @@ func (s *Server) startHttp2(tlsConf *tls.Config) error {
 	} else {
 		err = srv.ListenAndServe()
 	}
-
-	return err
+	if err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
 }
 
 func (s *Server) startHttp3(tlsConf *tls.Config) error {
@@ -246,7 +248,11 @@ func (s *Server) startHttp3(tlsConf *tls.Config) error {
 
 	logger.Debugf("[Triple][Server] triple HTTP/3 Server starting on %v", s.addr)
 
-	return s.http3Srv.Load().ListenAndServe()
+	err = s.http3Srv.Load().ListenAndServe()
+	if err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
 }
 
 func (s *Server) startHttp2AndHttp3(tlsConf *tls.Config) error {

--- a/protocol/triple/triple_protocol/server_lifecycle_test.go
+++ b/protocol/triple/triple_protocol/server_lifecycle_test.go
@@ -28,7 +28,6 @@ import (
 	"errors"
 	"math/big"
 	"net"
-	"net/http"
 	"syscall"
 	"testing"
 	"time"
@@ -175,7 +174,7 @@ func TestServer_HTTP2_StartAndStop(t *testing.T) {
 	require.Nil(t, srv.http3Srv.Load())
 
 	require.NoError(t, srv.Stop())
-	require.ErrorIs(t, waitForServerExit(t, errCh, 5*time.Second), http.ErrServerClosed)
+	require.NoError(t, waitForServerExit(t, errCh, 5*time.Second))
 }
 
 func TestServer_HTTP2_StartAndStopWithTLS(t *testing.T) {
@@ -186,7 +185,7 @@ func TestServer_HTTP2_StartAndStopWithTLS(t *testing.T) {
 	require.Nil(t, srv.http3Srv.Load())
 
 	require.NoError(t, srv.Stop())
-	require.ErrorIs(t, waitForServerExit(t, errCh, 5*time.Second), http.ErrServerClosed)
+	require.NoError(t, waitForServerExit(t, errCh, 5*time.Second))
 }
 
 func TestServer_HTTP3_StartAndStop(t *testing.T) {
@@ -200,7 +199,7 @@ func TestServer_HTTP3_StartAndStop(t *testing.T) {
 	require.Nil(t, srv.httpSrv.Load())
 
 	require.NoError(t, srv.Stop())
-	require.ErrorIs(t, waitForServerExit(t, errCh, 5*time.Second), http.ErrServerClosed)
+	require.NoError(t, waitForServerExit(t, errCh, 5*time.Second))
 }
 
 func TestServer_HTTP2AndHTTP3_StartAndStop(t *testing.T) {
@@ -215,8 +214,6 @@ func TestServer_HTTP2AndHTTP3_StartAndStop(t *testing.T) {
 	require.NotNil(t, srv.http3Srv.Load())
 
 	require.NoError(t, srv.Stop())
-	// startHttp2AndHttp3 swallows http.ErrServerClosed inside the errgroup,
-	// so Run returns nil after the servers are closed.
 	require.NoError(t, waitForServerExit(t, errCh, 5*time.Second))
 }
 
@@ -230,7 +227,7 @@ func TestServer_HTTP2_StartAndGracefulStop(t *testing.T) {
 	graceCtx, cancel := context.WithTimeout(context.Background(), constant.DefaultGracefulShutdownTimeout)
 	defer cancel()
 	require.NoError(t, srv.GracefulStop(graceCtx))
-	require.ErrorIs(t, waitForServerExit(t, errCh, 5*time.Second), http.ErrServerClosed)
+	require.NoError(t, waitForServerExit(t, errCh, 5*time.Second))
 }
 
 func TestServer_HTTP3_StartAndGracefulStop(t *testing.T) {
@@ -246,7 +243,7 @@ func TestServer_HTTP3_StartAndGracefulStop(t *testing.T) {
 	graceCtx, cancel := context.WithTimeout(context.Background(), constant.DefaultGracefulShutdownTimeout)
 	defer cancel()
 	require.NoError(t, srv.GracefulStop(graceCtx))
-	require.ErrorIs(t, waitForServerExit(t, errCh, 5*time.Second), http.ErrServerClosed)
+	require.NoError(t, waitForServerExit(t, errCh, 5*time.Second))
 }
 
 func TestServer_HTTP2AndHTTP3_StartAndGracefulStop(t *testing.T) {
@@ -263,8 +260,6 @@ func TestServer_HTTP2AndHTTP3_StartAndGracefulStop(t *testing.T) {
 	graceCtx, cancel := context.WithTimeout(context.Background(), constant.DefaultGracefulShutdownTimeout)
 	defer cancel()
 	require.NoError(t, srv.GracefulStop(graceCtx))
-	// startHttp2AndHttp3 swallows http.ErrServerClosed inside the errgroup,
-	// so Run returns nil after the servers are closed.
 	require.NoError(t, waitForServerExit(t, errCh, 5*time.Second))
 }
 
@@ -334,11 +329,36 @@ func TestServer_RepeatedStartStop(t *testing.T) {
 			}
 
 			require.NoError(t, srv.Stop())
-			if tc.protocol == constant.CallHTTP2AndHTTP3 {
-				require.NoError(t, waitForServerExit(t, errCh, 5*time.Second))
-			} else {
-				require.ErrorIs(t, waitForServerExit(t, errCh, 5*time.Second), http.ErrServerClosed)
-			}
+			require.NoError(t, waitForServerExit(t, errCh, 5*time.Second))
 		}
 	}
+}
+
+// TestServerRunReturnsBindErrorWhenPortInUse verifies that Run propagates a
+// genuine serve error (here a TCP port conflict) instead of swallowing it
+// together with http.ErrServerClosed. It guards the boundary of the shutdown
+// filter: only the normal-closure signal must be suppressed.
+func TestServerRunReturnsBindErrorWhenPortInUse(t *testing.T) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	srv := NewServer(l.Addr().String(), &global.TripleConfig{})
+	err = srv.Run(constant.CallHTTP2, nil)
+	require.Error(t, err)
+	require.True(t, isAddrInUse(err), "expected EADDRINUSE, got %v", err)
+}
+
+// TestServerRunHTTP3ReturnsBindErrorWhenPortInUse verifies the same boundary
+// for the HTTP/3 path, where the QUIC endpoint fails to bind the occupied
+// UDP port.
+func TestServerRunHTTP3ReturnsBindErrorWhenPortInUse(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer pc.Close()
+
+	srv := NewServer(pc.LocalAddr().String(), &global.TripleConfig{})
+	err = srv.Run(constant.CallHTTP3, newTestTLSConfig(t))
+	require.Error(t, err)
+	require.True(t, isAddrInUse(err), "expected EADDRINUSE, got %v", err)
 }


### PR DESCRIPTION
### Description
Fixes #3670

The single-protocol `Server.Run` paths returned `http.ErrServerClosed` verbatim after a normal `Stop`, so every clean shutdown surfaced the net/http normal-closure signal to the caller. The outer `startTransport` goroutine logs any non-nil error as `server serve failed`, so each shutdown produced a spurious error log; the dual-protocol path already swallowed the signal inside its errgroup, so single- and dual-protocol shutdown behaviour diverged.

Align the single-protocol paths with the dual-protocol one: filter `http.ErrServerClosed` in `startHttp2` / `startHttp3` before returning. Only the normal-closure signal is suppressed; genuine serve errors (e.g. `EADDRINUSE`) still propagate.

### Changes

- `triple_protocol/server.go` — filter `http.ErrServerClosed` in `startHttp2` / `startHttp3` before returning, matching the dual-protocol behaviour
- `triple_protocol/server_lifecycle_test.go` — switch the six `require.ErrorIs(..., http.ErrServerClosed)` assertions to `require.NoError`; fold the now-uniform `if/else` in `TestServer_RepeatedStartStop` into a single assertion; drop the stale comments that described only the dual-protocol swallowing behaviour

### Test

Add 2 tests guarding the boundary of the filter:

| Test | Description |
| --- | --- |
| `TestServerRunReturnsBindErrorWhenPortInUse` | Occupies the TCP port before `Run`, asserting that a genuine serve error (`EADDRINUSE`) is still propagated instead of being swallowed together with `http.ErrServerClosed` |
| `TestServerRunHTTP3ReturnsBindErrorWhenPortInUse` | Same boundary check on the HTTP/3 path: the QUIC endpoint fails to bind the occupied UDP port and `Run` still returns the error |

### Validation

- Before the fix, a normal `Stop` made `Run` return `http.ErrServerClosed` and the outer goroutine logged a spurious `server serve failed` error; after the fix `Run` returns `nil` and no error is logged
- The updated lifecycle tests fail on the pre-fix code and pass with the filter

### Checklist
- [x] I confirm the target branch is `develop`
- [x] I have run `make fmt` to format my code
- [x] I have run `make test` to run local tests
- [x] I have added tests that prove my fix is effective or that my feature works
