### PR TITLE
chore: add doc comments and unit tests for instance customizers

### DIFF
--- a/registry/servicediscovery/customizer/service_instance_host_port_customizer.go
+++ b/registry/servicediscovery/customizer/service_instance_host_port_customizer.go
@@ -30,6 +30,8 @@ func init() {
 	extension.AddCustomizers(&hostPortCustomizer{})
 }
 
+// hostPortCustomizer fills the host and port of a DefaultServiceInstance from
+// its exported service URLs.
 type hostPortCustomizer struct{}
 
 // GetPriority will return 1 so that it will be invoked in front of user defining Customizer
@@ -37,7 +39,11 @@ func (e *hostPortCustomizer) GetPriority() int {
 	return 1
 }
 
-// Customize calculate the revision for exported urls and then put it into instance metadata
+// Customize sets the host and port of the instance from the first exported
+// service URL, so that the instance carries a reachable address.
+// It only applies to *registry.DefaultServiceInstance, and does nothing when
+// the port is already set or when the instance has no exported service URLs.
+// An unparsable port leaves the port unchanged, while the host is still set.
 func (e *hostPortCustomizer) Customize(instance registry.ServiceInstance) {
 	if instance.GetPort() > 0 { // has set, avoid reset
 		return

--- a/registry/servicediscovery/customizer/service_instance_host_port_customizer_test.go
+++ b/registry/servicediscovery/customizer/service_instance_host_port_customizer_test.go
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package customizer
+
+import (
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/metadata/info"
+	"dubbo.apache.org/dubbo-go/v3/registry"
+)
+
+func TestHostPortCustomizerGetPriority(t *testing.T) {
+	c := &hostPortCustomizer{}
+	assert.Equal(t, 1, c.GetPriority())
+}
+
+// TestHostPortCustomizerPortAlreadySet verifies that an instance with a port
+// already set is not modified.
+func TestHostPortCustomizerPortAlreadySet(t *testing.T) {
+	c := &hostPortCustomizer{}
+	ins := &registry.DefaultServiceInstance{
+		Port:            20880,
+		ServiceMetadata: newTestMetadataInfo(newHostPortTestURL("dubbo", "20880", "127.0.0.1")),
+	}
+	c.Customize(ins)
+	assert.Equal(t, 20880, ins.Port)
+	assert.Empty(t, ins.Host, "host should not be modified when port is already set")
+}
+
+// TestHostPortCustomizerNilServiceMetadata verifies that nothing happens when
+// the instance carries no service metadata.
+func TestHostPortCustomizerNilServiceMetadata(t *testing.T) {
+	c := &hostPortCustomizer{}
+	ins := &registry.DefaultServiceInstance{}
+	c.Customize(ins)
+	assert.Equal(t, 0, ins.Port)
+	assert.Empty(t, ins.Host)
+}
+
+// TestHostPortCustomizerNoExportedURLs verifies that nothing happens when the
+// metadata info has no exported service URLs.
+func TestHostPortCustomizerNoExportedURLs(t *testing.T) {
+	c := &hostPortCustomizer{}
+	ins := &registry.DefaultServiceInstance{
+		ServiceMetadata: info.NewMetadataInfo("app", ""),
+	}
+	c.Customize(ins)
+	assert.Equal(t, 0, ins.Port)
+	assert.Empty(t, ins.Host)
+}
+
+// TestHostPortCustomizerNormal verifies that the host and port are taken from
+// the first exported service URL.
+func TestHostPortCustomizerNormal(t *testing.T) {
+	c := &hostPortCustomizer{}
+	ins := &registry.DefaultServiceInstance{
+		ServiceMetadata: newTestMetadataInfo(newHostPortTestURL("dubbo", "20880", "127.0.0.1")),
+	}
+	c.Customize(ins)
+	assert.Equal(t, "127.0.0.1", ins.Host)
+	assert.Equal(t, 20880, ins.Port)
+}
+
+// TestHostPortCustomizerOnlyFirstURL verifies that only the first exported URL
+// is used.
+func TestHostPortCustomizerOnlyFirstURL(t *testing.T) {
+	c := &hostPortCustomizer{}
+	mi := info.NewMetadataInfo("app", "")
+	mi.AddService(newHostPortTestURL("dubbo", "20880", "127.0.0.1"))
+	mi.AddService(newHostPortTestURL("tri", "50051", "10.0.0.1"))
+	ins := &registry.DefaultServiceInstance{ServiceMetadata: mi}
+	c.Customize(ins)
+	assert.Equal(t, "127.0.0.1", ins.Host)
+	assert.Equal(t, 20880, ins.Port)
+}
+
+// TestHostPortCustomizerUnparsablePort verifies that an unparsable port leaves
+// the port unchanged while the host is still set.
+func TestHostPortCustomizerUnparsablePort(t *testing.T) {
+	c := &hostPortCustomizer{}
+	ins := &registry.DefaultServiceInstance{
+		ServiceMetadata: newTestMetadataInfo(newHostPortTestURL("dubbo", "not-a-number", "127.0.0.1")),
+	}
+	c.Customize(ins)
+	assert.Equal(t, "127.0.0.1", ins.Host)
+	assert.Equal(t, 0, ins.Port, "unparsable port should leave the port unchanged")
+}
+
+// TestHostPortCustomizerNonDefaultInstance verifies that a non-DefaultServiceInstance
+// is never modified, even when it carries exported URLs.
+func TestHostPortCustomizerNonDefaultInstance(t *testing.T) {
+	c := &hostPortCustomizer{}
+	ins := &wrappedServiceInstance{
+		DefaultServiceInstance: &registry.DefaultServiceInstance{
+			ServiceMetadata: newTestMetadataInfo(newHostPortTestURL("dubbo", "20880", "127.0.0.1")),
+		},
+	}
+	c.Customize(ins)
+	assert.Equal(t, 0, ins.Port)
+	assert.Empty(t, ins.Host)
+}
+
+// wrappedServiceInstance wraps DefaultServiceInstance so that the type assertion
+// to *registry.DefaultServiceInstance fails while still implementing the interface.
+type wrappedServiceInstance struct {
+	*registry.DefaultServiceInstance
+}
+
+func newTestMetadataInfo(url *common.URL) *info.MetadataInfo {
+	mi := info.NewMetadataInfo("app", "")
+	mi.AddService(url)
+	return mi
+}
+
+func newHostPortTestURL(protocol, port, ip string) *common.URL {
+	return common.NewURLWithOptions(
+		common.WithProtocol(protocol),
+		common.WithPort(port),
+		common.WithIp(ip),
+	)
+}

--- a/registry/servicediscovery/customizer/service_instance_tag_customizer.go
+++ b/registry/servicediscovery/customizer/service_instance_tag_customizer.go
@@ -27,6 +27,7 @@ func init() {
 	extension.AddCustomizers(&tagCustomizer{})
 }
 
+// tagCustomizer writes the tag of the instance into its metadata.
 type tagCustomizer struct{}
 
 // GetPriority will return 2 so that it will be invoked in front of user defining Customizer

--- a/registry/servicediscovery/customizer/service_revision_customizer.go
+++ b/registry/servicediscovery/customizer/service_revision_customizer.go
@@ -37,6 +37,8 @@ func init() {
 	extension.AddCustomizers(&subscribedServicesRevisionMetadataCustomizer{})
 }
 
+// exportedServicesRevisionMetadataCustomizer writes a revision derived from the
+// exported service URLs of the registry-scoped metadata info.
 type exportedServicesRevisionMetadataCustomizer struct{}
 
 // GetPriority will return 1 so that it will be invoked in front of user defining Customizer
@@ -64,6 +66,8 @@ func (e *exportedServicesRevisionMetadataCustomizer) Customize(instance registry
 	instance.GetMetadata()[constant.ExportedServicesRevisionPropertyName] = revision
 }
 
+// subscribedServicesRevisionMetadataCustomizer writes a revision derived from
+// the subscribed service URLs of the registry-scoped metadata info.
 type subscribedServicesRevisionMetadataCustomizer struct{}
 
 // GetPriority will return 2 so that it will be invoked in front of user defining Customizer


### PR DESCRIPTION
### Description

This PR improves the comments and test coverage of the service discovery instance customizers.

- Adds doc comments to hostPortCustomizer, tagCustomizer, and the exported/subscribed revision customizers, explaining how host/port, tag, and revision affect the instance info registered to the registry.
- Fixes the wrong Customize comment in service_instance_host_port_customizer.go (was copied from the revision customizer).
- Adds unit tests for host/port writing covering: port already set, nil service metadata, no exported URLs, first-URL-only, unparsable port, and non-DefaultServiceInstance.

Refs https://github.com/apache/dubbo-go/issues/3644  (task5)

### 本地验证

```
~/project/dubbo-go$ go test ./registry/servicediscovery/customizer/...
ok      dubbo.apache.org/dubbo-go/v3/registry/servicediscovery/customizer      (cached)
```

### Checklist

- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
