### PR TITLE
refactor: replace vault jsonutil usage

### DIFF
--- a/common/dubboutil/json.go
+++ b/common/dubboutil/json.go
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dubboutil
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// EncodeJSON encodes in as JSON.
+func EncodeJSON(in any) ([]byte, error) {
+	if in == nil {
+		return nil, fmt.Errorf("input for encoding is nil")
+	}
+
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	if err := enc.Encode(in); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// DecodeJSON decodes JSON data into out.
+func DecodeJSON(data []byte, out any) error {
+	if len(data) == 0 {
+		return fmt.Errorf("'data' being decoded is nil")
+	}
+	if out == nil {
+		return fmt.Errorf("output parameter 'out' is nil")
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	// While decoding JSON values, interpret the integer values as json.Numbers
+	// instead of float64.
+	dec.UseNumber()
+	return dec.Decode(out)
+}

--- a/common/dubboutil/json.go
+++ b/common/dubboutil/json.go
@@ -29,12 +29,11 @@ func EncodeJSON(in any) ([]byte, error) {
 		return nil, fmt.Errorf("input for encoding is nil")
 	}
 
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	if err := enc.Encode(in); err != nil {
-		return nil, err
+	data, err := json.Marshal(in)
+	if err != nil {
+		return nil, fmt.Errorf("encode JSON: %w", err)
 	}
-	return buf.Bytes(), nil
+	return data, nil
 }
 
 // DecodeJSON decodes JSON data into out.

--- a/common/dubboutil/json_test.go
+++ b/common/dubboutil/json_test.go
@@ -20,26 +20,106 @@ package dubboutil
 import (
 	"encoding/json"
 	"testing"
-)
 
-import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestJSONHelpersUseNumber(t *testing.T) {
-	encoded, err := EncodeJSON(map[string]any{
-		"int":     42,
-		"float":   1.25,
-		"nullVal": nil,
+func TestEncodeJSON(t *testing.T) {
+	encoded, err := EncodeJSON(struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}{
+		Name:  "dubbo-go",
+		Count: 2,
 	})
 	require.NoError(t, err)
-	assert.JSONEq(t, `{"int":42,"float":1.25,"nullVal":null}`, string(encoded))
+	assert.Equal(t, `{"name":"dubbo-go","count":2}`, string(encoded))
+}
+
+func TestEncodeJSONNilInput(t *testing.T) {
+	encoded, err := EncodeJSON(nil)
+	require.EqualError(t, err, "input for encoding is nil")
+	assert.Nil(t, encoded)
+}
+
+func TestEncodeJSONMarshalError(t *testing.T) {
+	encoded, err := EncodeJSON(make(chan int))
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "encode JSON: json: unsupported type: chan int")
+	assert.Nil(t, encoded)
+}
+
+func TestDecodeJSON(t *testing.T) {
+	var decoded struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
+	err := DecodeJSON([]byte(`{"name":"dubbo-go","count":2}`), &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, "dubbo-go", decoded.Name)
+	assert.Equal(t, 2, decoded.Count)
+}
+
+func TestDecodeJSONUseNumber(t *testing.T) {
+	const largeInteger = int64(1<<53 + 1)
 
 	var decoded map[string]any
-	err = DecodeJSON(encoded, &decoded)
+	err := DecodeJSON([]byte(`{"int":9007199254740993,"float":1.25,"nullVal":null}`), &decoded)
 	require.NoError(t, err)
-	assert.Equal(t, json.Number("42"), decoded["int"])
+	assert.Equal(t, json.Number("9007199254740993"), decoded["int"])
+	decodedInteger, err := decoded["int"].(json.Number).Int64()
+	require.NoError(t, err)
+	assert.Equal(t, largeInteger, decodedInteger)
 	assert.Equal(t, json.Number("1.25"), decoded["float"])
 	assert.Nil(t, decoded["nullVal"])
+}
+
+func TestDecodeJSONInvalidArguments(t *testing.T) {
+	tests := []struct {
+		name string
+		data []byte
+		out  any
+		err  string
+	}{
+		{
+			name: "nil data",
+			out:  &map[string]any{},
+			err:  "'data' being decoded is nil",
+		},
+		{
+			name: "empty data",
+			data: []byte{},
+			out:  &map[string]any{},
+			err:  "'data' being decoded is nil",
+		},
+		{
+			name: "nil output",
+			data: []byte(`{}`),
+			err:  "output parameter 'out' is nil",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := DecodeJSON(test.data, test.out)
+			require.EqualError(t, err, test.err)
+		})
+	}
+}
+
+func TestDecodeJSONInvalidData(t *testing.T) {
+	var decoded map[string]any
+	err := DecodeJSON([]byte(`{"value":`), &decoded)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unexpected EOF")
+}
+
+func TestDecodeJSONTypeError(t *testing.T) {
+	var decoded struct {
+		Value int `json:"value"`
+	}
+	err := DecodeJSON([]byte(`{"value":3.14159}`), &decoded)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "cannot unmarshal number")
 }

--- a/common/dubboutil/json_test.go
+++ b/common/dubboutil/json_test.go
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dubboutil
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONHelpersUseNumber(t *testing.T) {
+	encoded, err := EncodeJSON(map[string]any{
+		"int":     42,
+		"float":   1.25,
+		"nullVal": nil,
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"int":42,"float":1.25,"nullVal":null}`, string(encoded))
+
+	var decoded map[string]any
+	err = DecodeJSON(encoded, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, json.Number("42"), decoded["int"])
+	assert.Equal(t, json.Number("1.25"), decoded["float"])
+	assert.Nil(t, decoded["nullVal"])
+}

--- a/common/dubboutil/json_test.go
+++ b/common/dubboutil/json_test.go
@@ -20,7 +20,9 @@ package dubboutil
 import (
 	"encoding/json"
 	"testing"
+)
 
+import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -34,7 +36,7 @@ func TestEncodeJSON(t *testing.T) {
 		Count: 2,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, `{"name":"dubbo-go","count":2}`, string(encoded))
+	assert.JSONEq(t, `{"name":"dubbo-go","count":2}`, string(encoded))
 }
 
 func TestEncodeJSONNilInput(t *testing.T) {
@@ -46,7 +48,7 @@ func TestEncodeJSONNilInput(t *testing.T) {
 func TestEncodeJSONMarshalError(t *testing.T) {
 	encoded, err := EncodeJSON(make(chan int))
 	require.Error(t, err)
-	assert.ErrorContains(t, err, "encode JSON: json: unsupported type: chan int")
+	require.ErrorContains(t, err, "encode JSON: json: unsupported type: chan int")
 	assert.Nil(t, encoded)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/grpc-ecosystem/grpc-opentracing v0.0.0-20180507213350-8e809c8a8645
 	github.com/hashicorp/golang-lru v0.5.4
-	github.com/hashicorp/vault/sdk v0.7.0
 	github.com/influxdata/tdigest v0.0.1
 	github.com/knadh/koanf v1.5.0
 	github.com/magiconair/properties v1.8.5
@@ -113,7 +112,6 @@ require (
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/openzipkin/zipkin-go v0.4.2 // indirect
 	github.com/pelletier/go-toml v1.9.3 // indirect
-	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -234,8 +234,6 @@ github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTg
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
-github.com/frankban/quicktest v1.10.0 h1:Gfh+GAJZOAoKZsIZeZbdn2JF10kN1XHNvjsvQK8gVkE=
-github.com/frankban/quicktest v1.10.0/go.mod h1:ui7WezCLWMWxVWr1GETZY3smRy0G4KWq9vcPtJmFl7Y=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -457,8 +455,6 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hashicorp/vault/api v1.0.4/go.mod h1:gDcqh3WGcR1cpF5AJz/B1UFheUEneMoIospckxBxk6Q=
 github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
-github.com/hashicorp/vault/sdk v0.7.0 h1:2pQRO40R1etpKkia5fb4kjrdYMx3BHklPxl1pxpxDHg=
-github.com/hashicorp/vault/sdk v0.7.0/go.mod h1:KyfArJkhooyba7gYCKSq8v66QdqJmnbAxtV/OX1+JTs=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=
@@ -635,8 +631,6 @@ github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCko
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
-github.com/pierrec/lz4 v2.6.1+incompatible h1:9UY3+iC23yxF0UfGaYrGplQ+79Rg+h/q9FV9ix19jjM=
-github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/registry/etcdv3/service_discovery.go
+++ b/registry/etcdv3/service_discovery.go
@@ -28,13 +28,12 @@ import (
 	gxetcd "github.com/dubbogo/gost/database/kv/etcd/v3"
 	gxpage "github.com/dubbogo/gost/hash/page"
 	"github.com/dubbogo/gost/log/logger"
-
-	"github.com/hashicorp/vault/sdk/helper/jsonutil"
 )
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/common/dubboutil"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/registry"
 	"dubbo.apache.org/dubbo-go/v3/remoting"
@@ -86,7 +85,7 @@ func (e *etcdV3ServiceDiscovery) Register(instance registry.ServiceInstance) err
 	path := toPath(instance)
 
 	if nil != e.client {
-		ins, err := jsonutil.EncodeJSON(instance)
+		ins, err := dubboutil.EncodeJSON(instance)
 		if err == nil {
 			err = e.client.RegisterTemp(path, string(ins))
 			if err != nil {
@@ -105,7 +104,7 @@ func (e *etcdV3ServiceDiscovery) Update(instance registry.ServiceInstance) error
 	path := toPath(instance)
 
 	if nil != e.client {
-		ins, err := jsonutil.EncodeJSON(instance)
+		ins, err := dubboutil.EncodeJSON(instance)
 		if err == nil {
 			if err = e.client.RegisterTemp(path, string(ins)); err != nil {
 				logger.Warnf("[Registry][Etcdv3] etcdV3ServiceDiscovery.client.RegisterTemp(path=%v instance=%v) = err=%v",
@@ -151,7 +150,7 @@ func (e *etcdV3ServiceDiscovery) GetInstances(serviceName string) []registry.Ser
 			serviceInstances := make([]registry.ServiceInstance, 0, len(vList))
 			for _, v := range vList {
 				instance := &registry.DefaultServiceInstance{}
-				err = jsonutil.DecodeJSON([]byte(v), &instance)
+				err = dubboutil.DecodeJSON([]byte(v), &instance)
 				if nil == err {
 					serviceInstances = append(serviceInstances, instance)
 				}
@@ -279,7 +278,7 @@ func (e *etcdV3ServiceDiscovery) registerServiceWatcher(serviceName string) erro
 func (e *etcdV3ServiceDiscovery) DataChange(eventType remoting.Event) bool {
 	if eventType.Action == remoting.EventTypeUpdate {
 		instance := &registry.DefaultServiceInstance{}
-		err := jsonutil.DecodeJSON([]byte(eventType.Content), &instance)
+		err := dubboutil.DecodeJSON([]byte(eventType.Content), &instance)
 		if err != nil {
 			instance.ServiceName = ""
 		}

--- a/registry/etcdv3/service_discovery_test.go
+++ b/registry/etcdv3/service_discovery_test.go
@@ -19,6 +19,7 @@ package etcdv3
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 )
 
@@ -30,6 +31,7 @@ import (
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/common/dubboutil"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 	"dubbo.apache.org/dubbo-go/v3/protocol/result"
@@ -49,6 +51,23 @@ func TestNewEtcdV3ServiceDiscovery(t *testing.T) {
 func TestEtcdV3ServiceDiscoveryGetDefaultPageSize(t *testing.T) {
 	serviceDiscovery := &etcdV3ServiceDiscovery{}
 	assert.Equal(t, registry.DefaultPageSize, serviceDiscovery.GetDefaultPageSize())
+}
+
+func TestEtcdV3JSONHelpers(t *testing.T) {
+	encoded, err := dubboutil.EncodeJSON(map[string]any{
+		"int":     42,
+		"float":   1.25,
+		"nullVal": nil,
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"int":42,"float":1.25,"nullVal":null}`, string(encoded))
+
+	var decoded map[string]any
+	err = dubboutil.DecodeJSON(encoded, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, json.Number("42"), decoded["int"])
+	assert.Equal(t, json.Number("1.25"), decoded["float"])
+	assert.Nil(t, decoded["nullVal"])
 }
 
 func TestFunction(t *testing.T) {

--- a/registry/etcdv3/service_discovery_test.go
+++ b/registry/etcdv3/service_discovery_test.go
@@ -24,6 +24,8 @@ import (
 )
 
 import (
+	gxset "github.com/dubbogo/gost/container/set"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,6 +38,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 	"dubbo.apache.org/dubbo-go/v3/protocol/result"
 	"dubbo.apache.org/dubbo-go/v3/registry"
+	"dubbo.apache.org/dubbo-go/v3/remoting"
 )
 
 const testName = "test"
@@ -51,6 +54,21 @@ func TestNewEtcdV3ServiceDiscovery(t *testing.T) {
 func TestEtcdV3ServiceDiscoveryGetDefaultPageSize(t *testing.T) {
 	serviceDiscovery := &etcdV3ServiceDiscovery{}
 	assert.Equal(t, registry.DefaultPageSize, serviceDiscovery.GetDefaultPageSize())
+}
+
+func TestEtcdV3ServiceDiscoveryDataChange(t *testing.T) {
+	serviceDiscovery := &etcdV3ServiceDiscovery{
+		instanceListenerMap: map[string]*gxset.HashSet{
+			testName: gxset.NewSet(),
+		},
+	}
+
+	updated := serviceDiscovery.DataChange(remoting.Event{
+		Action:  remoting.EventTypeUpdate,
+		Content: `{"ServiceName":"test"}`,
+	})
+
+	assert.True(t, updated)
 }
 
 func TestEtcdV3JSONHelpers(t *testing.T) {

--- a/tools/dubbogo-cli/cmd/testGenCode/template/newApp/go.sum
+++ b/tools/dubbogo-cli/cmd/testGenCode/template/newApp/go.sum
@@ -456,9 +456,6 @@ github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hashicorp/vault/api v1.0.4/go.mod h1:gDcqh3WGcR1cpF5AJz/B1UFheUEneMoIospckxBxk6Q=
-github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
-github.com/hashicorp/vault/sdk v0.7.0 h1:2pQRO40R1etpKkia5fb4kjrdYMx3BHklPxl1pxpxDHg=
-github.com/hashicorp/vault/sdk v0.7.0/go.mod h1:KyfArJkhooyba7gYCKSq8v66QdqJmnbAxtV/OX1+JTs=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=

--- a/tools/dubbogo-cli/cmd/testGenCode/template/newDemo/go.sum
+++ b/tools/dubbogo-cli/cmd/testGenCode/template/newDemo/go.sum
@@ -456,9 +456,6 @@ github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hashicorp/vault/api v1.0.4/go.mod h1:gDcqh3WGcR1cpF5AJz/B1UFheUEneMoIospckxBxk6Q=
-github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
-github.com/hashicorp/vault/sdk v0.7.0 h1:2pQRO40R1etpKkia5fb4kjrdYMx3BHklPxl1pxpxDHg=
-github.com/hashicorp/vault/sdk v0.7.0/go.mod h1:KyfArJkhooyba7gYCKSq8v66QdqJmnbAxtV/OX1+JTs=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=

--- a/tools/dubbogo-cli/generator/internal/scaffold/gosum.go
+++ b/tools/dubbogo-cli/generator/internal/scaffold/gosum.go
@@ -475,9 +475,6 @@ github.com/hashicorp/memberlist v0.3.0/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOn
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/serf v0.9.6/go.mod h1:TXZNMjZQijwlDvp+r0b63xZ45H7JmCmgg4gpTwn9UV4=
 github.com/hashicorp/vault/api v1.0.4/go.mod h1:gDcqh3WGcR1cpF5AJz/B1UFheUEneMoIospckxBxk6Q=
-github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvhkWnjtSYCaS2M=
-github.com/hashicorp/vault/sdk v0.7.0 h1:2pQRO40R1etpKkia5fb4kjrdYMx3BHklPxl1pxpxDHg=
-github.com/hashicorp/vault/sdk v0.7.0/go.mod h1:KyfArJkhooyba7gYCKSq8v66QdqJmnbAxtV/OX1+JTs=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hjson/hjson-go/v4 v4.0.0 h1:wlm6IYYqHjOdXH1gHev4VoXCaW20HdQAGCxdOEEg2cs=


### PR DESCRIPTION
### What changed
- Replaced Vault `jsonutil.EncodeJSON` / `jsonutil.DecodeJSON` usages in etcdv3 service discovery with local helpers backed by `encoding/json`.
- Preserved `DecodeJSON` number handling by using `json.Decoder.UseNumber()`.
- Removed the direct `github.com/hashicorp/vault/sdk` requirement from the main module.
- Cleaned stale Vault SDK checksum entries from dubbogo-cli scaffold/template go.sum data where applicable.

### Notes
- This PR intentionally covers only item 1 from #3693: Vault `jsonutil` -> `encoding/json`.
- `go mod tidy` still keeps `github.com/hashicorp/vault/sdk v0.1.13/go.mod` in the main `go.sum` through the transitive module path `github.com/knadh/koanf -> github.com/hashicorp/vault/api -> github.com/hashicorp/vault/sdk`. The main module itself does not need `github.com/hashicorp/vault/sdk` according to `go mod why -m`.

### Tests
- `go test -count=1 ./registry/etcdv3`
- `(cd tools/dubbogo-cli && go test -count=1 ./...)`

Refs #3693