### PR TITLE
fix(filter): make access log goroutine shutdown test race-safe

### DIFF
--- a/filter/accesslog/filter.go
+++ b/filter/accesslog/filter.go
@@ -90,28 +90,19 @@ type Filter struct {
 	ctx          context.Context
 	cancel       context.CancelFunc
 	shutdownOnce sync.Once
-	started      chan struct{} // closed once processLogs is running
-	done         chan struct{} // closed once processLogs has exited
 }
 
 func newFilter() filter.Filter {
 	if accessLogFilter == nil {
 		once.Do(func() {
 			ctx, cancel := context.WithCancel(context.Background())
-			f := &Filter{
+			accessLogFilter = &Filter{
 				logChan:   make(chan Data, LogMaxBuffer),
 				fileCache: make(map[string]*os.File),
 				ctx:       ctx,
 				cancel:    cancel,
-				started:   make(chan struct{}),
-				done:      make(chan struct{}),
 			}
-			accessLogFilter = f
-			go func() {
-				close(f.started)
-				f.processLogs()
-				close(f.done)
-			}()
+			go accessLogFilter.processLogs()
 		})
 	}
 	return accessLogFilter

--- a/filter/accesslog/filter.go
+++ b/filter/accesslog/filter.go
@@ -90,19 +90,28 @@ type Filter struct {
 	ctx          context.Context
 	cancel       context.CancelFunc
 	shutdownOnce sync.Once
+	started      chan struct{} // closed once processLogs is running
+	done         chan struct{} // closed once processLogs has exited
 }
 
 func newFilter() filter.Filter {
 	if accessLogFilter == nil {
 		once.Do(func() {
 			ctx, cancel := context.WithCancel(context.Background())
-			accessLogFilter = &Filter{
+			f := &Filter{
 				logChan:   make(chan Data, LogMaxBuffer),
 				fileCache: make(map[string]*os.File),
 				ctx:       ctx,
 				cancel:    cancel,
+				started:   make(chan struct{}),
+				done:      make(chan struct{}),
 			}
-			go accessLogFilter.processLogs()
+			accessLogFilter = f
+			go func() {
+				close(f.started)
+				f.processLogs()
+				close(f.done)
+			}()
 		})
 	}
 	return accessLogFilter

--- a/filter/accesslog/memory_leak_test.go
+++ b/filter/accesslog/memory_leak_test.go
@@ -18,8 +18,11 @@
 package accesslog
 
 import (
+	"bytes"
 	"context"
 	"os"
+	"runtime"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -44,12 +47,15 @@ func resetGlobalState() {
 	once = sync.Once{}
 }
 
-// TestAccessLogFilterGoroutineShutdown verifies that the background log
-// processing goroutine starts with the filter and fully exits on Shutdown.
-// It uses the filter's deterministic lifecycle signals instead of a
-// process-wide goroutine count, which is timing-sensitive under -race (a
-// leftover goroutine from a previous test can be exiting concurrently with a
-// newly started one, canceling out the count change).
+// TestAccessLogFilterGoroutineShutdown verifies that newFilter starts the
+// processLogs goroutine and that Shutdown terminates it. The start
+// assertion requires the processLogs goroutine to appear in a
+// runtime.Stack snapshot, so a future newFilter that forgets to start the
+// goroutine fails the test. The shutdown assertion tracks that exact
+// goroutine's ID instead of relying on the process-wide goroutine count,
+// which is timing-sensitive under -race: a leftover goroutine from a
+// previous test can be exiting concurrently with a newly started one,
+// canceling out the count change.
 func TestAccessLogFilterGoroutineShutdown(t *testing.T) {
 	resetGlobalState()
 
@@ -57,17 +63,54 @@ func TestAccessLogFilterGoroutineShutdown(t *testing.T) {
 	filter := newFilter()
 	assert.NotNil(t, filter)
 
-	f := filter.(*Filter)
-	// The background goroutine must be running; wait for the start signal.
-	<-f.started
+	// The processLogs goroutine must be running; capture its goroutine ID.
+	var gid int64
+	assert.Eventually(t, func() bool {
+		id, ok := processLogsGoroutineID()
+		if ok {
+			gid = id
+		}
+		return ok
+	}, 30*time.Second, 10*time.Millisecond, "processLogs goroutine did not start")
 
-	// Shutdown the filter and wait for the goroutine to actually exit.
+	// Shutdown the filter; that exact goroutine must exit.
 	Shutdown()
-	select {
-	case <-f.done:
-	case <-time.After(10 * time.Second):
-		t.Fatal("access log goroutine did not exit after Shutdown")
+	assert.Eventually(t, func() bool {
+		id, ok := processLogsGoroutineID()
+		return !ok || id != gid
+	}, 30*time.Second, 10*time.Millisecond, "processLogs goroutine did not exit after Shutdown")
+}
+
+// processLogsGoroutineID returns the goroutine ID of a running processLogs
+// goroutine found in the runtime.Stack snapshot, and whether one was found.
+func processLogsGoroutineID() (int64, bool) {
+	buf := make([]byte, 64<<10)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return findProcessLogsGoroutineID(buf[:n])
+		}
+		buf = make([]byte, len(buf)*2)
 	}
+}
+
+// findProcessLogsGoroutineID scans the stack snapshot for the processLogs
+// goroutine block and extracts its goroutine ID from the "goroutine <id>"
+// header line.
+func findProcessLogsGoroutineID(stack []byte) (int64, bool) {
+	for _, block := range bytes.Split(stack, []byte("\n\n")) {
+		if !bytes.Contains(block, []byte("accesslog.(*Filter).processLogs")) {
+			continue
+		}
+		fields := bytes.Fields(bytes.SplitN(block, []byte("\n"), 2)[0])
+		if len(fields) >= 2 {
+			id, err := strconv.ParseInt(string(fields[1]), 10, 64)
+			if err == nil {
+				return id, true
+			}
+		}
+	}
+	return 0, false
 }
 
 // TestAccessLogFilterFileHandleManagement tests proper file handle management

--- a/filter/accesslog/memory_leak_test.go
+++ b/filter/accesslog/memory_leak_test.go
@@ -20,7 +20,6 @@ package accesslog
 import (
 	"context"
 	"os"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -45,36 +44,30 @@ func resetGlobalState() {
 	once = sync.Once{}
 }
 
-// TestAccessLogFilterGoroutineShutdown tests that the goroutine is properly shut down
+// TestAccessLogFilterGoroutineShutdown verifies that the background log
+// processing goroutine starts with the filter and fully exits on Shutdown.
+// It uses the filter's deterministic lifecycle signals instead of a
+// process-wide goroutine count, which is timing-sensitive under -race (a
+// leftover goroutine from a previous test can be exiting concurrently with a
+// newly started one, canceling out the count change).
 func TestAccessLogFilterGoroutineShutdown(t *testing.T) {
 	resetGlobalState()
-
-	// Count goroutines before
-	initialGoroutines := runtime.NumGoroutine()
 
 	// Create filter (this should start the goroutine)
 	filter := newFilter()
 	assert.NotNil(t, filter)
 
-	// Give the goroutine time to start
-	time.Sleep(100 * time.Millisecond)
-	postCreateGoroutines := runtime.NumGoroutine()
+	f := filter.(*Filter)
+	// The background goroutine must be running; wait for the start signal.
+	<-f.started
 
-	// Should have at least one more goroutine
-	assert.Greater(t, postCreateGoroutines, initialGoroutines)
-
-	// Shutdown the filter
+	// Shutdown the filter and wait for the goroutine to actually exit.
 	Shutdown()
-
-	// Give goroutine time to exit
-	time.Sleep(100 * time.Millisecond)
-	runtime.GC() // Force garbage collection
-
-	postShutdownGoroutines := runtime.NumGoroutine()
-
-	// Goroutine count should be back to original or less
-	assert.LessOrEqual(t, postShutdownGoroutines, initialGoroutines+1,
-		"Goroutines should be cleaned up after shutdown")
+	select {
+	case <-f.done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("access log goroutine did not exit after Shutdown")
+	}
 }
 
 // TestAccessLogFilterFileHandleManagement tests proper file handle management

--- a/filter/accesslog/memory_leak_test.go
+++ b/filter/accesslog/memory_leak_test.go
@@ -98,7 +98,7 @@ func processLogsGoroutineID() (int64, bool) {
 // goroutine block and extracts its goroutine ID from the "goroutine <id>"
 // header line.
 func findProcessLogsGoroutineID(stack []byte) (int64, bool) {
-	for _, block := range bytes.Split(stack, []byte("\n\n")) {
+	for block := range bytes.SplitSeq(stack, []byte("\n\n")) {
 		if !bytes.Contains(block, []byte("accesslog.(*Filter).processLogs")) {
 			continue
 		}


### PR DESCRIPTION
### Description
Fixes #3712

### Test
```bash
@Y:~/projects/dubbo-go$ GOTOOLCHAIN=go1.25.6 go test ./filter/accesslog/ -run 'TestAccessLogFilter(FileHandleManagement|GoroutineShutdown)' -race -count=200 -cpu=1 2>&1 | grep -E '^(--- FAIL|ok|FAIL)|DATA RACE|not greater|did not exit'
ok      dubbo.apache.org/dubbo-go/v3/filter/accesslog   21.278s
```
### Checklist
- [x] I confirm the target branch is `develop`
- [x] I have run `make fmt` to format my code
- [x] I have run `make test` to run local tests
- [ ] I have added tests that prove my fix is effective or that my feature works
