### PR TITLE
fix(polaris): resolve nil pointer panic on startup and route miss (#3303)

### DIFF
--- a/cluster/cluster/failback/cluster_invoker.go
+++ b/cluster/cluster/failback/cluster_invoker.go
@@ -20,6 +20,7 @@ package failback
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -31,8 +32,6 @@ import (
 	"github.com/cenkalti/backoff/v4"
 
 	"github.com/dubbogo/gost/log/logger"
-
-	perrors "github.com/pkg/errors"
 )
 
 import (
@@ -193,7 +192,7 @@ func (invoker *failbackClusterInvoker) Invoke(ctx context.Context, invocation pr
 	ivk := invoker.DoSelect(loadBalance, invocation, invokers, invoked)
 	// DO INVOKE
 	if ivk == nil {
-		return &result.RPCResult{Err: perrors.New("invoker is nil")}
+		return &result.RPCResult{Err: fmt.Errorf("invoker is nil")}
 	}
 	res := ivk.Invoke(ctx, invocation)
 	if res.Error() != nil {

--- a/cluster/cluster/failback/cluster_invoker.go
+++ b/cluster/cluster/failback/cluster_invoker.go
@@ -31,6 +31,8 @@ import (
 	"github.com/cenkalti/backoff/v4"
 
 	"github.com/dubbogo/gost/log/logger"
+
+	perrors "github.com/pkg/errors"
 )
 
 import (
@@ -190,6 +192,9 @@ func (invoker *failbackClusterInvoker) Invoke(ctx context.Context, invocation pr
 	invoked := make([]protocolbase.Invoker, 0, len(invokers))
 	ivk := invoker.DoSelect(loadBalance, invocation, invokers, invoked)
 	// DO INVOKE
+	if ivk == nil {
+		return &result.RPCResult{Err: perrors.New("invoker is nil")}
+	}
 	res := ivk.Invoke(ctx, invocation)
 	if res.Error() != nil {
 		timerTask := newRetryTimerTask(loadBalance, invocation, invokers, ivk, invoker)

--- a/cluster/cluster/failback/cluster_invoker.go
+++ b/cluster/cluster/failback/cluster_invoker.go
@@ -20,7 +20,6 @@ package failback
 import (
 	"context"
 	"errors"
-	"fmt"
 	"strconv"
 	"sync"
 	"time"
@@ -192,7 +191,7 @@ func (invoker *failbackClusterInvoker) Invoke(ctx context.Context, invocation pr
 	ivk := invoker.DoSelect(loadBalance, invocation, invokers, invoked)
 	// DO INVOKE
 	if ivk == nil {
-		return &result.RPCResult{Err: fmt.Errorf("invoker is nil")}
+		return &result.RPCResult{Err: errors.New("invoker is nil")}
 	}
 	res := ivk.Invoke(ctx, invocation)
 	if res.Error() != nil {

--- a/cluster/cluster/failfast/cluster_invoker.go
+++ b/cluster/cluster/failfast/cluster_invoker.go
@@ -19,7 +19,7 @@ package failfast
 
 import (
 	"context"
-	"fmt"
+	"errors"
 )
 
 import (
@@ -56,7 +56,7 @@ func (invoker *failfastClusterInvoker) Invoke(ctx context.Context, invocation pr
 
 	ivk := invoker.DoSelect(loadbalance, invocation, invokers, nil)
 	if ivk == nil {
-		return &result.RPCResult{Err: fmt.Errorf("invoker is nil")}
+		return &result.RPCResult{Err: errors.New("invoker is nil")}
 	}
 	return ivk.Invoke(ctx, invocation)
 }

--- a/cluster/cluster/failfast/cluster_invoker.go
+++ b/cluster/cluster/failfast/cluster_invoker.go
@@ -19,10 +19,7 @@ package failfast
 
 import (
 	"context"
-)
-
-import (
-	perrors "github.com/pkg/errors"
+	"fmt"
 )
 
 import (
@@ -59,7 +56,7 @@ func (invoker *failfastClusterInvoker) Invoke(ctx context.Context, invocation pr
 
 	ivk := invoker.DoSelect(loadbalance, invocation, invokers, nil)
 	if ivk == nil {
-		return &result.RPCResult{Err: perrors.New("invoker is nil")}
+		return &result.RPCResult{Err: fmt.Errorf("invoker is nil")}
 	}
 	return ivk.Invoke(ctx, invocation)
 }

--- a/cluster/cluster/failfast/cluster_invoker.go
+++ b/cluster/cluster/failfast/cluster_invoker.go
@@ -22,6 +22,10 @@ import (
 )
 
 import (
+	perrors "github.com/pkg/errors"
+)
+
+import (
 	"dubbo.apache.org/dubbo-go/v3/cluster/cluster/base"
 	"dubbo.apache.org/dubbo-go/v3/cluster/directory"
 	protocolbase "dubbo.apache.org/dubbo-go/v3/protocol/base"
@@ -54,5 +58,8 @@ func (invoker *failfastClusterInvoker) Invoke(ctx context.Context, invocation pr
 	}
 
 	ivk := invoker.DoSelect(loadbalance, invocation, invokers, nil)
+	if ivk == nil {
+		return &result.RPCResult{Err: perrors.New("invoker is nil")}
+	}
 	return ivk.Invoke(ctx, invocation)
 }

--- a/cluster/cluster/failfast/cluster_test.go
+++ b/cluster/cluster/failfast/cluster_test.go
@@ -105,3 +105,27 @@ func TestFailfastInvokeFail(t *testing.T) {
 	assert.Equal(t, "error", result.Error().Error())
 	assert.Nil(t, result.Result())
 }
+
+// TestFailfastInvokeWithNoAvailableProvider verifies that invoking with
+// no available providers returns an error instead of panicking.
+func TestFailfastInvokeWithNoAvailableProvider(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	extension.SetLoadbalance("random", random.NewRandomLoadBalance)
+
+	// Simulate unavailable invoker causing DoSelect to return nil.
+	invoker := mock.NewMockInvoker(ctrl)
+	invoker.EXPECT().IsAvailable().Return(false).AnyTimes()
+	invoker.EXPECT().GetURL().Return(failfastUrl).AnyTimes()
+
+	staticDir := static.NewDirectory([]base.Invoker{invoker})
+	clusterInvoker := newFailfastCluster().Join(staticDir)
+
+	require.NotPanics(t, func() {
+		res := clusterInvoker.Invoke(context.Background(), &invocation.RPCInvocation{})
+		// Must return an error, not panic
+		require.NotNil(t, res)
+		require.Error(t, res.Error())
+	})
+}

--- a/cluster/cluster/failsafe/cluster_invoker.go
+++ b/cluster/cluster/failsafe/cluster_invoker.go
@@ -19,12 +19,11 @@ package failsafe
 
 import (
 	"context"
+	"fmt"
 )
 
 import (
 	"github.com/dubbogo/gost/log/logger"
-
-	perrors "github.com/pkg/errors"
 )
 
 import (
@@ -77,7 +76,7 @@ func (invoker *failsafeClusterInvoker) Invoke(ctx context.Context, invocation pr
 	ivk := invoker.DoSelect(loadbalance, invocation, invokers, invoked)
 	// DO INVOKE
 	if ivk == nil {
-		return &result.RPCResult{Err: perrors.New("invoker is nil")}
+		return &result.RPCResult{Err: fmt.Errorf("invoker is nil")}
 	}
 	res = ivk.Invoke(ctx, invocation)
 	if res.Error() != nil {

--- a/cluster/cluster/failsafe/cluster_invoker.go
+++ b/cluster/cluster/failsafe/cluster_invoker.go
@@ -19,7 +19,7 @@ package failsafe
 
 import (
 	"context"
-	"fmt"
+	"errors"
 )
 
 import (
@@ -76,7 +76,7 @@ func (invoker *failsafeClusterInvoker) Invoke(ctx context.Context, invocation pr
 	ivk := invoker.DoSelect(loadbalance, invocation, invokers, invoked)
 	// DO INVOKE
 	if ivk == nil {
-		return &result.RPCResult{Err: fmt.Errorf("invoker is nil")}
+		return &result.RPCResult{Err: errors.New("invoker is nil")}
 	}
 	res = ivk.Invoke(ctx, invocation)
 	if res.Error() != nil {

--- a/cluster/cluster/failsafe/cluster_invoker.go
+++ b/cluster/cluster/failsafe/cluster_invoker.go
@@ -23,6 +23,8 @@ import (
 
 import (
 	"github.com/dubbogo/gost/log/logger"
+
+	perrors "github.com/pkg/errors"
 )
 
 import (
@@ -74,6 +76,9 @@ func (invoker *failsafeClusterInvoker) Invoke(ctx context.Context, invocation pr
 
 	ivk := invoker.DoSelect(loadbalance, invocation, invokers, invoked)
 	// DO INVOKE
+	if ivk == nil {
+		return &result.RPCResult{Err: perrors.New("invoker is nil")}
+	}
 	res = ivk.Invoke(ctx, invocation)
 	if res.Error() != nil {
 		// ignore

--- a/cluster/router/polaris/router.go
+++ b/cluster/router/polaris/router.go
@@ -178,6 +178,7 @@ func (p *polarisRouter) Route(invokers []base.Invoker, url *common.URL,
 
 	resp, err := p.routerAPI.ProcessRouters(&req)
 	if err != nil {
+		logger.Warnf("[Router][Polaris] route miss, fallback: %+v", err)
 		return invokers
 	}
 
@@ -186,6 +187,11 @@ func (p *polarisRouter) Route(invokers []base.Invoker, url *common.URL,
 		if val, ok := invokersMap[resp.GetInstances()[i].GetId()]; ok {
 			ret = append(ret, val)
 		}
+	}
+
+	if len(ret) == 0 {
+		logger.Warn("[Router][Polaris] route rule yielded no invokers, fallback")
+		return invokers
 	}
 
 	return ret

--- a/registry/polaris/registry.go
+++ b/registry/polaris/registry.go
@@ -270,6 +270,10 @@ func (pr *polarisRegistry) LoadSubscribeInstances(url *common.URL, notify regist
 		GetInstancesRequest: model.GetInstancesRequest{
 			Service:   serviceName,
 			Namespace: pr.namespace,
+			// Polaris evaluates routing rules during GetInstances by default. At subscribe
+			// time there is no uid label, so the filter rejects all instances. Skip it here;
+			// polarisRouter.Route handles per-call routing instead.
+			SkipRouteFilter: true,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes #3303 

### Background
Configuring Polaris route rules without a catch-all fallback crashes the dubbo-go consumer with a nil pointer panic. This happens in two places:

- **Startup:** Polaris attempts to filter instances before any RPC `uid` exists, rejecting all providers and failing initialization.
- **Runtime:** If a request misses the configured route rules, the router returns an empty list, causing `failfast` (and other cluster invokers) to panic on a nil invoker.

### Changes
- Disable route filtering during directory initialization.
- Fall back to all instances in polarisRouter.Route on route miss.
- Add nil guards to failfast/failsafe/failback cluster