### PR TITLE
fix(dubbo): accept bare-ms timeout attachment so failover retries keep the configured timeout

### DIFF
--- a/protocol/dubbo/dubbo_invoker.go
+++ b/protocol/dubbo/dubbo_invoker.go
@@ -163,7 +163,12 @@ func (di *DubboInvoker) Invoke(ctx context.Context, ivc base.Invocation) result.
 func (di *DubboInvoker) getTimeout(ivc *invocation.RPCInvocation) time.Duration {
 	timeout := di.timeout                                                //default timeout
 	if attachTimeout, ok := ivc.GetAttachment(constant.TimeoutKey); ok { //check invocation timeout
-		timeout, _ = time.ParseDuration(attachTimeout)
+		// the timeout below is written back as bare milliseconds, so accept both formats
+		if d, err := time.ParseDuration(attachTimeout); err == nil {
+			timeout = d
+		} else if ms, err := strconv.Atoi(attachTimeout); err == nil {
+			timeout = time.Duration(ms) * time.Millisecond
+		}
 	} else { // check method timeout
 		methodName := ivc.MethodName()
 		if di.GetURL().GetParamBool(constant.GenericKey, false) {

--- a/protocol/dubbo/dubbo_invoker.go
+++ b/protocol/dubbo/dubbo_invoker.go
@@ -163,11 +163,10 @@ func (di *DubboInvoker) Invoke(ctx context.Context, ivc base.Invocation) result.
 func (di *DubboInvoker) getTimeout(ivc *invocation.RPCInvocation) time.Duration {
 	timeout := di.timeout                                                //default timeout
 	if attachTimeout, ok := ivc.GetAttachment(constant.TimeoutKey); ok { //check invocation timeout
-		// the timeout below is written back as bare milliseconds, so accept both formats
 		if d, err := time.ParseDuration(attachTimeout); err == nil {
 			timeout = d
-		} else if ms, err := strconv.Atoi(attachTimeout); err == nil {
-			timeout = time.Duration(ms) * time.Millisecond
+		} else if d, err := time.ParseDuration(attachTimeout + "ms"); err == nil {
+			timeout = d
 		}
 	} else { // check method timeout
 		methodName := ivc.MethodName()

--- a/protocol/dubbo/dubbo_invoker_test.go
+++ b/protocol/dubbo/dubbo_invoker_test.go
@@ -31,6 +31,7 @@ import (
 	"dubbo.apache.org/dubbo-go/v3/common"
 	"dubbo.apache.org/dubbo-go/v3/common/constant"
 	"dubbo.apache.org/dubbo-go/v3/global"
+	"dubbo.apache.org/dubbo-go/v3/protocol/invocation"
 )
 
 func TestNewDubboInvokerUsesGlobalDefaultTimeout(t *testing.T) {
@@ -61,6 +62,19 @@ func TestNewDubboInvokerUsesTimeoutParam(t *testing.T) {
 	invoker := NewDubboInvoker(url, nil)
 
 	assert.Equal(t, 5*time.Second, invoker.timeout)
+}
+
+func TestGetTimeoutAcrossAttemptsOnSameInvocation(t *testing.T) {
+	url, err := common.NewURL("dubbo://127.0.0.1:20880/org.apache.dubbo.UserProvider?timeout=10s")
+	require.NoError(t, err)
+
+	invoker := NewDubboInvoker(url, nil)
+	inv := invocation.NewRPCInvocation("GetUser", nil, nil)
+
+	// the first attempt writes the timeout back as bare milliseconds;
+	// retries on the same invocation (failover) must resolve the same timeout
+	assert.Equal(t, 10*time.Second, invoker.getTimeout(inv))
+	assert.Equal(t, 10*time.Second, invoker.getTimeout(inv))
 }
 
 //

--- a/protocol/dubbo/dubbo_invoker_test.go
+++ b/protocol/dubbo/dubbo_invoker_test.go
@@ -18,6 +18,8 @@
 package dubbo
 
 import (
+	"math"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -74,6 +76,24 @@ func TestGetTimeoutAcrossAttemptsOnSameInvocation(t *testing.T) {
 	// the first attempt writes the timeout back as bare milliseconds;
 	// retries on the same invocation (failover) must resolve the same timeout
 	assert.Equal(t, 10*time.Second, invoker.getTimeout(inv))
+	assert.Equal(t, 10*time.Second, invoker.getTimeout(inv))
+}
+
+func TestGetTimeoutBareMsOverflowBoundary(t *testing.T) {
+	url, err := common.NewURL("dubbo://127.0.0.1:20880/org.apache.dubbo.UserProvider?timeout=10s")
+	require.NoError(t, err)
+
+	invoker := NewDubboInvoker(url, nil)
+
+	// the largest whole milliseconds time.Duration can represent (9223372036854)
+	maxMs := math.MaxInt64 / int64(time.Millisecond)
+	inv := invocation.NewRPCInvocation("GetUser", nil, nil)
+	inv.SetAttachment(constant.TimeoutKey, strconv.FormatInt(maxMs, 10))
+	assert.Equal(t, time.Duration(maxMs)*time.Millisecond, invoker.getTimeout(inv))
+
+	// one more millisecond would overflow into a negative duration; keep the default
+	inv = invocation.NewRPCInvocation("GetUser", nil, nil)
+	inv.SetAttachment(constant.TimeoutKey, strconv.FormatInt(maxMs+1, 10))
 	assert.Equal(t, 10*time.Second, invoker.getTimeout(inv))
 }
 


### PR DESCRIPTION
### Description
Fixes #3710

### Checklist
- [x] I confirm the target branch is `develop`
- [x] I have run `make fmt` to format my code
- [x] I have run `make test` to run local tests
- [x] I have added tests that prove my fix is effective or that my feature works
