### PR TITLE
feat(triple): performance optimization for Triple unary hot path

### DIFF
--- a/global/triple_config.go
+++ b/global/triple_config.go
@@ -49,16 +49,17 @@ type TripleConfig struct {
 
 	// KeepAliveTimeout defines the keep-alive timeout for client.
 	KeepAliveTimeout string `yaml:"keep-alive-timeout" json:"keep-alive-timeout,omitempty" property:"keep-alive-timeout"`
-	// UnaryFastPath enables the unary fast path for client, off by default.
+	// UnaryFastPath enables the unary fast path for client, on by default.
 	UnaryFastPath bool `yaml:"unary-fast-path" json:"unary-fast-path,omitempty" property:"unary-fast-path"`
 }
 
 // DefaultTripleConfig returns a default TripleConfig instance.
 func DefaultTripleConfig() *TripleConfig {
 	return &TripleConfig{
-		Http3:   DefaultHttp3Config(),
-		Cors:    DefaultCorsConfig(),
-		OpenAPI: DefaultOpenAPIConfig(),
+		Http3:         DefaultHttp3Config(),
+		Cors:          DefaultCorsConfig(),
+		OpenAPI:       DefaultOpenAPIConfig(),
+		UnaryFastPath: true,
 	}
 }
 

--- a/global/triple_config.go
+++ b/global/triple_config.go
@@ -50,8 +50,8 @@ type TripleConfig struct {
 	// KeepAliveTimeout defines the keep-alive timeout for client.
 	KeepAliveTimeout string `yaml:"keep-alive-timeout" json:"keep-alive-timeout,omitempty" property:"keep-alive-timeout"`
 	// UnaryFastPath enables the unary fast path for client, on by default.
-	// It only applies to the Triple (connect) protocol; the default gRPC
-	// wire format never reaches it.
+	// It applies to unary calls on both the gRPC and the Triple (connect)
+	// wire formats; streaming calls always use duplexHTTPCall.
 	UnaryFastPath bool `yaml:"unary-fast-path" json:"unary-fast-path,omitempty" property:"unary-fast-path"`
 }
 

--- a/global/triple_config.go
+++ b/global/triple_config.go
@@ -50,6 +50,8 @@ type TripleConfig struct {
 	// KeepAliveTimeout defines the keep-alive timeout for client.
 	KeepAliveTimeout string `yaml:"keep-alive-timeout" json:"keep-alive-timeout,omitempty" property:"keep-alive-timeout"`
 	// UnaryFastPath enables the unary fast path for client, on by default.
+	// It only applies to the Triple (connect) protocol; the default gRPC
+	// wire format never reaches it.
 	UnaryFastPath bool `yaml:"unary-fast-path" json:"unary-fast-path,omitempty" property:"unary-fast-path"`
 }
 

--- a/global/triple_config.go
+++ b/global/triple_config.go
@@ -52,16 +52,19 @@ type TripleConfig struct {
 	// UnaryFastPath enables the unary fast path for client, on by default.
 	// It applies to unary calls on both the gRPC and the Triple (connect)
 	// wire formats; streaming calls always use duplexHTTPCall.
-	UnaryFastPath bool `yaml:"unary-fast-path" json:"unary-fast-path,omitempty" property:"unary-fast-path"`
+	// A nil value means the field is not explicitly set, and the default
+	// (enabled) applies.
+	UnaryFastPath *bool `default:"true" yaml:"unary-fast-path" json:"unary-fast-path,omitempty" property:"unary-fast-path"`
 }
 
 // DefaultTripleConfig returns a default TripleConfig instance.
 func DefaultTripleConfig() *TripleConfig {
+	unaryFastPath := true
 	return &TripleConfig{
 		Http3:         DefaultHttp3Config(),
 		Cors:          DefaultCorsConfig(),
 		OpenAPI:       DefaultOpenAPIConfig(),
-		UnaryFastPath: true,
+		UnaryFastPath: &unaryFastPath,
 	}
 }
 
@@ -69,6 +72,12 @@ func DefaultTripleConfig() *TripleConfig {
 func (t *TripleConfig) Clone() *TripleConfig {
 	if t == nil {
 		return nil
+	}
+
+	var newUnaryFastPath *bool
+	if t.UnaryFastPath != nil {
+		newUnaryFastPath = new(bool)
+		*newUnaryFastPath = *t.UnaryFastPath
 	}
 
 	return &TripleConfig{
@@ -80,6 +89,6 @@ func (t *TripleConfig) Clone() *TripleConfig {
 
 		KeepAliveInterval: t.KeepAliveInterval,
 		KeepAliveTimeout:  t.KeepAliveTimeout,
-		UnaryFastPath:     t.UnaryFastPath,
+		UnaryFastPath:     newUnaryFastPath,
 	}
 }

--- a/global/triple_config.go
+++ b/global/triple_config.go
@@ -49,6 +49,8 @@ type TripleConfig struct {
 
 	// KeepAliveTimeout defines the keep-alive timeout for client.
 	KeepAliveTimeout string `yaml:"keep-alive-timeout" json:"keep-alive-timeout,omitempty" property:"keep-alive-timeout"`
+	// UnaryFastPath enables the unary fast path for client, off by default.
+	UnaryFastPath bool `yaml:"unary-fast-path" json:"unary-fast-path,omitempty" property:"unary-fast-path"`
 }
 
 // DefaultTripleConfig returns a default TripleConfig instance.
@@ -75,5 +77,6 @@ func (t *TripleConfig) Clone() *TripleConfig {
 
 		KeepAliveInterval: t.KeepAliveInterval,
 		KeepAliveTimeout:  t.KeepAliveTimeout,
+		UnaryFastPath:     t.UnaryFastPath,
 	}
 }

--- a/protocol/triple/client.go
+++ b/protocol/triple/client.go
@@ -184,8 +184,10 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 	// The unary fast path is on by default. It routes unary calls through
 	// unaryFastPathCall on both the gRPC and the Triple (connect) wire
 	// formats; streaming calls always use duplexHTTPCall.
+	// A nil UnaryFastPath means the field was not explicitly set, so the
+	// default (enabled) applies.
 	if tripleConf != nil {
-		if tripleConf.UnaryFastPath {
+		if tripleConf.UnaryFastPath == nil || *tripleConf.UnaryFastPath {
 			cliOpts = append(cliOpts, tri.WithUnaryFastPath())
 		} else {
 			cliOpts = append(cliOpts, tri.WithoutUnaryFastPath())

--- a/protocol/triple/client.go
+++ b/protocol/triple/client.go
@@ -181,8 +181,8 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 	}
 	cliOpts = append(cliOpts, clientKeepAliveOpts...)
 
-	// The unary fast path is on by default; an explicit unary-fast-path: false
-	// in the config opts back out to the duplex path.
+	// The unary fast path is on by default. It only applies to the Triple
+	// (connect) protocol; the client below defaults to the gRPC wire format.
 	if tripleConf != nil {
 		if tripleConf.UnaryFastPath {
 			cliOpts = append(cliOpts, tri.WithUnaryFastPath())
@@ -193,12 +193,6 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 
 	// Build the HTTP transport used by the Triple client.
 	var transport http.RoundTripper
-
-	// Always select the Triple protocol explicitly, regardless of the HTTP
-	// transport variant. The triple_protocol.Client defaults to the gRPC
-	// protocol; without this option the unary fast path (and Triple-specific
-	// behavior) would never be reachable.
-	cliOpts = append(cliOpts, tri.WithTriple())
 
 	var callProtocol string
 	if tripleConf != nil && tripleConf.Http3 != nil && tripleConf.Http3.Enable {
@@ -211,10 +205,13 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 	switch callProtocol {
 	case constant.CallHTTP:
 		// Backward compatibility path for callers that still request HTTP/1.1.
-		// Triple itself requires HTTP/2 or HTTP/3 trailer support.
+		// Triple itself requires HTTP/2 or HTTP/3 trailer support, so HTTP/1.1
+		// callers use the Triple (connect) protocol, which does not rely on
+		// trailers.
 		transport = &http.Transport{
 			TLSClientConfig: cfg,
 		}
+		cliOpts = append(cliOpts, tri.WithTriple())
 	case constant.CallHTTP2:
 		// HTTP/2 transport only configures keepalive (ReadIdleTimeout/PingTimeout) and TLS;
 		// All other knobs keep the http2.Transport defaults.

--- a/protocol/triple/client.go
+++ b/protocol/triple/client.go
@@ -181,8 +181,9 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 	}
 	cliOpts = append(cliOpts, clientKeepAliveOpts...)
 
-	// The unary fast path is on by default. It only applies to the Triple
-	// (connect) protocol; the client below defaults to the gRPC wire format.
+	// The unary fast path is on by default. It routes unary calls through
+	// unaryFastPathCall on both the gRPC and the Triple (connect) wire
+	// formats; streaming calls always use duplexHTTPCall.
 	if tripleConf != nil {
 		if tripleConf.UnaryFastPath {
 			cliOpts = append(cliOpts, tri.WithUnaryFastPath())

--- a/protocol/triple/client.go
+++ b/protocol/triple/client.go
@@ -181,9 +181,14 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 	}
 	cliOpts = append(cliOpts, clientKeepAliveOpts...)
 
-	// Optionally enable the unary fast path, off by default.
-	if tripleConf != nil && tripleConf.UnaryFastPath {
-		cliOpts = append(cliOpts, tri.WithUnaryFastPath())
+	// The unary fast path is on by default; an explicit unary-fast-path: false
+	// in the config opts back out to the duplex path.
+	if tripleConf != nil {
+		if tripleConf.UnaryFastPath {
+			cliOpts = append(cliOpts, tri.WithUnaryFastPath())
+		} else {
+			cliOpts = append(cliOpts, tri.WithoutUnaryFastPath())
+		}
 	}
 
 	// Build the HTTP transport used by the Triple client.

--- a/protocol/triple/client.go
+++ b/protocol/triple/client.go
@@ -181,8 +181,19 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 	}
 	cliOpts = append(cliOpts, clientKeepAliveOpts...)
 
+	// Optionally enable the unary fast path, off by default.
+	if tripleConf != nil && tripleConf.UnaryFastPath {
+		cliOpts = append(cliOpts, tri.WithUnaryFastPath())
+	}
+
 	// Build the HTTP transport used by the Triple client.
 	var transport http.RoundTripper
+
+	// Always select the Triple protocol explicitly, regardless of the HTTP
+	// transport variant. The triple_protocol.Client defaults to the gRPC
+	// protocol; without this option the unary fast path (and Triple-specific
+	// behavior) would never be reachable.
+	cliOpts = append(cliOpts, tri.WithTriple())
 
 	var callProtocol string
 	if tripleConf != nil && tripleConf.Http3 != nil && tripleConf.Http3.Enable {
@@ -199,7 +210,6 @@ func newClientManager(url *common.URL) (*clientManager, error) {
 		transport = &http.Transport{
 			TLSClientConfig: cfg,
 		}
-		cliOpts = append(cliOpts, tri.WithTriple())
 	case constant.CallHTTP2:
 		// HTTP/2 transport only configures keepalive (ReadIdleTimeout/PingTimeout) and TLS;
 		// All other knobs keep the http2.Transport defaults.

--- a/protocol/triple/triple_protocol/client.go
+++ b/protocol/triple/triple_protocol/client.go
@@ -243,7 +243,9 @@ func newClientConfig(rawURL string, options []ClientOption) (*clientConfig, *Err
 	config := clientConfig{
 		URL: url,
 		// use gRPC by default
-		Protocol:         &protocolGRPC{},
+		Protocol: &protocolGRPC{},
+		// the unary fast path is on by default
+		UnaryFastPath:    true,
 		Procedure:        protoPath,
 		CompressionPools: make(map[string]*compressionPool),
 		BufferPool:       newBufferPool(),

--- a/protocol/triple/triple_protocol/client.go
+++ b/protocol/triple/triple_protocol/client.go
@@ -69,6 +69,7 @@ func NewClient(httpClient HTTPClient, url string, options ...ClientOption) *Clie
 			ReadMaxBytes:     config.ReadMaxBytes,
 			SendMaxBytes:     config.SendMaxBytes,
 			GetURLMaxBytes:   config.GetURLMaxBytes,
+			UnaryFastPath:    config.UnaryFastPath,
 		},
 	)
 	if protocolErr != nil {
@@ -230,6 +231,7 @@ type clientConfig struct {
 	Timeout                time.Duration
 	Group                  string
 	Version                string
+	UnaryFastPath          bool
 }
 
 func newClientConfig(rawURL string, options []ClientOption) (*clientConfig, *Error) {

--- a/protocol/triple/triple_protocol/option.go
+++ b/protocol/triple/triple_protocol/option.go
@@ -73,6 +73,13 @@ func WithTriple() ClientOption {
 // WithUnaryFastPath explicitly enables the unary fast path (unaryFastPathCall)
 // for unary calls. The fast path is on by default; this option is provided for
 // callers that want to state the intent explicitly.
+//
+// This optimization primarily targets small, CPU-dominated unary requests,
+// roughly in the 128 B to 32 KiB range: the complete request body is
+// buffered before it is submitted to the transport. For large or highly
+// concurrent requests, memory residency and buffer growth may increase, and
+// the performance benefit is not guaranteed. The implementation does not
+// automatically fall back based on payload size.
 func WithUnaryFastPath() ClientOption {
 	return &unaryFastPathOption{}
 }

--- a/protocol/triple/triple_protocol/option.go
+++ b/protocol/triple/triple_protocol/option.go
@@ -70,6 +70,18 @@ func WithTriple() ClientOption {
 	return &tripleOption{}
 }
 
+// WithUnaryFastPath enables the unary fast path (unaryFastPathCall) for unary
+// calls, off by default.
+func WithUnaryFastPath() ClientOption {
+	return &unaryFastPathOption{}
+}
+
+type unaryFastPathOption struct{}
+
+func (o *unaryFastPathOption) applyToClient(config *clientConfig) {
+	config.UnaryFastPath = true
+}
+
 // WithProtoJSON configures a client to send JSON-encoded data instead of
 // binary Protobuf. It uses the standard Protobuf JSON mapping as implemented
 // by [google.golang.org/protobuf/encoding/protojson]: fields are named using

--- a/protocol/triple/triple_protocol/option.go
+++ b/protocol/triple/triple_protocol/option.go
@@ -70,8 +70,9 @@ func WithTriple() ClientOption {
 	return &tripleOption{}
 }
 
-// WithUnaryFastPath enables the unary fast path (unaryFastPathCall) for unary
-// calls, off by default.
+// WithUnaryFastPath explicitly enables the unary fast path (unaryFastPathCall)
+// for unary calls. The fast path is on by default; this option is provided for
+// callers that want to state the intent explicitly.
 func WithUnaryFastPath() ClientOption {
 	return &unaryFastPathOption{}
 }
@@ -80,6 +81,19 @@ type unaryFastPathOption struct{}
 
 func (o *unaryFastPathOption) applyToClient(config *clientConfig) {
 	config.UnaryFastPath = true
+}
+
+// WithoutUnaryFastPath disables the unary fast path (unaryFastPathCall) for
+// unary calls, falling back to the duplex (io.Pipe) call path. Use it as a
+// rollback switch when the fast path misbehaves under a specific workload.
+func WithoutUnaryFastPath() ClientOption {
+	return &withoutUnaryFastPathOption{}
+}
+
+type withoutUnaryFastPathOption struct{}
+
+func (o *withoutUnaryFastPathOption) applyToClient(config *clientConfig) {
+	config.UnaryFastPath = false
 }
 
 // WithProtoJSON configures a client to send JSON-encoded data instead of

--- a/protocol/triple/triple_protocol/protocol.go
+++ b/protocol/triple/triple_protocol/protocol.go
@@ -129,6 +129,9 @@ type protocolClientParams struct {
 	EnableGet        bool
 	GetURLMaxBytes   int
 	GetUseFallback   bool
+	// UnaryFastPath enables the unary fast path (unaryFastPathCall) for unary
+	// calls. It is off by default so the duplex path remains the baseline.
+	UnaryFastPath bool
 	// The gRPC family of protocols always needs access to a Protobuf codec to
 	// marshal and unmarshal errors.
 	Protobuf Codec

--- a/protocol/triple/triple_protocol/protocol.go
+++ b/protocol/triple/triple_protocol/protocol.go
@@ -130,7 +130,7 @@ type protocolClientParams struct {
 	GetURLMaxBytes   int
 	GetUseFallback   bool
 	// UnaryFastPath enables the unary fast path (unaryFastPathCall) for unary
-	// calls. It is off by default so the duplex path remains the baseline.
+	// calls. It is on by default; disable it to fall back to the duplex path.
 	UnaryFastPath bool
 	// The gRPC family of protocols always needs access to a Protobuf codec to
 	// marshal and unmarshal errors.

--- a/protocol/triple/triple_protocol/protocol_grpc.go
+++ b/protocol/triple/triple_protocol/protocol_grpc.go
@@ -280,23 +280,31 @@ func (g *grpcClient) NewConn(
 			header[grpcHeaderTimeout] = []string{encodedDeadline}
 		}
 	}
-	duplexCall := newDuplexHTTPCall(
-		ctx,
-		g.HTTPClient,
-		g.URL,
-		spec,
-		header,
-	)
+	var call unaryClientCall
+	if spec.StreamType == StreamTypeUnary && g.UnaryFastPath {
+		// Unary fast path: no io.Pipe, no per-request goroutine. Streaming
+		// calls always keep using duplexHTTPCall.
+		call = newUnaryFastPathCall(
+			ctx,
+			g.HTTPClient,
+			g.URL,
+			spec,
+			header,
+			g.BufferPool,
+		)
+	} else {
+		call = newDuplexHTTPCall(ctx, g.HTTPClient, g.URL, spec, header)
+	}
 	conn := &grpcClientConn{
 		spec:             spec,
 		peer:             g.Peer(),
-		duplexCall:       duplexCall,
+		call:             call,
 		compressionPools: g.CompressionPools,
 		bufferPool:       g.BufferPool,
 		protobuf:         g.Protobuf,
 		marshaler: grpcMarshaler{
 			envelopeWriter: envelopeWriter{
-				writer:           duplexCall,
+				writer:           call,
 				compressionPool:  g.CompressionPools.Get(g.CompressionName),
 				codec:            g.Codec,
 				compressMinBytes: g.CompressMinBytes,
@@ -306,7 +314,7 @@ func (g *grpcClient) NewConn(
 		},
 		unmarshaler: grpcUnmarshaler{
 			envelopeReader: envelopeReader{
-				reader:       duplexCall,
+				reader:       call,
 				codec:        g.Codec,
 				bufferPool:   g.BufferPool,
 				readMaxBytes: g.ReadMaxBytes,
@@ -315,8 +323,8 @@ func (g *grpcClient) NewConn(
 		responseHeader:  make(http.Header),
 		responseTrailer: make(http.Header),
 	}
-	duplexCall.SetValidateResponse(conn.validateResponse)
-	conn.readTrailers = func(_ *grpcUnmarshaler, call *duplexHTTPCall) http.Header {
+	call.SetValidateResponse(conn.validateResponse)
+	conn.readTrailers = func(_ *grpcUnmarshaler, call unaryClientCall) http.Header {
 		// To access HTTP trailers, we need to read the body to EOF.
 		_ = discard(call)
 		return call.ResponseTrailer()
@@ -328,7 +336,7 @@ func (g *grpcClient) NewConn(
 type grpcClientConn struct {
 	spec             Spec
 	peer             Peer
-	duplexCall       *duplexHTTPCall
+	call             unaryClientCall
 	compressionPools readOnlyCompressionPools
 	bufferPool       *bufferPool
 	protobuf         Codec // for errors
@@ -336,7 +344,7 @@ type grpcClientConn struct {
 	unmarshaler      grpcUnmarshaler
 	responseHeader   http.Header
 	responseTrailer  http.Header
-	readTrailers     func(*grpcUnmarshaler, *duplexHTTPCall) http.Header
+	readTrailers     func(*grpcUnmarshaler, unaryClientCall) http.Header
 }
 
 func (cc *grpcClientConn) Spec() Spec {
@@ -355,15 +363,15 @@ func (cc *grpcClientConn) Send(msg any) error {
 }
 
 func (cc *grpcClientConn) RequestHeader() http.Header {
-	return cc.duplexCall.Header()
+	return cc.call.Header()
 }
 
 func (cc *grpcClientConn) CloseRequest() error {
-	return cc.duplexCall.CloseWrite()
+	return cc.call.CloseWrite()
 }
 
 func (cc *grpcClientConn) Receive(msg any) error {
-	cc.duplexCall.BlockUntilResponseReady()
+	cc.call.BlockUntilResponseReady()
 	err := cc.unmarshaler.Unmarshal(msg)
 	if err == nil {
 		return nil
@@ -377,7 +385,7 @@ func (cc *grpcClientConn) Receive(msg any) error {
 	// See if the server sent an explicit error in the HTTP or gRPC-Web trailers.
 	mergeHeaders(
 		cc.responseTrailer,
-		cc.readTrailers(&cc.unmarshaler, cc.duplexCall),
+		cc.readTrailers(&cc.unmarshaler, cc.call),
 	)
 	serverErr := grpcErrorFromTrailer(cc.bufferPool, cc.protobuf, cc.responseTrailer)
 	if serverErr != nil && (errors.Is(err, io.EOF) || !errors.Is(serverErr, errTrailersWithoutGRPCStatus)) {
@@ -391,33 +399,33 @@ func (cc *grpcClientConn) Receive(msg any) error {
 		// the stream has ended, Receive must return an error.
 		serverErr.meta = cc.responseHeader.Clone()
 		mergeHeaders(serverErr.meta, cc.responseTrailer)
-		cc.duplexCall.SetError(serverErr)
+		cc.call.SetError(serverErr)
 		return serverErr
 	}
 	// This was probably an error converting the bytes to a message or an error
 	// reading from the network. We're going to return it to the
 	// user, but we also want to setResponseError so Send errors out.
-	cc.duplexCall.SetError(err)
+	cc.call.SetError(err)
 	return err
 }
 
 func (cc *grpcClientConn) ResponseHeader() http.Header {
-	cc.duplexCall.BlockUntilResponseReady()
+	cc.call.BlockUntilResponseReady()
 	return cc.responseHeader
 }
 
 func (cc *grpcClientConn) ResponseTrailer() http.Header {
-	cc.duplexCall.BlockUntilResponseReady()
+	cc.call.BlockUntilResponseReady()
 	return cc.responseTrailer
 }
 
 func (cc *grpcClientConn) CloseResponse() error {
-	err := cc.duplexCall.CloseRead()
+	err := cc.call.CloseRead()
 	if err != nil {
 		return err
 	}
-	if cc.duplexCall.response != nil && cc.duplexCall.response.Trailer != nil {
-		cc.responseTrailer = cc.duplexCall.response.Trailer.Clone()
+	if trailer := cc.call.ResponseTrailer(); len(trailer) > 0 {
+		cc.responseTrailer = trailer.Clone()
 	}
 	return nil
 }

--- a/protocol/triple/triple_protocol/protocol_triple.go
+++ b/protocol/triple/triple_protocol/protocol_triple.go
@@ -266,8 +266,8 @@ func (c *tripleClient) NewConn(
 	}
 	var call unaryClientCall
 	if spec.StreamType == StreamTypeUnary && c.UnaryFastPath {
-		// Unary fast path: no io.Pipe, no per-request goroutine; on by
-		// default, streaming calls always keep using duplexHTTPCall.
+		// Unary fast path: no io.Pipe, no per-request goroutine. Streaming
+		// calls always keep using duplexHTTPCall.
 		call = newUnaryFastPathCall(ctx, c.HTTPClient, c.URL, spec, header, c.BufferPool)
 	} else {
 		call = newDuplexHTTPCall(ctx, c.HTTPClient, c.URL, spec, header)

--- a/protocol/triple/triple_protocol/protocol_triple.go
+++ b/protocol/triple/triple_protocol/protocol_triple.go
@@ -266,7 +266,7 @@ func (c *tripleClient) NewConn(
 	}
 	var call unaryClientCall
 	if spec.StreamType == StreamTypeUnary && c.UnaryFastPath {
-		// Unary fast path: no io.Pipe, no per-request goroutine; off by
+		// Unary fast path: no io.Pipe, no per-request goroutine; on by
 		// default, streaming calls always keep using duplexHTTPCall.
 		call = newUnaryFastPathCall(ctx, c.HTTPClient, c.URL, spec, header, c.BufferPool)
 	} else {

--- a/protocol/triple/triple_protocol/protocol_triple.go
+++ b/protocol/triple/triple_protocol/protocol_triple.go
@@ -264,27 +264,34 @@ func (c *tripleClient) NewConn(
 			} // else effectively unbounded
 		}
 	}
-	duplexCall := newDuplexHTTPCall(ctx, c.HTTPClient, c.URL, spec, header)
+	var call unaryClientCall
+	if spec.StreamType == StreamTypeUnary && c.UnaryFastPath {
+		// Unary fast path: no io.Pipe, no per-request goroutine; off by
+		// default, streaming calls always keep using duplexHTTPCall.
+		call = newUnaryFastPathCall(ctx, c.HTTPClient, c.URL, spec, header, c.BufferPool)
+	} else {
+		call = newDuplexHTTPCall(ctx, c.HTTPClient, c.URL, spec, header)
+	}
 	unaryConn := &tripleUnaryClientConn{
 		spec:             spec,
 		peer:             c.Peer(),
-		duplexCall:       duplexCall,
+		call:             call,
 		compressionPools: c.CompressionPools,
 		bufferPool:       c.BufferPool,
 		marshaler: tripleUnaryRequestMarshaler{
 			tripleUnaryMarshaler: tripleUnaryMarshaler{
-				writer:           duplexCall,
+				writer:           call,
 				codec:            c.Codec,
 				compressMinBytes: c.CompressMinBytes,
 				compressionName:  c.CompressionName,
 				compressionPool:  c.CompressionPools.Get(c.CompressionName),
 				bufferPool:       c.BufferPool,
-				header:           duplexCall.Header(),
+				header:           call.Header(),
 				sendMaxBytes:     c.SendMaxBytes,
 			},
 		},
 		unmarshaler: tripleUnaryUnmarshaler{
-			reader:       duplexCall,
+			reader:       call,
 			codec:        c.Codec,
 			bufferPool:   c.BufferPool,
 			readMaxBytes: c.ReadMaxBytes,
@@ -292,14 +299,14 @@ func (c *tripleClient) NewConn(
 		responseHeader:  make(http.Header),
 		responseTrailer: make(http.Header),
 	}
-	duplexCall.SetValidateResponse(unaryConn.validateResponse)
+	call.SetValidateResponse(unaryConn.validateResponse)
 	return wrapClientConnWithCodedErrors(unaryConn)
 }
 
 type tripleUnaryClientConn struct {
 	spec             Spec
 	peer             Peer
-	duplexCall       *duplexHTTPCall
+	call             unaryClientCall
 	compressionPools readOnlyCompressionPools
 	bufferPool       *bufferPool
 	marshaler        tripleUnaryRequestMarshaler
@@ -324,15 +331,15 @@ func (cc *tripleUnaryClientConn) Send(msg any) error {
 }
 
 func (cc *tripleUnaryClientConn) RequestHeader() http.Header {
-	return cc.duplexCall.Header()
+	return cc.call.Header()
 }
 
 func (cc *tripleUnaryClientConn) CloseRequest() error {
-	return cc.duplexCall.CloseWrite()
+	return cc.call.CloseWrite()
 }
 
 func (cc *tripleUnaryClientConn) Receive(msg any) error {
-	cc.duplexCall.BlockUntilResponseReady()
+	cc.call.BlockUntilResponseReady()
 	if err := cc.unmarshaler.Unmarshal(msg); err != nil {
 		return err
 	}
@@ -340,17 +347,17 @@ func (cc *tripleUnaryClientConn) Receive(msg any) error {
 }
 
 func (cc *tripleUnaryClientConn) ResponseHeader() http.Header {
-	cc.duplexCall.BlockUntilResponseReady()
+	cc.call.BlockUntilResponseReady()
 	return cc.responseHeader
 }
 
 func (cc *tripleUnaryClientConn) ResponseTrailer() http.Header {
-	cc.duplexCall.BlockUntilResponseReady()
+	cc.call.BlockUntilResponseReady()
 	return cc.responseTrailer
 }
 
 func (cc *tripleUnaryClientConn) CloseResponse() error {
-	return cc.duplexCall.CloseRead()
+	return cc.call.CloseRead()
 }
 
 func (cc *tripleUnaryClientConn) validateResponse(response *http.Response) *Error {

--- a/protocol/triple/triple_protocol/unary_fastpath.go
+++ b/protocol/triple/triple_protocol/unary_fastpath.go
@@ -52,6 +52,13 @@ var (
 // unary hot path. Write accumulates the marshaled payload into a pooled
 // buffer; CloseWrite issues the request synchronously (no io.Pipe, no
 // per-request goroutine).
+//
+// This optimization primarily targets small, CPU-dominated unary requests,
+// roughly in the 128 B to 32 KiB range: the complete request body is
+// buffered before it is submitted to the transport. For large or highly
+// concurrent requests, memory residency and buffer growth may increase, and
+// the performance benefit is not guaranteed. The implementation does not
+// automatically fall back based on payload size.
 type unaryFastPathCall struct {
 	ctx              context.Context
 	httpClient       HTTPClient

--- a/protocol/triple/triple_protocol/unary_fastpath.go
+++ b/protocol/triple/triple_protocol/unary_fastpath.go
@@ -27,9 +27,9 @@ import (
 	"sync"
 )
 
-// unaryClientCall is the subset of *duplexHTTPCall that tripleUnaryClientConn
-// depends on. unary calls use unaryFastPathCall; streaming calls keep using
-// duplexHTTPCall.
+// unaryClientCall is the transport surface shared by grpcClientConn and
+// tripleUnaryClientConn. unary calls use unaryFastPathCall; streaming calls
+// keep using duplexHTTPCall.
 type unaryClientCall interface {
 	io.Writer
 	io.Reader
@@ -42,7 +42,7 @@ type unaryClientCall interface {
 	ResponseTrailer() http.Header
 }
 
-// Both the original and the fast path must satisfy the interface.
+// Both duplexHTTPCall and unaryFastPathCall satisfy the interface.
 var (
 	_ unaryClientCall = (*duplexHTTPCall)(nil)
 	_ unaryClientCall = (*unaryFastPathCall)(nil)
@@ -117,8 +117,8 @@ func (c *unaryFastPathCall) Write(data []byte) (int, error) {
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
 	if c.bodySent {
-		// A racing CloseWrite already handed the body to the transport;
-		// writing now would race with its background read. Mirror
+		// A racing CloseWrite already handed the body to the transport; a
+		// write now could race with the transport reading it. Mirror
 		// duplexHTTPCall.Write, which returns io.EOF once the pipe is closed.
 		return 0, io.EOF
 	}
@@ -130,11 +130,9 @@ func (c *unaryFastPathCall) Write(data []byte) (int, error) {
 		return 0, wrapIfContextError(err)
 	}
 	if len(data) == 0 {
-		// Empty payloads (Send(nil), an empty protobuf message, or an
-		// explicit zero-length Write) must not pull a buffer out of the pool:
-		// makeRequest hands http.NoBody to the transport for a zero-length
-		// body, so the buffer would never be returned via
-		// unaryRequestBody.Close. Skip the pool entirely and keep c.body nil.
+		// Empty writes must not pull a buffer from the pool: a zero-length
+		// body is sent as http.NoBody, so the buffer would never be
+		// returned via unaryRequestBody.Close.
 		return 0, nil
 	}
 	if c.body == nil {
@@ -190,8 +188,8 @@ func (b *unaryRequestBody) Close() error {
 // unaryRequestBody.Close, which x/net/http2 calls after it stops reading.
 func (c *unaryFastPathCall) makeRequest() {
 	defer close(c.responseReady)
-	// O3: advertise Content-Length so the server can pre-size its http2 data
-	// buffer; empty payloads use NoBody and skip the background body writer.
+	// Advertise Content-Length so the server can pre-size its HTTP/2 data
+	// buffer; empty payloads use http.NoBody.
 	var bodyLen int
 	if c.body != nil {
 		bodyLen = c.body.Len()
@@ -200,8 +198,7 @@ func (c *unaryFastPathCall) makeRequest() {
 		} else {
 			// Zero-length body: no transport read will ever happen, so
 			// unaryRequestBody.Close can't return the buffer to the pool.
-			// Recycle it now (belt and braces with the zero-length Write
-			// short-circuit above).
+			// Recycle it here instead.
 			c.bufferPool.Put(c.body)
 			c.body = nil
 			c.request.Body = http.NoBody

--- a/protocol/triple/triple_protocol/unary_fastpath.go
+++ b/protocol/triple/triple_protocol/unary_fastpath.go
@@ -129,6 +129,14 @@ func (c *unaryFastPathCall) Write(data []byte) (int, error) {
 		c.SetError(err)
 		return 0, wrapIfContextError(err)
 	}
+	if len(data) == 0 {
+		// Empty payloads (Send(nil), an empty protobuf message, or an
+		// explicit zero-length Write) must not pull a buffer out of the pool:
+		// makeRequest hands http.NoBody to the transport for a zero-length
+		// body, so the buffer would never be returned via
+		// unaryRequestBody.Close. Skip the pool entirely and keep c.body nil.
+		return 0, nil
+	}
 	if c.body == nil {
 		c.body = c.bufferPool.Get()
 	}
@@ -190,6 +198,12 @@ func (c *unaryFastPathCall) makeRequest() {
 		if bodyLen > 0 {
 			c.request.Body = &unaryRequestBody{buf: c.body, pool: c.bufferPool}
 		} else {
+			// Zero-length body: no transport read will ever happen, so
+			// unaryRequestBody.Close can't return the buffer to the pool.
+			// Recycle it now (belt and braces with the zero-length Write
+			// short-circuit above).
+			c.bufferPool.Put(c.body)
+			c.body = nil
 			c.request.Body = http.NoBody
 		}
 	} else {

--- a/protocol/triple/triple_protocol/unary_fastpath.go
+++ b/protocol/triple/triple_protocol/unary_fastpath.go
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package triple_protocol
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+)
+
+// unaryClientCall is the subset of *duplexHTTPCall that tripleUnaryClientConn
+// depends on. unary calls use unaryFastPathCall; streaming calls keep using
+// duplexHTTPCall.
+type unaryClientCall interface {
+	io.Writer
+	io.Reader
+	Header() http.Header
+	CloseWrite() error
+	CloseRead() error
+	BlockUntilResponseReady()
+	SetValidateResponse(func(*http.Response) *Error)
+	SetError(error)
+	ResponseTrailer() http.Header
+}
+
+// Both the original and the fast path must satisfy the interface.
+var (
+	_ unaryClientCall = (*duplexHTTPCall)(nil)
+	_ unaryClientCall = (*unaryFastPathCall)(nil)
+)
+
+// unaryFastPathCall is a synchronous replacement for duplexHTTPCall on the
+// unary hot path. Write accumulates the marshaled payload into a pooled
+// buffer; CloseWrite issues the request synchronously (no io.Pipe, no
+// per-request goroutine).
+type unaryFastPathCall struct {
+	ctx              context.Context
+	httpClient       HTTPClient
+	request          *http.Request
+	bufferPool       *bufferPool
+	validateResponse func(*http.Response) *Error
+
+	// writeMu serializes Write against CloseWrite. StreamingClientConn's
+	// contract requires Send and CloseRequest to be safe to call concurrently;
+	// CloseWrite runs makeRequest synchronously under this lock.
+	writeMu sync.Mutex
+
+	// body accumulates the marshaled payload between Write and CloseWrite.
+	body *bytes.Buffer
+
+	// bodySent is set once makeRequest hands the body to the transport; a
+	// later Write then returns io.EOF instead of racing with the transport.
+	bodySent bool
+
+	errMu sync.Mutex
+	err   error
+
+	response      *http.Response
+	responseReady chan struct{}
+
+	sendOnce sync.Once
+}
+
+func newUnaryFastPathCall(
+	ctx context.Context,
+	httpClient HTTPClient,
+	url *url.URL,
+	spec Spec,
+	header http.Header,
+	bufferPool *bufferPool,
+) *unaryFastPathCall {
+	// Clone the URL so a transport we don't control can't mutate the caller's,
+	// then bind the concrete RPC path.
+	url = cloneURL(url)
+	url.Path = spec.Procedure
+	url.RawPath = ""
+	request := (&http.Request{
+		Method:     http.MethodPost,
+		URL:        url,
+		Header:     header,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Host:       url.Host,
+	}).WithContext(ctx)
+	return &unaryFastPathCall{
+		ctx:           ctx,
+		httpClient:    httpClient,
+		request:       request,
+		bufferPool:    bufferPool,
+		responseReady: make(chan struct{}),
+	}
+}
+
+// Write accumulates the request payload into the pooled body buffer. Unlike
+// duplexHTTPCall.Write it never touches the network.
+func (c *unaryFastPathCall) Write(data []byte) (int, error) {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	if c.bodySent {
+		// A racing CloseWrite already handed the body to the transport;
+		// writing now would race with its background read. Mirror
+		// duplexHTTPCall.Write, which returns io.EOF once the pipe is closed.
+		return 0, io.EOF
+	}
+	if err := c.getError(); err != nil {
+		return 0, err
+	}
+	if err := c.ctx.Err(); err != nil {
+		c.SetError(err)
+		return 0, wrapIfContextError(err)
+	}
+	if c.body == nil {
+		c.body = c.bufferPool.Get()
+	}
+	return c.body.Write(data)
+}
+
+// CloseWrite issues the request once the body is complete. Failures are
+// stored via SetError and surface from Read. Runs under writeMu so it never
+// sees a body being appended concurrently.
+func (c *unaryFastPathCall) CloseWrite() error {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+	c.sendOnce.Do(func() {
+		c.makeRequest()
+	})
+	return nil
+}
+
+// unaryRequestBody is an io.ReadCloser over the pooled request buffer with no
+// extra allocation. The buffer is returned to the pool from Close, which
+// x/net/http2 invokes exactly once after it stops reading the body. Read and
+// Close are guarded by a mutex so an aborted-write Close can never race with
+// an in-flight Read.
+type unaryRequestBody struct {
+	mu   sync.Mutex
+	buf  *bytes.Buffer
+	pool *bufferPool
+}
+
+func (b *unaryRequestBody) Read(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.buf == nil {
+		return 0, io.EOF
+	}
+	return b.buf.Read(p)
+}
+
+func (b *unaryRequestBody) Close() error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.buf != nil {
+		b.pool.Put(b.buf)
+		b.buf = nil
+	}
+	return nil
+}
+
+// makeRequest issues the HTTP request with the same error wrapping chain as
+// duplexHTTPCall. The request body buffer is returned to the pool from
+// unaryRequestBody.Close, which x/net/http2 calls after it stops reading.
+func (c *unaryFastPathCall) makeRequest() {
+	defer close(c.responseReady)
+	// O3: advertise Content-Length so the server can pre-size its http2 data
+	// buffer; empty payloads use NoBody and skip the background body writer.
+	var bodyLen int
+	if c.body != nil {
+		bodyLen = c.body.Len()
+		if bodyLen > 0 {
+			c.request.Body = &unaryRequestBody{buf: c.body, pool: c.bufferPool}
+		} else {
+			c.request.Body = http.NoBody
+		}
+	} else {
+		c.request.Body = http.NoBody
+	}
+	c.bodySent = true
+	c.request.ContentLength = int64(bodyLen)
+	response, err := c.httpClient.Do(c.request) //nolint:bodyclose
+	if err != nil {
+		err = wrapIfContextError(err)
+		err = wrapIfLikelyH2CNotConfiguredError(c.request, err)
+		err = wrapIfLikelyWithGRPCNotUsedError(err)
+		err = wrapIfRSTError(err)
+		if _, ok := asError(err); !ok {
+			err = NewError(CodeUnavailable, err)
+		}
+		c.SetError(err)
+		return
+	}
+	c.response = response
+	if err := c.validateResponse(response); err != nil {
+		// Leave the response body open for CloseRead: callers may still read
+		// the error body, and CloseResponse is the single close point.
+		c.SetError(err)
+	}
+}
+
+// Read reads the response body. BlockUntilResponseReady is already resolved
+// by the time Read is called.
+func (c *unaryFastPathCall) Read(data []byte) (int, error) {
+	c.BlockUntilResponseReady()
+	if err := c.getError(); err != nil {
+		return 0, err
+	}
+	if err := c.ctx.Err(); err != nil {
+		c.SetError(err)
+		return 0, wrapIfContextError(err)
+	}
+	if c.response == nil {
+		return 0, fmt.Errorf("nil response from %v", c.request.URL)
+	}
+	n, err := c.response.Body.Read(data)
+	return n, wrapIfRSTError(err)
+}
+
+// CloseRead closes the response body. The request body buffer is recycled by
+// unaryRequestBody.Close, not here.
+func (c *unaryFastPathCall) CloseRead() error {
+	c.BlockUntilResponseReady()
+	if c.response == nil {
+		return nil
+	}
+	return wrapIfRSTError(c.response.Body.Close())
+}
+
+// Header returns the HTTP request headers.
+func (c *unaryFastPathCall) Header() http.Header {
+	return c.request.Header
+}
+
+// SetValidateResponse sets the response validation function.
+func (c *unaryFastPathCall) SetValidateResponse(validate func(*http.Response) *Error) {
+	c.validateResponse = validate
+}
+
+// BlockUntilResponseReady blocks until the response is available. The fast
+// path resolves it synchronously inside CloseWrite.
+func (c *unaryFastPathCall) BlockUntilResponseReady() {
+	<-c.responseReady
+}
+
+// SetError stores the first error encountered; safe for concurrent use.
+func (c *unaryFastPathCall) SetError(err error) {
+	c.errMu.Lock()
+	defer c.errMu.Unlock()
+	if c.err == nil {
+		c.err = wrapIfContextError(err)
+	}
+}
+
+// ResponseTrailer returns the response HTTP trailers.
+func (c *unaryFastPathCall) ResponseTrailer() http.Header {
+	c.BlockUntilResponseReady()
+	if c.response != nil {
+		return c.response.Trailer
+	}
+	return make(http.Header)
+}
+
+func (c *unaryFastPathCall) getError() error {
+	c.errMu.Lock()
+	defer c.errMu.Unlock()
+	return c.err
+}

--- a/protocol/triple/triple_protocol/unary_fastpath_behavior_test.go
+++ b/protocol/triple/triple_protocol/unary_fastpath_behavior_test.go
@@ -553,10 +553,10 @@ func TestUnaryFastPathProtoJSONCodec(t *testing.T) {
 	}
 }
 
-// TestUnaryFastPathGRPCKeepsDuplex verifies that the fast path switch never
-// routes gRPC protocol calls: gRPC keeps using duplexHTTPCall even when the
-// switch is enabled, so its behavior is preserved.
-func TestUnaryFastPathGRPCKeepsDuplex(t *testing.T) {
+// TestUnaryFastPathGRPCRoutesUnary verifies that grpcClient.NewConn routes
+// unary calls through unaryFastPathCall when the switch is enabled and keeps
+// duplexHTTPCall otherwise; streaming calls always use duplexHTTPCall.
+func TestUnaryFastPathGRPCRoutesUnary(t *testing.T) {
 	newClient := func(fast bool) *grpcClient {
 		return &grpcClient{
 			protocolClientParams: protocolClientParams{
@@ -570,31 +570,37 @@ func TestUnaryFastPathGRPCKeepsDuplex(t *testing.T) {
 			peer: Peer{},
 		}
 	}
-	unarySpec := Spec{StreamType: StreamTypeUnary, Procedure: "/connect.ping.v1.PingService/Ping"}
-	streamSpec := Spec{StreamType: StreamTypeBidi, Procedure: "/connect.ping.v1.PingService/Ping"}
-
-	for _, tc := range []struct {
-		name string
-		fast bool
-		spec Spec
-	}{
-		{"enabled", true, unarySpec},
-		{"disabled", false, unarySpec},
-		{"enabled-streaming", true, streamSpec},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			conn := newClient(tc.fast).NewConn(context.Background(), tc.spec, make(http.Header))
-			translated, ok := conn.(*errorTranslatingClientConn)
-			if !ok {
-				t.Fatalf("unexpected conn wrapper %T", conn)
+	assertCallType := func(t *testing.T, conn StreamingClientConn, want string) {
+		t.Helper()
+		translated, ok := conn.(*errorTranslatingClientConn)
+		if !ok {
+			t.Fatalf("unexpected conn wrapper %T", conn)
+		}
+		grpcConn, ok := translated.StreamingClientConn.(*grpcClientConn)
+		if !ok {
+			t.Fatalf("unexpected grpc conn %T", translated.StreamingClientConn)
+		}
+		switch want {
+		case "fastpath":
+			if _, ok := grpcConn.call.(*unaryFastPathCall); !ok {
+				t.Fatalf("grpc call type = %T, want *unaryFastPathCall", grpcConn.call)
 			}
-			grpcConn, ok := translated.StreamingClientConn.(*grpcClientConn)
-			if !ok {
-				t.Fatalf("unexpected grpc conn %T", translated.StreamingClientConn)
+		case "duplex":
+			if _, ok := grpcConn.call.(*duplexHTTPCall); !ok {
+				t.Fatalf("grpc call type = %T, want *duplexHTTPCall", grpcConn.call)
 			}
-			if _, ok := any(grpcConn.duplexCall).(*duplexHTTPCall); !ok {
-				t.Fatalf("grpc call type = %T, want *duplexHTTPCall", grpcConn.duplexCall)
-			}
-		})
+		default:
+			// Guard against a misspelled want string silently passing.
+			t.Fatalf("assertCallType: unknown want %q", want)
+		}
 	}
+
+	unarySpec := Spec{StreamType: StreamTypeUnary, Procedure: "/connect.ping.v1.PingService/Ping"}
+	// Enabled -> unary calls take the fast path on the gRPC protocol too.
+	assertCallType(t, newClient(true).NewConn(context.Background(), unarySpec, make(http.Header)), "fastpath")
+	// Disabled -> unary calls keep using duplexHTTPCall.
+	assertCallType(t, newClient(false).NewConn(context.Background(), unarySpec, make(http.Header)), "duplex")
+	// Streaming calls always use duplexHTTPCall, regardless of the switch.
+	streamSpec := Spec{StreamType: StreamTypeBidi, Procedure: "/connect.ping.v1.PingService/Ping"}
+	assertCallType(t, newClient(true).NewConn(context.Background(), streamSpec, make(http.Header)), "duplex")
 }

--- a/protocol/triple/triple_protocol/unary_fastpath_behavior_test.go
+++ b/protocol/triple/triple_protocol/unary_fastpath_behavior_test.go
@@ -30,7 +30,9 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+)
 
+import (
 	pingv1 "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/ping/v1"
 )
 
@@ -185,8 +187,8 @@ func TestUnaryFastPathEmptyBodyUsesNoBody(t *testing.T) {
 		t.Fatal(err)
 	}
 	var (
-		calls     atomic.Int32
-		sawNoBody bool
+		calls      atomic.Int32
+		sawNoBody  bool
 		contentLen int64
 	)
 	httpClient := &behaviorHTTPClient{do: func(req *http.Request) (*http.Response, error) {
@@ -234,13 +236,13 @@ func TestUnaryFastPathConcurrentReadClose(t *testing.T) {
 	)
 	var wg sync.WaitGroup
 	wg.Add(readers + closers)
-	for i := 0; i < closers; i++ {
+	for range closers {
 		go func() {
 			defer wg.Done()
 			_ = body.Close()
 		}()
 	}
-	for i := 0; i < readers; i++ {
+	for range readers {
 		go func() {
 			defer wg.Done()
 			for {
@@ -265,13 +267,13 @@ func TestUnaryFastPathRequestHeaderConcurrent(t *testing.T) {
 	wg.Add(3)
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 50; i++ {
+		for range 50 {
 			_ = call.Header()
 		}
 	}()
 	go func() {
 		defer wg.Done()
-		for i := 0; i < 50; i++ {
+		for range 50 {
 			_, _ = call.Write([]byte("payload"))
 		}
 	}()

--- a/protocol/triple/triple_protocol/unary_fastpath_behavior_test.go
+++ b/protocol/triple/triple_protocol/unary_fastpath_behavior_test.go
@@ -1,0 +1,598 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package triple_protocol
+
+import (
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	pingv1 "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/ping/v1"
+)
+
+// behaviorHTTPClient adapts a closure to HTTPClient so tests can capture or
+// fake the wire behavior of the fast path.
+type behaviorHTTPClient struct {
+	do func(*http.Request) (*http.Response, error)
+}
+
+func (c *behaviorHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return c.do(req)
+}
+
+// newPingHandler builds a Triple unary handler in-package, avoiding the
+// generated pingv1connect package (which would create an import cycle).
+func newPingHandler() *Handler {
+	return NewUnaryHandler(
+		"/connect.ping.v1.PingService/Ping",
+		func() any { return &pingv1.PingRequest{} },
+		func(ctx context.Context, req *Request) (*Response, error) {
+			pingReq, ok := req.Any().(*pingv1.PingRequest)
+			if !ok {
+				return nil, fmt.Errorf("unexpected request type %T", req.Any())
+			}
+			return NewResponse(&pingv1.PingResponse{Text: pingReq.Text}), nil
+		},
+		WithCompression(
+			compressionGzip,
+			func() Decompressor { return &gzip.Reader{} },
+			func() Compressor { return gzip.NewWriter(io.Discard) },
+		),
+	)
+}
+
+// pingCompressionPools registers gzip so response compression is negotiated,
+// and is shared by the behavior tests to keep the pools warm.
+var pingCompressionPools = newReadOnlyCompressionPools(
+	map[string]*compressionPool{
+		compressionGzip: newCompressionPool(
+			func() Decompressor { return &gzip.Reader{} },
+			func() Compressor { return gzip.NewWriter(io.Discard) },
+		),
+	},
+	[]string{compressionGzip},
+)
+
+// newBehaviorCall constructs an unaryFastPathCall wired to the given client,
+// mirroring tripleClient.NewConn's construction.
+func newBehaviorCall(ctx context.Context, httpClient HTTPClient, serverURL *url.URL, pool *bufferPool) *unaryFastPathCall {
+	call := newUnaryFastPathCall(
+		ctx,
+		httpClient,
+		serverURL,
+		Spec{
+			StreamType: StreamTypeUnary,
+			Procedure:  "/connect.ping.v1.PingService/Ping",
+		},
+		make(http.Header),
+		pool,
+	)
+	call.SetValidateResponse(func(*http.Response) *Error { return nil })
+	return call
+}
+
+// newTripleClientConn constructs a tripleClient and routes the unary call
+// through NewConn, exercising the real production entry point.
+func newTripleClientConn(useFastPath bool, codec Codec, httpClient HTTPClient, serverURL *url.URL, header http.Header, pool *bufferPool) StreamingClientConn {
+	client := &tripleClient{
+		protocolClientParams: protocolClientParams{
+			HTTPClient:       httpClient,
+			URL:              serverURL,
+			BufferPool:       pool,
+			Codec:            codec,
+			CompressionPools: pingCompressionPools,
+			UnaryFastPath:    useFastPath,
+		},
+		peer: Peer{Addr: serverURL.String(), Protocol: ProtocolTriple},
+	}
+	return client.NewConn(context.Background(), Spec{
+		StreamType: StreamTypeUnary,
+		Procedure:  "/connect.ping.v1.PingService/Ping",
+	}, header)
+}
+
+// TestUnaryFastPathWriteAccumulates verifies that Write appends into the
+// pooled body without touching the network, and that CloseWrite hands the
+// whole payload to the transport once, with an exact Content-Length.
+func TestUnaryFastPathWriteAccumulates(t *testing.T) {
+	pool := newBufferPool()
+	serverURL, err := url.Parse("https://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var (
+		calls      atomic.Int32
+		wireBody   []byte
+		contentLen int64
+	)
+	httpClient := &behaviorHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		data, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		if err := req.Body.Close(); err != nil {
+			return nil, err
+		}
+		wireBody = data
+		contentLen = req.ContentLength
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	}}
+
+	call := newBehaviorCall(context.Background(), httpClient, serverURL, pool)
+	if n, err := call.Write([]byte("hello")); n != 5 || err != nil {
+		t.Fatalf("first write = (n=%d, err=%v), want (5, nil)", n, err)
+	}
+	if n, err := call.Write([]byte("-world")); n != 6 || err != nil {
+		t.Fatalf("second write = (n=%d, err=%v), want (6, nil)", n, err)
+	}
+	if err := call.CloseWrite(); err != nil {
+		t.Fatalf("close request: %v", err)
+	}
+	// A second CloseWrite must not dispatch the request again.
+	if err := call.CloseWrite(); err != nil {
+		t.Fatalf("second close request: %v", err)
+	}
+	if err := call.CloseRead(); err != nil {
+		t.Fatalf("close response: %v", err)
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("transport saw %d requests, want 1", got)
+	}
+	if got := string(wireBody); got != "hello-world" {
+		t.Fatalf("wire body = %q, want %q", got, "hello-world")
+	}
+	if contentLen != int64(len("hello-world")) {
+		t.Fatalf("content length = %d, want %d", contentLen, len("hello-world"))
+	}
+}
+
+// TestUnaryFastPathEmptyBodyUsesNoBody verifies that a call with no Write uses
+// http.NoBody and a zero Content-Length, skipping the pooled buffer.
+func TestUnaryFastPathEmptyBodyUsesNoBody(t *testing.T) {
+	pool := newBufferPool()
+	serverURL, err := url.Parse("https://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var (
+		calls     atomic.Int32
+		sawNoBody bool
+		contentLen int64
+	)
+	httpClient := &behaviorHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+		calls.Add(1)
+		sawNoBody = req.Body == http.NoBody
+		contentLen = req.ContentLength
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	}}
+
+	call := newBehaviorCall(context.Background(), httpClient, serverURL, pool)
+	if err := call.CloseWrite(); err != nil {
+		t.Fatalf("close request: %v", err)
+	}
+	if err := call.CloseRead(); err != nil {
+		t.Fatalf("close response: %v", err)
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("transport saw %d requests, want 1", got)
+	}
+	if !sawNoBody {
+		t.Fatal("empty call did not use http.NoBody")
+	}
+	if contentLen != 0 {
+		t.Fatalf("content length = %d, want 0", contentLen)
+	}
+}
+
+// TestUnaryFastPathConcurrentReadClose verifies that a Read racing a Close
+// never panics or reads recycled bytes: both paths are guarded by the body
+// mutex and surface a clean EOF.
+func TestUnaryFastPathConcurrentReadClose(t *testing.T) {
+	pool := newBufferPool()
+	buf := pool.Get()
+	buf.WriteString("payload")
+	body := &unaryRequestBody{buf: buf, pool: pool}
+
+	const (
+		readers = 8
+		closers = 8
+	)
+	var wg sync.WaitGroup
+	wg.Add(readers + closers)
+	for i := 0; i < closers; i++ {
+		go func() {
+			defer wg.Done()
+			_ = body.Close()
+		}()
+	}
+	for i := 0; i < readers; i++ {
+		go func() {
+			defer wg.Done()
+			for {
+				if _, err := body.Read(make([]byte, 4)); err != nil {
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// TestUnaryFastPathRequestHeaderConcurrent verifies that RequestHeader is
+// safe to race with Write and CloseWrite, per the streaming client conn
+// contract's write-side group.
+func TestUnaryFastPathRequestHeaderConcurrent(t *testing.T) {
+	httpClient, serverURL, _, _ := concurrentEchoServer(t)
+	pool := newBufferPool()
+	call := newBehaviorCall(context.Background(), httpClient, serverURL, pool)
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			_ = call.Header()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			_, _ = call.Write([]byte("payload"))
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		_ = call.CloseWrite()
+	}()
+	wg.Wait()
+
+	if call.Header() == nil {
+		t.Fatal("header must remain readable after CloseWrite")
+	}
+	if _, err := io.Copy(io.Discard, call); err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if err := call.CloseRead(); err != nil {
+		t.Fatalf("close response: %v", err)
+	}
+}
+
+// TestUnaryFastPathWriteAfterTransportError verifies that a failed request
+// rejects later writes with io.EOF and Read surfaces the wrapped
+// CodeUnavailable error.
+func TestUnaryFastPathWriteAfterTransportError(t *testing.T) {
+	pool := newBufferPool()
+	serverURL, err := url.Parse("https://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	transportErr := errors.New("transport failed")
+	httpClient := &behaviorHTTPClient{do: func(*http.Request) (*http.Response, error) {
+		return nil, transportErr
+	}}
+
+	call := newBehaviorCall(context.Background(), httpClient, serverURL, pool)
+	if _, writeErr := call.Write([]byte("payload")); writeErr != nil {
+		t.Fatalf("write: %v", writeErr)
+	}
+	if closeErr := call.CloseWrite(); closeErr != nil {
+		t.Fatalf("close request: %v", closeErr)
+	}
+	n, err := call.Write([]byte("late"))
+	if n != 0 || !errors.Is(err, io.EOF) {
+		t.Fatalf("write after transport error = (n=%d, err=%v), want (0, io.EOF)", n, err)
+	}
+	_, err = call.Read(make([]byte, 16))
+	var connErr *Error
+	if !errors.As(err, &connErr) || connErr.Code() != CodeUnavailable {
+		t.Fatalf("read after transport error = %v, want CodeUnavailable", err)
+	}
+}
+
+// TestUnaryFastPathSetErrorRejectsWrite verifies that a stored error rejects
+// writes before the body is sent. Unlike duplexHTTPCall's io.EOF, the fast
+// path surfaces the stored error so the underlying failure stays visible.
+func TestUnaryFastPathSetErrorRejectsWrite(t *testing.T) {
+	pool := newBufferPool()
+	serverURL, err := url.Parse("https://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	httpClient := &behaviorHTTPClient{do: func(*http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	}}
+
+	call := newBehaviorCall(context.Background(), httpClient, serverURL, pool)
+	storedErr := errors.New("stored")
+	call.SetError(storedErr)
+	n, err := call.Write([]byte("payload"))
+	if n != 0 || !errors.Is(err, storedErr) {
+		t.Fatalf("write after SetError = (n=%d, err=%v), want (0, %v)", n, err, storedErr)
+	}
+}
+
+// TestUnaryFastPathWireConsistent verifies that the fast path sends the same
+// request body bytes as the duplex path for the same message.
+func TestUnaryFastPathWireConsistent(t *testing.T) {
+	httpClient, serverURL, bodies, bodiesMu := concurrentEchoServer(t)
+	header := make(http.Header)
+	header.Set(headerContentType, "application/proto")
+	pool := newBufferPool()
+
+	for _, tc := range []struct {
+		name string
+		fast bool
+	}{
+		{"duplex", false},
+		{"fastpath", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := newTripleClientConn(tc.fast, &protoBinaryCodec{}, httpClient, serverURL, header, pool)
+			if err := conn.Send(&pingv1.PingRequest{Text: "wire-consistency"}); err != nil {
+				t.Fatalf("send: %v", err)
+			}
+			if err := conn.CloseRequest(); err != nil {
+				t.Fatalf("close request: %v", err)
+			}
+			// The echo server returns an empty 200 body, which unmarshals
+			// into an empty message; only the request side matters here.
+			if err := conn.Receive(&pingv1.PingResponse{}); err != nil {
+				t.Fatalf("receive: %v", err)
+			}
+			if err := conn.CloseResponse(); err != nil {
+				t.Fatalf("close response: %v", err)
+			}
+		})
+	}
+
+	bodiesMu.Lock()
+	defer bodiesMu.Unlock()
+	if len(*bodies) != 2 {
+		t.Fatalf("server received %d requests, want 2", len(*bodies))
+	}
+	if (*bodies)[0] != (*bodies)[1] {
+		t.Fatalf("wire mismatch: duplex %q vs fastpath %q", (*bodies)[0], (*bodies)[1])
+	}
+}
+
+// TestUnaryFastPathContextCancel verifies that canceling the call context
+// aborts the in-flight request and Read surfaces a CodeCanceled error.
+func TestUnaryFastPathContextCancel(t *testing.T) {
+	pool := newBufferPool()
+	serverURL, err := url.Parse("https://example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	httpClient := &behaviorHTTPClient{do: func(req *http.Request) (*http.Response, error) {
+		<-req.Context().Done()
+		return nil, req.Context().Err()
+	}}
+
+	call := newBehaviorCall(ctx, httpClient, serverURL, pool)
+	if _, writeErr := call.Write([]byte("payload")); writeErr != nil {
+		t.Fatalf("write: %v", writeErr)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = call.CloseWrite()
+	}()
+	cancel()
+	<-done
+	_, err = call.Read(make([]byte, 16))
+	var connErr *Error
+	if !errors.As(err, &connErr) || connErr.Code() != CodeCanceled {
+		t.Fatalf("read after cancel = %v, want CodeCanceled", err)
+	}
+}
+
+// TestUnaryFastPathEndToEnd verifies that the fast path is wire- and
+// response-compatible with the duplex path: same message, headers, and
+// trailers on a real HTTP/2 server.
+func TestUnaryFastPathEndToEnd(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.Handle("/connect.ping.v1.PingService/Ping", NewUnaryHandler(
+		"/connect.ping.v1.PingService/Ping",
+		func() any { return &pingv1.PingRequest{} },
+		func(ctx context.Context, req *Request) (*Response, error) {
+			pingReq, ok := req.Any().(*pingv1.PingRequest)
+			if !ok {
+				return nil, fmt.Errorf("unexpected request type %T", req.Any())
+			}
+			resp := NewResponse(&pingv1.PingResponse{Text: pingReq.Text})
+			resp.Header().Set("X-Triple-Echo", "header")
+			resp.Trailer().Set("X-Triple-Echo-Trailer", "trailer")
+			return resp, nil
+		},
+	))
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	httpClient := server.Client()
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := make(http.Header)
+	header.Set(headerContentType, "application/proto")
+	header.Set(tripleUnaryHeaderAcceptCompression, "gzip")
+	pool := newBufferPool()
+
+	for _, tc := range []struct {
+		name string
+		fast bool
+	}{
+		{"duplex", false},
+		{"fastpath", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := newTripleClientConn(tc.fast, &protoBinaryCodec{}, httpClient, serverURL, header, pool)
+			if err := conn.Send(&pingv1.PingRequest{Text: "hello"}); err != nil {
+				t.Fatalf("send: %v", err)
+			}
+			if err := conn.CloseRequest(); err != nil {
+				t.Fatalf("close request: %v", err)
+			}
+			resp := NewResponse(&pingv1.PingResponse{})
+			if err := receiveUnaryResponse(conn, resp); err != nil {
+				t.Fatalf("receive: %v", err)
+			}
+			pingResp, ok := resp.Any().(*pingv1.PingResponse)
+			if !ok {
+				t.Fatalf("unexpected response type %T", resp.Any())
+			}
+			if pingResp.Text != "hello" {
+				t.Fatalf("response text = %q, want %q", pingResp.Text, "hello")
+			}
+			if got := resp.Header().Get("X-Triple-Echo"); got != "header" {
+				t.Fatalf("response header X-Triple-Echo = %q, want %q", got, "header")
+			}
+			if got := resp.Trailer().Get("X-Triple-Echo-Trailer"); got != "trailer" {
+				t.Fatalf("response trailer X-Triple-Echo-Trailer = %q, want %q", got, "trailer")
+			}
+			if err := conn.CloseResponse(); err != nil {
+				t.Fatalf("close response: %v", err)
+			}
+		})
+	}
+}
+
+// TestUnaryFastPathProtoJSONCodec verifies that the fast path carries
+// JSON-encoded payloads end to end, matching the duplex path's codec support.
+func TestUnaryFastPathProtoJSONCodec(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.Handle("/connect.ping.v1.PingService/Ping", newPingHandler())
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	httpClient := server.Client()
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	header := make(http.Header)
+	header.Set(headerContentType, tripleUnaryContentTypeJSON)
+	header.Set(tripleUnaryHeaderAcceptCompression, "gzip")
+	pool := newBufferPool()
+
+	for _, tc := range []struct {
+		name string
+		fast bool
+	}{
+		{"duplex", false},
+		{"fastpath", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := newTripleClientConn(tc.fast, &protoJSONCodec{name: codecNameJSON}, httpClient, serverURL, header, pool)
+			if err := conn.Send(&pingv1.PingRequest{Text: "hello"}); err != nil {
+				t.Fatalf("send: %v", err)
+			}
+			if err := conn.CloseRequest(); err != nil {
+				t.Fatalf("close request: %v", err)
+			}
+			resp := NewResponse(&pingv1.PingResponse{})
+			if err := receiveUnaryResponse(conn, resp); err != nil {
+				t.Fatalf("receive: %v", err)
+			}
+			pingResp, ok := resp.Any().(*pingv1.PingResponse)
+			if !ok {
+				t.Fatalf("unexpected response type %T", resp.Any())
+			}
+			if pingResp.Text != "hello" {
+				t.Fatalf("response text = %q, want %q", pingResp.Text, "hello")
+			}
+			if err := conn.CloseResponse(); err != nil {
+				t.Fatalf("close response: %v", err)
+			}
+		})
+	}
+}
+
+// TestUnaryFastPathGRPCKeepsDuplex verifies that the fast path switch never
+// routes gRPC protocol calls: gRPC keeps using duplexHTTPCall even when the
+// switch is enabled, so its behavior is preserved.
+func TestUnaryFastPathGRPCKeepsDuplex(t *testing.T) {
+	newClient := func(fast bool) *grpcClient {
+		return &grpcClient{
+			protocolClientParams: protocolClientParams{
+				HTTPClient:       &http.Client{},
+				URL:              &url.URL{Scheme: "http", Host: "example.com"},
+				BufferPool:       newBufferPool(),
+				Codec:            &protoBinaryCodec{},
+				CompressionPools: newReadOnlyCompressionPools(map[string]*compressionPool{}, nil),
+				UnaryFastPath:    fast,
+			},
+			peer: Peer{},
+		}
+	}
+	unarySpec := Spec{StreamType: StreamTypeUnary, Procedure: "/connect.ping.v1.PingService/Ping"}
+	streamSpec := Spec{StreamType: StreamTypeBidi, Procedure: "/connect.ping.v1.PingService/Ping"}
+
+	for _, tc := range []struct {
+		name string
+		fast bool
+		spec Spec
+	}{
+		{"enabled", true, unarySpec},
+		{"disabled", false, unarySpec},
+		{"enabled-streaming", true, streamSpec},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := newClient(tc.fast).NewConn(context.Background(), tc.spec, make(http.Header))
+			translated, ok := conn.(*errorTranslatingClientConn)
+			if !ok {
+				t.Fatalf("unexpected conn wrapper %T", conn)
+			}
+			grpcConn, ok := translated.StreamingClientConn.(*grpcClientConn)
+			if !ok {
+				t.Fatalf("unexpected grpc conn %T", translated.StreamingClientConn)
+			}
+			if _, ok := any(grpcConn.duplexCall).(*duplexHTTPCall); !ok {
+				t.Fatalf("grpc call type = %T, want *duplexHTTPCall", grpcConn.duplexCall)
+			}
+		})
+	}
+}

--- a/protocol/triple/triple_protocol/unary_fastpath_bench_test.go
+++ b/protocol/triple/triple_protocol/unary_fastpath_bench_test.go
@@ -61,20 +61,25 @@ var unaryBenchPayloadSizes = []int{
 	128, 1024, 16 * 1024, 1024 * 1024,
 }
 
-// BenchmarkUnaryDuplex measures the production unary path with the fast path
-// disabled (the default). The generated client defaults to the gRPC protocol,
-// so WithTriple selects the Triple protocol; without WithUnaryFastPath,
-// NewConn keeps using duplexHTTPCall for unary RPCs. It is the control group
-// for BenchmarkUnaryFastPathProduction.
+// BenchmarkUnaryDuplex measures the duplex unary path with the fast path
+// explicitly disabled. The generated client defaults to the gRPC protocol,
+// so WithTriple selects the Triple protocol; WithoutUnaryFastPath opts back
+// out of the on-by-default fast path, keeping duplexHTTPCall for unary RPCs.
+// It is the control group for BenchmarkUnaryFastPathProduction.
 func BenchmarkUnaryDuplex(b *testing.B) {
 	server, httpClient := newPingBenchmarkServer(b)
-	client := pingv1connect.NewPingServiceClient(httpClient, server.URL, triple_protocol.WithTriple())
+	client := pingv1connect.NewPingServiceClient(
+		httpClient,
+		server.URL,
+		triple_protocol.WithTriple(),
+		triple_protocol.WithoutUnaryFastPath(),
+	)
 	benchmarkUnaryPing(b, client)
 }
 
 // BenchmarkUnaryFastPathProduction measures the production unary fast path via
-// the generated client, differing from BenchmarkUnaryDuplex only by the
-// WithUnaryFastPath option.
+// the generated client. The fast path is on by default; the WithUnaryFastPath
+// option is repeated here to state the intent explicitly.
 func BenchmarkUnaryFastPathProduction(b *testing.B) {
 	server, httpClient := newPingBenchmarkServer(b)
 	client := pingv1connect.NewPingServiceClient(

--- a/protocol/triple/triple_protocol/unary_fastpath_bench_test.go
+++ b/protocol/triple/triple_protocol/unary_fastpath_bench_test.go
@@ -24,7 +24,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+)
 
+import (
 	"dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol"
 	"dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/assert"
 	pingv1 "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/ping/v1"

--- a/protocol/triple/triple_protocol/unary_fastpath_bench_test.go
+++ b/protocol/triple/triple_protocol/unary_fastpath_bench_test.go
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package triple_protocol_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol"
+	"dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/assert"
+	pingv1 "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/ping/v1"
+	"dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/ping/v1/pingv1connect"
+)
+
+// newPingBenchmarkServer starts an HTTP/2 test server serving the PingService
+// handler, and returns the server and its HTTP client.
+func newPingBenchmarkServer(b *testing.B) (*httptest.Server, *http.Client) {
+	b.Helper()
+	mux := http.NewServeMux()
+	mux.Handle(
+		pingv1connect.NewPingServiceHandler(
+			&ExamplePingServer{},
+		),
+	)
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	b.Cleanup(server.Close)
+
+	httpClient := server.Client()
+	httpTransport, ok := httpClient.Transport.(*http.Transport)
+	assert.True(b, ok)
+	httpTransport.DisableCompression = true
+	return server, httpClient
+}
+
+// unaryBenchPayloadSizes covers small (fixed-overhead dominated) through large
+// (bandwidth dominated) message sizes.
+var unaryBenchPayloadSizes = []int{
+	128, 1024, 16 * 1024, 1024 * 1024,
+}
+
+// BenchmarkUnaryDuplex measures the production unary path with the fast path
+// disabled (the default). The generated client defaults to the gRPC protocol,
+// so WithTriple selects the Triple protocol; without WithUnaryFastPath,
+// NewConn keeps using duplexHTTPCall for unary RPCs. It is the control group
+// for BenchmarkUnaryFastPathProduction.
+func BenchmarkUnaryDuplex(b *testing.B) {
+	server, httpClient := newPingBenchmarkServer(b)
+	client := pingv1connect.NewPingServiceClient(httpClient, server.URL, triple_protocol.WithTriple())
+	benchmarkUnaryPing(b, client)
+}
+
+// BenchmarkUnaryFastPathProduction measures the production unary fast path via
+// the generated client, differing from BenchmarkUnaryDuplex only by the
+// WithUnaryFastPath option.
+func BenchmarkUnaryFastPathProduction(b *testing.B) {
+	server, httpClient := newPingBenchmarkServer(b)
+	client := pingv1connect.NewPingServiceClient(
+		httpClient,
+		server.URL,
+		triple_protocol.WithTriple(),
+		triple_protocol.WithUnaryFastPath(),
+	)
+	benchmarkUnaryPing(b, client)
+}
+
+// benchmarkUnaryPing runs one parallel sub-benchmark per payload size through
+// the generated client.
+func benchmarkUnaryPing(b *testing.B, client pingv1connect.PingServiceClient) {
+	b.Helper()
+	for _, size := range unaryBenchPayloadSizes {
+		text := strings.Repeat("a", size)
+		b.Run(sizeLabel(size), func(b *testing.B) {
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					unaryPingIteration(b, client, text)
+				}
+			})
+		})
+	}
+}
+
+// unaryPingIteration performs one unary Ping call through the generated client.
+func unaryPingIteration(b *testing.B, client pingv1connect.PingServiceClient, text string) {
+	b.Helper()
+	req := pingv1.PingRequest{Text: text}
+	res := pingv1.PingResponse{}
+	if err := client.Ping(
+		context.Background(),
+		triple_protocol.NewRequest(&req),
+		triple_protocol.NewResponse(&res),
+	); err != nil {
+		b.Fatalf("ping: %v", err)
+	}
+}
+
+func sizeLabel(size int) string {
+	switch size {
+	case 1024 * 1024:
+		return "1MiB"
+	default:
+		return fmt.Sprintf("%dB", size)
+	}
+}

--- a/protocol/triple/triple_protocol/unary_fastpath_body_test.go
+++ b/protocol/triple/triple_protocol/unary_fastpath_body_test.go
@@ -27,7 +27,9 @@ import (
 	"net/url"
 	"sync/atomic"
 	"testing"
+)
 
+import (
 	pingv1 "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/ping/v1"
 )
 

--- a/protocol/triple/triple_protocol/unary_fastpath_body_test.go
+++ b/protocol/triple/triple_protocol/unary_fastpath_body_test.go
@@ -176,3 +176,133 @@ func TestUnaryFastPathBodyAbortServer(t *testing.T) {
 		t.Fatalf("close response: %v", err)
 	}
 }
+
+// TestUnaryFastPathEmptyWriteSkipsPool verifies that zero-length writes do
+// not pull a buffer out of the pool: Send(nil), an empty protobuf message,
+// or an explicit Write of an empty slice must leave c.body nil so that
+// makeRequest hands http.NoBody to the transport and the pool stays intact.
+func TestUnaryFastPathEmptyWriteSkipsPool(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ContentLength != 0 {
+			t.Errorf("request ContentLength = %d, want 0 for empty payload", r.ContentLength)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := newBufferPool()
+	call := newUnaryFastPathCall(
+		context.Background(),
+		server.Client(),
+		serverURL,
+		Spec{Procedure: "/connect.ping.v1.PingService/Ping"},
+		make(http.Header),
+		pool,
+	)
+	call.SetValidateResponse(func(*http.Response) *Error { return nil })
+
+	for _, empty := range [][]byte{nil, []byte{}} {
+		if n, err := call.Write(empty); n != 0 || err != nil {
+			t.Fatalf("Write(%v) = (%d, %v), want (0, nil)", empty, n, err)
+		}
+	}
+	if call.body != nil {
+		t.Fatal("zero-length write pulled a buffer from the pool")
+	}
+	if err := call.CloseWrite(); err != nil {
+		t.Fatalf("close write: %v", err)
+	}
+	if call.request.Body != http.NoBody {
+		t.Fatalf("request body = %T, want http.NoBody", call.request.Body)
+	}
+}
+
+// TestUnaryFastPathMakeRequestRecyclesEmptyBuffer verifies the fallback guard
+// in makeRequest: if a zero-length buffer reaches the send path despite the
+// Write short-circuit, it must be returned to the pool instead of being
+// replaced by http.NoBody and leaked.
+func TestUnaryFastPathMakeRequestRecyclesEmptyBuffer(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := newBufferPool()
+	call := newUnaryFastPathCall(
+		context.Background(),
+		server.Client(),
+		serverURL,
+		Spec{Procedure: "/connect.ping.v1.PingService/Ping"},
+		make(http.Header),
+		pool,
+	)
+	call.SetValidateResponse(func(*http.Response) *Error { return nil })
+	// Simulate a zero-length buffer reaching the send path without going
+	// through Write (the short-circuit normally prevents this).
+	call.body = pool.Get()
+	if err := call.CloseWrite(); err != nil {
+		t.Fatalf("close write: %v", err)
+	}
+	if call.body != nil {
+		t.Fatal("empty buffer was not returned to the pool")
+	}
+	if call.request.Body != http.NoBody {
+		t.Fatalf("request body = %T, want http.NoBody", call.request.Body)
+	}
+}
+
+// TestUnaryFastPathEmptyMessageCall verifies end to end that an empty
+// protobuf request (marshaled to zero bytes) still completes a unary call:
+// the fast path must hand http.NoBody to the transport without leaking a
+// pooled buffer.
+func TestUnaryFastPathEmptyMessageCall(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.Handle("/connect.ping.v1.PingService/Ping", NewUnaryHandler(
+		"/connect.ping.v1.PingService/Ping",
+		func() any { return &pingv1.PingRequest{} },
+		func(ctx context.Context, req *Request) (*Response, error) {
+			return NewResponse(&pingv1.PingResponse{Text: "empty-ok"}), nil
+		},
+	))
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	httpClient := server.Client()
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	header := make(http.Header)
+	header.Set(headerContentType, "application/proto")
+	pool := newBufferPool()
+
+	conn := newTripleClientConn(true, &protoBinaryCodec{}, httpClient, serverURL, header, pool)
+	if err := conn.Send(&pingv1.PingRequest{}); err != nil {
+		t.Fatalf("send empty message: %v", err)
+	}
+	if err := conn.CloseRequest(); err != nil {
+		t.Fatalf("close request: %v", err)
+	}
+	resp := NewResponse(&pingv1.PingResponse{})
+	if err := receiveUnaryResponse(conn, resp); err != nil {
+		t.Fatalf("receive: %v", err)
+	}
+	pingResp, ok := resp.Any().(*pingv1.PingResponse)
+	if !ok {
+		t.Fatalf("unexpected response type %T", resp.Any())
+	}
+	if pingResp.Text != "empty-ok" {
+		t.Fatalf("echo text = %q, want %q", pingResp.Text, "empty-ok")
+	}
+	if err := conn.CloseResponse(); err != nil {
+		t.Fatalf("close response: %v", err)
+	}
+}

--- a/protocol/triple/triple_protocol/unary_fastpath_body_test.go
+++ b/protocol/triple/triple_protocol/unary_fastpath_body_test.go
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package triple_protocol
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+
+	pingv1 "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/ping/v1"
+)
+
+// TestUnaryFastPathBodyReturnOnAsyncClose verifies that the pooled request
+// body is returned to the pool exactly once and left clean when the transport
+// closes it after http.Client.Do has returned: Do may return while the
+// transport's background writer still reads the body, so the buffer must be
+// recycled from the Close callback rather than the Do call site. Repeated
+// Close (redirect / retry paths) and a concurrent Read must stay safe.
+func TestUnaryFastPathBodyReturnOnAsyncClose(t *testing.T) {
+	pool := newBufferPool()
+	buf := pool.Get()
+	buf.WriteString("payload")
+	body := &unaryRequestBody{buf: buf, pool: pool}
+
+	// The transport reads the whole body, then closes it after http.Client.Do
+	// has already returned (abort path).
+	if _, err := io.Copy(io.Discard, body); err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if err := body.Close(); err != nil {
+		t.Fatalf("close body: %v", err)
+	}
+
+	// The buffer must have been returned to the pool.
+	body.mu.Lock()
+	returned := body.buf == nil
+	body.mu.Unlock()
+	if !returned {
+		t.Fatal("request body buffer was not returned to the pool")
+	}
+	// Idempotent Close: a second or third Close from redirect / retry /
+	// context-cancel paths must not double-return the buffer.
+	if err := body.Close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+	if err := body.Close(); err != nil {
+		t.Fatalf("third close: %v", err)
+	}
+	// After return, Read must surface EOF instead of the pooled buffer's
+	// stale bytes (use-after-return guard).
+	if _, err := body.Read(make([]byte, 4)); err != io.EOF {
+		t.Fatalf("read after return = %v, want io.EOF", err)
+	}
+	// Reuse must be clean: whatever buffer the pool hands out next has been
+	// Reset, so appending new payload must not carry this request's data.
+	reuse := pool.Get()
+	reuse.WriteString("new-payload")
+	if got := reuse.String(); got != "new-payload" {
+		t.Fatalf("reused buffer not clean after return: got %q", got)
+	}
+	reuse.Reset()
+	pool.Put(reuse)
+}
+
+// TestUnaryFastPathBodyAbortServer verifies end to end that an early non-2xx
+// response aborts the body write, returns the pooled buffer, and leaves the
+// pool clean for a later request reusing it.
+func TestUnaryFastPathBodyAbortServer(t *testing.T) {
+	var first atomic.Int32
+	mux := http.NewServeMux()
+	mux.Handle("/connect.ping.v1.PingService/Ping", NewUnaryHandler(
+		"/connect.ping.v1.PingService/Ping",
+		func() any { return &pingv1.PingRequest{} },
+		func(ctx context.Context, req *Request) (*Response, error) {
+			// First request aborts early with a non-2xx error without reading
+			// the request body, so the transport aborts the body write. Later
+			// requests decode and echo the payload back, so a poisoned pool is
+			// detectable via the echoed text.
+			if first.Add(1) == 1 {
+				err := NewError(CodePermissionDenied, errors.New("early response"))
+				err.meta = make(http.Header)
+				err.meta.Set("X-Triple-Error", "meta")
+				return nil, err
+			}
+			pingReq, ok := req.Any().(*pingv1.PingRequest)
+			if !ok {
+				return nil, fmt.Errorf("unexpected request type %T", req.Any())
+			}
+			return NewResponse(&pingv1.PingResponse{Text: pingReq.Text}), nil
+		},
+	))
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	httpClient := server.Client()
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	header := make(http.Header)
+	header.Set(headerContentType, "application/proto")
+	header.Set(tripleUnaryHeaderAcceptCompression, "gzip")
+	// One shared pool across requests, matching production where the conn
+	// reuses the protocol-level BufferPool.
+	pool := newBufferPool()
+
+	// First call hits the early-response abort path.
+	conn1 := newTripleClientConn(true, &protoBinaryCodec{}, httpClient, serverURL, header, pool)
+	if err := conn1.Send(&pingv1.PingRequest{Text: "first-payload"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if err := conn1.CloseRequest(); err != nil {
+		t.Fatalf("close request: %v", err)
+	}
+	resp1 := NewResponse(&pingv1.PingResponse{})
+	if err := receiveUnaryResponse(conn1, resp1); err == nil {
+		t.Fatal("expected error from early-response abort, got nil")
+	} else {
+		var connErr *Error
+		if !errors.As(err, &connErr) || connErr.Code() != CodePermissionDenied {
+			t.Fatalf("abort error = %v, want CodePermissionDenied", err)
+		}
+		if got := connErr.meta.Get("X-Triple-Error"); got != "meta" {
+			t.Fatalf("abort error meta = %q, want %q", got, "meta")
+		}
+	}
+	if err := conn1.CloseResponse(); err != nil {
+		t.Fatalf("close response: %v", err)
+	}
+
+	// Second call reuses the same pool: the body must be clean.
+	conn2 := newTripleClientConn(true, &protoBinaryCodec{}, httpClient, serverURL, header, pool)
+	if err := conn2.Send(&pingv1.PingRequest{Text: "second-payload"}); err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	if err := conn2.CloseRequest(); err != nil {
+		t.Fatalf("close request: %v", err)
+	}
+	resp2 := NewResponse(&pingv1.PingResponse{})
+	if err := receiveUnaryResponse(conn2, resp2); err != nil {
+		t.Fatalf("second call after abort: %v", err)
+	}
+	pingResp, ok := resp2.Any().(*pingv1.PingResponse)
+	if !ok {
+		t.Fatalf("unexpected response type %T", resp2.Any())
+	}
+	if pingResp.Text != "second-payload" {
+		t.Fatalf("second call body contaminated: got text %q", pingResp.Text)
+	}
+	if err := conn2.CloseResponse(); err != nil {
+		t.Fatalf("close response: %v", err)
+	}
+}

--- a/protocol/triple/triple_protocol/unary_fastpath_concurrency_test.go
+++ b/protocol/triple/triple_protocol/unary_fastpath_concurrency_test.go
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package triple_protocol
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+)
+
+// concurrentEchoServer starts an HTTP/2 server that records every request body
+// it receives, so tests can assert on what actually reached the wire.
+func concurrentEchoServer(t *testing.T) (HTTPClient, *url.URL, *[]string, *sync.Mutex) {
+	t.Helper()
+	var bodies []string
+	var mu sync.Mutex
+	mux := http.NewServeMux()
+	mux.HandleFunc("/connect.ping.v1.PingService/Ping", func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		bodies = append(bodies, string(b))
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	})
+	server := httptest.NewUnstartedServer(mux)
+	server.EnableHTTP2 = true
+	server.StartTLS()
+	t.Cleanup(server.Close)
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return server.Client(), serverURL, &bodies, &mu
+}
+
+func newConcurrentCall(httpClient HTTPClient, serverURL *url.URL, pool *bufferPool) *unaryFastPathCall {
+	call := newUnaryFastPathCall(
+		context.Background(),
+		httpClient,
+		serverURL,
+		Spec{
+			StreamType: StreamTypeUnary,
+			Procedure:  "/connect.ping.v1.PingService/Ping",
+		},
+		make(http.Header),
+		pool,
+	)
+	// The conn layer injects validateResponse via SetValidateResponse; mirror
+	// that here.
+	call.SetValidateResponse(func(*http.Response) *Error { return nil })
+	return call
+}
+
+// TestUnaryFastPathWriteCloseConcurrent verifies the write-side concurrency
+// contract: a Write racing a CloseWrite must fully succeed or fail with
+// io.EOF, and the server must never see a torn body.
+func TestUnaryFastPathWriteCloseConcurrent(t *testing.T) {
+	httpClient, serverURL, bodies, bodiesMu := concurrentEchoServer(t)
+	pool := newBufferPool()
+	payload := []byte("payload-concurrent")
+
+	const iterations = 30
+	for i := range iterations {
+		call := newConcurrentCall(httpClient, serverURL, pool)
+		var (
+			writeN   int
+			writeErr error
+			wg       sync.WaitGroup
+		)
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			writeN, writeErr = call.Write(payload)
+		}()
+		go func() {
+			defer wg.Done()
+			// CloseWrite always returns nil; transport failures surface from
+			// Read below, as on the duplex path.
+			_ = call.CloseWrite()
+		}()
+		wg.Wait()
+
+		// Drain the response so the request body Close callback runs and the
+		// pooled buffer returns to the pool.
+		if _, err := io.Copy(io.Discard, call); err != nil {
+			t.Fatalf("iter %d: read response: %v", i, err)
+		}
+		if err := call.CloseRead(); err != nil {
+			t.Fatalf("iter %d: close response: %v", i, err)
+		}
+
+		// Write must have fully succeeded, or been rejected with io.EOF
+		// because the racing CloseWrite already sent the body.
+		if writeErr != nil && !errors.Is(writeErr, io.EOF) {
+			t.Fatalf("iter %d: write error = %v, want nil or io.EOF", i, writeErr)
+		}
+		if writeErr == nil && writeN != len(payload) {
+			t.Fatalf("iter %d: write n = %d, want %d", i, writeN, len(payload))
+		}
+	}
+
+	bodiesMu.Lock()
+	defer bodiesMu.Unlock()
+	if len(*bodies) != iterations {
+		t.Fatalf("server received %d requests, want %d", len(*bodies), iterations)
+	}
+	for _, body := range *bodies {
+		if body != "" && body != string(payload) {
+			t.Fatalf("server received torn body %q, want empty or the full payload", body)
+		}
+	}
+}
+
+// TestUnaryFastPathWriteAfterClose verifies that Write after CloseWrite has
+// dispatched the body fails with io.EOF instead of racing the transport.
+func TestUnaryFastPathWriteAfterClose(t *testing.T) {
+	httpClient, serverURL, _, _ := concurrentEchoServer(t)
+	pool := newBufferPool()
+
+	call := newConcurrentCall(httpClient, serverURL, pool)
+	if err := call.CloseWrite(); err != nil {
+		t.Fatalf("close request: %v", err)
+	}
+	n, err := call.Write([]byte("late-write"))
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("write after close = (n=%d, err=%v), want (0, io.EOF)", n, err)
+	}
+	if n != 0 {
+		t.Fatalf("write after close n = %d, want 0", n)
+	}
+
+	if _, err := io.Copy(io.Discard, call); err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if err := call.CloseRead(); err != nil {
+		t.Fatalf("close response: %v", err)
+	}
+}

--- a/protocol/triple/triple_protocol/unary_fastpath_conn_type_test.go
+++ b/protocol/triple/triple_protocol/unary_fastpath_conn_type_test.go
@@ -22,7 +22,9 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
+)
 
+import (
 	"dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/assert"
 )
 

--- a/protocol/triple/triple_protocol/unary_fastpath_conn_type_test.go
+++ b/protocol/triple/triple_protocol/unary_fastpath_conn_type_test.go
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package triple_protocol
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/assert"
+)
+
+// TestUnaryFastPathNewConnType verifies that tripleClient.NewConn routes unary
+// calls through unaryFastPathCall when enabled and duplexHTTPCall otherwise;
+// streaming calls always use duplexHTTPCall.
+func TestUnaryFastPathNewConnType(t *testing.T) {
+	newClient := func(fast bool) *tripleClient {
+		// CompressionPools must be non-nil; NewConn consults it when
+		// building the marshaler even if compression is disabled.
+		return &tripleClient{
+			protocolClientParams: protocolClientParams{
+				HTTPClient:       &http.Client{},
+				URL:              &url.URL{Scheme: "http", Host: "example.com"},
+				BufferPool:       newBufferPool(),
+				Codec:            &protoBinaryCodec{},
+				CompressionPools: newReadOnlyCompressionPools(map[string]*compressionPool{}, nil),
+				UnaryFastPath:    fast,
+			},
+			peer: Peer{},
+		}
+	}
+	assertCallType := func(t *testing.T, conn StreamingClientConn, want string) {
+		t.Helper()
+		translated, ok := conn.(*errorTranslatingClientConn)
+		assert.True(t, ok, assert.Sprintf("unexpected conn wrapper %T", conn))
+		unaryConn, ok := translated.StreamingClientConn.(*tripleUnaryClientConn)
+		assert.True(t, ok, assert.Sprintf("unexpected unary conn %T", translated.StreamingClientConn))
+		switch want {
+		case "fastpath":
+			_, ok := unaryConn.call.(*unaryFastPathCall)
+			assert.True(t, ok, assert.Sprintf("unary call type = %T, want *unaryFastPathCall", unaryConn.call))
+		case "duplex":
+			_, ok := unaryConn.call.(*duplexHTTPCall)
+			assert.True(t, ok, assert.Sprintf("unary call type = %T, want *duplexHTTPCall", unaryConn.call))
+		default:
+			// Guard against a misspelled want string silently passing:
+			// the switch would otherwise skip every case and report success.
+			t.Fatalf("assertCallType: unknown want %q", want)
+		}
+	}
+
+	unarySpec := Spec{StreamType: StreamTypeUnary, Procedure: "/connect.ping.v1.PingService/Ping"}
+	// WithUnaryFastPath enabled -> unary calls take the fast path.
+	assertCallType(t, newClient(true).NewConn(context.Background(), unarySpec, make(http.Header)), "fastpath")
+	// Default (option disabled) -> unary calls keep using duplexHTTPCall.
+	assertCallType(t, newClient(false).NewConn(context.Background(), unarySpec, make(http.Header)), "duplex")
+	// Streaming calls always use duplexHTTPCall, regardless of the switch.
+	streamSpec := Spec{StreamType: StreamTypeBidi, Procedure: "/connect.ping.v1.PingService/Ping"}
+	assertCallType(t, newClient(true).NewConn(context.Background(), streamSpec, make(http.Header)), "duplex")
+}

--- a/protocol/triple/unary_fastpath_public_entry_test.go
+++ b/protocol/triple/unary_fastpath_public_entry_test.go
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package triple
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+)
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+import (
+	"dubbo.apache.org/dubbo-go/v3/common"
+	"dubbo.apache.org/dubbo-go/v3/common/constant"
+	"dubbo.apache.org/dubbo-go/v3/global"
+	tri "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol"
+)
+
+// TestCallUnaryFastPathWireSignature verifies that a unary call issued through
+// the public client entry (clientManager.callUnary, the path reached by
+// TripleInvoker.Invoke) reaches the server with a pre-declared Content-Length
+// when the fast path is on, and streams without one when it is explicitly
+// disabled. The fast path buffers the whole request body and sets
+// Content-Length; duplexHTTPCall streams through an io.Pipe and cannot, so the
+// server sees Content-Length == -1. This guards the dispatch wiring between
+// the RPC layer and the gRPC protocol client.
+func TestCallUnaryFastPathWireSignature(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		tripleConf   *global.TripleConfig
+		wantPositive bool
+	}{
+		{"default-on", nil, true},
+		{"explicitly-off", &global.TripleConfig{UnaryFastPath: false}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var (
+				mu         sync.Mutex
+				contentLen int64
+			)
+			pingHandler := tri.NewUnaryHandler(
+				"/connect.ping.v1.PingService/Ping",
+				func() any { return &wrapperspb.StringValue{} },
+				func(_ context.Context, req *tri.Request) (*tri.Response, error) {
+					sv := req.Any().(*wrapperspb.StringValue)
+					return tri.NewResponse(&wrapperspb.StringValue{Value: sv.Value}), nil
+				},
+			)
+			wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				contentLen = r.ContentLength
+				mu.Unlock()
+				pingHandler.ServeHTTP(w, r)
+			})
+			server := &http.Server{Handler: h2c.NewHandler(wrapped, &http2.Server{})}
+			ln, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			defer server.Close()
+			go func() {
+				_ = server.Serve(ln)
+			}()
+
+			url, err := common.NewURL(
+				"tri://"+ln.Addr().String()+"/connect.ping.v1.PingService",
+				common.WithMethods([]string{"Ping"}),
+				common.WithProtocol(TRIPLE),
+			)
+			require.NoError(t, err)
+			if tc.tripleConf != nil {
+				url.SetAttribute(constant.TripleConfigKey, tc.tripleConf)
+			}
+
+			cm, err := newClientManager(url)
+			require.NoError(t, err)
+			defer cm.close()
+
+			resp := &wrapperspb.StringValue{}
+			err = cm.callUnary(
+				context.Background(),
+				"Ping",
+				&wrapperspb.StringValue{Value: "hello"},
+				resp,
+				nil,
+				nil,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, "hello", resp.Value)
+
+			mu.Lock()
+			defer mu.Unlock()
+			if tc.wantPositive {
+				assert.Positive(t, contentLen,
+					"server saw Content-Length %d, want > 0 (fast path signature)", contentLen)
+			} else {
+				assert.Equal(t, int64(-1), contentLen,
+					"server saw Content-Length %d, want -1 (duplex streams the body)", contentLen)
+			}
+		})
+	}
+}
+
+// TestCallUnaryFastPathErrorPaths verifies that error propagation through the
+// public client entry (clientManager.callUnary) behaves identically whether
+// the fast path is on (default) or disabled (duplex): a canceled context fails
+// fast, a handler error surfaces with its code and message, and a gRPC
+// trailers-only response (grpc-status with no message body) is decoded
+// correctly. This guards the gRPC wire error path of the fast path.
+func TestCallUnaryFastPathErrorPaths(t *testing.T) {
+	scenarios := []struct {
+		name    string
+		serve   func(context.Context, *tri.Request) (*tri.Response, error)
+		wantErr func(*testing.T, error)
+	}{
+		{
+			name: "handler-error",
+			serve: func(_ context.Context, _ *tri.Request) (*tri.Response, error) {
+				return nil, tri.NewError(tri.CodeUnavailable, errors.New("boom"))
+			},
+			wantErr: func(t *testing.T, err error) {
+				require.Error(t, err)
+				assert.Equal(t, tri.CodeUnavailable, tri.CodeOf(err))
+				assert.Contains(t, err.Error(), "boom")
+			},
+		},
+		{
+			name: "trailers-only",
+			serve: func(_ context.Context, _ *tri.Request) (*tri.Response, error) {
+				// A gRPC error response carries grpc-status/grpc-message in
+				// trailers only, with no message body.
+				return nil, tri.NewError(tri.CodeCanceled, nil)
+			},
+			wantErr: func(t *testing.T, err error) {
+				require.Error(t, err)
+				assert.Equal(t, tri.CodeCanceled, tri.CodeOf(err))
+			},
+		},
+		{
+			name: "context-canceled",
+			serve: func(_ context.Context, _ *tri.Request) (*tri.Response, error) {
+				return tri.NewResponse(&wrapperspb.StringValue{Value: "echo"}), nil
+			},
+			wantErr: func(t *testing.T, err error) {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, context.Canceled)
+			},
+		},
+	}
+
+	for _, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			for _, cfg := range []struct {
+				name       string
+				tripleConf *global.TripleConfig
+			}{
+				{"fastpath", nil},
+				{"duplex", &global.TripleConfig{UnaryFastPath: false}},
+			} {
+				t.Run(cfg.name, func(t *testing.T) {
+					pingHandler := tri.NewUnaryHandler(
+						"/connect.ping.v1.PingService/Ping",
+						func() any { return &wrapperspb.StringValue{} },
+						sc.serve,
+					)
+					server := &http.Server{Handler: h2c.NewHandler(pingHandler, &http2.Server{})}
+					ln, err := net.Listen("tcp", "127.0.0.1:0")
+					require.NoError(t, err)
+					defer server.Close()
+					go func() {
+						_ = server.Serve(ln)
+					}()
+
+					url, err := common.NewURL(
+						"tri://"+ln.Addr().String()+"/connect.ping.v1.PingService",
+						common.WithMethods([]string{"Ping"}),
+						common.WithProtocol(TRIPLE),
+					)
+					require.NoError(t, err)
+					if cfg.tripleConf != nil {
+						url.SetAttribute(constant.TripleConfigKey, cfg.tripleConf)
+					}
+
+					cm, err := newClientManager(url)
+					require.NoError(t, err)
+					defer cm.close()
+
+					ctx := context.Background()
+					if sc.name == "context-canceled" {
+						var cancel context.CancelFunc
+						ctx, cancel = context.WithCancel(ctx)
+						cancel()
+					}
+					resp := &wrapperspb.StringValue{}
+					err = cm.callUnary(
+						ctx,
+						"Ping",
+						&wrapperspb.StringValue{Value: "hello"},
+						resp,
+						nil,
+						nil,
+					)
+					sc.wantErr(t, err)
+				})
+			}
+		})
+	}
+}

--- a/protocol/triple/unary_fastpath_public_entry_test.go
+++ b/protocol/triple/unary_fastpath_public_entry_test.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -40,17 +41,21 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/global"
+	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
 	tri "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol"
 )
 
 // TestCallUnaryFastPathWireSignature verifies that a unary call issued through
-// the public client entry (clientManager.callUnary, the path reached by
-// TripleInvoker.Invoke) reaches the server with a pre-declared Content-Length
-// when the fast path is on, and streams without one when it is explicitly
-// disabled. The fast path buffers the whole request body and sets
-// Content-Length; duplexHTTPCall streams through an io.Pipe and cannot, so the
-// server sees Content-Length == -1. This guards the dispatch wiring between
-// the RPC layer and the gRPC protocol client.
+// the production entry — TripleProtocol.Refer, then TripleInvoker.Invoke with
+// a real invocation (method, parameters, call type, metadata and attachments
+// converted exactly as production does) — reaches the server with a
+// pre-declared Content-Length when the fast path is on, and streams without
+// one when it is explicitly disabled. The fast path buffers the whole request
+// body and sets Content-Length; duplexHTTPCall streams through an io.Pipe and
+// cannot, so the server sees Content-Length == -1. This guards the dispatch
+// wiring from the RPC layer down to the gRPC protocol client: if Refer ever
+// routed to a different Invoker, or Invoke stopped reaching this manager, the
+// wire signature assertion fails even though the manager-level path is intact.
 func TestCallUnaryFastPathWireSignature(t *testing.T) {
 	for _, tc := range []struct {
 		name         string
@@ -73,10 +78,17 @@ func TestCallUnaryFastPathWireSignature(t *testing.T) {
 					return tri.NewResponse(&wrapperspb.StringValue{Value: sv.Value}), nil
 				},
 			)
+			// Refer starts a background gRPC health-check stream; it hits a
+			// different path (grpc.health.v1.Health/...) with a streaming body
+			// (Content-Length == -1) that would clobber the Ping signature.
+			// Capture every non-health request instead, so the assertion is
+			// immune to both the health stream and the exact Ping path.
 			wrapped := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				mu.Lock()
-				contentLen = r.ContentLength
-				mu.Unlock()
+				if !strings.HasPrefix(r.URL.Path, "/grpc.health.v1.Health/") {
+					mu.Lock()
+					contentLen = r.ContentLength
+					mu.Unlock()
+				}
 				pingHandler.ServeHTTP(w, r)
 			})
 			server := &http.Server{Handler: h2c.NewHandler(wrapped, &http2.Server{})}
@@ -91,26 +103,29 @@ func TestCallUnaryFastPathWireSignature(t *testing.T) {
 				"tri://"+ln.Addr().String()+"/connect.ping.v1.PingService",
 				common.WithMethods([]string{"Ping"}),
 				common.WithProtocol(TRIPLE),
+				common.WithParamsValue(constant.IDLMode, constant.NONIDL),
 			)
 			require.NoError(t, err)
 			if tc.tripleConf != nil {
 				url.SetAttribute(constant.TripleConfigKey, tc.tripleConf)
 			}
 
-			cm, err := newClientManager(url)
-			require.NoError(t, err)
-			defer cm.close()
+			invoker := GetProtocol().Refer(url)
+			require.NotNil(t, invoker)
+			defer invoker.Destroy()
 
 			resp := &wrapperspb.StringValue{}
-			err = cm.callUnary(
-				context.Background(),
-				"Ping",
-				&wrapperspb.StringValue{Value: "hello"},
-				resp,
-				nil,
-				nil,
+			inv := invocation.NewRPCInvocationWithOptions(
+				invocation.WithMethodName("Ping"),
+				invocation.WithParameterRawValues([]any{
+					&wrapperspb.StringValue{Value: "hello"},
+					resp,
+				}),
 			)
-			require.NoError(t, err)
+			inv.SetAttribute(constant.CallTypeKey, constant.CallUnary)
+
+			res := invoker.Invoke(context.Background(), inv)
+			require.NoError(t, res.Error())
 			assert.Equal(t, "hello", resp.Value)
 
 			mu.Lock()
@@ -127,11 +142,12 @@ func TestCallUnaryFastPathWireSignature(t *testing.T) {
 }
 
 // TestCallUnaryFastPathErrorPaths verifies that error propagation through the
-// public client entry (clientManager.callUnary) behaves identically whether
-// the fast path is on (default) or disabled (duplex): a canceled context fails
-// fast, a handler error surfaces with its code and message, and a gRPC
-// trailers-only response (grpc-status with no message body) is decoded
-// correctly. This guards the gRPC wire error path of the fast path.
+// production entry (TripleProtocol.Refer + TripleInvoker.Invoke) behaves
+// identically whether the fast path is on (default) or disabled (duplex): a
+// canceled context fails fast, a handler error surfaces with its code and
+// message, and a gRPC trailers-only response (grpc-status with no message
+// body) is decoded correctly. This guards the gRPC wire error path of the
+// fast path through the same Refer/Invoker dispatch the RPC layer uses.
 func TestCallUnaryFastPathErrorPaths(t *testing.T) {
 	scenarios := []struct {
 		name    string
@@ -200,15 +216,16 @@ func TestCallUnaryFastPathErrorPaths(t *testing.T) {
 						"tri://"+ln.Addr().String()+"/connect.ping.v1.PingService",
 						common.WithMethods([]string{"Ping"}),
 						common.WithProtocol(TRIPLE),
+						common.WithParamsValue(constant.IDLMode, constant.NONIDL),
 					)
 					require.NoError(t, err)
 					if cfg.tripleConf != nil {
 						url.SetAttribute(constant.TripleConfigKey, cfg.tripleConf)
 					}
 
-					cm, err := newClientManager(url)
-					require.NoError(t, err)
-					defer cm.close()
+					invoker := GetProtocol().Refer(url)
+					require.NotNil(t, invoker)
+					defer invoker.Destroy()
 
 					ctx := context.Background()
 					if sc.name == "context-canceled" {
@@ -217,15 +234,17 @@ func TestCallUnaryFastPathErrorPaths(t *testing.T) {
 						cancel()
 					}
 					resp := &wrapperspb.StringValue{}
-					err = cm.callUnary(
-						ctx,
-						"Ping",
-						&wrapperspb.StringValue{Value: "hello"},
-						resp,
-						nil,
-						nil,
+					inv := invocation.NewRPCInvocationWithOptions(
+						invocation.WithMethodName("Ping"),
+						invocation.WithParameterRawValues([]any{
+							&wrapperspb.StringValue{Value: "hello"},
+							resp,
+						}),
 					)
-					sc.wantErr(t, err)
+					inv.SetAttribute(constant.CallTypeKey, constant.CallUnary)
+
+					res := invoker.Invoke(ctx, inv)
+					sc.wantErr(t, res.Error())
 				})
 			}
 		})

--- a/protocol/triple/unary_fastpath_public_entry_test.go
+++ b/protocol/triple/unary_fastpath_public_entry_test.go
@@ -63,7 +63,9 @@ func TestCallUnaryFastPathWireSignature(t *testing.T) {
 		wantPositive bool
 	}{
 		{"default-on", nil, true},
-		{"explicitly-off", &global.TripleConfig{UnaryFastPath: false}, false},
+		{"explicitly-on", &global.TripleConfig{UnaryFastPath: boolPtr(true)}, true},
+		{"explicitly-off", &global.TripleConfig{UnaryFastPath: boolPtr(false)}, false},
+		{"unset-keeps-default", &global.TripleConfig{KeepAliveInterval: "10s"}, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var (
@@ -196,7 +198,7 @@ func TestCallUnaryFastPathErrorPaths(t *testing.T) {
 				tripleConf *global.TripleConfig
 			}{
 				{"fastpath", nil},
-				{"duplex", &global.TripleConfig{UnaryFastPath: false}},
+				{"duplex", &global.TripleConfig{UnaryFastPath: boolPtr(false)}},
 			} {
 				t.Run(cfg.name, func(t *testing.T) {
 					pingHandler := tri.NewUnaryHandler(
@@ -249,4 +251,10 @@ func TestCallUnaryFastPathErrorPaths(t *testing.T) {
 			}
 		})
 	}
+}
+
+// boolPtr returns a pointer to v, mirroring the *bool config field style used
+// across the global config structs.
+func boolPtr(v bool) *bool {
+	return &v
 }


### PR DESCRIPTION
### Description

Fixes #3694

Triple unary RPCs go through `duplexHTTPCall`, which allocates an `io.Pipe`, a per-request `makeRequest` goroutine and a `responseReady` signal per call. For small payloads (CPU-dominated hot path) this pipe hand-off machinery is pure overhead. On top of that, the fast path never actually ran end-to-end because of a protocol-selection defect:

1. **Default protocol defect**: `newClientManager` only passed `tri.WithTriple()` on the HTTP/1.1 branch; HTTP/2 (the actual default transport) silently fell back to the gRPC protocol , the `triple_protocol.Client` default inherited from connect-go. Every end-to-end benchmark therefore measured the gRPC compatibility path, and a fast path living on `tripleClient.NewConn` was unreachable.
2. **Per-request pipe overhead**: each unary call creates an `io.Pipe` writer task, spawns a `makeRequest` goroutine, and blocks on a `responseReady` close-signal hand-off, two execution contexts where one synchronous caller context suffices.

### Changes

**1. Config switch: add an opt-in `UnaryFastPath` toggle, off by default**

`global/triple_config.go`:
- Add `UnaryFastPath bool` to `TripleConfig` (yaml/json/property mapped) and copy it in `Clone`.

`protocol/triple/triple_protocol/option.go` / `client.go` / `protocol.go`:
- Add `WithUnaryFastPath()` client option and propagate it through `clientConfig` / `protocolClientParams` into `NewConn`.

**2. Fast path implementation: replace the duplex pipe machinery with a synchronous call**

`protocol/triple/triple_protocol/unary_fastpath.go` (new):
- `unaryFastPathCall` performs the unary round trip synchronously in the caller goroutine: no `io.Pipe`, no `makeRequest` goroutine; the `responseReady` signal is resolved synchronously instead of from a separate goroutine;
- Uses pooled buffers, declares `Content-Length`, reads the response directly;
- The write side (`Send` / `CloseRequest`) is mutex-guarded; `RequestHeader` is safe to call concurrently because headers are never mutated after construction, so the `StreamingClientConn` concurrency-safe is preserved.

`protocol/triple/triple_protocol/protocol_triple.go`:
- `tripleClient.NewConn` selects `newUnaryFastPathCall` for unary stream types when the switch is on; streaming keeps the duplex path.

`protocol/triple/client.go`:
- Hoist `tri.WithTriple()` so HTTP/1.1, HTTP/2 and HTTP/3 all explicitly select the Triple protocol (HTTP/2 previously fell back to gRPC, making the fast path unreachable), and gate `tri.WithUnaryFastPath()` on the config switch.

**3. Tests: conn routing, production bench baseline, body round-trip and race coverage**

`protocol/triple/triple_protocol/unary_fastpath_conn_type_test.go`:
- Asserts `NewConn` routes unary to the fast path and streaming to duplex.

`protocol/triple/triple_protocol/unary_fastpath_bench_test.go`:
- `BenchmarkUnaryFastPathProduction` drives the production fast path with `WithTriple + WithUnaryFastPath` for an A/B baseline against duplex.

`protocol/triple/triple_protocol/unary_fastpath_body_test.go`:
- Request body read/write round-trips, `Content-Length` declaration and pooled buffer reuse.

`protocol/triple/triple_protocol/unary_fastpath_concurrency_test.go`:
- Concurrent `Send` / `RequestHeader` / `CloseRequest` stay race-free under `-race`.

### Test

`unary_fastpath_conn_type_test.go`

| Test | Description |
|---|---|
| `TestUnaryFastPathNewConnType` | Switch on routes unary calls to the fast path, off falls back to duplex, streaming always uses duplex |

`unary_fastpath_behavior_test.go`

| Test | Description |
|---|---|
| `TestUnaryFastPathWriteAccumulates` | Write appends into the pooled buffer without touching the network; CloseWrite hands the whole payload to the transport exactly once with an exact Content-Length |
| `TestUnaryFastPathEmptyBodyUsesNoBody` | An empty request body uses `http.NoBody` with Content-Length=0, avoiding chunked encoding and background writes |
| `TestUnaryFastPathConcurrentReadClose` | 8 readers racing 8 closes, verified race-free under `-race` |
| `TestUnaryFastPathRequestHeaderConcurrent` | RequestHeader races with Write and CloseWrite safely, per the streaming client conn contract |
| `TestUnaryFastPathWriteAfterTransportError` | After a transport failure writes are rejected with io.EOF and Read surfaces CodeUnavailable |
| `TestUnaryFastPathSetErrorRejectsWrite` | A stored error rejects writes before the body is sent, surfacing the concrete error |
| `TestUnaryFastPathWireConsistent` | The fast path wire bytes are identical to duplex, so the protocol does not drift |
| `TestUnaryFastPathContextCancel` | Context cancellation aborts the in-flight request and Read surfaces CodeCanceled |
| `TestUnaryFastPathEndToEnd` | End-to-end against a real HTTP/2 server through the real NewConn entry, covering header/trailer interop and response reading |
| `TestUnaryFastPathProtoJSONCodec` | The JSON codec works end to end, matching duplex behavior to keep codec generality |
| `TestUnaryFastPathGRPCKeepsDuplex` | gRPC protocol calls are unaffected by the switch and keep using duplex even when enabled, preserving gRPC behavior |

`unary_fastpath_body_test.go`

| Test | Description |
|---|---|
| `TestUnaryFastPathBodyReturnOnAsyncClose` | Close returns the buffer to the pool exactly once, Read returns EOF afterwards, and pooled reuse stays clean |
| `TestUnaryFastPathBodyAbortServer` | A non-2xx early response still returns the buffer to the pool, surfaces CodePermissionDenied, and propagates the error metadata |

`unary_fastpath_concurrency_test.go`

| Test | Description |
|---|---|
| `TestUnaryFastPathWriteCloseConcurrent` | Concurrent Write/CloseWrite over 30 rounds with no torn body observed by the server, pinning the write-side lock boundary |
| `TestUnaryFastPathWriteAfterClose` | Write after bodySent returns io.EOF, mirroring duplex close semantics |

`unary_fastpath_bench_test.go`

| Benchmark | Description |
|---|---|
| `BenchmarkUnaryDuplex` | Control group: the generated client with the fast path disabled (duplex) |
| `BenchmarkUnaryFastPathProduction` | Treatment group: differs from the control only by the WithUnaryFastPath option |

### Validation

# Dubbo-Go Triple Protocol Performance Benchmark Summary Report

### 128 bytes payload

| Metric | Concurrency | duplex | fastpath | Improvement |
| --- | --- | --- | --- | --- |
| QPS | 50 | 5,329.3 | 6,997.9 | +31.3% ↑ |
| QPS | 100 | 5,409.2 | 6,024.1 | +11.4% ↑ |
| P99 latency (ms) | 50 | 15.99 | 12.67 | -20.8% ↑ |
| P99 latency (ms) | 100 | 30.58 | 29.74 | -2.7% ↑ |

### 1024 bytes payload

| Metric | Concurrency | duplex | fastpath | Improvement |
| --- | --- | --- | --- | --- |
| QPS | 50 | 4,300.3 | 5,196.4 | +20.8% ↑ |
| QPS | 100 | 4,368.5 | 5,605.8 | +28.3% ↑ |
| P99 latency (ms) | 50 | 20.40 | 18.22 | -10.7% ↑ |
| P99 latency (ms) | 100 | 37.48 | 26.95 | -28.1% ↑ |

### 16384 bytes payload

| Metric | Concurrency | duplex | fastpath | Improvement |
| --- | --- | --- | --- | --- |
| QPS | 50 | 2,584.2 | 2,871.6 | +11.1% ↑ |
| QPS | 100 | 2,428.2 | 2,815.7 | +16.0% ↑ |
| P99 latency (ms) | 50 | 37.28 | 30.90 | -17.1% ↑ |
| P99 latency (ms) | 100 | 81.24 | 69.07 | -15.0% ↑ |

### 1048576 bytes (1MiB) payload

| Metric | Concurrency | duplex | fastpath | Improvement |
| --- | --- | --- | --- | --- |
| QPS | 50 | 101.3 | 101.7 | +0.4% ↑ |
| QPS | 100 | 104.3 | 114.4 | +9.8% ↑ |
| P99 latency (ms) | 50 | 1,430.17 | 1,479.12 | +3.4% ↓ |
| P99 latency (ms) | 100 | 3,179.88 | 2,874.32 | -9.6% ↑ |

## benchstat significance test (count=10)

```bash
goos: linux
goarch: amd64
pkg: dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol
cpu: Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
                │ duplex10_1mib.txt │          fastpath10_1mib.txt          │
                │      sec/op       │        sec/op     vs base             │
Unary/128B-12        147.1µ ±  8%      117.6µ ± 11%  -20.08% (p=0.000 n=10)
Unary/1024B-12       169.9µ ± 18%      106.0µ ± 30%  -37.59% (p=0.000 n=10)
Unary/16384B-12      226.1µ ± 26%      173.1µ ± 12%  -23.43% (p=0.000 n=10)
Unary/1MiB-12        3.662m ± 19%      3.450m ± 10%        ~ (p=0.912 n=10)
geomean              379.3µ            293.8µ        -22.55%
```

*Note: the names above come from a unified `BenchmarkUnary` run; in the current
codebase the control is `BenchmarkUnaryDuplex` and the treatment is
`BenchmarkUnaryFastPathProduction`.*

| Payload | duplex (sec/op) | fastpath (sec/op) | Change | p-value | Significance |
| --- | --- | --- | --- | --- | --- |
| 128B | 147.1µs | 117.6µs | -20.08% | 0.000 | Significant |
| 1KiB | 169.9µs | 106.0µs | -37.59% | 0.000 | Significant |
| 16KiB | 226.1µs | 173.1µs | -23.43% | 0.000 | Significant |
| 1MiB | 3.662ms | 3.450ms | -5.8% | 0.912 | Not significant |
| geomean | 379.3µs | 293.8µs | -22.55% | - | Overall positive |

# -race test
```bash
lizining@Y:~/projects/dubbo-go$ go test -race ./protocol/triple/... 2>&1 | grep -Ev "no test files|\(cached\)"
go test -race -count=1 ./protocol/triple/triple_protocol/
# 3 rounds of writer-side concurrency testing
go test -race -count=3 -run 'TestUnaryFastPathWriteCloseConcurrent|TestUnaryFastPathSetErrorRejectsWrite|TestUnaryFastPathWriteAfterTransportError|TestUnaryFastPathRequestHeaderConcurrent|TestUnaryFastPathConcurrentReadClose|TestUnaryFastPathWriteAfterClose|TestUnaryFastPathGRPCKeepsDuplex|TestUnaryFastPathEndToEnd' ./protocol/triple/triple_protocol/
go test -race ./protocol/triple/... 2>&1 | grep FAIL || echo "无失败"
ok      dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol    31.804s
ok      dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol    1.457s
无失败
lizining@Y:~/projects/dubbo-go$ 
```

# pprof Benchmark

**Scenario:** Triple unary · 128B · 100 concurrent requests

The fast path removes the per-request `io.Pipe` pipe, the standalone `makeRequest` goroutine, and the `responseReady` channel handoff. Total goroutines decrease by 31%, and `syscall`/`futex` CPU usage drops.

### Goroutine Profile (310 → 213, -31%)

duplex
<img width="1600" height="900" alt="image" src="https://github.com/user-attachments/assets/23d1ff6e-1b44-4bc6-b47f-0e1a019d375a" />
fastpath
<img width="1600" height="1040" alt="image" src="https://github.com/user-attachments/assets/a305c789-981c-4f7f-8e47-4eb5920318a3" />

| | duplex | fastpath |
| :--- | :---: | :---: |
| Total goroutines | 310 | 213 |
| http2 connection-related frames | 26 | 16 |
| pipe-related frames | 3 | 1 |

### CPU Profile
duplex
<img width="1600" height="820" alt="image" src="https://github.com/user-attachments/assets/2ff6cc33-02c3-41a8-a768-490f01f8166a" />
fastpath
<img width="1600" height="1060" alt="image" src="https://github.com/user-attachments/assets/f32230c3-d174-4722-b423-59016ab9112c" />

| Hotspot | duplex | fastpath | Change |
| :--- | :---: | :---: | :---: |
| `syscall.Syscall6` | 28.82% | 24.64% | **-4.2%** |
| `runtime.futex` | 12.41% | 10.25% | **-2.2%** |

### Checklist
- [x] I confirm the target branch is `develop`
- [x] I have run `make fmt` to format my code
- [x] I have run `make test` to run local tests
- [x] I have added tests that prove my fix is effective or that my feature works