### PR TITLE
docs: complete Triple configuration field comments

### DIFF
--- a/filter/generic/generalizer/map_test.go
+++ b/filter/generic/generalizer/map_test.go
@@ -88,7 +88,7 @@ func TestMTagRoundTrip(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "42", generalizedMap["user_id"])
 
-	realized, err := mockMapGeneralizer.Realize(generalized, reflect.TypeOf(original))
+	realized, err := mockMapGeneralizer.Realize(generalized, reflect.TypeFor[testMTagObj]())
 	require.NoError(t, err)
 	assert.Equal(t, original, realized)
 }

--- a/global/http3_config.go
+++ b/global/http3_config.go
@@ -19,27 +19,32 @@ package global
 
 // Http3Config represents the config of http3 protocol.
 type Http3Config struct {
-	// Enable defines whether to enable HTTP/3 support.
-	// When set to true, both HTTP/2 and HTTP/3 servers will be started simultaneously.
-	// When set to false, only HTTP/2 server will be started.
+	// Enable defines whether HTTP/3 support is enabled for server and client.
+	// When true, a valid TLS configuration is required; otherwise, initialization fails.
+	// With valid TLS, server starts both HTTP/2 and HTTP/3,
+	// and client uses a dual HTTP/2 and HTTP/3 transport.
+	// When false, server starts only HTTP/2, and client uses an HTTP/2 transport.
 	// The default value is false.
 	Enable bool `yaml:"enable" json:"enable,omitempty"`
-	// Negotiation defines whether to enable HTTP/3 negotiation.
-	// If set to true, HTTP/2 alt-svc negotiation will be enabled,
+
+	// Negotiation defines whether HTTP/3 negotiation is enabled for server.
+	// When true, HTTP/3 is advertised through Alt-Svc,
 	// allowing clients to negotiate between HTTP/2 and HTTP/3.
-	// If set to false, HTTP/2 alt-svc negotiation will be skipped,
-	// Clients cannot discover HTTP/3 via Alt-Svc.
+	// When false, HTTP/3 is not advertised through Alt-Svc.
 	// The default value is true.
-	// ref: https://quic-go.net/docs/http3/server/#advertising-http3-via-alt-svc
+	// For more details, see https://quic-go.net/docs/http3/server/#advertising-http3-via-alt-svc.
 	Negotiation bool `yaml:"negotiation" json:"negotiation,omitempty"`
 
-	// KeepAlivePeriod defines how often to send keep-alive packets.
+	// KeepAlivePeriod defines how often keep-alive packets are sent for server and client.
 	KeepAlivePeriod string `yaml:"keep-alive-period" json:"keep-alive-period,omitempty"`
-	// MaxIdleTimeout defines the maximum idle timeout for QUIC connections.
+
+	// MaxIdleTimeout defines the maximum idle timeout for QUIC connections on server and client.
 	MaxIdleTimeout string `yaml:"max-idle-timeout" json:"max-idle-timeout,omitempty"`
-	// MaxIncomingStreams defines the maximum number of concurrent bidirectional streams.
+
+	// MaxIncomingStreams defines the maximum number of concurrent bidirectional streams accepted by server and client.
 	MaxIncomingStreams int64 `yaml:"max-incoming-streams" json:"max-incoming-streams,omitempty"`
-	// MaxIncomingUniStreams defines the maximum number of concurrent unidirectional streams.
+
+	// MaxIncomingUniStreams defines the maximum number of concurrent unidirectional streams accepted by server and client.
 	MaxIncomingUniStreams int64 `yaml:"max-incoming-uni-streams" json:"max-incoming-uni-streams,omitempty"`
 }
 

--- a/global/protocol_config.go
+++ b/global/protocol_config.go
@@ -23,26 +23,34 @@ import (
 
 // ProtocolConfig represents the config of protocol.
 type ProtocolConfig struct {
+	// Name defines the protocol name for server.
 	Name string `yaml:"name" json:"name,omitempty" property:"name"`
-	Ip   string `yaml:"ip"  json:"ip,omitempty" property:"ip"`
+
+	// Ip defines the listening IP address for server.
+	Ip string `yaml:"ip"  json:"ip,omitempty" property:"ip"`
+
+	// Port defines the listening port for server.
 	Port string `yaml:"port" json:"port,omitempty" property:"port"`
 
 	// TODO: maybe Params is useless, find a ideal way to config dubbo protocol, ref: TripleConfig.
+	// Params defines additional protocol parameters for server.
 	Params any `yaml:"params" json:"params,omitempty" property:"params"`
 
-	// TripleConfig holds the Triple protocol configuration.
+	// TripleConfig holds the Triple protocol configuration for server.
 	TripleConfig *TripleConfig `yaml:"triple" json:"triple,omitempty" property:"triple"`
 
 	// TODO: remove MaxServerSendMsgSize and MaxServerRecvMsgSize when version 4.0.0
 	//
-	// MaxServerSendMsgSize defines the max size of server send message, 1mb=1000kb=1000000b 1mib=1024kb=1048576b.
-	// more detail to see https://pkg.go.dev/github.com/dustin/go-humanize#pkg-constants
+	// MaxServerSendMsgSize defines the maximum size of messages sent by server.
+	// Supported units include 1mb=1000kb=1000000b and 1mib=1024kb=1048576b.
+	// For more details, see https://pkg.go.dev/github.com/dustin/go-humanize#pkg-constants.
 	//
 	// Deprecated: use "ClientProtocolConfig.TripleConfig.MaxServerSendMsgSize" or in config tag "protocol_config/triple/max-server-send-msg-size" instead
 	MaxServerSendMsgSize string `yaml:"max-server-send-msg-size" json:"max-server-send-msg-size,omitempty"`
+
 	// TODO: remove MaxServerSendMsgSize and MaxServerRecvMsgSize when version 4.0.0
 	//
-	// MaxServerRecvMsgSize defines the max size of server receive message.
+	// MaxServerRecvMsgSize defines the maximum size of messages received by server.
 	//
 	// Deprecated: use "ClientProtocolConfig.TripleConfig.MaxServerRecvMsgSize" or in config tag "protocol_config/triple/max-server-recv-msg-size" instead
 	MaxServerRecvMsgSize string `default:"4mib" yaml:"max-server-recv-msg-size" json:"max-server-recv-msg-size,omitempty"`

--- a/global/triple_config.go
+++ b/global/triple_config.go
@@ -24,24 +24,30 @@ type TripleConfig struct {
 	//
 	// for server
 	//
-	// MaxServerSendMsgSize defines the max size of server send message, 1mb=1000kb=1000000b 1mib=1024kb=1048576b.
-	// more detail to see https://pkg.go.dev/github.com/dustin/go-humanize#pkg-constants
+	// MaxServerSendMsgSize defines the maximum size of messages sent by server.
+	// Supported units include 1mb=1000kb=1000000b and 1mib=1024kb=1048576b.
+	// For more details, see https://pkg.go.dev/github.com/dustin/go-humanize#pkg-constants.
 	MaxServerSendMsgSize string `yaml:"max-server-send-msg-size" json:"max-server-send-msg-size,omitempty"`
-	// MaxServerRecvMsgSize defines the max size of server receive message.
+
+	// MaxServerRecvMsgSize defines the maximum size of messages received by server.
 	MaxServerRecvMsgSize string `yaml:"max-server-recv-msg-size" json:"max-server-recv-msg-size,omitempty"`
-	// Http3 holds the HTTP/3 transport configuration.
+
+	// Http3 holds the HTTP/3 transport configuration for server and client.
 	Http3 *Http3Config `yaml:"http3" json:"http3,omitempty"`
-	// Cors configures CORS for Triple protocol handlers.
+
+	// Cors configures CORS for Triple protocol handlers on server.
 	Cors *CorsConfig `yaml:"cors" json:"cors,omitempty"`
-	// OpenAPI configures OpenAPI documentation generation.
+
+	// OpenAPI configures OpenAPI documentation generation for server.
 	OpenAPI *OpenAPIConfig `yaml:"openapi" json:"openapi,omitempty"`
 
 	//
 	// for client
 	//
-	// KeepAliveInterval defines the duration of keep alive interval.
+	// KeepAliveInterval defines the keep-alive interval for client.
 	KeepAliveInterval string `yaml:"keep-alive-interval" json:"keep-alive-interval,omitempty" property:"keep-alive-interval"`
-	// KeepAliveTimeout defines the duration of keep alive timeout.
+
+	// KeepAliveTimeout defines the keep-alive timeout for client.
 	KeepAliveTimeout string `yaml:"keep-alive-timeout" json:"keep-alive-timeout,omitempty" property:"keep-alive-timeout"`
 }
 


### PR DESCRIPTION
## Description

issue #3598

@Alanxtl 
11. 补齐 Triple 配置结构注释任务

### 变更情况

#### global/protocol_config.go

- 补齐 `ProtocolConfig` 各字段的统一注释
- 明确各配置字段用于 server
- 标记 `MaxServerSendMsgSize` 和 `MaxServerRecvMsgSize` 为废弃字段
- 更新废弃字段的替代配置说明
- 保留消息大小单位及参考链接

#### global/triple_config.go

- 补齐 `TripleConfig` 各字段的统一注释
- 明确消息大小、CORS 和 OpenAPI 配置用于 server
- 明确 keepalive 配置用于 client
- 明确 HTTP/3 配置同时用于 server 和 client

#### global/http3_config.go

- 统一 `Http3Config` 各字段的注释
- 明确 Enable 同时用于 server 和 client，Negotiation 用于 server
- 明确 QUIC keepalive、空闲超时和并发流配置同时用于 server 和 client
- 优化 HTTP/3 Alt-Svc 协商相关说明

以上仅涉及配置结构注释，不包含代码逻辑变更。

## Checklist

- [x] 我确认目标分支为 develop
- [x] 代码已通过本地测试
- [x] 本次仅修改注释，不涉及逻辑变更，无需新增测试