### PR TITLE
feat(triple): add HTTP/3 transport options

### DIFF
--- a/protocol/triple/options.go
+++ b/protocol/triple/options.go
@@ -118,7 +118,7 @@ func WithCORS(opts ...CORSOption) Option {
 	}
 }
 
-// Http3Enable enables HTTP/3 support for the Triple protocol.
+// WithHttp3Enable enables HTTP/3 support for the Triple protocol.
 // This option configures the server to start both HTTP/2 and HTTP/3 servers
 // simultaneously, providing modern HTTP/3 capabilities alongside traditional HTTP/2.
 //
@@ -132,7 +132,7 @@ func WithCORS(opts ...CORSOption) Option {
 //
 //	// Basic HTTP/3 enablement
 //	server := triple.NewServer(
-//	    triple.Http3Enable(),
+//	    triple.WithHttp3Enable(),
 //	)
 //
 // Requirements:
@@ -150,13 +150,18 @@ func WithCORS(opts ...CORSOption) Option {
 //
 // NOTICE: This API is EXPERIMENTAL and may be changed or removed in
 // a later release.
-func Http3Enable() Option {
+func WithHttp3Enable() Option {
 	return func(opts *Options) {
 		opts.Triple.Http3.Enable = true
 	}
 }
 
-// Http3Negotiation configures HTTP/3 negotiation behavior for the Triple protocol.
+// Http3Enable enables HTTP/3 support for the Triple protocol.
+func Http3Enable() Option {
+	return WithHttp3Enable()
+}
+
+// WithHttp3Negotiation configures HTTP/3 negotiation behavior for the Triple protocol.
 // This option controls whether HTTP/2 Alternative Services (Alt-Svc) negotiation
 // is enabled when both HTTP/2 and HTTP/3 servers are running simultaneously.
 //
@@ -164,14 +169,14 @@ func Http3Enable() Option {
 //
 //	// Enable HTTP/3 negotiation (default behavior)
 //	server := triple.NewServer(
-//	    triple.Http3Enable(),
-//	    triple.Http3Negotiation(true),
+//	    triple.WithHttp3Enable(),
+//	    triple.WithHttp3Negotiation(true),
 //	)
 //
 //	// Disable HTTP/3 negotiation for explicit protocol control
 //	server := triple.NewServer(
-//	    triple.Http3Enable(),
-//	    triple.Http3Negotiation(false),
+//	    triple.WithHttp3Enable(),
+//	    triple.WithHttp3Negotiation(false),
 //	)
 //
 // Default Behavior:
@@ -182,35 +187,40 @@ func Http3Enable() Option {
 //
 // NOTICE: This API is EXPERIMENTAL and may be changed or removed in
 // a later release.
-func Http3Negotiation(negotiation bool) Option {
+func WithHttp3Negotiation(negotiation bool) Option {
 	return func(opts *Options) {
 		opts.Triple.Http3.Negotiation = negotiation
 	}
 }
 
-// Http3KeepAlivePeriod sets how often the HTTP/3 transport sends QUIC keep-alive packets.
-func Http3KeepAlivePeriod(period time.Duration) Option {
+// Http3Negotiation configures HTTP/3 negotiation behavior for the Triple protocol.
+func Http3Negotiation(negotiation bool) Option {
+	return WithHttp3Negotiation(negotiation)
+}
+
+// WithHttp3KeepAlivePeriod sets how often the HTTP/3 transport sends QUIC keep-alive packets.
+func WithHttp3KeepAlivePeriod(period time.Duration) Option {
 	return func(opts *Options) {
 		opts.Triple.Http3.KeepAlivePeriod = period.String()
 	}
 }
 
-// Http3MaxIdleTimeout sets the maximum idle timeout for HTTP/3 QUIC connections.
-func Http3MaxIdleTimeout(timeout time.Duration) Option {
+// WithHttp3MaxIdleTimeout sets the maximum idle timeout for HTTP/3 QUIC connections.
+func WithHttp3MaxIdleTimeout(timeout time.Duration) Option {
 	return func(opts *Options) {
 		opts.Triple.Http3.MaxIdleTimeout = timeout.String()
 	}
 }
 
-// Http3MaxIncomingStreams sets the maximum number of concurrent HTTP/3 bidirectional streams.
-func Http3MaxIncomingStreams(streams int64) Option {
+// WithHttp3MaxIncomingStreams sets the maximum number of concurrent HTTP/3 bidirectional streams.
+func WithHttp3MaxIncomingStreams(streams int64) Option {
 	return func(opts *Options) {
 		opts.Triple.Http3.MaxIncomingStreams = streams
 	}
 }
 
-// Http3MaxIncomingUniStreams sets the maximum number of concurrent HTTP/3 unidirectional streams.
-func Http3MaxIncomingUniStreams(streams int64) Option {
+// WithHttp3MaxIncomingUniStreams sets the maximum number of concurrent HTTP/3 unidirectional streams.
+func WithHttp3MaxIncomingUniStreams(streams int64) Option {
 	return func(opts *Options) {
 		opts.Triple.Http3.MaxIncomingUniStreams = streams
 	}

--- a/protocol/triple/options.go
+++ b/protocol/triple/options.go
@@ -157,6 +157,8 @@ func WithHttp3Enable() Option {
 }
 
 // Http3Enable enables HTTP/3 support for the Triple protocol.
+//
+// Deprecated: use WithHttp3Enable instead.
 func Http3Enable() Option {
 	return WithHttp3Enable()
 }
@@ -194,6 +196,8 @@ func WithHttp3Negotiation(negotiation bool) Option {
 }
 
 // Http3Negotiation configures HTTP/3 negotiation behavior for the Triple protocol.
+//
+// Deprecated: use WithHttp3Negotiation instead.
 func Http3Negotiation(negotiation bool) Option {
 	return WithHttp3Negotiation(negotiation)
 }

--- a/protocol/triple/options.go
+++ b/protocol/triple/options.go
@@ -188,6 +188,34 @@ func Http3Negotiation(negotiation bool) Option {
 	}
 }
 
+// Http3KeepAlivePeriod sets how often the HTTP/3 transport sends QUIC keep-alive packets.
+func Http3KeepAlivePeriod(period time.Duration) Option {
+	return func(opts *Options) {
+		opts.Triple.Http3.KeepAlivePeriod = period.String()
+	}
+}
+
+// Http3MaxIdleTimeout sets the maximum idle timeout for HTTP/3 QUIC connections.
+func Http3MaxIdleTimeout(timeout time.Duration) Option {
+	return func(opts *Options) {
+		opts.Triple.Http3.MaxIdleTimeout = timeout.String()
+	}
+}
+
+// Http3MaxIncomingStreams sets the maximum number of concurrent HTTP/3 bidirectional streams.
+func Http3MaxIncomingStreams(streams int64) Option {
+	return func(opts *Options) {
+		opts.Triple.Http3.MaxIncomingStreams = streams
+	}
+}
+
+// Http3MaxIncomingUniStreams sets the maximum number of concurrent HTTP/3 unidirectional streams.
+func Http3MaxIncomingUniStreams(streams int64) Option {
+	return func(opts *Options) {
+		opts.Triple.Http3.MaxIncomingUniStreams = streams
+	}
+}
+
 // CORSOption configures a single aspect of CORS.
 type CORSOption func(*global.CorsConfig)
 

--- a/protocol/triple/options_test.go
+++ b/protocol/triple/options_test.go
@@ -47,3 +47,16 @@ func TestHTTP3TransportOptions(t *testing.T) {
 	assert.Equal(t, int64(128), opts.Triple.Http3.MaxIncomingStreams)
 	assert.Equal(t, int64(64), opts.Triple.Http3.MaxIncomingUniStreams)
 }
+
+func TestHTTP3DeprecatedAliases(t *testing.T) {
+	opts := NewOptions(
+		Http3Enable(),
+		Http3Negotiation(false),
+	)
+
+	require.NotNil(t, opts)
+	require.NotNil(t, opts.Triple)
+	require.NotNil(t, opts.Triple.Http3)
+	assert.True(t, opts.Triple.Http3.Enable)
+	assert.False(t, opts.Triple.Http3.Negotiation)
+}

--- a/protocol/triple/options_test.go
+++ b/protocol/triple/options_test.go
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package triple
+
+import (
+	"testing"
+	"time"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTP3TransportOptions(t *testing.T) {
+	opts := NewOptions(
+		Http3KeepAlivePeriod(15*time.Second),
+		Http3MaxIdleTimeout(30*time.Second),
+		Http3MaxIncomingStreams(128),
+		Http3MaxIncomingUniStreams(64),
+	)
+
+	require.NotNil(t, opts)
+	require.NotNil(t, opts.Triple)
+	require.NotNil(t, opts.Triple.Http3)
+	assert.Equal(t, "15s", opts.Triple.Http3.KeepAlivePeriod)
+	assert.Equal(t, "30s", opts.Triple.Http3.MaxIdleTimeout)
+	assert.Equal(t, int64(128), opts.Triple.Http3.MaxIncomingStreams)
+	assert.Equal(t, int64(64), opts.Triple.Http3.MaxIncomingUniStreams)
+}

--- a/protocol/triple/options_test.go
+++ b/protocol/triple/options_test.go
@@ -29,15 +29,19 @@ import (
 
 func TestHTTP3TransportOptions(t *testing.T) {
 	opts := NewOptions(
-		Http3KeepAlivePeriod(15*time.Second),
-		Http3MaxIdleTimeout(30*time.Second),
-		Http3MaxIncomingStreams(128),
-		Http3MaxIncomingUniStreams(64),
+		WithHttp3Enable(),
+		WithHttp3Negotiation(false),
+		WithHttp3KeepAlivePeriod(15*time.Second),
+		WithHttp3MaxIdleTimeout(30*time.Second),
+		WithHttp3MaxIncomingStreams(128),
+		WithHttp3MaxIncomingUniStreams(64),
 	)
 
 	require.NotNil(t, opts)
 	require.NotNil(t, opts.Triple)
 	require.NotNil(t, opts.Triple.Http3)
+	assert.True(t, opts.Triple.Http3.Enable)
+	assert.False(t, opts.Triple.Http3.Negotiation)
 	assert.Equal(t, "15s", opts.Triple.Http3.KeepAlivePeriod)
 	assert.Equal(t, "30s", opts.Triple.Http3.MaxIdleTimeout)
 	assert.Equal(t, int64(128), opts.Triple.Http3.MaxIncomingStreams)


### PR DESCRIPTION
### What changed

This adds code-level Triple options for the existing HTTP/3 transport config fields:

- `triple.Http3KeepAlivePeriod`
- `triple.Http3MaxIdleTimeout`
- `triple.Http3MaxIncomingStreams`
- `triple.Http3MaxIncomingUniStreams`

These options populate `global.Http3Config`, which is already consumed by the shared `Http3Config -> quic.Config` mapping path for HTTP/3 transport setup.

### Why

This is the next small step for #3102 after the server, direct HTTP/3 client, and dual transport paths were wired to the shared HTTP/3 config mapper. It lets users configure the existing core QUIC settings through the code-level Triple option API.

Part of #3102.

### Tests

- `go test ./protocol ./protocol/triple/... -count=1`
- `go vet ./protocol ./protocol/triple/...`
- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.7.2 run ./protocol/triple/... --timeout=10m`