### PR TITLE
fix(filter/generic): guard $invoke arg type assertions to avoid panic

### DIFF
--- a/filter/generic/service_filter.go
+++ b/filter/generic/service_filter.go
@@ -76,8 +76,6 @@ func (f *genericServiceFilter) Invoke(ctx context.Context, invoker base.Invoker,
 	}
 
 	// get real invocation info from the generic invocation
-	// IsGenericInvocation only guarantees len(Arguments)==3, not the element types;
-	// guard the assertions so a malformed $invoke returns an error instead of panicking.
 	mtdName, ok := inv.Arguments()[0].(string)
 	if !ok {
 		return &result.RPCResult{Err: perrors.Errorf("$invoke: arg[0] must be string, got %T", inv.Arguments()[0])}

--- a/filter/generic/service_filter.go
+++ b/filter/generic/service_filter.go
@@ -76,10 +76,18 @@ func (f *genericServiceFilter) Invoke(ctx context.Context, invoker base.Invoker,
 	}
 
 	// get real invocation info from the generic invocation
-	mtdName := inv.Arguments()[0].(string)
+	// IsGenericInvocation only guarantees len(Arguments)==3, not the element types;
+	// guard the assertions so a malformed $invoke returns an error instead of panicking.
+	mtdName, ok := inv.Arguments()[0].(string)
+	if !ok {
+		return &result.RPCResult{Err: perrors.Errorf("$invoke: arg[0] must be string, got %T", inv.Arguments()[0])}
+	}
 	// types are not required in dubbo-go, for dubbo-go client to dubbo-go server, types could be nil
 	types := inv.Arguments()[1]
-	args := inv.Arguments()[2].([]hessian.Object)
+	args, ok := inv.Arguments()[2].([]hessian.Object)
+	if !ok {
+		return &result.RPCResult{Err: perrors.Errorf("$invoke: arg[2] must be []hessian.Object, got %T", inv.Arguments()[2])}
+	}
 
 	logger.Debugf("[Filter][Generic] received a generic invocation, methodName=%s types=%v args=%v", mtdName, types, args)
 

--- a/filter/generic/service_filter_test.go
+++ b/filter/generic/service_filter_test.go
@@ -269,6 +269,55 @@ func TestServiceFilter_InvokeWithUnsupportedGenericMode(t *testing.T) {
 	}
 }
 
+// TestServiceFilter_InvokeRejectsMalformedArgs ensures a $invoke with wrong-typed
+// arguments returns an error instead of panicking. See service_filter.go:79,82.
+func TestServiceFilter_InvokeRejectsMalformedArgs(t *testing.T) {
+	filter := &genericServiceFilter{}
+
+	cases := []struct {
+		name string
+		args []any
+		want string
+	}{
+		{
+			name: "arg0-not-string",
+			args: []any{123, []string{}, []hessian.Object{}},
+			want: "$invoke: arg[0] must be string, got int",
+		},
+		{
+			name: "arg0-nil",
+			args: []any{nil, []string{}, []hessian.Object{}},
+			want: "$invoke: arg[0] must be string, got <nil>",
+		},
+		{
+			name: "arg2-not-hessian-slice",
+			args: []any{"Hello", []string{}, "not-a-slice"},
+			want: "$invoke: arg[2] must be []hessian.Object, got string",
+		},
+		{
+			name: "arg2-nil",
+			args: []any{"Hello", []string{}, nil},
+			want: "$invoke: arg[2] must be []hessian.Object, got <nil>",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inv := invocation.NewRPCInvocation(constant.Generic, tc.args,
+				map[string]any{constant.GenericKey: "true"})
+
+			ctrl := gomock.NewController(t)
+			mockInvoker := mock.NewMockInvoker(ctrl)
+			mockInvoker.EXPECT().Invoke(gomock.Any(), gomock.Any()).Times(0)
+
+			res := filter.Invoke(context.Background(), mockInvoker, inv)
+
+			require.EqualError(t, res.Error(), tc.want)
+			assert.Nil(t, res.Result())
+		})
+	}
+}
+
 func TestServiceFilter_InvokeWithEmptyGenericModeUsesDefault(t *testing.T) {
 	filter := &genericServiceFilter{}
 	service := &MockHelloService{}


### PR DESCRIPTION
### Description
Fixes #3679

`genericServiceFilter.Invoke` (`filter/generic/service_filter.go:79,82`) performed unguarded type assertions on the generic-call arguments:

```go
mtdName := inv.Arguments()[0].(string)
// ...
args := inv.Arguments()[2].([]hessian.Object)
```

`IsGenericInvocation()` (`protocol/invocation/rpcinvocation.go:94-99`) only checks that `MethodName` is `$invoke`/`$invokeAsync` and that `len(Arguments) == 3`; it does **not** validate the element types. A malformed or malicious `$invoke` request with wrong-typed arguments reached these lines and panicked with `interface conversion: interface {} is X, not Y`.

`genericServiceFilter` is in `DefaultServiceFilters` (`common/constant/default.go:67-69`), so this was reachable by any inbound dubbo request with no opt-in required.

This PR replaces the two bare assertions with comma-ok form and returns a `perrors`-wrapped error via `result.RPCResult{Err}` (matching the existing error-return style used at `service_filter.go:92,99`), so a malformed `$invoke` now returns an error instead of panicking.

### Checklist
- [x] I confirm the target branch is `develop`
- [x] I have run `make fmt` to format my code
- [x] I have run `make test` to run local tests
- [x] I have added tests that prove my fix is effective or that my feature works