### PR TITLE
chore: add doc comments and unit tests for metadata customizers

### DIFF
--- a/registry/servicediscovery/customizer/metadata_service_url_params_customizer.go
+++ b/registry/servicediscovery/customizer/metadata_service_url_params_customizer.go
@@ -22,15 +22,17 @@ import (
 )
 
 import (
+	gxset "github.com/dubbogo/gost/container/set"
+	"github.com/dubbogo/gost/log/logger"
+)
+
+import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/metadata"
 	"dubbo.apache.org/dubbo-go/v3/metadata/info"
 	"dubbo.apache.org/dubbo-go/v3/registry"
-
-	gxset "github.com/dubbogo/gost/container/set"
-	"github.com/dubbogo/gost/log/logger"
 )
 
 func init() {

--- a/registry/servicediscovery/customizer/metadata_service_url_params_customizer.go
+++ b/registry/servicediscovery/customizer/metadata_service_url_params_customizer.go
@@ -22,17 +22,15 @@ import (
 )
 
 import (
-	gxset "github.com/dubbogo/gost/container/set"
-	"github.com/dubbogo/gost/log/logger"
-)
-
-import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/metadata"
 	"dubbo.apache.org/dubbo-go/v3/metadata/info"
 	"dubbo.apache.org/dubbo-go/v3/registry"
+
+	gxset "github.com/dubbogo/gost/container/set"
+	"github.com/dubbogo/gost/log/logger"
 )
 
 func init() {
@@ -46,6 +44,9 @@ func init() {
 	extension.AddCustomizers(&metadataServiceURLParamsMetadataCustomizer{exceptKeys: exceptKeys})
 }
 
+// metadataServiceURLParamsMetadataCustomizer writes the metadata service URL
+// params into the instance metadata as JSON.
+// exceptKeys is currently unused.
 type metadataServiceURLParamsMetadataCustomizer struct {
 	exceptKeys *gxset.HashSet
 }
@@ -55,6 +56,9 @@ func (m *metadataServiceURLParamsMetadataCustomizer) GetPriority() int {
 	return 0
 }
 
+// Customize writes the metadata service URL params into the instance metadata
+// under MetadataServiceURLParamsPropertyName; when the metadata service URL is
+// nil, it returns without writing, otherwise the params JSON overwrites the key.
 func (m *metadataServiceURLParamsMetadataCustomizer) Customize(instance registry.ServiceInstance) {
 	// TODO: GetMetadataService() is a global singleton and returns the same metadata service URL
 	// regardless of which registry this instance belongs to. In a multi-registry setup each
@@ -74,6 +78,9 @@ func (m *metadataServiceURLParamsMetadataCustomizer) Customize(instance registry
 	instance.GetMetadata()[constant.MetadataServiceURLParamsPropertyName] = string(str)
 }
 
+// convertToParams converts the URL params into a map[string]string.
+// Only keys contained in info.IncludeKeys with non-empty values are kept;
+// the port and protocol are always appended from the URL.
 func (m *metadataServiceURLParamsMetadataCustomizer) convertToParams(url *common.URL) map[string]string {
 	// those keys are useless
 	p := make(map[string]string, len(url.GetParams()))

--- a/registry/servicediscovery/customizer/metadata_service_url_params_customizer_test.go
+++ b/registry/servicediscovery/customizer/metadata_service_url_params_customizer_test.go
@@ -40,6 +40,9 @@ func TestMetadataServiceURLParamsMetadataCustomizerGetPriority(t *testing.T) {
 
 // TestMetadataServiceURLParamsCustomizeNilURL verifies that when the metadata
 // service URL is not exported (nil), Customize writes nothing into metadata.
+// The URL comes from the global metadata.GetMetadataService() singleton whose
+// metadataUrl is nil by default; there is no exported setter and no test in
+// this package modifies it, so the nil state is deterministic.
 func TestMetadataServiceURLParamsCustomizeNilURL(t *testing.T) {
 	msup := &metadataServiceURLParamsMetadataCustomizer{exceptKeys: gxset.NewSet()}
 	ins := &registry.DefaultServiceInstance{}

--- a/registry/servicediscovery/customizer/metadata_service_url_params_customizer_test.go
+++ b/registry/servicediscovery/customizer/metadata_service_url_params_customizer_test.go
@@ -22,24 +22,68 @@ import (
 )
 
 import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/registry"
+
 	gxset "github.com/dubbogo/gost/container/set"
 
 	"github.com/stretchr/testify/assert"
 )
 
-import (
-	"dubbo.apache.org/dubbo-go/v3/registry"
-)
-
-func TestMetadataServiceURLParamsMetadataCustomizer(t *testing.T) {
-
+func TestMetadataServiceURLParamsMetadataCustomizerGetPriority(t *testing.T) {
 	msup := &metadataServiceURLParamsMetadataCustomizer{exceptKeys: gxset.NewSet()}
 	assert.Equal(t, 0, msup.GetPriority())
-
-	msup.Customize(createInstance())
 }
 
-func createInstance() registry.ServiceInstance {
+// TestMetadataServiceURLParamsCustomizeNilURL verifies that when the metadata
+// service URL is not exported (nil), Customize writes nothing into metadata.
+func TestMetadataServiceURLParamsCustomizeNilURL(t *testing.T) {
+	msup := &metadataServiceURLParamsMetadataCustomizer{exceptKeys: gxset.NewSet()}
 	ins := &registry.DefaultServiceInstance{}
-	return ins
+	msup.Customize(ins)
+	_, ok := ins.GetMetadata()[constant.MetadataServiceURLParamsPropertyName]
+	assert.False(t, ok, "nothing should be written when the metadata service URL is nil")
+}
+
+func TestConvertToParams(t *testing.T) {
+	msup := &metadataServiceURLParamsMetadataCustomizer{exceptKeys: gxset.NewSet()}
+
+	u := common.NewURLWithOptions(
+		common.WithProtocol("dubbo"),
+		common.WithPort("20880"),
+		common.WithParamsValue(constant.TimeoutKey, "3000"), // in IncludeKeys, should be kept
+		common.WithParamsValue(constant.PathKey, "/path"),   // in IncludeKeys, should be kept
+		common.WithParamsValue(constant.VersionKey, ""),     // empty value, should be dropped
+		common.WithParamsValue("custom.arbitrary.key", "x"), // not in IncludeKeys, should be dropped
+	)
+
+	ps := msup.convertToParams(u)
+
+	assert.Equal(t, "3000", ps[constant.TimeoutKey])
+	assert.Equal(t, "/path", ps[constant.PathKey])
+	// port/protocol are always appended even if absent from URL params
+	assert.Equal(t, "dubbo", ps[constant.ProtocolKey])
+	assert.Equal(t, "20880", ps[constant.PortKey])
+	// empty values are dropped
+	_, ok := ps[constant.VersionKey]
+	assert.False(t, ok, "empty value param should be dropped")
+	// keys outside info.IncludeKeys are dropped
+	_, ok = ps["custom.arbitrary.key"]
+	assert.False(t, ok, "param not in IncludeKeys should be dropped")
+}
+
+func TestConvertToParamsAlwaysAppendsPortAndProtocol(t *testing.T) {
+	msup := &metadataServiceURLParamsMetadataCustomizer{exceptKeys: gxset.NewSet()}
+
+	// URL without explicit port/protocol params
+	u := common.NewURLWithOptions(
+		common.WithProtocol("tri"),
+		common.WithPort("50051"),
+	)
+
+	ps := msup.convertToParams(u)
+
+	assert.Equal(t, "tri", ps[constant.ProtocolKey])
+	assert.Equal(t, "50051", ps[constant.PortKey])
 }

--- a/registry/servicediscovery/customizer/metadata_service_url_params_customizer_test.go
+++ b/registry/servicediscovery/customizer/metadata_service_url_params_customizer_test.go
@@ -22,13 +22,15 @@ import (
 )
 
 import (
-	"dubbo.apache.org/dubbo-go/v3/common"
-	"dubbo.apache.org/dubbo-go/v3/common/constant"
-	"dubbo.apache.org/dubbo-go/v3/registry"
-
 	gxset "github.com/dubbogo/gost/container/set"
 
 	"github.com/stretchr/testify/assert"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/registry"
 )
 
 func TestMetadataServiceURLParamsMetadataCustomizerGetPriority(t *testing.T) {

--- a/registry/servicediscovery/customizer/metadata_service_version_customizer.go
+++ b/registry/servicediscovery/customizer/metadata_service_version_customizer.go
@@ -22,11 +22,13 @@ import (
 )
 
 import (
+	"github.com/dubbogo/gost/log/logger"
+)
+
+import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/registry"
-
-	"github.com/dubbogo/gost/log/logger"
 )
 
 func init() {

--- a/registry/servicediscovery/customizer/metadata_service_version_customizer.go
+++ b/registry/servicediscovery/customizer/metadata_service_version_customizer.go
@@ -22,20 +22,19 @@ import (
 )
 
 import (
-	"github.com/dubbogo/gost/log/logger"
-)
-
-import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/registry"
+
+	"github.com/dubbogo/gost/log/logger"
 )
 
 func init() {
 	extension.AddCustomizers(&MetadtaServiceVersionCustomizer{})
 }
 
-// MetadtaServiceVersionCustomizer will try to add meta-v key to instance metadata
+// MetadtaServiceVersionCustomizer writes the metadata service version into the
+// instance metadata according to the protocol of the exported service.
 type MetadtaServiceVersionCustomizer struct {
 }
 
@@ -44,7 +43,12 @@ func (p *MetadtaServiceVersionCustomizer) GetPriority() int {
 	return 0
 }
 
-// Customize put the the string like [{"protocol": "dubbo", "port": 123}] into instance's metadata
+// Customize writes the metadata service version into the instance metadata
+// under MetadataVersion ("meta-v"). It only runs when the metadata storage
+// type is local. The protocol is read from the params JSON stored at
+// MetadataServiceURLParamsPropertyName: tri writes v2, any other protocol
+// (including empty) writes v1. An unparsable params JSON leaves the metadata
+// unchanged, otherwise the version overwrites the previous value.
 func (p *MetadtaServiceVersionCustomizer) Customize(instance registry.ServiceInstance) {
 	if instance.GetMetadata()[constant.MetadataStorageTypePropertyName] != constant.DefaultMetadataStorageType {
 		return

--- a/registry/servicediscovery/customizer/metadata_service_version_customizer.go
+++ b/registry/servicediscovery/customizer/metadata_service_version_customizer.go
@@ -36,7 +36,7 @@ func init() {
 }
 
 // MetadtaServiceVersionCustomizer writes the metadata service version into the
-// instance metadata according to the protocol of the exported service.
+// instance metadata according to the protocol of the metadata service URL.
 type MetadtaServiceVersionCustomizer struct {
 }
 

--- a/registry/servicediscovery/customizer/metadata_service_version_customizer_test.go
+++ b/registry/servicediscovery/customizer/metadata_service_version_customizer_test.go
@@ -35,7 +35,8 @@ func TestMetadtaServiceVersionCustomizerGetPriority(t *testing.T) {
 	assert.Equal(t, 0, p.GetPriority())
 }
 
-// TestMetadtaServiceVersionCustomizerTriProtocol verifies that tri writes v2.
+// TestMetadtaServiceVersionCustomizerTriProtocol verifies that a tri metadata
+// service URL writes v2.
 func TestMetadtaServiceVersionCustomizerTriProtocol(t *testing.T) {
 	p := &MetadtaServiceVersionCustomizer{}
 	ins := newVersionInstance(`{"protocol":"tri","port":"20880"}`)
@@ -43,7 +44,8 @@ func TestMetadtaServiceVersionCustomizerTriProtocol(t *testing.T) {
 	assert.Equal(t, constant.MetadataServiceV2Version, ins.GetMetadata()[constant.MetadataVersion])
 }
 
-// TestMetadtaServiceVersionCustomizerDubboProtocol verifies that dubbo writes v1.
+// TestMetadtaServiceVersionCustomizerDubboProtocol verifies that a dubbo
+// metadata service URL writes v1.
 func TestMetadtaServiceVersionCustomizerDubboProtocol(t *testing.T) {
 	p := &MetadtaServiceVersionCustomizer{}
 	ins := newVersionInstance(`{"protocol":"dubbo","port":"20880"}`)

--- a/registry/servicediscovery/customizer/metadata_service_version_customizer_test.go
+++ b/registry/servicediscovery/customizer/metadata_service_version_customizer_test.go
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package customizer
+
+import (
+	"testing"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/registry"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetadtaServiceVersionCustomizerGetPriority(t *testing.T) {
+	p := &MetadtaServiceVersionCustomizer{}
+	assert.Equal(t, 0, p.GetPriority())
+}
+
+// TestMetadtaServiceVersionCustomizerTriProtocol verifies that tri writes v2.
+func TestMetadtaServiceVersionCustomizerTriProtocol(t *testing.T) {
+	p := &MetadtaServiceVersionCustomizer{}
+	ins := newVersionInstance(`{"protocol":"tri","port":"20880"}`)
+	p.Customize(ins)
+	assert.Equal(t, constant.MetadataServiceV2Version, ins.GetMetadata()[constant.MetadataVersion])
+}
+
+// TestMetadtaServiceVersionCustomizerDubboProtocol verifies that dubbo writes v1.
+func TestMetadtaServiceVersionCustomizerDubboProtocol(t *testing.T) {
+	p := &MetadtaServiceVersionCustomizer{}
+	ins := newVersionInstance(`{"protocol":"dubbo","port":"20880"}`)
+	p.Customize(ins)
+	assert.Equal(t, constant.MetadataServiceV1Version, ins.GetMetadata()[constant.MetadataVersion])
+}
+
+// TestMetadtaServiceVersionCustomizerUnknownProtocol verifies that any protocol
+// other than tri (including an absent one) falls back to v1.
+func TestMetadtaServiceVersionCustomizerUnknownProtocol(t *testing.T) {
+	p := &MetadtaServiceVersionCustomizer{}
+	ins := newVersionInstance(`{"port":"20880"}`)
+	p.Customize(ins)
+	assert.Equal(t, constant.MetadataServiceV1Version, ins.GetMetadata()[constant.MetadataVersion])
+}
+
+// TestMetadtaServiceVersionCustomizerNonLocalStorage verifies that the version
+// is not written when the metadata storage type is not local.
+func TestMetadtaServiceVersionCustomizerNonLocalStorage(t *testing.T) {
+	p := &MetadtaServiceVersionCustomizer{}
+	ins := &registry.DefaultServiceInstance{
+		Metadata: map[string]string{
+			constant.MetadataStorageTypePropertyName: "remote",
+			constant.MetadataServiceURLParamsPropertyName: `{"protocol":"tri","port":"20880"}`,
+		},
+	}
+	p.Customize(ins)
+	_, ok := ins.GetMetadata()[constant.MetadataVersion]
+	assert.False(t, ok, "version should not be written for non-local storage type")
+}
+
+// TestMetadtaServiceVersionCustomizerInvalidJSON verifies that an unparsable
+// params JSON leaves the metadata unchanged.
+func TestMetadtaServiceVersionCustomizerInvalidJSON(t *testing.T) {
+	p := &MetadtaServiceVersionCustomizer{}
+	ins := newVersionInstance("not-a-json")
+	p.Customize(ins)
+	_, ok := ins.GetMetadata()[constant.MetadataVersion]
+	assert.False(t, ok, "version should not be written when the params JSON is invalid")
+}
+
+// newVersionInstance creates an instance with local storage type and the given
+// metadata service url params JSON.
+func newVersionInstance(paramsJSON string) registry.ServiceInstance {
+	return &registry.DefaultServiceInstance{
+		Metadata: map[string]string{
+			constant.MetadataStorageTypePropertyName: constant.DefaultMetadataStorageType,
+			constant.MetadataServiceURLParamsPropertyName: paramsJSON,
+		},
+	}
+}

--- a/registry/servicediscovery/customizer/metadata_service_version_customizer_test.go
+++ b/registry/servicediscovery/customizer/metadata_service_version_customizer_test.go
@@ -22,10 +22,12 @@ import (
 )
 
 import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/registry"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMetadtaServiceVersionCustomizerGetPriority(t *testing.T) {
@@ -64,7 +66,7 @@ func TestMetadtaServiceVersionCustomizerNonLocalStorage(t *testing.T) {
 	p := &MetadtaServiceVersionCustomizer{}
 	ins := &registry.DefaultServiceInstance{
 		Metadata: map[string]string{
-			constant.MetadataStorageTypePropertyName: "remote",
+			constant.MetadataStorageTypePropertyName:      "remote",
 			constant.MetadataServiceURLParamsPropertyName: `{"protocol":"tri","port":"20880"}`,
 		},
 	}
@@ -88,7 +90,7 @@ func TestMetadtaServiceVersionCustomizerInvalidJSON(t *testing.T) {
 func newVersionInstance(paramsJSON string) registry.ServiceInstance {
 	return &registry.DefaultServiceInstance{
 		Metadata: map[string]string{
-			constant.MetadataStorageTypePropertyName: constant.DefaultMetadataStorageType,
+			constant.MetadataStorageTypePropertyName:      constant.DefaultMetadataStorageType,
 			constant.MetadataServiceURLParamsPropertyName: paramsJSON,
 		},
 	}

--- a/registry/servicediscovery/customizer/protocol_ports_metadata_customizer.go
+++ b/registry/servicediscovery/customizer/protocol_ports_metadata_customizer.go
@@ -23,14 +23,12 @@ import (
 )
 
 import (
-	"github.com/dubbogo/gost/log/logger"
-)
-
-import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/metadata"
 	"dubbo.apache.org/dubbo-go/v3/registry"
+
+	"github.com/dubbogo/gost/log/logger"
 )
 
 func init() {
@@ -46,7 +44,12 @@ func (p *ProtocolPortsMetadataCustomizer) GetPriority() int {
 	return 0
 }
 
-// Customize put the the string like [{"protocol": "dubbo", "port": 123}] into instance's metadata
+// Customize writes the exported service endpoints into the instance metadata
+// under ServiceInstanceEndpoints ("dubbo.endpoints"). The URLs come from
+// metadata.GetMetadataService().GetExportedServiceURLs(); it returns without
+// writing when the list is empty (client side) or on error. URLs with an empty
+// protocol are skipped and unparsable ports are recorded as 0, then the
+// endpoints JSON overwrites the key.
 func (p *ProtocolPortsMetadataCustomizer) Customize(instance registry.ServiceInstance) {
 	list, err := metadata.GetMetadataService().GetExportedServiceURLs()
 	if err != nil {
@@ -75,6 +78,7 @@ func (p *ProtocolPortsMetadataCustomizer) Customize(instance registry.ServiceIns
 }
 
 // endpointsStr convert the map to json like [{"protocol": "dubbo", "port": 123}]
+// It returns "" when the map is empty or the marshaling fails.
 func endpointsStr(protocolMap map[string]int) string {
 	if len(protocolMap) == 0 {
 		return ""

--- a/registry/servicediscovery/customizer/protocol_ports_metadata_customizer.go
+++ b/registry/servicediscovery/customizer/protocol_ports_metadata_customizer.go
@@ -23,12 +23,14 @@ import (
 )
 
 import (
+	"github.com/dubbogo/gost/log/logger"
+)
+
+import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/metadata"
 	"dubbo.apache.org/dubbo-go/v3/registry"
-
-	"github.com/dubbogo/gost/log/logger"
 )
 
 func init() {

--- a/registry/servicediscovery/customizer/protocol_ports_metadata_customizer_test.go
+++ b/registry/servicediscovery/customizer/protocol_ports_metadata_customizer_test.go
@@ -23,12 +23,14 @@ import (
 )
 
 import (
+	"github.com/stretchr/testify/assert"
+)
+
+import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/metadata"
 	"dubbo.apache.org/dubbo-go/v3/registry"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestProtocolPortsMetadataCustomizerGetPriority(t *testing.T) {

--- a/registry/servicediscovery/customizer/protocol_ports_metadata_customizer_test.go
+++ b/registry/servicediscovery/customizer/protocol_ports_metadata_customizer_test.go
@@ -24,6 +24,7 @@ import (
 
 import (
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 import (
@@ -67,7 +68,7 @@ func TestProtocolPortsCustomizeWithURLs(t *testing.T) {
 	str := ins.GetMetadata()[constant.ServiceInstanceEndpoints]
 	assert.NotEmpty(t, str)
 	var endpoints []registry.Endpoint
-	assert.NoError(t, json.Unmarshal([]byte(str), &endpoints))
+	require.NoError(t, json.Unmarshal([]byte(str), &endpoints))
 	assert.Len(t, endpoints, 2)
 
 	got := make(map[string]int)
@@ -96,7 +97,7 @@ func TestProtocolPortsCustomizeSkipsEmptyProtocol(t *testing.T) {
 
 	str := ins.GetMetadata()[constant.ServiceInstanceEndpoints]
 	var endpoints []registry.Endpoint
-	assert.NoError(t, json.Unmarshal([]byte(str), &endpoints))
+	require.NoError(t, json.Unmarshal([]byte(str), &endpoints))
 	assert.Len(t, endpoints, 1, "URL with empty protocol should be skipped")
 	assert.Equal(t, "dubbo", endpoints[0].Protocol)
 	assert.Equal(t, 20881, endpoints[0].Port)
@@ -120,7 +121,7 @@ func TestProtocolPortsCustomizeUnparsablePort(t *testing.T) {
 
 	str := ins.GetMetadata()[constant.ServiceInstanceEndpoints]
 	var endpoints []registry.Endpoint
-	assert.NoError(t, json.Unmarshal([]byte(str), &endpoints))
+	require.NoError(t, json.Unmarshal([]byte(str), &endpoints))
 	assert.Len(t, endpoints, 2)
 
 	ports := make(map[string]int)
@@ -132,14 +133,14 @@ func TestProtocolPortsCustomizeUnparsablePort(t *testing.T) {
 }
 
 func TestEndpointsStrEmpty(t *testing.T) {
-	assert.Equal(t, "", endpointsStr(map[string]int{}))
-	assert.Equal(t, "", endpointsStr(nil))
+	assert.Empty(t, endpointsStr(map[string]int{}))
+	assert.Empty(t, endpointsStr(nil))
 }
 
 func TestEndpointsStrNormal(t *testing.T) {
 	str := endpointsStr(map[string]int{"dubbo": 123})
 	var endpoints []registry.Endpoint
-	assert.NoError(t, json.Unmarshal([]byte(str), &endpoints))
+	require.NoError(t, json.Unmarshal([]byte(str), &endpoints))
 	assert.Len(t, endpoints, 1)
 	assert.Equal(t, "dubbo", endpoints[0].Protocol)
 	assert.Equal(t, 123, endpoints[0].Port)

--- a/registry/servicediscovery/customizer/protocol_ports_metadata_customizer_test.go
+++ b/registry/servicediscovery/customizer/protocol_ports_metadata_customizer_test.go
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package customizer
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/metadata"
+	"dubbo.apache.org/dubbo-go/v3/registry"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProtocolPortsMetadataCustomizerGetPriority(t *testing.T) {
+	p := &ProtocolPortsMetadataCustomizer{}
+	assert.Equal(t, 0, p.GetPriority())
+}
+
+// TestProtocolPortsCustomizeEmptyList verifies that no endpoints are written
+// when there are no exported service URLs (client side).
+func TestProtocolPortsCustomizeEmptyList(t *testing.T) {
+	p := &ProtocolPortsMetadataCustomizer{}
+	ins := &registry.DefaultServiceInstance{}
+	p.Customize(ins)
+	_, ok := ins.GetMetadata()[constant.ServiceInstanceEndpoints]
+	assert.False(t, ok, "endpoints should not be written for an empty exported URL list")
+}
+
+// TestProtocolPortsCustomizeWithURLs verifies that endpoints are derived from
+// the exported service URLs and written as a JSON array.
+func TestProtocolPortsCustomizeWithURLs(t *testing.T) {
+	urlDubbo := newEndpointTestURL("dubbo", "20880")
+	urlTri := newEndpointTestURL("tri", "50051")
+	metadata.AddService("protocol-ports-test", urlDubbo)
+	metadata.AddService("protocol-ports-test", urlTri)
+	t.Cleanup(func() {
+		metadata.RemoveService("protocol-ports-test", urlDubbo)
+		metadata.RemoveService("protocol-ports-test", urlTri)
+	})
+
+	p := &ProtocolPortsMetadataCustomizer{}
+	ins := &registry.DefaultServiceInstance{}
+	p.Customize(ins)
+
+	str := ins.GetMetadata()[constant.ServiceInstanceEndpoints]
+	assert.NotEmpty(t, str)
+	var endpoints []registry.Endpoint
+	assert.NoError(t, json.Unmarshal([]byte(str), &endpoints))
+	assert.Len(t, endpoints, 2)
+
+	got := make(map[string]int)
+	for _, e := range endpoints {
+		got[e.Protocol] = e.Port
+	}
+	assert.Equal(t, 20880, got["dubbo"])
+	assert.Equal(t, 50051, got["tri"])
+}
+
+// TestProtocolPortsCustomizeSkipsEmptyProtocol verifies that URLs with an empty
+// protocol are skipped and do not appear in the endpoints.
+func TestProtocolPortsCustomizeSkipsEmptyProtocol(t *testing.T) {
+	urlNoProtocol := newEndpointTestURL("", "20880")
+	urlDubbo := newEndpointTestURL("dubbo", "20881")
+	metadata.AddService("protocol-ports-skip", urlNoProtocol)
+	metadata.AddService("protocol-ports-skip", urlDubbo)
+	t.Cleanup(func() {
+		metadata.RemoveService("protocol-ports-skip", urlNoProtocol)
+		metadata.RemoveService("protocol-ports-skip", urlDubbo)
+	})
+
+	p := &ProtocolPortsMetadataCustomizer{}
+	ins := &registry.DefaultServiceInstance{}
+	p.Customize(ins)
+
+	str := ins.GetMetadata()[constant.ServiceInstanceEndpoints]
+	var endpoints []registry.Endpoint
+	assert.NoError(t, json.Unmarshal([]byte(str), &endpoints))
+	assert.Len(t, endpoints, 1, "URL with empty protocol should be skipped")
+	assert.Equal(t, "dubbo", endpoints[0].Protocol)
+	assert.Equal(t, 20881, endpoints[0].Port)
+}
+
+// TestProtocolPortsCustomizeUnparsablePort verifies that an unparsable port is
+// recorded as 0 (the endpoint is still kept) and does not abort the whole write.
+func TestProtocolPortsCustomizeUnparsablePort(t *testing.T) {
+	urlBadPort := newEndpointTestURL("dubbo", "not-a-number")
+	urlTri := newEndpointTestURL("tri", "50051")
+	metadata.AddService("protocol-ports-badport", urlBadPort)
+	metadata.AddService("protocol-ports-badport", urlTri)
+	t.Cleanup(func() {
+		metadata.RemoveService("protocol-ports-badport", urlBadPort)
+		metadata.RemoveService("protocol-ports-badport", urlTri)
+	})
+
+	p := &ProtocolPortsMetadataCustomizer{}
+	ins := &registry.DefaultServiceInstance{}
+	p.Customize(ins)
+
+	str := ins.GetMetadata()[constant.ServiceInstanceEndpoints]
+	var endpoints []registry.Endpoint
+	assert.NoError(t, json.Unmarshal([]byte(str), &endpoints))
+	assert.Len(t, endpoints, 2)
+
+	ports := make(map[string]int)
+	for _, e := range endpoints {
+		ports[e.Protocol] = e.Port
+	}
+	assert.Equal(t, 0, ports["dubbo"], "unparsable port should be recorded as 0")
+	assert.Equal(t, 50051, ports["tri"], "other endpoints should still be written")
+}
+
+func TestEndpointsStrEmpty(t *testing.T) {
+	assert.Equal(t, "", endpointsStr(map[string]int{}))
+	assert.Equal(t, "", endpointsStr(nil))
+}
+
+func TestEndpointsStrNormal(t *testing.T) {
+	str := endpointsStr(map[string]int{"dubbo": 123})
+	var endpoints []registry.Endpoint
+	assert.NoError(t, json.Unmarshal([]byte(str), &endpoints))
+	assert.Len(t, endpoints, 1)
+	assert.Equal(t, "dubbo", endpoints[0].Protocol)
+	assert.Equal(t, 123, endpoints[0].Port)
+}
+
+// newEndpointTestURL builds a URL with the given protocol and port for testing.
+func newEndpointTestURL(protocol, port string) *common.URL {
+	return common.NewURLWithOptions(
+		common.WithInterface("org.example.TestService"),
+		common.WithProtocol(protocol),
+		common.WithPort(port),
+	)
+}


### PR DESCRIPTION
### Description

This PR improves the comments and test coverage of the service discovery metadata customizers.

- Adds doc comments to metadataServiceURLParamsMetadataCustomizer, MetadtaServiceVersionCustomizer, and ProtocolPortsMetadataCustomizer, explaining the metadata key written, the source of the parameters, how empty values are handled, and the overwrite behavior.
- Adds unit tests covering metadata param extraction (IncludeKeys filtering, empty-value skipping, port/protocol always appended), version writing (tri -> v2, other/empty protocol -> v1, non-local storage skipped, invalid JSON skipped), and protocol port writing (empty list, empty protocol skipped, unparsable port recorded as 0).

Refs https://github.com/apache/dubbo-go/issues/3644 (task4)

### 本地验证

```
~/project/dubbo-go$ go test -count=1 ./registry/servicediscovery/customizer/...
ok      dubbo.apache.org/dubbo-go/v3/registry/servicediscovery/customizer      0.112s
```

### Checklist

- [x] I confirm the target branch is `develop`
- [x] Code has passed local testing
- [x] I have added tests that prove my fix is effective or that my feature works
