### PR TITLE
fix(invocation): guard ActualMethodName type assertion to avoid panic

### DIFF
--- a/protocol/invocation/rpcinvocation.go
+++ b/protocol/invocation/rpcinvocation.go
@@ -86,7 +86,8 @@ func (r *RPCInvocation) ActualMethodName() string {
 	if r.IsGenericInvocation() {
 		// IsGenericInvocation only guarantees len(Arguments)==3, not the element types;
 		// guard the assertion so a malformed $invoke falls back to MethodName() instead of panicking.
-		mtdName, ok := r.Arguments()[0].(string)
+		args := r.Arguments()
+		mtdName, ok := args[0].(string)
 		if !ok {
 			return r.MethodName()
 		}

--- a/protocol/invocation/rpcinvocation.go
+++ b/protocol/invocation/rpcinvocation.go
@@ -84,10 +84,15 @@ func (r *RPCInvocation) MethodName() string {
 // ActualMethodName gets actual invocation method name. It returns the method name been called if it's a generic call
 func (r *RPCInvocation) ActualMethodName() string {
 	if r.IsGenericInvocation() {
-		return r.Arguments()[0].(string)
-	} else {
-		return r.MethodName()
+		// IsGenericInvocation only guarantees len(Arguments)==3, not the element types;
+		// guard the assertion so a malformed $invoke falls back to MethodName() instead of panicking.
+		mtdName, ok := r.Arguments()[0].(string)
+		if !ok {
+			return r.MethodName()
+		}
+		return mtdName
 	}
+	return r.MethodName()
 }
 
 // IsGenericInvocation gets if this is a generic invocation

--- a/protocol/invocation/rpcinvocation_test.go
+++ b/protocol/invocation/rpcinvocation_test.go
@@ -186,7 +186,9 @@ func TestRPCInvocation_ActualMethodName_MalformedArgs(t *testing.T) {
 				WithArguments(tc.args),
 			)
 			// Should fall back to MethodName() without panicking.
-			assert.Equal(t, tc.want, inv.ActualMethodName())
+			require.NotPanics(t, func() {
+				assert.Equal(t, tc.want, inv.ActualMethodName())
+			})
 		})
 	}
 }

--- a/protocol/invocation/rpcinvocation_test.go
+++ b/protocol/invocation/rpcinvocation_test.go
@@ -164,6 +164,33 @@ func TestRPCInvocation_ActualMethodName(t *testing.T) {
 	assert.Equal(t, "actualAsyncMethod", invocation.ActualMethodName())
 }
 
+// TestRPCInvocation_ActualMethodName_MalformedArgs ensures a malformed $invoke
+// (arg[0] not a string) falls back to MethodName() instead of panicking.
+// See issue #3683.
+func TestRPCInvocation_ActualMethodName_MalformedArgs(t *testing.T) {
+	cases := []struct {
+		name   string
+		method string
+		args   []any
+		want   string
+	}{
+		{name: "invoke-arg0-int", method: constant.Generic, args: []any{123, []string{}, []any{}}, want: constant.Generic},
+		{name: "invoke-arg0-nil", method: constant.Generic, args: []any{nil, []string{}, []any{}}, want: constant.Generic},
+		{name: "invokeAsync-arg0-int", method: constant.GenericAsync, args: []any{123, []string{}, []any{}}, want: constant.GenericAsync},
+		{name: "invokeAsync-arg0-nil", method: constant.GenericAsync, args: []any{nil, []string{}, []any{}}, want: constant.GenericAsync},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inv := NewRPCInvocationWithOptions(
+				WithMethodName(tc.method),
+				WithArguments(tc.args),
+			)
+			// Should fall back to MethodName() without panicking.
+			assert.Equal(t, tc.want, inv.ActualMethodName())
+		})
+	}
+}
+
 func TestRPCInvocation_IsGenericInvocation(t *testing.T) {
 	// Test non-generic invocation
 	invocation := NewRPCInvocationWithOptions(


### PR DESCRIPTION
### Description
Fixes #3683

`RPCInvocation.ActualMethodName()` (`protocol/invocation/rpcinvocation.go:89`) performed an unguarded type assertion on the first generic-call argument:

```go
func (r *RPCInvocation) ActualMethodName() string {
    if r.IsGenericInvocation() {
        return r.Arguments()[0].(string)   // panics if arg[0] is not a string
    }
    return r.MethodName()
}
```

`IsGenericInvocation()` only checks `len(Arguments)==3`, not the element types. A malformed `$invoke` with a non-string `arg[0]` reached this line and panicked with `interface conversion: interface {} is X, not string`.

This is the same class of bug fixed in #3680 for `genericServiceFilter.Invoke`. In the default `DefaultServiceFilters` chain, `genericServiceFilter` runs before `otelServerFilter` and short-circuits malformed invocations, so `ActualMethodName()` is not reached by default. However, the filter order is user-configurable, and if a custom chain places `otelServerTrace` before `generic_service` (or omits `generic_service`), the panic becomes reachable on the server side via `filter/otel/trace/filter.go:83`.

This PR replaces the bare assertion with comma-ok form. Since `ActualMethodName() string` is an interface method on `base.Invocation` with no error return, it falls back to `r.MethodName()` on type mismatch (instead of returning an error like #3680 did). The interface signature is unchanged; all 7 call sites are unaffected.

### Checklist
- [x] I confirm the target branch is `develop`
- [x] I have run `make fmt` to format my code
- [x] I have run `make test` to run local tests
- [x] I have added tests that prove my fix is effective or that my feature works