### PR TITLE
fix(benchmark): drain in-flight requests before canceling ctx in engine.Stop()

### DIFF
--- a/tools/benchmark/client/engine/engine.go
+++ b/tools/benchmark/client/engine/engine.go
@@ -114,8 +114,8 @@ func (e *Engine) worker(benchmarkFunc BenchmarkFunc) {
 func (e *Engine) Stop() {
 	e.stopOnce.Do(func() {
 		close(e.stopChan)
-		e.cancel()
 		e.wg.Wait()
+		e.cancel()
 		logger.Info("[INFO] Benchmark completed")
 	})
 }


### PR DESCRIPTION
### Description
Fixes #3675

`engine.Stop()` cancels the parent context before draining in-flight requests, causing up to `concurrency` requests to be recorded as `context canceled` failures on every benchmark teardown. In low-QPS scenarios (1MiB payload), the failure rate reaches 0.86%, making the success-rate metric inaccurate.

Swap `e.cancel()` and `e.wg.Wait()` so that in-flight requests complete naturally before the context is canceled. The `benchmarkFunc(ctx)` already has a `requestTimeout` safety bound

### Changes

- `tools/benchmark/client/engine/engine.go` — swap `e.cancel()` and `e.wg.Wait()` in `Stop()`

### Test

| Test | Description |
| --- | --- |
| 1MiB payload, 50 concurrency, 10s benchmark (before fix) | Failure <=50, logs flooded with `lastErr=canceled: context canceled` |
| 1MiB payload, 50 concurrency, 10s benchmark (after fix) | Failure = 0, Success Rate = 100% |

Validation was performed via manual benchmark reproduction.

### Validation

- Before fix: `Stop()` kills in-flight requests as `context canceled`, low-QPS scenarios show 99.27% success rate
- After fix: in-flight requests complete naturally, success rate 100.00%, no spurious errors
- `go build ./tools/benchmark/client/...` passes
- `go test ./tools/benchmark/...` passes

### Checklist
- [x] I confirm the target branch is `develop`
- [x] I have run `make fmt` to format my code
- [x] I have run `make test` to run local tests
- [ ] I have added tests that prove my fix is effective or that my feature works
