### PR TITLE
refactor: replace concurrent map usage

### DIFF
--- a/common/dubboutil/map.go
+++ b/common/dubboutil/map.go
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dubboutil
+
+import (
+	"sync"
+)
+
+// LoadSyncMap loads a typed value from m.
+func LoadSyncMap[T any](m *sync.Map, key any) (T, bool) {
+	var zero T
+	if m == nil {
+		return zero, false
+	}
+
+	value, ok := m.Load(key)
+	if !ok {
+		return zero, false
+	}
+
+	typedValue, ok := value.(T)
+	if !ok {
+		return zero, false
+	}
+	return typedValue, true
+}
+
+// LoadOrStoreSyncMap loads a typed value from m or stores value when key is absent.
+func LoadOrStoreSyncMap[T any](m *sync.Map, key any, value T) (T, bool, bool) {
+	var zero T
+	if m == nil {
+		return zero, false, false
+	}
+
+	actual, loaded := m.LoadOrStore(key, value)
+	typedValue, ok := actual.(T)
+	if !ok {
+		return zero, loaded, false
+	}
+	return typedValue, loaded, true
+}

--- a/common/dubboutil/map_test.go
+++ b/common/dubboutil/map_test.go
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dubboutil
+
+import (
+	"sync"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadOrStoreSyncMapConcurrentFirstInitialization(t *testing.T) {
+	const goroutines = 64
+
+	type state struct {
+		id int
+	}
+
+	var states sync.Map
+	start := make(chan struct{})
+	values := make(chan *state, goroutines)
+	okValues := make(chan bool, goroutines)
+	wg := sync.WaitGroup{}
+
+	for range goroutines {
+		wg.Go(func() {
+			<-start
+			value, _, ok := LoadOrStoreSyncMap(&states, "key", &state{id: 1})
+			okValues <- ok
+			values <- value
+		})
+	}
+
+	close(start)
+	wg.Wait()
+	close(values)
+	close(okValues)
+
+	for ok := range okValues {
+		assert.True(t, ok)
+	}
+
+	var first *state
+	for value := range values {
+		if first == nil {
+			first = value
+			continue
+		}
+		assert.Same(t, first, value)
+	}
+
+	count := 0
+	states.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 1, count)
+}
+
+func TestLoadSyncMapReturnsFalseForWrongType(t *testing.T) {
+	var states sync.Map
+	states.Store("key", "value")
+
+	value, ok := LoadSyncMap[*struct{}](&states, "key")
+	assert.False(t, ok)
+	assert.Nil(t, value)
+}

--- a/filter/exec_limit/filter.go
+++ b/filter/exec_limit/filter.go
@@ -51,12 +51,11 @@ import (
 
 import (
 	"github.com/dubbogo/gost/log/logger"
-
-	"github.com/modern-go/concurrent"
 )
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/common/dubboutil"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/filter"
 	_ "dubbo.apache.org/dubbo-go/v3/filter/handler"
@@ -74,7 +73,7 @@ func init() {
 }
 
 type executeLimitFilter struct {
-	executeState *concurrent.Map
+	executeState sync.Map
 }
 
 // ExecuteState defines the concurrent count
@@ -86,9 +85,7 @@ type ExecuteState struct {
 func newFilter() filter.Filter {
 	if executeLimit == nil {
 		once.Do(func() {
-			executeLimit = &executeLimitFilter{
-				executeState: concurrent.NewMap(),
-			}
+			executeLimit = &executeLimitFilter{}
 		})
 	}
 	return executeLimit
@@ -120,12 +117,16 @@ func (f *executeLimitFilter) Invoke(ctx context.Context, invoker base.Invoker, i
 		return invoker.Invoke(ctx, invocation)
 	}
 
-	state, _ := f.executeState.LoadOrStore(limitTarget, &ExecuteState{
+	state, _, ok := dubboutil.LoadOrStoreSyncMap(&f.executeState, limitTarget, &ExecuteState{
 		concurrentCount: 0,
 	})
+	if !ok {
+		logger.Errorf("[Filter][ExecLimit] invalid execute state type, url=%s target=%s", ivkURL.String(), limitTarget)
+		return invoker.Invoke(ctx, invocation)
+	}
 
-	concurrentCount := state.(*ExecuteState).increase()
-	defer state.(*ExecuteState).decrease()
+	concurrentCount := state.increase()
+	defer state.decrease()
 	if concurrentCount > limitRate {
 		logger.Errorf("[Filter][ExecLimit] the invocation was rejected due to over the execute limitation, url=%s", ivkURL.String())
 		rejectedHandlerConfig := ivkURL.GetParam(methodConfigPrefix+constant.ExecuteRejectedExecutionHandlerKey,

--- a/filter/exec_limit/filter_test.go
+++ b/filter/exec_limit/filter_test.go
@@ -20,6 +20,7 @@ package exec_limit
 import (
 	"context"
 	"net/url"
+	"sync"
 	"testing"
 )
 
@@ -30,6 +31,7 @@ import (
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/common/dubboutil"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
 	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
 )
@@ -82,4 +84,49 @@ func TestFilterInvoke(t *testing.T) {
 	result := limitFilter.Invoke(context.Background(), base.NewBaseInvoker(invokeUrl), invoc)
 	assert.NotNil(t, result)
 	assert.NoError(t, result.Error())
+}
+
+func TestExecuteLimitStateConcurrentFirstInitialization(t *testing.T) {
+	const goroutines = 64
+
+	limitFilter := &executeLimitFilter{}
+
+	start := make(chan struct{})
+	states := make(chan *ExecuteState, goroutines)
+	okValues := make(chan bool, goroutines)
+	wg := sync.WaitGroup{}
+
+	for range goroutines {
+		wg.Go(func() {
+			<-start
+			state, _, ok := dubboutil.LoadOrStoreSyncMap(&limitFilter.executeState, "service#method", &ExecuteState{})
+			okValues <- ok
+			states <- state
+		})
+	}
+
+	close(start)
+	wg.Wait()
+	close(states)
+	close(okValues)
+
+	for ok := range okValues {
+		assert.True(t, ok)
+	}
+
+	var first *ExecuteState
+	for state := range states {
+		if first == nil {
+			first = state
+			continue
+		}
+		assert.Same(t, first, state)
+	}
+
+	count := 0
+	limitFilter.executeState.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, 1, count)
 }

--- a/filter/tps/limiter/method_service.go
+++ b/filter/tps/limiter/method_service.go
@@ -24,13 +24,12 @@ import (
 
 import (
 	"github.com/dubbogo/gost/log/logger"
-
-	"github.com/modern-go/concurrent"
 )
 
 import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/common/dubboutil"
 	"dubbo.apache.org/dubbo-go/v3/common/extension"
 	"dubbo.apache.org/dubbo-go/v3/filter"
 	"dubbo.apache.org/dubbo-go/v3/protocol/base"
@@ -112,16 +111,16 @@ func init() {
  * In this case, only UpdateUser will be limited by its configuration (70 times in 40000ms)
  */
 type MethodServiceTpsLimiter struct {
-	tpsState *concurrent.Map
+	tpsState sync.Map
 }
 
 // IsAllowable based on method-level and service-level.
 // The method-level has high priority which means that if there is any rate limit configuration for the method,
 // the service-level rate limit strategy will be ignored.
 // The key point is how to keep thread-safe
-// This implementation use concurrent map + loadOrStore to make implementation thread-safe
-// You can image that even multiple threads create limiter, but only one could store the limiter into tpsState
-func (limiter MethodServiceTpsLimiter) IsAllowable(url *common.URL, invocation base.Invocation) bool {
+// This implementation uses sync.Map + LoadOrStore to make implementation thread-safe.
+// You can imagine that even when multiple goroutines create limiters, only one can store the limiter into tpsState.
+func (limiter *MethodServiceTpsLimiter) IsAllowable(url *common.URL, invocation base.Invocation) bool {
 	methodConfigPrefix := "methods." + invocation.MethodName() + "."
 
 	methodLimitRateConfig := url.GetParam(methodConfigPrefix+constant.TPSLimitRateKey, "")
@@ -137,10 +136,10 @@ func (limiter MethodServiceTpsLimiter) IsAllowable(url *common.URL, invocation b
 	}
 
 	// looking up the limiter from 'cache'
-	limitState, found := limiter.tpsState.Load(limitTarget)
+	limitState, found := dubboutil.LoadSyncMap[filter.TpsLimitStrategy](&limiter.tpsState, limitTarget)
 	if found {
 		// the limiter has been cached, we return its result
-		return limitState.(filter.TpsLimitStrategy).IsAllowable()
+		return limitState.IsAllowable()
 	}
 
 	// we could not find the limiter, and try to create one.
@@ -173,9 +172,17 @@ func (limiter MethodServiceTpsLimiter) IsAllowable(url *common.URL, invocation b
 	}
 
 	// we using loadOrStore to ensure thread-safe
-	limitState, _ = limiter.tpsState.LoadOrStore(limitTarget, limitStateCreator.Create(int(limitRate), int(limitInterval)))
+	limitState, _, ok := dubboutil.LoadOrStoreSyncMap[filter.TpsLimitStrategy](
+		&limiter.tpsState,
+		limitTarget,
+		limitStateCreator.Create(int(limitRate), int(limitInterval)),
+	)
+	if !ok {
+		logger.Warnf("[Filter][TPS] invalid TPS limit strategy state type, invocation=%s", url.ServiceKey()+"#"+invocation.MethodName())
+		return true
+	}
 
-	return limitState.(filter.TpsLimitStrategy).IsAllowable()
+	return limitState.IsAllowable()
 }
 
 // getLimitConfig will try to fetch the configuration from url.
@@ -215,9 +222,7 @@ var (
 // GetMethodServiceTpsLimiter will return an MethodServiceTpsLimiter instance.
 func GetMethodServiceTpsLimiter() filter.TpsLimiter {
 	methodServiceTpsLimiterOnce.Do(func() {
-		methodServiceTpsLimiterInstance = &MethodServiceTpsLimiter{
-			tpsState: concurrent.NewMap(),
-		}
+		methodServiceTpsLimiterInstance = &MethodServiceTpsLimiter{}
 	})
 	return methodServiceTpsLimiterInstance
 }

--- a/filter/tps/limiter/method_service_test.go
+++ b/filter/tps/limiter/method_service_test.go
@@ -19,6 +19,8 @@ package limiter
 
 import (
 	"net/url"
+	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -144,6 +146,58 @@ func TestMethodServiceTpsLimiterImplIsAllowableBothMethodAndService(t *testing.T
 	assert.True(t, result)
 }
 
+func TestMethodServiceTpsLimiterConcurrentFirstInitialization(t *testing.T) {
+	const goroutines = 64
+
+	methodName := "hello-concurrent"
+	strategyKey := "concurrent-first-init"
+	invoc := invocation.NewRPCInvocation(methodName, []any{"OK"}, make(map[string]any))
+	invokeUrl := common.NewURLWithOptions(
+		common.WithParams(url.Values{}),
+		common.WithParamsValue(constant.InterfaceKey, methodName),
+		common.WithParamsValue(constant.TPSLimitRateKey, "1000"),
+		common.WithParamsValue(constant.TPSLimitIntervalKey, "60000"),
+		common.WithParamsValue(constant.TPSLimitStrategyKey, strategyKey),
+	)
+
+	creator := &countingStrategyCreator{}
+	extension.SetTpsLimitStrategy(strategyKey, creator)
+
+	limiter := &MethodServiceTpsLimiter{}
+
+	start := make(chan struct{})
+	results := make(chan bool, goroutines)
+	wg := sync.WaitGroup{}
+	for range goroutines {
+		wg.Go(func() {
+			<-start
+			results <- limiter.IsAllowable(invokeUrl, invoc)
+		})
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+
+	for result := range results {
+		assert.True(t, result)
+	}
+
+	count := 0
+	var stored filter.TpsLimitStrategy
+	limiter.tpsState.Range(func(_, value any) bool {
+		count++
+		stored = value.(filter.TpsLimitStrategy)
+		return true
+	})
+	assert.Equal(t, 1, count)
+
+	storedStrategy, ok := stored.(*countingStrategy)
+	assert.True(t, ok)
+	assert.Equal(t, int64(goroutines), storedStrategy.calls.Load())
+	assert.GreaterOrEqual(t, creator.created.Load(), int64(1))
+}
+
 type mockStrategyCreator struct {
 	rate     int
 	interval int
@@ -155,4 +209,22 @@ func (creator *mockStrategyCreator) Create(rate int, interval int) filter.TpsLim
 	assert.Equal(creator.t, creator.rate, rate)
 	assert.Equal(creator.t, creator.interval, interval)
 	return creator.strategy
+}
+
+type countingStrategyCreator struct {
+	created atomic.Int64
+}
+
+func (creator *countingStrategyCreator) Create(int, int) filter.TpsLimitStrategy {
+	creator.created.Add(1)
+	return &countingStrategy{}
+}
+
+type countingStrategy struct {
+	calls atomic.Int64
+}
+
+func (strategy *countingStrategy) IsAllowable() bool {
+	strategy.calls.Add(1)
+	return true
 }

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ require (
 	github.com/magiconair/properties v1.8.5
 	github.com/mattn/go-colorable v0.1.13
 	github.com/mitchellh/mapstructure v1.5.0
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 	github.com/nacos-group/nacos-sdk-go/v2 v2.2.5
 	github.com/natefinch/lumberjack v2.0.0+incompatible
 	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852
@@ -109,6 +108,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/openzipkin/zipkin-go v0.4.2 // indirect

--- a/tools/dubbogo-cli/cmd/testGenCode/template/newApp/go.sum
+++ b/tools/dubbogo-cli/cmd/testGenCode/template/newApp/go.sum
@@ -580,9 +580,6 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=

--- a/tools/dubbogo-cli/cmd/testGenCode/template/newDemo/go.sum
+++ b/tools/dubbogo-cli/cmd/testGenCode/template/newDemo/go.sum
@@ -580,9 +580,6 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=

--- a/tools/dubbogo-cli/generator/internal/scaffold/gosum.go
+++ b/tools/dubbogo-cli/generator/internal/scaffold/gosum.go
@@ -599,9 +599,6 @@ github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zxSIeXaQ=
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
-github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
-github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=


### PR DESCRIPTION
## Summary

Refs #3693

Replace direct `github.com/modern-go/concurrent` usage in exec-limit and method-service TPS limiter with the standard library `sync.Map`.

## Changes

- Add typed `sync.Map` helpers under `common/dubboutil` for `Load` and `LoadOrStore` call sites.
- Migrate `filter/exec_limit` state storage to zero-value `sync.Map`.
- Migrate `filter/tps/limiter` state storage to zero-value `sync.Map` and pointer receiver to avoid copying `sync.Map` after use.
- Add concurrent first-initialization tests for the shared helper, exec-limit state, and TPS limiter state.
- Remove `modern-go/concurrent` from generated CLI project checksum templates/scaffold.
- Move `github.com/modern-go/concurrent` from direct require to indirect only; it is still pulled transitively by dependencies such as `gost`, `nacos-sdk-go`, `json-iterator`, and `prometheus/client_golang`.

## Validation

- `make fmt`
- `make check-fmt`
- `go test -count=1 ./common/dubboutil ./filter/exec_limit ./filter/tps/limiter`
- `go test -race -count=1 ./common/dubboutil ./filter/exec_limit ./filter/tps/limiter`
- `go test -count=1 ./filter/exec_limit ./filter/tps/...`
- `(cd tools/dubbogo-cli && go test -count=1 ./...)`
- `go vet ./common/dubboutil ./filter/exec_limit ./filter/tps/...`
- `git grep -n "github.com/modern-go/concurrent\|concurrent.NewMap\|concurrent\.Map" -- '*.go'` returns no matches