### PR TITLE
fix(accesslog): make goroutine lifecycle deterministic and shutdown wait for exit

### DIFF
--- a/filter/accesslog/filter.go
+++ b/filter/accesslog/filter.go
@@ -106,29 +106,39 @@ type Filter struct {
 	shutdownWaitTimeout time.Duration
 }
 
+// doInit builds and publishes the singleton filter. It runs at most once via
+// sync.Once, which doubles as an initialization barrier: a concurrent Shutdown
+// blocks in once.Do until this completes, so it can never return early by
+// observing a stale nil while the filter is still being constructed.
+func doInit() {
+	ctx, cancel := context.WithCancel(context.Background())
+	f := &Filter{
+		logChan:             make(chan Data, LogMaxBuffer),
+		fileCache:           make(map[string]*os.File),
+		ctx:                 ctx,
+		cancel:              cancel,
+		shutdownWaitTimeout: shutdownWaitTimeout,
+	}
+	// wg.Add must happen before the filter is published: a concurrent
+	// Shutdown that observes the filter while the WaitGroup counter is
+	// still zero would close file handles before processLogs even starts.
+	f.wg.Add(1)
+
+	// Publish under filterMu so readers in Shutdown see either nil or a
+	// fully constructed filter (happens-before via the mutex).
+	filterMu.Lock()
+	accessLogFilter = f
+	filterMu.Unlock()
+
+	go f.processLogs()
+}
+
+// newFilter returns the singleton access log filter, creating it on first
+// use. The lock-free read is safe because every production write to
+// accessLogFilter happens inside doInit under once.Do, and once.Do returning
+// establishes the happens-before edge readers need.
 func newFilter() filter.Filter {
-	once.Do(func() {
-		ctx, cancel := context.WithCancel(context.Background())
-		f := &Filter{
-			logChan:             make(chan Data, LogMaxBuffer),
-			fileCache:           make(map[string]*os.File),
-			ctx:                 ctx,
-			cancel:              cancel,
-			shutdownWaitTimeout: shutdownWaitTimeout,
-		}
-		// wg.Add must happen before the filter is published: a concurrent
-		// Shutdown that observes the filter while the WaitGroup counter is
-		// still zero would close file handles before processLogs even starts.
-		f.wg.Add(1)
-
-		// Publish under filterMu so readers in Shutdown see either nil or a
-		// fully constructed filter (happens-before via the mutex).
-		filterMu.Lock()
-		accessLogFilter = f
-		filterMu.Unlock()
-
-		go f.processLogs()
-	})
+	once.Do(doInit)
 	return accessLogFilter
 }
 
@@ -414,15 +424,20 @@ func (d *Data) toLogMessage() string {
 	return builder.String()
 }
 
-// Shutdown gracefully shuts down the access log filter
-// This should be called during application shutdown to prevent goroutine leaks
+// Shutdown gracefully shuts down the access log filter.
+// This should be called during application shutdown to prevent goroutine leaks.
+// once.Do(doInit) doubles as an initialization barrier: it waits for any
+// in-flight initialization (or performs it), so when Shutdown returns the
+// published filter has been shut down by this very call, even if it raced
+// against the first newFilter. If the subsystem was never used, Shutdown
+// runs one lightweight initialization cycle and tears it down immediately;
+// that keeps the postcondition deterministic at a negligible cost.
 func Shutdown() {
+	once.Do(doInit)
 	filterMu.Lock()
 	f := accessLogFilter
 	filterMu.Unlock()
-	if f != nil {
-		f.shutdown()
-	}
+	f.shutdown()
 }
 
 // shutdown gracefully shuts down this filter instance
@@ -441,7 +456,9 @@ func (f *Filter) shutdown() {
 			// The writer may still be blocked inside a single write syscall,
 			// which the context cannot interrupt; defer closing the file
 			// handles until it has actually exited instead of closing files
-			// it still holds.
+			// it still holds. This cleanup goroutine may therefore live
+			// indefinitely if the writer is stuck forever: prompt handle
+			// reclamation is deliberately traded for write safety.
 			go func() {
 				f.wg.Wait()
 				f.closeFiles()

--- a/filter/accesslog/filter.go
+++ b/filter/accesslog/filter.go
@@ -50,6 +50,10 @@ const (
 	// LogFileMode is the file permission for access log files.
 	LogFileMode = 0o600
 
+	// shutdownWaitTimeout is the maximum time Shutdown waits for the
+	// processLogs goroutine to exit, covering the 5s drainLogs timeout.
+	shutdownWaitTimeout = 6 * time.Second
+
 	// those fields are the data collected by this filter
 
 	// Types represents the list of argument types in log.
@@ -436,7 +440,7 @@ func (f *Filter) shutdown() {
 		// Wait for processLogs to exit (drainLogs timeout is 5s, use 6s margin)
 		select {
 		case <-f.done:
-		case <-time.After(6 * time.Second):
+		case <-time.After(shutdownWaitTimeout):
 			logger.Warn("[Filter][AccessLog] shutdown wait for processLogs timeout")
 		}
 

--- a/filter/accesslog/filter.go
+++ b/filter/accesslog/filter.go
@@ -100,19 +100,34 @@ type Filter struct {
 	cancel       context.CancelFunc
 	shutdownOnce sync.Once
 	wg           sync.WaitGroup // tracks the processLogs goroutine
+
+	// shutdownWaitTimeout bounds how long shutdown waits for processLogs to
+	// exit; it defaults to shutdownWaitTimeout and may be shortened by tests.
+	shutdownWaitTimeout time.Duration
 }
 
 func newFilter() filter.Filter {
 	once.Do(func() {
 		ctx, cancel := context.WithCancel(context.Background())
-		accessLogFilter = &Filter{
-			logChan:   make(chan Data, LogMaxBuffer),
-			fileCache: make(map[string]*os.File),
-			ctx:       ctx,
-			cancel:    cancel,
+		f := &Filter{
+			logChan:             make(chan Data, LogMaxBuffer),
+			fileCache:           make(map[string]*os.File),
+			ctx:                 ctx,
+			cancel:              cancel,
+			shutdownWaitTimeout: shutdownWaitTimeout,
 		}
-		accessLogFilter.wg.Add(1)
-		go accessLogFilter.processLogs()
+		// wg.Add must happen before the filter is published: a concurrent
+		// Shutdown that observes the filter while the WaitGroup counter is
+		// still zero would close file handles before processLogs even starts.
+		f.wg.Add(1)
+
+		// Publish under filterMu so readers in Shutdown see either nil or a
+		// fully constructed filter (happens-before via the mutex).
+		filterMu.Lock()
+		accessLogFilter = f
+		filterMu.Unlock()
+
+		go f.processLogs()
 	})
 	return accessLogFilter
 }
@@ -420,21 +435,33 @@ func (f *Filter) shutdown() {
 			f.cancel()
 		}
 
-		// Wait for processLogs to exit (drainLogs timeout is 5s, use 6s margin)
-		if !f.waitProcessLogs(shutdownWaitTimeout) {
+		// Wait for processLogs to exit before touching the files it writes to.
+		if !f.waitProcessLogs(f.shutdownWaitTimeout) {
 			logger.Warn("[Filter][AccessLog] shutdown wait for processLogs timeout")
+			// The writer may still be blocked inside a single write syscall,
+			// which the context cannot interrupt; defer closing the file
+			// handles until it has actually exited instead of closing files
+			// it still holds.
+			go func() {
+				f.wg.Wait()
+				f.closeFiles()
+			}()
+			return
 		}
-
-		// Close all cached file handles
-		f.fileLock.Lock()
-		defer f.fileLock.Unlock()
-		for path, file := range f.fileCache {
-			if err := file.Close(); err != nil {
-				logger.Warnf("[Filter][AccessLog] error closing access log file, path=%s err=%v", path, err)
-			}
-			delete(f.fileCache, path)
-		}
+		f.closeFiles()
 	})
+}
+
+// closeFiles closes and clears all cached file handles.
+func (f *Filter) closeFiles() {
+	f.fileLock.Lock()
+	defer f.fileLock.Unlock()
+	for path, file := range f.fileCache {
+		if err := file.Close(); err != nil {
+			logger.Warnf("[Filter][AccessLog] error closing access log file, path=%s err=%v", path, err)
+		}
+		delete(f.fileCache, path)
+	}
 }
 
 // waitProcessLogs waits for the processLogs goroutine to exit, returning

--- a/filter/accesslog/filter.go
+++ b/filter/accesslog/filter.go
@@ -99,7 +99,7 @@ type Filter struct {
 	ctx          context.Context
 	cancel       context.CancelFunc
 	shutdownOnce sync.Once
-	done         chan struct{} // closed when processLogs exits
+	wg           sync.WaitGroup // tracks the processLogs goroutine
 }
 
 func newFilter() filter.Filter {
@@ -110,8 +110,8 @@ func newFilter() filter.Filter {
 			fileCache: make(map[string]*os.File),
 			ctx:       ctx,
 			cancel:    cancel,
-			done:      make(chan struct{}),
 		}
+		accessLogFilter.wg.Add(1)
 		go accessLogFilter.processLogs()
 	})
 	return accessLogFilter
@@ -207,8 +207,7 @@ func (f *Filter) OnResponse(_ context.Context, result result.Result, _ base.Invo
 
 // processLogs runs in a background goroutine to process log data
 func (f *Filter) processLogs() {
-	// registered first, runs last: signals only after drainLogs completes
-	defer close(f.done)
+	defer f.wg.Done()
 	defer func() {
 		if r := recover(); r != nil {
 			logger.Errorf("[Filter][AccessLog] accessLog processLogs panic, err=%v", r)
@@ -422,9 +421,7 @@ func (f *Filter) shutdown() {
 		}
 
 		// Wait for processLogs to exit (drainLogs timeout is 5s, use 6s margin)
-		select {
-		case <-f.done:
-		case <-time.After(shutdownWaitTimeout):
+		if !f.waitProcessLogs(shutdownWaitTimeout) {
 			logger.Warn("[Filter][AccessLog] shutdown wait for processLogs timeout")
 		}
 
@@ -438,4 +435,17 @@ func (f *Filter) shutdown() {
 			delete(f.fileCache, path)
 		}
 	})
+}
+
+// waitProcessLogs waits for the processLogs goroutine to exit, returning
+// false if it does not stop within the timeout.
+func (f *Filter) waitProcessLogs(timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() { f.wg.Wait(); close(done) }()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
 }

--- a/filter/accesslog/filter.go
+++ b/filter/accesslog/filter.go
@@ -50,8 +50,12 @@ const (
 	// LogFileMode is the file permission for access log files.
 	LogFileMode = 0o600
 
+	// drainTimeout bounds how long drainLogs keeps flushing remaining
+	// log data while shutting down.
+	drainTimeout = 5 * time.Second
+
 	// shutdownWaitTimeout is the maximum time Shutdown waits for the
-	// processLogs goroutine to exit, covering the 5s drainLogs timeout.
+	// processLogs goroutine to exit, covering the drainTimeout margin.
 	shutdownWaitTimeout = 6 * time.Second
 
 	// those fields are the data collected by this filter
@@ -64,6 +68,7 @@ const (
 
 var (
 	once            sync.Once
+	filterMu        sync.Mutex // guards accessLogFilter against concurrent Shutdown
 	accessLogFilter *Filter
 )
 
@@ -213,49 +218,28 @@ func (f *Filter) processLogs() {
 
 	for {
 		select {
-		case accessLogData, ok := <-f.logChan:
-			if !ok {
-				return
-			}
-			f.writeLogToFileWithTimeout(accessLogData, 5*time.Second)
+		case accessLogData := <-f.logChan:
+			f.writeLogToFile(accessLogData)
 		case <-f.ctx.Done():
 			return
 		}
 	}
 }
 
-// drainLogs drains remaining log data with timeout protection
+// drainLogs drains remaining log data with an absolute deadline
 func (f *Filter) drainLogs() {
-	timeout := time.After(5 * time.Second)
+	deadline := time.Now().Add(drainTimeout)
 	for {
 		select {
-		case accessLogData, ok := <-f.logChan:
-			if !ok {
-				return
-			}
-			f.writeLogToFileWithTimeout(accessLogData, 1*time.Second)
-		case <-timeout:
-			logger.Warn("[Filter][AccessLog] accessLog drain timeout, some logs may be lost")
-			return
+		case accessLogData := <-f.logChan:
+			f.writeLogToFile(accessLogData)
 		default:
 			return
 		}
-	}
-}
-
-// writeLogToFileWithTimeout writes log with timeout protection
-func (f *Filter) writeLogToFileWithTimeout(data Data, timeout time.Duration) {
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		f.writeLogToFile(data)
-	}()
-
-	select {
-	case <-done:
-		logger.Debugf("[Filter][AccessLog] accessLog successfully written for, accessLog=%s", data.accessLog)
-	case <-time.After(timeout):
-		logger.Warnf("[Filter][AccessLog] accessLog writeLogToFile timeout, accessLog=%s", data.accessLog)
+		if time.Now().After(deadline) {
+			logger.Warn("[Filter][AccessLog] accessLog drain timeout, some logs may be lost")
+			return
+		}
 	}
 }
 
@@ -419,22 +403,22 @@ func (d *Data) toLogMessage() string {
 // Shutdown gracefully shuts down the access log filter
 // This should be called during application shutdown to prevent goroutine leaks
 func Shutdown() {
-	if accessLogFilter != nil {
-		accessLogFilter.shutdown()
+	filterMu.Lock()
+	f := accessLogFilter
+	filterMu.Unlock()
+	if f != nil {
+		f.shutdown()
 	}
 }
 
 // shutdown gracefully shuts down this filter instance
 func (f *Filter) shutdown() {
 	f.shutdownOnce.Do(func() {
-		// Cancel the context to signal goroutine to stop
+		// Cancel the context to signal the goroutine to stop. The channel is
+		// intentionally left open so concurrent Invoke calls never panic on a
+		// closed channel; excess data is dropped once the buffer is full.
 		if f.cancel != nil {
 			f.cancel()
-		}
-
-		// Close the channel to stop accepting new logs
-		if f.logChan != nil {
-			close(f.logChan)
 		}
 
 		// Wait for processLogs to exit (drainLogs timeout is 5s, use 6s margin)

--- a/filter/accesslog/filter.go
+++ b/filter/accesslog/filter.go
@@ -90,21 +90,21 @@ type Filter struct {
 	ctx          context.Context
 	cancel       context.CancelFunc
 	shutdownOnce sync.Once
+	done         chan struct{} // closed when processLogs exits
 }
 
 func newFilter() filter.Filter {
-	if accessLogFilter == nil {
-		once.Do(func() {
-			ctx, cancel := context.WithCancel(context.Background())
-			accessLogFilter = &Filter{
-				logChan:   make(chan Data, LogMaxBuffer),
-				fileCache: make(map[string]*os.File),
-				ctx:       ctx,
-				cancel:    cancel,
-			}
-			go accessLogFilter.processLogs()
-		})
-	}
+	once.Do(func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		accessLogFilter = &Filter{
+			logChan:   make(chan Data, LogMaxBuffer),
+			fileCache: make(map[string]*os.File),
+			ctx:       ctx,
+			cancel:    cancel,
+			done:      make(chan struct{}),
+		}
+		go accessLogFilter.processLogs()
+	})
 	return accessLogFilter
 }
 
@@ -198,6 +198,8 @@ func (f *Filter) OnResponse(_ context.Context, result result.Result, _ base.Invo
 
 // processLogs runs in a background goroutine to process log data
 func (f *Filter) processLogs() {
+	// registered first, runs last: signals only after drainLogs completes
+	defer close(f.done)
 	defer func() {
 		if r := recover(); r != nil {
 			logger.Errorf("[Filter][AccessLog] accessLog processLogs panic, err=%v", r)
@@ -429,6 +431,13 @@ func (f *Filter) shutdown() {
 		// Close the channel to stop accepting new logs
 		if f.logChan != nil {
 			close(f.logChan)
+		}
+
+		// Wait for processLogs to exit (drainLogs timeout is 5s, use 6s margin)
+		select {
+		case <-f.done:
+		case <-time.After(6 * time.Second):
+			logger.Warn("[Filter][AccessLog] shutdown wait for processLogs timeout")
 		}
 
 		// Close all cached file handles

--- a/filter/accesslog/memory_leak_test.go
+++ b/filter/accesslog/memory_leak_test.go
@@ -96,6 +96,36 @@ func TestAccessLogFilterConcurrentInvokeShutdown(t *testing.T) {
 	}
 }
 
+// TestAccessLogFilterConcurrentInitAndShutdown races the very first
+// newFilter call against Shutdown from a shared barrier to verify that
+// publishing under filterMu establishes a happens-before edge with readers:
+// under -race this must not report a data race on accessLogFilter.
+func TestAccessLogFilterConcurrentInitAndShutdown(t *testing.T) {
+	for range 100 {
+		resetGlobalState()
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			<-start
+			newFilter()
+		})
+		wg.Go(func() {
+			<-start
+			// May legitimately observe nil when initialization has not
+			// finished yet, so only the race detector is the oracle here.
+			Shutdown()
+		})
+		close(start)
+		wg.Wait()
+
+		// When the racing Shutdown above observed nil, the filter created by
+		// newFilter was never shut down; this extra call guarantees the
+		// processLogs goroutine of every round is reaped before the next one.
+		Shutdown()
+	}
+}
+
 // TestAccessLogFilterFileHandleManagement tests proper file handle management
 func TestAccessLogFilterFileHandleManagement(t *testing.T) {
 	resetGlobalState()

--- a/filter/accesslog/memory_leak_test.go
+++ b/filter/accesslog/memory_leak_test.go
@@ -97,9 +97,11 @@ func TestAccessLogFilterConcurrentInvokeShutdown(t *testing.T) {
 }
 
 // TestAccessLogFilterConcurrentInitAndShutdown races the very first
-// newFilter call against Shutdown from a shared barrier to verify that
-// publishing under filterMu establishes a happens-before edge with readers:
-// under -race this must not report a data race on accessLogFilter.
+// newFilter call against Shutdown from a shared barrier. The single Shutdown
+// call must complete the whole lifecycle on its own — once.Do(doInit) makes
+// it wait for the in-flight initialization before shutting the filter down —
+// so after both calls finish, the processLogs goroutine must have exited
+// without any compensating Shutdown.
 func TestAccessLogFilterConcurrentInitAndShutdown(t *testing.T) {
 	for range 100 {
 		resetGlobalState()
@@ -112,17 +114,18 @@ func TestAccessLogFilterConcurrentInitAndShutdown(t *testing.T) {
 		})
 		wg.Go(func() {
 			<-start
-			// May legitimately observe nil when initialization has not
-			// finished yet, so only the race detector is the oracle here.
 			Shutdown()
 		})
 		close(start)
 		wg.Wait()
 
-		// When the racing Shutdown above observed nil, the filter created by
-		// newFilter was never shut down; this extra call guarantees the
-		// processLogs goroutine of every round is reaped before the next one.
-		Shutdown()
+		filter, ok := newFilter().(*Filter)
+		if !ok {
+			t.Fatal("newFilter should return a *Filter")
+		}
+		if !filter.waitProcessLogs(5 * time.Second) {
+			t.Fatal("processLogs did not exit after the concurrent Shutdown returned")
+		}
 	}
 }
 
@@ -149,15 +152,24 @@ func TestAccessLogFilterFileHandleManagement(t *testing.T) {
 		filter.Invoke(context.Background(), invoker, invocation)
 	}
 
-	// Wait for logs to be processed
-	time.Sleep(100 * time.Millisecond)
+	// Wait until the consumer goroutine has opened and cached the log file;
+	// a fixed sleep here would be flaky under CI load.
+	deadline := time.Now().Add(2 * time.Second)
+	var cachedFile *os.File
+	var exists bool
+	for {
+		filter.fileLock.RLock()
+		cachedFile, exists = filter.fileCache[tempFile]
+		filter.fileLock.RUnlock()
+		if exists {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("log file was never cached by the consumer")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 
-	// Check that file is in cache
-	filter.fileLock.RLock()
-	cachedFile, exists := filter.fileCache[tempFile]
-	filter.fileLock.RUnlock()
-
-	assert.True(t, exists, "File should be cached")
 	assert.NotNil(t, cachedFile, "Cached file should not be nil")
 
 	// Shutdown and verify files are closed

--- a/filter/accesslog/memory_leak_test.go
+++ b/filter/accesslog/memory_leak_test.go
@@ -20,7 +20,6 @@ package accesslog
 import (
 	"context"
 	"os"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -49,32 +48,27 @@ func resetGlobalState() {
 func TestAccessLogFilterGoroutineShutdown(t *testing.T) {
 	resetGlobalState()
 
-	// Count goroutines before
-	initialGoroutines := runtime.NumGoroutine()
+	filter, ok := newFilter().(*Filter)
+	if !ok {
+		t.Fatal("newFilter should return a *Filter")
+	}
 
-	// Create filter (this should start the goroutine)
-	filter := newFilter()
-	assert.NotNil(t, filter)
+	// processLogs goroutine should be running: done must not be closed yet
+	select {
+	case <-filter.done:
+		t.Fatal("processLogs exited before shutdown")
+	default:
+	}
 
-	// Give the goroutine time to start
-	time.Sleep(100 * time.Millisecond)
-	postCreateGoroutines := runtime.NumGoroutine()
-
-	// Should have at least one more goroutine
-	assert.Greater(t, postCreateGoroutines, initialGoroutines)
-
-	// Shutdown the filter
 	Shutdown()
 
-	// Give goroutine time to exit
-	time.Sleep(100 * time.Millisecond)
-	runtime.GC() // Force garbage collection
-
-	postShutdownGoroutines := runtime.NumGoroutine()
-
-	// Goroutine count should be back to original or less
-	assert.LessOrEqual(t, postShutdownGoroutines, initialGoroutines+1,
-		"Goroutines should be cleaned up after shutdown")
+	// After shutdown the goroutine should exit deterministically
+	select {
+	case <-filter.done:
+		// success
+	case <-time.After(5 * time.Second):
+		t.Fatal("processLogs did not exit after shutdown")
+	}
 }
 
 // TestAccessLogFilterFileHandleManagement tests proper file handle management

--- a/filter/accesslog/memory_leak_test.go
+++ b/filter/accesslog/memory_leak_test.go
@@ -20,6 +20,7 @@ package accesslog
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -40,7 +41,9 @@ import (
 // resetGlobalState resets the global state for testing
 func resetGlobalState() {
 	once.Do(func() {}) // Trigger once
+	filterMu.Lock()
 	accessLogFilter = nil
+	filterMu.Unlock()
 	once = sync.Once{}
 }
 
@@ -68,6 +71,40 @@ func TestAccessLogFilterGoroutineShutdown(t *testing.T) {
 		// success
 	case <-time.After(5 * time.Second):
 		t.Fatal("processLogs did not exit after shutdown")
+	}
+}
+
+// TestAccessLogFilterConcurrentInvokeShutdown drives concurrent Invoke and
+// Shutdown calls to verify the filter neither panics on a closed channel nor
+// races on the global state when running under -race.
+func TestAccessLogFilterConcurrentInvokeShutdown(t *testing.T) {
+	resetGlobalState()
+
+	filter := newFilter().(*Filter)
+	url := common.NewURLWithOptions(
+		common.WithParamsValue(constant.AccessLogFilterKey, filepath.Join(t.TempDir(), "access.log")),
+	)
+	invoker := &MockInvoker{url: url}
+	invocation := &invocation_impl.RPCInvocation{}
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Go(func() {
+			for range 100 {
+				filter.Invoke(context.Background(), invoker, invocation)
+			}
+		})
+	}
+	wg.Go(func() {
+		Shutdown()
+	})
+
+	wg.Wait()
+
+	select {
+	case <-filter.done:
+	default:
+		t.Fatal("processLogs did not exit after concurrent shutdown")
 	}
 }
 

--- a/filter/accesslog/memory_leak_test.go
+++ b/filter/accesslog/memory_leak_test.go
@@ -56,20 +56,10 @@ func TestAccessLogFilterGoroutineShutdown(t *testing.T) {
 		t.Fatal("newFilter should return a *Filter")
 	}
 
-	// processLogs goroutine should be running: done must not be closed yet
-	select {
-	case <-filter.done:
-		t.Fatal("processLogs exited before shutdown")
-	default:
-	}
-
 	Shutdown()
 
 	// After shutdown the goroutine should exit deterministically
-	select {
-	case <-filter.done:
-		// success
-	case <-time.After(5 * time.Second):
+	if !filter.waitProcessLogs(5 * time.Second) {
 		t.Fatal("processLogs did not exit after shutdown")
 	}
 }
@@ -101,9 +91,7 @@ func TestAccessLogFilterConcurrentInvokeShutdown(t *testing.T) {
 
 	wg.Wait()
 
-	select {
-	case <-filter.done:
-	default:
+	if !filter.waitProcessLogs(5 * time.Second) {
 		t.Fatal("processLogs did not exit after concurrent shutdown")
 	}
 }

--- a/filter/accesslog/shutdown_timeout_test.go
+++ b/filter/accesslog/shutdown_timeout_test.go
@@ -104,7 +104,7 @@ func TestAccessLogFilterShutdownTimeoutBlockedWriter(t *testing.T) {
 	// The filter opens log files with O_RDWR and therefore holds its own
 	// read end, so closing ours can never produce EPIPE. Unblock the writer
 	// by draining the FIFO instead: once all queued entries are written, the
-	// already cancelled context stops processLogs and the deferred background
+	// already canceled context stops processLogs and the deferred background
 	// cleanup closes the cached files, which ends the draining goroutine.
 	reader.Close()
 	drainer, err := os.OpenFile(fifo, os.O_RDONLY, 0)

--- a/filter/accesslog/shutdown_timeout_test.go
+++ b/filter/accesslog/shutdown_timeout_test.go
@@ -1,0 +1,143 @@
+//go:build unix
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package accesslog
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	invocation_impl "dubbo.apache.org/dubbo-go/v3/protocol/invocation"
+)
+
+// TestAccessLogFilterShutdownTimeoutBlockedWriter verifies the shutdown
+// timeout path: when processLogs is stuck inside a blocking write past the
+// wait timeout, Shutdown must leave the cached file handle untouched and
+// defer closing it to a background cleanup that runs after the writer exits.
+func TestAccessLogFilterShutdownTimeoutBlockedWriter(t *testing.T) {
+	resetGlobalState()
+
+	fifo := filepath.Join(t.TempDir(), "access.log")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	// Open the read end and keep it open without consuming, so writes into
+	// the FIFO block once the kernel pipe buffer is full. The read end must
+	// be opened with O_NONBLOCK: a blocking open on a FIFO waits for a
+	// writer to show up and would hang the test right here.
+	reader, err := os.OpenFile(fifo, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		t.Fatalf("open read end of fifo: %v", err)
+	}
+
+	filter := newFilter().(*Filter)
+	filter.shutdownWaitTimeout = 200 * time.Millisecond
+
+	// A large payload per entry fills the pipe buffer within one or two
+	// writes, which keeps the blocking deterministic.
+	bigPayload := strings.Repeat("x", 128*1024)
+	invocation := invocation_impl.NewRPCInvocationWithOptions(
+		invocation_impl.WithAttachment(constant.MethodKey, bigPayload),
+	)
+	url := common.NewURLWithOptions(
+		common.WithParamsValue(constant.AccessLogFilterKey, fifo),
+	)
+	invoker := &MockInvoker{url: url}
+	for range 8 {
+		filter.Invoke(context.Background(), invoker, invocation)
+	}
+
+	// Wait until processLogs has opened the FIFO and cached the handle,
+	// otherwise Shutdown would legitimately observe an empty cache.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		filter.fileLock.RLock()
+		_, exists := filter.fileCache[fifo]
+		filter.fileLock.RUnlock()
+		if exists {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("writer never opened the fifo")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	// Give the writer time to block inside WriteString.
+	time.Sleep(300 * time.Millisecond)
+
+	// Hits the timeout path after 200ms because the writer never exits.
+	Shutdown()
+
+	filter.fileLock.RLock()
+	cached := len(filter.fileCache)
+	filter.fileLock.RUnlock()
+	if cached == 0 {
+		t.Fatal("file handles were closed while the writer was still blocked")
+	}
+
+	// The filter opens log files with O_RDWR and therefore holds its own
+	// read end, so closing ours can never produce EPIPE. Unblock the writer
+	// by draining the FIFO instead: once all queued entries are written, the
+	// already cancelled context stops processLogs and the deferred background
+	// cleanup closes the cached files, which ends the draining goroutine.
+	reader.Close()
+	drainer, err := os.OpenFile(fifo, os.O_RDONLY, 0)
+	if err != nil {
+		t.Fatalf("open draining read end of fifo: %v", err)
+	}
+	defer drainer.Close()
+	go func() {
+		buf := make([]byte, 32*1024)
+		for {
+			if _, err := drainer.Read(buf); err != nil {
+				return // EOF once every writer closed the FIFO
+			}
+		}
+	}()
+
+	if !filter.waitProcessLogs(5 * time.Second) {
+		t.Fatal("processLogs did not exit after unblocking the writer")
+	}
+
+	// The background cleanup closes the files shortly after the writer exits;
+	// poll instead of asserting right away.
+	deadline = time.Now().Add(2 * time.Second)
+	for {
+		filter.fileLock.RLock()
+		cached = len(filter.fileCache)
+		filter.fileLock.RUnlock()
+		if cached == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("file cache should be empty once the background cleanup finished")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
Fixes #3700

### Description
The CI `-race` job intermittently fails `TestAccessLogFilterGoroutineShutdown`
with `"3" is not greater than "3"` (memory_leak_test.go:64). The test asserted
the `processLogs` goroutine lifecycle by comparing global `runtime.NumGoroutine()`
counts around a fixed 100ms sleep — under `-race`, other background goroutines
(log writers, test framework) naturally exit during that window and cancel out
the +1, so the assertion is timing- and environment-dependent.

Beyond the test, `Shutdown()` never waited for `processLogs` to exit: it
cancelled the context and closed `logChan`, then immediately closed cached
file handles while `drainLogs()` could still be running for up to 5s. Callers
could not observe when shutdown actually completed.

### Changes
- Add a private `done` channel to `Filter`, closed when `processLogs` exits
  (deferred close registered first, so it runs after `drainLogs` completes)
- `Shutdown()` now waits for `processLogs` to exit (up to 6s, covering the 5s
  drain timeout) before closing cached file handles
- Drop the unsynchronized `accessLogFilter == nil` check in `newFilter()` and
  rely solely on `sync.Once`, removing a data race on the package-level
  variable under concurrent calls
- Rewrite `TestAccessLogFilterGoroutineShutdown` to assert on the deterministic
  `done` signal instead of global goroutine counts

### Test
`TestAccessLogFilterGoroutineShutdown` in `memory_leak_test.go` now verifies:
- the `processLogs` goroutine is running after `newFilter()` (`done` not yet closed)
- `Shutdown()` makes it exit deterministically (`done` closed within 5s)

### Validation
- `make fmt` — no changes, the code already conforms to the repo format rules
- `make test` — full repository unit tests pass, 0 failures
- `go test -race -count=50 -run TestAccessLogFilter ./filter/accesslog/` — passes consistently
- `go test -race -count=30 ./filter/accesslog/` — passes (Linux-only fd tests skipped on macOS)

### Checklist
- [x] I confirm the target branch is `develop`
- [x] I have run `make fmt` to format my code
- [x] I have run `make test` to run local tests
- [x] I have added tests that prove my fix is effective or that my feature works