### PR TITLE
feat(triple): cut per-message marshal allocations with a pooled MarshalAppend codec path

### DIFF
--- a/protocol/triple/triple_protocol/buffer_pool.go
+++ b/protocol/triple/triple_protocol/buffer_pool.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	initialBufferSize    = 512
-	maxRecycleBufferSize = 8 * 1024 * 1024 // if >8MiB, don't hold onto a buffer
+	maxRecycleBufferSize = 8 * 1024 * 1024 // Don't recycle buffers larger than this.
 )
 
 type bufferPool struct {
@@ -54,4 +54,28 @@ func (b *bufferPool) Put(buffer *bytes.Buffer) {
 	}
 	buffer.Reset()
 	b.Pool.Put(buffer)
+}
+
+// marshalToPool serializes message with appender into a *bytes.Buffer drawn
+// from pool and returns it. If the pooled array is too small and the appender
+// grows the slice, the larger array is swapped in so it can be recycled once
+// the caller returns the buffer. On failure the buffer is put back and a
+// CodeInternal error is returned.
+func marshalToPool(pool *bufferPool, appender marshalAppender, message any) (*bytes.Buffer, *Error) {
+	buffer := pool.Get()
+	raw, err := appender.MarshalAppend(buffer.Bytes(), message)
+	if err != nil {
+		pool.Put(buffer)
+		return nil, errorf(CodeInternal, "marshal message: %w", err)
+	}
+	if cap(raw) > buffer.Cap() {
+		// MarshalAppend grew the slice: swap the larger array in so it can be
+		// recycled next time.
+		*buffer = *bytes.NewBuffer(raw)
+	} else {
+		// No reallocation occurred; adopt the bytes the appender already wrote
+		// into the pooled array.
+		buffer.Write(raw)
+	}
+	return buffer, nil
 }

--- a/protocol/triple/triple_protocol/codec.go
+++ b/protocol/triple/triple_protocol/codec.go
@@ -98,6 +98,17 @@ type stableCodec interface {
 	IsBinary() bool
 }
 
+// marshalAppender is an extension to Codec for serializing into a caller-provided
+// buffer. Codecs that implement it can serialize with zero allocation when the
+// buffer's capacity is sufficient (protobuf fast path); otherwise the appender
+// itself grows the buffer. MarshalAppend must produce output byte-identical to
+// Marshal for the same message — the extension only changes where the bytes are
+// written. Codecs that do not implement it are unaffected.
+type marshalAppender interface {
+	// MarshalAppend marshals the given message, appending the result to dst.
+	MarshalAppend(dst []byte, message any) ([]byte, error)
+}
+
 // protoBinaryCodec handles standard protobuf binary serialization for IDL
 // calls. Non-IDL (Java Dubbo Triple generic call) wrapper handling on the
 // server side is handled by tripleServerCodecSession, which delegates to
@@ -114,6 +125,14 @@ func (c *protoBinaryCodec) Marshal(message any) ([]byte, error) {
 		return nil, errNotProto(message)
 	}
 	return proto.Marshal(protoMessage)
+}
+
+func (c *protoBinaryCodec) MarshalAppend(dst []byte, message any) ([]byte, error) {
+	protoMessage, ok := message.(proto.Message)
+	if !ok {
+		return nil, errNotProto(message)
+	}
+	return proto.MarshalOptions{}.MarshalAppend(dst, protoMessage)
 }
 
 func (c *protoBinaryCodec) Unmarshal(data []byte, message any) error {
@@ -636,6 +655,43 @@ func (s *tripleServerCodecSession) Marshal(message any) ([]byte, error) {
 	}
 	// Non-IDL: wrap the response in a TripleResponseWrapper whose Data is
 	// serialized with the inner codec resolved from the request's SerializeType.
+	wrapper, err := s.responseWrapper(message)
+	if err != nil {
+		return nil, err
+	}
+	return proto.Marshal(wrapper)
+}
+
+// MarshalAppend extends Marshal for the marshalAppender fast path. The IDL
+// proto leg forwards to the delegate's appender (zero allocation when the
+// pooled buffer's cap is sufficient); the Non-IDL leg still serializes the
+// inner payload with the inner codec, but appends the outer
+// TripleResponseWrapper into the caller-provided buffer instead of allocating
+// a fresh slice.
+func (s *tripleServerCodecSession) MarshalAppend(dst []byte, message any) ([]byte, error) {
+	if pm, isProto := message.(proto.Message); isProto {
+		if appender, ok := s.delegate.(marshalAppender); ok {
+			return appender.MarshalAppend(dst, pm)
+		}
+		// A custom proto codec without the appender extension must still
+		// round-trip; fall back to a plain marshal plus append. The output is
+		// byte-for-byte what Marshal would produce.
+		raw, err := s.delegate.Marshal(pm)
+		if err != nil {
+			return nil, err
+		}
+		return append(dst, raw...), nil
+	}
+	wrapper, err := s.responseWrapper(message)
+	if err != nil {
+		return nil, err
+	}
+	return proto.MarshalOptions{}.MarshalAppend(dst, wrapper)
+}
+
+// responseWrapper builds the TripleResponseWrapper for a Non-IDL response,
+// resolving the inner codec from the SerializeType captured by Unmarshal.
+func (s *tripleServerCodecSession) responseWrapper(message any) (*interoperability.TripleResponseWrapper, error) {
 	inner, err := resolveInnerCodec(s.serializeType)
 	if err != nil {
 		return nil, fmt.Errorf("marshal triple wrapper response: %w", err)
@@ -667,10 +723,10 @@ func (s *tripleServerCodecSession) Marshal(message any) ([]byte, error) {
 	}
 	// Use inner.Name() instead of s.serializeType so that an absent SerializeType
 	// (defaulted to hessian2 by resolveInnerCodec) is normalized on the wire.
-	return proto.Marshal(&interoperability.TripleResponseWrapper{
+	return &interoperability.TripleResponseWrapper{
 		SerializeType: inner.Name(),
 		Data:          data,
-	})
+	}, nil
 }
 
 // unmarshalWrapperRequestArgs decodes the inner args of a TripleRequestWrapper

--- a/protocol/triple/triple_protocol/envelope.go
+++ b/protocol/triple/triple_protocol/envelope.go
@@ -76,15 +76,37 @@ func (w *envelopeWriter) Marshal(message any) *Error {
 		}
 		return nil
 	}
-	raw, err := w.codec.Marshal(message)
-	if err != nil {
-		if w.backupCodec != nil && w.codec.Name() != w.backupCodec.Name() {
-			logger.Debugf("[Triple][Codec] failed to marshal message with primary codec %s, trying fallback codec %s", w.codec.Name(), w.backupCodec.Name())
-			raw, err = w.backupCodec.Marshal(message)
-		}
+	// Fast path: if the codec can append to a caller-provided buffer, marshal
+	// directly into a pooled buffer to avoid the per-request allocation.
+	if appender, ok := w.codec.(marshalAppender); ok {
+		buffer, err := marshalToPool(w.bufferPool, appender, message)
 		if err != nil {
-			return errorf(CodeInternal, "marshal message: %w", err)
+			// Preserve the backup-codec fallback semantics of the slow path.
+			// Only a marshal failure may fall back; write failures (I/O,
+			// compression, or the sendMaxBytes limit) are terminal and must
+			// never retry through the backup codec.
+			if w.backupCodec != nil && w.codec.Name() != w.backupCodec.Name() {
+				logger.Debugf("[Triple][Codec] failed to marshal message with primary codec %s, trying fallback codec %s", w.codec.Name(), w.backupCodec.Name())
+				return w.marshalWithFallback(w.backupCodec, message)
+			}
+			return err
 		}
+		defer w.bufferPool.Put(buffer)
+		return w.Write(&envelope{Data: buffer})
+	}
+	return w.marshalWithFallback(w.codec, message)
+}
+
+// marshalWithFallback is the slow path: Marshal, falling back to the backup
+// codec on error, then wrap the result in a fresh buffer.
+func (w *envelopeWriter) marshalWithFallback(codec Codec, message any) *Error {
+	raw, err := codec.Marshal(message)
+	if err != nil && w.backupCodec != nil && codec.Name() != w.backupCodec.Name() {
+		logger.Debugf("[Triple][Codec] failed to marshal message with primary codec %s, trying fallback codec %s", codec.Name(), w.backupCodec.Name())
+		raw, err = w.backupCodec.Marshal(message)
+	}
+	if err != nil {
+		return errorf(CodeInternal, "marshal message: %w", err)
 	}
 	// We can't avoid allocating the byte slice, so we may as well reuse it once
 	// we're done with it.

--- a/protocol/triple/triple_protocol/marshal_perf_bench_test.go
+++ b/protocol/triple/triple_protocol/marshal_perf_bench_test.go
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package triple_protocol
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+import (
+	pingv1 "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/ping/v1"
+)
+
+// noAppenderCodec wraps a Codec without exposing the marshalAppender extension,
+// so the marshaler takes the pre-optimization slow path (codec.Marshal into a
+// freshly allocated slice wrapped by a new *bytes.Buffer). It is the A/B
+// baseline for the MarshalAppend fast path.
+type noAppenderCodec struct{ Codec }
+
+// marshalPerfPayloadSizes covers fixed-overhead-dominated small messages
+// through bandwidth-dominated large messages.
+var marshalPerfPayloadSizes = []int{128, 1024, 16 * 1024, 1024 * 1024}
+
+func marshalPerfSizeLabel(size int) string {
+	if size == 1024*1024 {
+		return "1MiB"
+	}
+	return fmt.Sprintf("%dB", size)
+}
+
+func newMarshalPerfMessage(size int) *pingv1.PingRequest {
+	return &pingv1.PingRequest{Text: strings.Repeat("a", size)}
+}
+
+// benchMarshalConfig controls which branches of the marshal fast/slow paths a
+// benchmark drives. With compress enabled, marshalers are configured with a
+// gzip compression pool (compressMinBytes left at 0, so every message takes
+// the compression branch); sendMaxBytes, when non-zero, exercises the size
+// limit checks after marshaling and after compression.
+type benchMarshalConfig struct {
+	compress     bool
+	sendMaxBytes int
+}
+
+// newBenchGzipPool returns a gzip compression pool for benchmarks. The
+// initial io.Discard sink is replaced by the compressionPool with Reset on
+// each use.
+func newBenchGzipPool() *compressionPool {
+	return newCompressionPool(
+		func() Decompressor { return &gzip.Reader{} },
+		func() Compressor { return gzip.NewWriter(io.Discard) },
+	)
+}
+
+// benchTripleUnaryMarshaler drives tripleUnaryMarshaler.Marshal with the given
+// codec. protoBinaryCodec exercises the MarshalAppend fast path;
+// noAppenderCodec exercises the codec.Marshal slow path.
+func benchTripleUnaryMarshaler(b *testing.B, codec Codec, message *pingv1.PingRequest, cfg benchMarshalConfig) {
+	b.Helper()
+	m := &tripleUnaryMarshaler{
+		writer:       io.Discard,
+		codec:        codec,
+		bufferPool:   newBufferPool(),
+		sendMaxBytes: cfg.sendMaxBytes,
+	}
+	if cfg.compress {
+		m.compressionPool = newBenchGzipPool()
+		m.compressionName = compressionGzip
+		// setHeaderCanonical writes into header on the compressed path.
+		m.header = make(http.Header)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := m.Marshal(message); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func runUnaryMarshalerBench(b *testing.B, codec Codec, cfg benchMarshalConfig) {
+	for _, size := range marshalPerfPayloadSizes {
+		b.Run(marshalPerfSizeLabel(size), func(b *testing.B) {
+			benchTripleUnaryMarshaler(b, codec, newMarshalPerfMessage(size), cfg)
+		})
+	}
+}
+
+func BenchmarkUnaryMarshalerFastPath(b *testing.B) {
+	runUnaryMarshalerBench(b, &protoBinaryCodec{}, benchMarshalConfig{})
+}
+
+func BenchmarkUnaryMarshalerSlowPath(b *testing.B) {
+	runUnaryMarshalerBench(b, &noAppenderCodec{&protoBinaryCodec{}}, benchMarshalConfig{})
+}
+
+// BenchmarkUnaryMarshaler*Compressed drive the gzip-compressed branch of the
+// fast/slow paths (second pooled buffer, compression header, compressed-size
+// limit check) with a generous sendMaxBytes so the limit is exercised but
+// never tripped.
+func BenchmarkUnaryMarshalerFastPathCompressed(b *testing.B) {
+	runUnaryMarshalerBench(b, &protoBinaryCodec{}, benchMarshalConfig{compress: true, sendMaxBytes: 1 << 30})
+}
+
+func BenchmarkUnaryMarshalerSlowPathCompressed(b *testing.B) {
+	runUnaryMarshalerBench(b, &noAppenderCodec{&protoBinaryCodec{}}, benchMarshalConfig{compress: true, sendMaxBytes: 1 << 30})
+}
+
+// benchEnvelopeWriter drives envelopeWriter.Marshal with the given codec.
+func benchEnvelopeWriter(b *testing.B, codec Codec, message *pingv1.PingRequest, cfg benchMarshalConfig) {
+	b.Helper()
+	w := &envelopeWriter{
+		writer:       io.Discard,
+		codec:        codec,
+		bufferPool:   newBufferPool(),
+		sendMaxBytes: cfg.sendMaxBytes,
+	}
+	if cfg.compress {
+		w.compressionPool = newBenchGzipPool()
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := w.Marshal(message); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func runEnvelopeWriterBench(b *testing.B, codec Codec, cfg benchMarshalConfig) {
+	for _, size := range marshalPerfPayloadSizes {
+		b.Run(marshalPerfSizeLabel(size), func(b *testing.B) {
+			benchEnvelopeWriter(b, codec, newMarshalPerfMessage(size), cfg)
+		})
+	}
+}
+
+func BenchmarkEnvelopeWriterFastPath(b *testing.B) {
+	runEnvelopeWriterBench(b, &protoBinaryCodec{}, benchMarshalConfig{})
+}
+
+func BenchmarkEnvelopeWriterSlowPath(b *testing.B) {
+	runEnvelopeWriterBench(b, &noAppenderCodec{&protoBinaryCodec{}}, benchMarshalConfig{})
+}
+
+// BenchmarkEnvelopeWriter*Compressed drive the gzip-compressed branch of
+// envelopeWriter.Write (compression into a second pooled buffer plus the
+// compressed-size limit check).
+func BenchmarkEnvelopeWriterFastPathCompressed(b *testing.B) {
+	runEnvelopeWriterBench(b, &protoBinaryCodec{}, benchMarshalConfig{compress: true, sendMaxBytes: 1 << 30})
+}
+
+func BenchmarkEnvelopeWriterSlowPathCompressed(b *testing.B) {
+	runEnvelopeWriterBench(b, &noAppenderCodec{&protoBinaryCodec{}}, benchMarshalConfig{compress: true, sendMaxBytes: 1 << 30})
+}

--- a/protocol/triple/triple_protocol/marshal_perf_bench_test.go
+++ b/protocol/triple/triple_protocol/marshal_perf_bench_test.go
@@ -30,10 +30,10 @@ import (
 	pingv1 "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/ping/v1"
 )
 
-// noAppenderCodec wraps a Codec without exposing the marshalAppender extension,
-// so the marshaler takes the pre-optimization slow path (codec.Marshal into a
-// freshly allocated slice wrapped by a new *bytes.Buffer). It is the A/B
-// baseline for the MarshalAppend fast path.
+// noAppenderCodec embeds a Codec without the marshalAppender extension, so
+// the marshaler's appender type assertion fails and marshaling takes the
+// codec.Marshal slow path — the baseline that the fast path is measured
+// against.
 type noAppenderCodec struct{ Codec }
 
 // marshalPerfPayloadSizes covers fixed-overhead-dominated small messages
@@ -51,11 +51,8 @@ func newMarshalPerfMessage(size int) *pingv1.PingRequest {
 	return &pingv1.PingRequest{Text: strings.Repeat("a", size)}
 }
 
-// benchMarshalConfig controls which branches of the marshal fast/slow paths a
-// benchmark drives. With compress enabled, marshalers are configured with a
-// gzip compression pool (compressMinBytes left at 0, so every message takes
-// the compression branch); sendMaxBytes, when non-zero, exercises the size
-// limit checks after marshaling and after compression.
+// benchMarshalConfig selects which marshal branches a benchmark drives: gzip
+// compression and the sendMaxBytes limit checks.
 type benchMarshalConfig struct {
 	compress     bool
 	sendMaxBytes int
@@ -113,10 +110,8 @@ func BenchmarkUnaryMarshalerSlowPath(b *testing.B) {
 	runUnaryMarshalerBench(b, &noAppenderCodec{&protoBinaryCodec{}}, benchMarshalConfig{})
 }
 
-// BenchmarkUnaryMarshaler*Compressed drive the gzip-compressed branch of the
-// fast/slow paths (second pooled buffer, compression header, compressed-size
-// limit check) with a generous sendMaxBytes so the limit is exercised but
-// never tripped.
+// BenchmarkUnaryMarshaler*Compressed drive the gzip-compressed fast and slow
+// paths with a generous sendMaxBytes that is exercised but never tripped.
 func BenchmarkUnaryMarshalerFastPathCompressed(b *testing.B) {
 	runUnaryMarshalerBench(b, &protoBinaryCodec{}, benchMarshalConfig{compress: true, sendMaxBytes: 1 << 30})
 }

--- a/protocol/triple/triple_protocol/marshal_perf_regression_test.go
+++ b/protocol/triple/triple_protocol/marshal_perf_regression_test.go
@@ -1,0 +1,918 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package triple_protocol
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+)
+
+import (
+	pingv1 "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/ping/v1"
+)
+
+// ---------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------
+
+// syncBuffer is an io.Writer that is safe for concurrent use. It lets
+// concurrency tests share one envelopeWriter without corrupting output.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) Bytes() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]byte(nil), s.buf.Bytes()...)
+}
+
+func (s *syncBuffer) Len() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Len()
+}
+
+// regressionCodecList returns the two codecs under test: the fast path
+// (implements marshalAppender) and the slow path (does not).
+func regressionCodecList() []struct {
+	name  string
+	codec Codec
+} {
+	return []struct {
+		name  string
+		codec Codec
+	}{
+		{name: "fast", codec: &protoBinaryCodec{}},
+		{name: "slow", codec: &noAppenderCodec{&protoBinaryCodec{}}},
+	}
+}
+
+func newTestGzipCompressionPool() *compressionPool {
+	return newCompressionPool(
+		func() Decompressor { return &gzip.Reader{} },
+		func() Compressor { return gzip.NewWriter(io.Discard) },
+	)
+}
+
+// newEnvelopeWriterForTest builds an envelopeWriter (gRPC/Triple wire) with
+// optional gzip compression.
+func newEnvelopeWriterForTest(t *testing.T, codec Codec, compress bool, compressMinBytes, sendMaxBytes int) (*envelopeWriter, *syncBuffer) {
+	t.Helper()
+	out := &syncBuffer{}
+	w := &envelopeWriter{
+		writer:           out,
+		codec:            codec,
+		compressMinBytes: compressMinBytes,
+		bufferPool:       newBufferPool(),
+		sendMaxBytes:     sendMaxBytes,
+	}
+	if compress {
+		w.compressionPool = newTestGzipCompressionPool()
+	}
+	return w, out
+}
+
+// newTripleMarshalerForTest builds a tripleUnaryMarshaler (Triple HTTP body
+// wire) with optional gzip compression.
+func newTripleMarshalerForTest(
+	t *testing.T,
+	codec Codec,
+	compress bool,
+	compressMinBytes, sendMaxBytes int,
+) (*tripleUnaryMarshaler, *syncBuffer, http.Header) {
+	t.Helper()
+	out := &syncBuffer{}
+	header := make(http.Header)
+	m := &tripleUnaryMarshaler{
+		writer:           out,
+		codec:            codec,
+		compressMinBytes: compressMinBytes,
+		bufferPool:       newBufferPool(),
+		header:           header,
+		sendMaxBytes:     sendMaxBytes,
+	}
+	if compress {
+		m.compressionPool = newTestGzipCompressionPool()
+		m.compressionName = compressionGzip
+	}
+	return m, out, header
+}
+
+func regressionPayloadSizes() []int {
+	mi := 1024 * 1024
+	return []int{0, 1, 511, 512, 513, 1024, 8*mi - 1, 8 * mi, 8*mi + 1}
+}
+
+func regressionSizeLabel(size int) string {
+	switch size {
+	case 0:
+		return "empty"
+	case 1024:
+		return "1KiB"
+	case 8*1024*1024 - 1:
+		return "8MiB-1"
+	case 8 * 1024 * 1024:
+		return "8MiB"
+	case 8*1024*1024 + 1:
+		return "8MiB+1"
+	default:
+		return fmt.Sprintf("%dB", size)
+	}
+}
+
+// envelopePrefix parses the 5-byte gRPC/Triple envelope prefix written by
+// envelopeWriter: byte 0 is flags, bytes 1..4 (wire[1:5]) are the big-endian
+// payload length.
+func envelopePrefix(t *testing.T, wire []byte) (flags byte, length int) {
+	t.Helper()
+	if len(wire) < 5 {
+		t.Fatalf("wire output shorter than envelope prefix: got %d bytes", len(wire))
+	}
+	return wire[0], int(binary.BigEndian.Uint32(wire[1:5]))
+}
+
+func wantCode(t *testing.T, err *Error, want Code) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected *Error with code %v, got nil", want)
+	}
+	if got := err.Code(); got != want {
+		t.Fatalf("expected code %v, got %v (message: %v)", want, got, err)
+	}
+}
+
+// ---------------------------------------------------------------
+// 1. Wire byte parity: fast path output == slow path output
+// ---------------------------------------------------------------
+
+// TestMarshalPerfWireParity locks the core correctness invariant: for the
+// same message and compression setting, the MarshalAppend fast path must emit
+// byte-for-byte the same wire output as the pre-optimization codec.Marshal
+// slow path. Runs on both the triple HTTP body wire (tripleUnaryMarshaler)
+// and the gRPC/Triple envelope wire (envelopeWriter).
+func TestMarshalPerfWireParity(t *testing.T) {
+	for _, compress := range []bool{false, true} {
+		t.Run(fmt.Sprintf("compressed=%v", compress), func(t *testing.T) {
+			for _, size := range regressionPayloadSizes() {
+				size := size
+				t.Run(regressionSizeLabel(size), func(t *testing.T) {
+					t.Parallel()
+					msg := newMarshalPerfMessage(size)
+
+					// triple HTTP body wire
+					t.Run("triple", func(t *testing.T) {
+						var fastWire, slowWire []byte
+						var fastHeader, slowHeader http.Header
+						for _, c := range regressionCodecList() {
+							m, out, header := newTripleMarshalerForTest(t, c.codec, compress, 0, 0)
+							if err := m.Marshal(msg); err != nil {
+								t.Fatalf("%s path triple marshal: %v", c.name, err)
+							}
+							switch c.name {
+							case "fast":
+								fastWire, fastHeader = out.Bytes(), header
+							case "slow":
+								slowWire, slowHeader = out.Bytes(), header
+							}
+						}
+						if !bytes.Equal(fastWire, slowWire) {
+							t.Fatalf("triple wire mismatch: fast %d bytes vs slow %d bytes", len(fastWire), len(slowWire))
+						}
+						if compress {
+							if fastHeader.Get(tripleUnaryHeaderCompression) != compressionGzip ||
+								slowHeader.Get(tripleUnaryHeaderCompression) != compressionGzip {
+								t.Fatalf("compression header not set identically: fast=%q slow=%q",
+									fastHeader.Get(tripleUnaryHeaderCompression), slowHeader.Get(tripleUnaryHeaderCompression))
+							}
+						}
+					})
+
+					// gRPC/Triple envelope wire (5-byte prefix framing)
+					t.Run("envelope", func(t *testing.T) {
+						var fastWire, slowWire []byte
+						for _, c := range regressionCodecList() {
+							w, out := newEnvelopeWriterForTest(t, c.codec, compress, 0, 0)
+							if err := w.Marshal(msg); err != nil {
+								t.Fatalf("%s path envelope marshal: %v", c.name, err)
+							}
+							switch c.name {
+							case "fast":
+								fastWire = out.Bytes()
+							case "slow":
+								slowWire = out.Bytes()
+							}
+						}
+						if !bytes.Equal(fastWire, slowWire) {
+							t.Fatalf("envelope wire mismatch: fast %d bytes vs slow %d bytes", len(fastWire), len(slowWire))
+						}
+					})
+				})
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------
+// 2. Pool invariants and envelope boundaries
+// ---------------------------------------------------------------
+
+func TestMarshalPerfPoolInvariants(t *testing.T) {
+	t.Parallel()
+
+	t.Run("get returns empty buffer", func(t *testing.T) {
+		pool := newBufferPool()
+		buf := pool.Get()
+		defer pool.Put(buf)
+		if buf.Len() != 0 {
+			t.Fatalf("bufferPool.Get() returned buffer with Len()==%d, want 0", buf.Len())
+		}
+	})
+
+	t.Run("put resets length", func(t *testing.T) {
+		pool := newBufferPool()
+		buf := pool.Get()
+		if _, err := buf.WriteString("junk to reset"); err != nil {
+			t.Fatal(err)
+		}
+		pool.Put(buf)
+		again := pool.Get()
+		defer pool.Put(again)
+		if again.Len() != 0 {
+			t.Fatalf("reused buffer not reset: Len()==%d, want 0", again.Len())
+		}
+	})
+
+	t.Run("nil message writes nothing", func(t *testing.T) {
+		for _, c := range regressionCodecList() {
+			w, out := newEnvelopeWriterForTest(t, c.codec, false, 0, 0)
+			if err := w.Marshal(nil); err != nil {
+				t.Fatalf("%s path nil message: %v", c.name, err)
+			}
+			if out.Len() != 0 {
+				t.Fatalf("%s path nil message wrote %d bytes, want 0", c.name, out.Len())
+			}
+		}
+	})
+
+	t.Run("empty proto yields zero-length envelope", func(t *testing.T) {
+		// compressMinBytes=1: an empty payload (0 < 1) must not be compressed,
+		// so the envelope is exactly a 5-byte prefix announcing length 0.
+		for _, c := range regressionCodecList() {
+			w, out := newEnvelopeWriterForTest(t, c.codec, true, 1, 0)
+			msg := &pingv1.PingRequest{Text: ""}
+			if err := w.Marshal(msg); err != nil {
+				t.Fatalf("%s path: %v", c.name, err)
+			}
+			flags, length := envelopePrefix(t, out.Bytes())
+			if flags != 0 {
+				t.Fatalf("%s path: empty payload compressed (flags=%#x), want 0", c.name, flags)
+			}
+			if length != 0 {
+				t.Fatalf("%s path: envelope length %d, want 0", c.name, length)
+			}
+			if out.Len() != 5 {
+				t.Fatalf("%s path: wire length %d, want exactly 5 (prefix only)", c.name, out.Len())
+			}
+		}
+	})
+
+	t.Run("compressMinBytes boundary does not panic", func(t *testing.T) {
+		// The compression decision is made on the codec's encoded output
+		// length, not the message's Text length (protobuf adds tag+length
+		// prefix bytes). Anchor the boundary on the real encoded length:
+		// threshold == encoded length compresses, threshold == length+1 does
+		// not. Both paths must survive the boundary and agree on the flag.
+		codec := &protoBinaryCodec{}
+		for _, size := range []int{511, 512, 513} {
+			msg := newMarshalPerfMessage(size)
+			raw, err := codec.Marshal(msg)
+			if err != nil {
+				t.Fatal(err)
+			}
+			encodedLen := len(raw)
+			for _, minBytes := range []int{encodedLen, encodedLen + 1} {
+				wantCompressed := minBytes <= encodedLen
+				for _, c := range regressionCodecList() {
+					w, out := newEnvelopeWriterForTest(t, c.codec, true, minBytes, 0)
+					if err := w.Marshal(msg); err != nil {
+						t.Fatalf("%s path size %d minBytes %d: %v", c.name, size, minBytes, err)
+					}
+					flags, _ := envelopePrefix(t, out.Bytes())
+					gotCompressed := flags&flagEnvelopeCompressed != 0
+					if gotCompressed != wantCompressed {
+						t.Fatalf("%s path size %d (encoded %d) minBytes %d: compressed=%v, want %v",
+							c.name, size, encodedLen, minBytes, gotCompressed, wantCompressed)
+					}
+				}
+			}
+		}
+	})
+}
+
+// ---------------------------------------------------------------
+// 3. backupCodec fallback parity (fast and slow paths)
+// ---------------------------------------------------------------
+
+// errorCodec implements Codec and marshalAppender, always failing. It forces
+// the envelopeWriter fast path (MarshalAppend) and slow path (Marshal) into
+// their backup-codec fallback branches.
+type errorCodec struct{}
+
+var _ Codec = errorCodec{}
+var _ marshalAppender = errorCodec{}
+
+func (errorCodec) Name() string { return "always-error" }
+
+func (errorCodec) Marshal(any) ([]byte, error) {
+	return nil, errors.New("primary codec marshal failed")
+}
+
+func (errorCodec) MarshalAppend(dst []byte, _ any) ([]byte, error) {
+	return nil, errors.New("primary codec marshal failed")
+}
+
+func (errorCodec) Unmarshal([]byte, any) error {
+	return errors.New("primary codec unmarshal failed")
+}
+
+func TestMarshalPerfBackupCodecFallback(t *testing.T) {
+	msg := &pingv1.PingRequest{Text: "fallback"}
+	// Reference wire bytes produced by the healthy codec.
+	var refBytes []byte
+	{
+		ref, out := newEnvelopeWriterForTest(t, &protoBinaryCodec{}, false, 0, 0)
+		if err := ref.Marshal(msg); err != nil {
+			t.Fatal(err)
+		}
+		refBytes = out.Bytes()
+	}
+
+	t.Run("primary fails fast path falls back", func(t *testing.T) {
+		// errorCodec implements marshalAppender, so the fast path is taken;
+		// on failure it must fall back to the backup codec and produce the
+		// same wire bytes as the healthy codec.
+		w, out := newEnvelopeWriterForTest(t, errorCodec{}, false, 0, 0)
+		w.backupCodec = &protoBinaryCodec{}
+		if err := w.Marshal(msg); err != nil {
+			t.Fatalf("fast fallback: %v", err)
+		}
+		if got := out.Bytes(); !bytes.Equal(got, refBytes) {
+			t.Fatalf("fast fallback wire mismatch: got %d bytes, want %d", len(got), len(refBytes))
+		}
+	})
+
+	t.Run("primary fails slow path falls back", func(t *testing.T) {
+		w, out := newEnvelopeWriterForTest(t, &noAppenderCodec{errorCodec{}}, false, 0, 0)
+		w.backupCodec = &protoBinaryCodec{}
+		if err := w.Marshal(msg); err != nil {
+			t.Fatalf("slow fallback: %v", err)
+		}
+		if got := out.Bytes(); !bytes.Equal(got, refBytes) {
+			t.Fatalf("slow fallback wire mismatch: got %d bytes, want %d", len(got), len(refBytes))
+		}
+	})
+
+	t.Run("write failure with healthy appender does not fall back", func(t *testing.T) {
+		// Regression: the fast path may fall back only on a marshal failure.
+		// A healthy appender codec whose marshal succeeds but whose write fails
+		// (I/O error, compression, or the sendMaxBytes limit) must surface that
+		// error as-is; the backup codec must not be consulted and the writer
+		// must not see a second write attempt.
+		backup := &countingNamedCodec{Codec: &protoBinaryCodec{}, name: "hessian2"}
+		out := &failingWriter{}
+		w := &envelopeWriter{
+			writer:      out,
+			codec:       &protoBinaryCodec{}, // implements marshalAppender
+			backupCodec: backup,
+			bufferPool:  newBufferPool(),
+		}
+		wantCode(t, w.Marshal(msg), CodeUnknown)
+		if out.writes != 1 {
+			t.Fatalf("writer called %d times, want 1 (write failure must not retry)", out.writes)
+		}
+		if backup.marshalCalls != 0 {
+			t.Fatalf("backup codec Marshal called %d times on a write failure, want 0", backup.marshalCalls)
+		}
+	})
+
+	t.Run("same name does not double fallback", func(t *testing.T) {
+		// Backup shares the failing codec's name; no fallback may occur (that
+		// would risk infinite recursion), so the error surfaces. errorCodec
+		// implements marshalAppender (fast leg); wrapping it hides the
+		// extension (slow leg).
+		legs := []struct {
+			name  string
+			codec Codec
+		}{
+			{name: "fast", codec: errorCodec{}},
+			{name: "slow", codec: &noAppenderCodec{errorCodec{}}},
+		}
+		for _, leg := range legs {
+			w, _ := newEnvelopeWriterForTest(t, leg.codec, false, 0, 0)
+			w.backupCodec = &failingNamedCodec{name: "always-error"}
+			if err := w.Marshal(msg); err == nil {
+				t.Fatalf("%s path: expected error when backup shares codec name, got nil", leg.name)
+			} else if asErr, ok := asError(err); ok && asErr.Code() != CodeInternal {
+				t.Fatalf("%s path: expected CodeInternal, got %v", leg.name, asErr.Code())
+			}
+		}
+	})
+
+	t.Run("nil backup returns internal error", func(t *testing.T) {
+		for _, c := range regressionCodecList() {
+			w, _ := newEnvelopeWriterForTest(t, errorCodec{}, false, 0, 0)
+			if c.name == "slow" {
+				w.codec = &noAppenderCodec{errorCodec{}}
+			}
+			w.backupCodec = nil
+			err := w.Marshal(msg)
+			if err == nil {
+				t.Fatalf("%s path: expected error with nil backup, got nil", c.name)
+			}
+			wantCode(t, err, CodeInternal)
+		}
+	})
+}
+
+// failingNamedCodec lets tests control the Name() seen by the fallback check.
+type failingNamedCodec struct {
+	errorCodec
+	name string
+}
+
+func (c *failingNamedCodec) Name() string { return c.name }
+
+// failingWriter is an io.Writer that records how many times it was called and
+// always fails, letting tests observe spurious write retries.
+type failingWriter struct {
+	writes int
+}
+
+func (w *failingWriter) Write(p []byte) (int, error) {
+	w.writes++
+	return 0, errors.New("write failed")
+}
+
+// countingNamedCodec wraps a codec under a distinct Name and counts Marshal
+// calls, letting tests observe whether the backup-codec fallback ran.
+type countingNamedCodec struct {
+	Codec
+	name         string
+	marshalCalls int
+}
+
+func (c *countingNamedCodec) Name() string { return c.name }
+
+func (c *countingNamedCodec) Marshal(message any) ([]byte, error) {
+	c.marshalCalls++
+	return c.Codec.Marshal(message)
+}
+
+// ---------------------------------------------------------------
+// 4. Compression threshold and sendMaxBytes consistency
+// ---------------------------------------------------------------
+
+func TestMarshalPerfCompressionAndMaxBytes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sendMaxBytes exceeded returns ResourceExhausted on both paths", func(t *testing.T) {
+		msg := newMarshalPerfMessage(1024)
+		for _, wire := range []string{"envelope", "triple"} {
+			for _, c := range regressionCodecList() {
+				switch wire {
+				case "envelope":
+					w, _ := newEnvelopeWriterForTest(t, c.codec, false, 0, 100)
+					wantCode(t, w.Marshal(msg), CodeResourceExhausted)
+				case "triple":
+					m, _, _ := newTripleMarshalerForTest(t, c.codec, false, 0, 100)
+					wantCode(t, m.Marshal(msg), CodeResourceExhausted)
+				}
+			}
+		}
+	})
+
+	t.Run("compressed over-limit also returns ResourceExhausted", func(t *testing.T) {
+		// sendMaxBytes=1 with gzip enabled: even the compressed form of any
+		// non-empty message exceeds 1 byte, so both paths must reject it.
+		msg := newMarshalPerfMessage(64)
+		for _, wire := range []string{"envelope", "triple"} {
+			for _, c := range regressionCodecList() {
+				switch wire {
+				case "envelope":
+					w, _ := newEnvelopeWriterForTest(t, c.codec, true, 0, 1)
+					wantCode(t, w.Marshal(msg), CodeResourceExhausted)
+				case "triple":
+					m, _, _ := newTripleMarshalerForTest(t, c.codec, true, 0, 1)
+					wantCode(t, m.Marshal(msg), CodeResourceExhausted)
+				}
+			}
+		}
+	})
+
+	t.Run("compression header set identically on triple wire", func(t *testing.T) {
+		msg := newMarshalPerfMessage(1024)
+		for _, c := range regressionCodecList() {
+			m, _, header := newTripleMarshalerForTest(t, c.codec, true, 512, 0)
+			if err := m.Marshal(msg); err != nil {
+				t.Fatalf("%s path: %v", c.name, err)
+			}
+			if got := header.Get(tripleUnaryHeaderCompression); got != compressionGzip {
+				t.Fatalf("%s path: compression header %q, want %q", c.name, got, compressionGzip)
+			}
+		}
+	})
+}
+
+// ---------------------------------------------------------------
+// 5. >8MiB buffers are dropped, not recycled (no residue)
+// ---------------------------------------------------------------
+
+func TestMarshalPerfLargeBufferDropped(t *testing.T) {
+	t.Parallel()
+
+	t.Run("pool refuses to recycle oversized buffer", func(t *testing.T) {
+		pool := newBufferPool()
+		big := pool.Get()
+		data := make([]byte, 8*1024*1024+1)
+		if _, err := big.Write(data); err != nil {
+			t.Fatal(err)
+		}
+		if big.Cap() <= maxRecycleBufferSize {
+			t.Fatalf("test setup: buffer cap %d not larger than %d", big.Cap(), maxRecycleBufferSize)
+		}
+		pool.Put(big)
+		next := pool.Get()
+		defer pool.Put(next)
+		if next.Cap() > maxRecycleBufferSize {
+			t.Fatalf("pool recycled an oversized buffer: cap %d > max %d", next.Cap(), maxRecycleBufferSize)
+		}
+		if next.Len() != 0 {
+			t.Fatalf("pool returned non-empty buffer: Len()==%d", next.Len())
+		}
+	})
+
+	t.Run("large message does not poison subsequent small message", func(t *testing.T) {
+		large := newMarshalPerfMessage(8*1024*1024 + 1)
+		small := newMarshalPerfMessage(1)
+		for _, wire := range []string{"envelope", "triple"} {
+			for _, c := range regressionCodecList() {
+				// newMarshalTo returns a marshal function whose marshaler is
+				// bound to the given buffer pool, so callers control sharing.
+				newMarshalTo := func(pool *bufferPool) func(*pingv1.PingRequest) ([]byte, error) {
+					out := &bytes.Buffer{}
+					switch wire {
+					case "envelope":
+						w := &envelopeWriter{writer: out, codec: c.codec, bufferPool: pool}
+						return func(msg *pingv1.PingRequest) ([]byte, error) {
+							out.Reset()
+							if err := w.Marshal(msg); err != nil {
+								return nil, err
+							}
+							return out.Bytes(), nil
+						}
+					default: // triple
+						m := &tripleUnaryMarshaler{writer: out, codec: c.codec, bufferPool: pool}
+						return func(msg *pingv1.PingRequest) ([]byte, error) {
+							out.Reset()
+							if err := m.Marshal(msg); err != nil {
+								return nil, err
+							}
+							return out.Bytes(), nil
+						}
+					}
+				}
+				// Marshal the huge message first, then the tiny one through the
+				// SAME marshaler and buffer pool: if an 8MiB+1 buffer were ever
+				// recycled without being dropped/reset, residue would leak into
+				// the small message's wire bytes below.
+				shared := newMarshalTo(newBufferPool())
+				if _, err := shared(large); err != nil {
+					t.Fatalf("%s/%s large marshal: %v", wire, c.name, err)
+				}
+				afterLarge, err := shared(small)
+				if err != nil {
+					t.Fatalf("%s/%s small marshal after large: %v", wire, c.name, err)
+				}
+				// The tiny message's wire bytes must be exactly the same as if
+				// it had never been preceded by an 8MiB+1 message. The reference
+				// is marshaled on an independent, uncontaminated pool.
+				expected, err := newMarshalTo(newBufferPool())(small)
+				if err != nil {
+					t.Fatalf("%s/%s reference small marshal: %v", wire, c.name, err)
+				}
+				if !bytes.Equal(afterLarge, expected) {
+					t.Fatalf("%s/%s small message output changed after 8MiB+1 message: got %d bytes, want %d",
+						wire, c.name, len(afterLarge), len(expected))
+				}
+				if len(afterLarge) == 0 {
+					t.Fatalf("%s/%s small message produced empty output", wire, c.name)
+				}
+			}
+		}
+	})
+}
+
+// ---------------------------------------------------------------
+// 6. Concurrency (run under -race)
+// ---------------------------------------------------------------
+
+func TestMarshalPerfConcurrentSend(t *testing.T) {
+	// Production sends are serialized per connection, but bufferPool is shared
+	// across connections/goroutines. This test drives many goroutines, each
+	// with its own envelopeWriter but sharing one bufferPool, to lock the
+	// sync.Pool race-safety invariant under -race and verify no errors and no
+	// lost/corrupted output.
+	msg := newMarshalPerfMessage(128)
+	sharedPool := newBufferPool()
+	// Per-iteration output length on a single reference call.
+	ref := &envelopeWriter{writer: &syncBuffer{}, codec: &protoBinaryCodec{}, bufferPool: sharedPool}
+	refOut := &syncBuffer{}
+	ref.writer = refOut
+	if err := ref.Marshal(msg); err != nil {
+		t.Fatal(err)
+	}
+	perIter := refOut.Len()
+	if perIter <= 5 {
+		t.Fatalf("unexpected reference envelope length %d", perIter)
+	}
+
+	const goroutines = 32
+	const iters = 100
+	var wg sync.WaitGroup
+	errCh := make(chan error, goroutines)
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			out := &syncBuffer{}
+			w := &envelopeWriter{
+				writer:     out,
+				codec:      &protoBinaryCodec{},
+				bufferPool: sharedPool,
+			}
+			for i := 0; i < iters; i++ {
+				if err := w.Marshal(msg); err != nil {
+					errCh <- fmt.Errorf("concurrent marshal: %w", err)
+					return
+				}
+			}
+			if out.Len() != iters*perIter {
+				errCh <- fmt.Errorf("goroutine output length %d, want %d", out.Len(), iters*perIter)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatal(err)
+	}
+}
+
+// ---------------------------------------------------------------
+// 7. Type guard: the fast path is limited to codecs whose MarshalAppend
+//    semantics are byte-identical to Marshal (protoBinaryCodec and the
+//    server codec session, which delegates to it for IDL proto messages).
+// ---------------------------------------------------------------
+
+func TestMarshalPerfTypeGuard(t *testing.T) {
+	t.Parallel()
+
+	implements := func(c Codec) bool {
+		_, ok := c.(marshalAppender)
+		return ok
+	}
+
+	if !implements(&protoBinaryCodec{}) {
+		t.Fatal("protoBinaryCodec must implement marshalAppender")
+	}
+	// tripleServerCodecSession wraps the proto codec on the server response
+	// path; it must reach the fast path too, or the optimization is skipped
+	// for every native triple server response.
+	if !implements(&tripleServerCodecSession{delegate: &protoBinaryCodec{}}) {
+		t.Fatal("tripleServerCodecSession must implement marshalAppender (server response fast path)")
+	}
+
+	never := []struct {
+		name  string
+		codec Codec
+	}{
+		{name: "noAppender wrapper", codec: &noAppenderCodec{&protoBinaryCodec{}}},
+		{name: "proto wrapper (hessian inner)", codec: newProtoWrapperCodec(&hessian2Codec{})},
+		{name: "hessian2", codec: &hessian2Codec{}},
+		{name: "msgpack", codec: &msgpackCodec{}},
+		{name: "json", codec: &protoJSONCodec{name: codecNameJSON}},
+	}
+	for _, tc := range never {
+		if implements(tc.codec) {
+			t.Fatalf("%s must NOT implement marshalAppender (fast path scope leak)", tc.name)
+		}
+	}
+}
+
+// ---------------------------------------------------------------
+// 8. Error guard: non-proto message never panics, errors as CodeInternal
+// ---------------------------------------------------------------
+
+func TestMarshalPerfErrorGuard(t *testing.T) {
+	t.Parallel()
+
+	nonProto := any("definitely not a proto message")
+
+	t.Run("MarshalAppend rejects non-proto", func(t *testing.T) {
+		c := &protoBinaryCodec{}
+		_, err := c.MarshalAppend(make([]byte, 0, 16), nonProto)
+		if err == nil {
+			t.Fatal("expected errNotProto from MarshalAppend, got nil")
+		}
+	})
+
+	t.Run("marshalers return CodeInternal without panicking", func(t *testing.T) {
+		for _, wire := range []string{"envelope", "triple"} {
+			for _, c := range regressionCodecList() {
+				var err *Error
+				switch wire {
+				case "envelope":
+					w, _ := newEnvelopeWriterForTest(t, c.codec, false, 0, 0)
+					err = w.Marshal(nonProto)
+				case "triple":
+					m, _, _ := newTripleMarshalerForTest(t, c.codec, false, 0, 0)
+					err = m.Marshal(nonProto)
+				}
+				wantCode(t, err, CodeInternal)
+			}
+		}
+	})
+
+	t.Run("primary error with nil backup is CodeInternal", func(t *testing.T) {
+		// Already exercised in the fallback test; assert the plain error text
+		// does not swallow the underlying errNotProto cause.
+		c := &protoBinaryCodec{}
+		_, err := c.MarshalAppend(nil, nonProto)
+		if err == nil || !strings.Contains(err.Error(), "doesn't implement proto.Message") {
+			t.Fatalf("expected errNotProto naming proto.Message, got: %v", err)
+		}
+	})
+}
+
+// fastPathProbeCodec distinguishes the marshalAppender fast path from the
+// codec.Marshal slow path: Marshal always fails, MarshalAppend counts calls.
+// Wire-parity tests alone cannot catch a silent regression back to the slow
+// path because both paths emit byte-equal output; this probe turns any such
+// leak into a hard test failure.
+type fastPathProbeCodec struct {
+	appendCalls int
+}
+
+var _ Codec = (*fastPathProbeCodec)(nil)
+var _ marshalAppender = (*fastPathProbeCodec)(nil)
+
+func (c *fastPathProbeCodec) Name() string { return codecNameProto }
+func (c *fastPathProbeCodec) Marshal(any) ([]byte, error) {
+	return nil, errors.New("slow path taken: codec.Marshal must not run on the marshalAppender fast path")
+}
+func (c *fastPathProbeCodec) Unmarshal([]byte, any) error { return nil }
+func (c *fastPathProbeCodec) MarshalAppend(dst []byte, _ any) ([]byte, error) {
+	c.appendCalls++
+	return append(dst, "probe-payload"...), nil
+}
+
+// ---------------------------------------------------------------
+// 9. Server codec session fast path: triple server responses reach the
+//    MarshalAppend branch with byte-identical output
+// ---------------------------------------------------------------
+
+// TestMarshalPerfServerSessionFastPath locks the server-side fix: the triple
+// handler always wraps the proto codec in tripleServerCodecSession
+// (protocol_triple.go), which now implements marshalAppender. IDL proto
+// responses must marshal through the same fast path as the naked codec, and
+// Non-IDL wrapped responses must produce the same bytes via MarshalAppend as
+// via Marshal.
+func TestMarshalPerfServerSessionFastPath(t *testing.T) {
+	t.Parallel()
+
+	msg := &pingv1.PingRequest{Text: "server-session"}
+
+	t.Run("IDL proto response matches naked codec wire", func(t *testing.T) {
+		// codecSession implements marshalAppender, so tripleUnaryMarshaler
+		// takes the MarshalAppend branch on the server response path.
+		fast, outFast, _ := newTripleMarshalerForTest(t, &tripleServerCodecSession{delegate: &protoBinaryCodec{}}, false, 0, 0)
+		if err := fast.Marshal(msg); err != nil {
+			t.Fatalf("session marshal: %v", err)
+		}
+		ref, outRef, _ := newTripleMarshalerForTest(t, &protoBinaryCodec{}, false, 0, 0)
+		if err := ref.Marshal(msg); err != nil {
+			t.Fatalf("reference marshal: %v", err)
+		}
+		if got, want := outFast.Bytes(), outRef.Bytes(); !bytes.Equal(got, want) {
+			t.Fatalf("session fast path wire mismatch: got %d bytes, want %d", len(got), len(want))
+		}
+	})
+
+	t.Run("Non-IDL wrapped MarshalAppend equals Marshal", func(t *testing.T) {
+		messages := []struct {
+			name string
+			msg  any
+		}{
+			{name: "scalar payload", msg: "payload"},
+			{name: "one-result container", msg: []any{"payload"}},
+			{name: "void container", msg: []any{}},
+		}
+		for _, serializeType := range []string{codecNameHessian2, codecNameMsgPack} {
+			for _, mc := range messages {
+				session := &tripleServerCodecSession{delegate: &protoBinaryCodec{}, serializeType: serializeType}
+				got, err := session.MarshalAppend(nil, mc.msg)
+				if err != nil {
+					t.Fatalf("%s/%s MarshalAppend: %v", serializeType, mc.name, err)
+				}
+				want, err := session.Marshal(mc.msg)
+				if err != nil {
+					t.Fatalf("%s/%s Marshal: %v", serializeType, mc.name, err)
+				}
+				if !bytes.Equal(got, want) {
+					t.Fatalf("%s/%s MarshalAppend != Marshal (%d vs %d bytes)", serializeType, mc.name, len(got), len(want))
+				}
+			}
+		}
+	})
+
+	t.Run("custom proto delegate without appender falls back", func(t *testing.T) {
+		// A session over a proto codec lacking the appender extension must not
+		// break: MarshalAppend degrades to marshal-plus-append, byte-equal to
+		// the naked codec's output.
+		session := &tripleServerCodecSession{delegate: &noAppenderCodec{&protoBinaryCodec{}}}
+		got, err := session.MarshalAppend(nil, msg)
+		if err != nil {
+			t.Fatalf("fallback MarshalAppend: %v", err)
+		}
+		want, err := (&protoBinaryCodec{}).Marshal(msg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(got, want) {
+			t.Fatalf("fallback MarshalAppend mismatch: got %d bytes, want %d", len(got), len(want))
+		}
+	})
+
+	t.Run("server response must hit MarshalAppend, not the slow path", func(t *testing.T) {
+		// The probe's Marshal always fails, so a successful Marshal can only
+		// have gone through MarshalAppend. Catches the regression where the
+		// codecSession wrapper stops implementing marshalAppender or the
+		// marshaler silently falls back to codec.Marshal.
+		for _, compress := range []bool{false, true} {
+			probe := &fastPathProbeCodec{}
+			session := &tripleServerCodecSession{delegate: probe}
+			m, _, _ := newTripleMarshalerForTest(t, session, compress, 0, 0)
+			if err := m.Marshal(msg); err != nil {
+				t.Fatalf("compressed=%v Marshal: %v (slow path leaked into server responses?)", compress, err)
+			}
+			if probe.appendCalls != 1 {
+				t.Fatalf("compressed=%v MarshalAppend calls = %d, want 1 (fast path not taken)", compress, probe.appendCalls)
+			}
+		}
+	})
+
+	t.Run("envelope writer session must hit MarshalAppend", func(t *testing.T) {
+		// The session may also sit behind an envelopeWriter (gRPC/Triple
+		// envelope wire); the same no-slow-path guarantee must hold there.
+		probe := &fastPathProbeCodec{}
+		session := &tripleServerCodecSession{delegate: probe}
+		w, _ := newEnvelopeWriterForTest(t, session, false, 0, 0)
+		if err := w.Marshal(msg); err != nil {
+			t.Fatalf("envelope Marshal: %v (slow path leaked?)", err)
+		}
+		if probe.appendCalls != 1 {
+			t.Fatalf("envelope MarshalAppend calls = %d, want 1 (fast path not taken)", probe.appendCalls)
+		}
+	})
+}

--- a/protocol/triple/triple_protocol/marshal_perf_regression_test.go
+++ b/protocol/triple/triple_protocol/marshal_perf_regression_test.go
@@ -34,9 +34,6 @@ import (
 	pingv1 "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/ping/v1"
 )
 
-// ---------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------
 // syncBuffer is an io.Writer that is safe for concurrent use. It lets
 // concurrency tests share one envelopeWriter without corrupting output.
 type syncBuffer struct {
@@ -171,15 +168,8 @@ func wantCode(t *testing.T, err *Error, want Code) {
 	}
 }
 
-// ---------------------------------------------------------------
-// 1. Wire byte parity: fast path output == slow path output
-// ---------------------------------------------------------------
-
-// TestMarshalPerfWireParity locks the core correctness invariant: for the
-// same message and compression setting, the MarshalAppend fast path must emit
-// byte-for-byte the same wire output as the pre-optimization codec.Marshal
-// slow path. Runs on both the triple HTTP body wire (tripleUnaryMarshaler)
-// and the gRPC/Triple envelope wire (envelopeWriter).
+// TestMarshalPerfWireParity verifies that the MarshalAppend fast path and the
+// codec.Marshal slow path emit byte-identical wire output on both wire types.
 func TestMarshalPerfWireParity(t *testing.T) {
 	for _, compress := range []bool{false, true} {
 		t.Run(fmt.Sprintf("compressed=%v", compress), func(t *testing.T) {
@@ -241,10 +231,8 @@ func TestMarshalPerfWireParity(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------
-// 2. Pool invariants and envelope boundaries
-// ---------------------------------------------------------------
-
+// TestMarshalPerfPoolInvariants verifies buffer pool reuse invariants and
+// envelope framing for empty and nil messages.
 func TestMarshalPerfPoolInvariants(t *testing.T) {
 	t.Parallel()
 
@@ -306,11 +294,8 @@ func TestMarshalPerfPoolInvariants(t *testing.T) {
 	})
 
 	t.Run("compressMinBytes boundary does not panic", func(t *testing.T) {
-		// The compression decision is made on the codec's encoded output
-		// length, not the message's Text length (protobuf adds tag+length
-		// prefix bytes). Anchor the boundary on the real encoded length:
-		// threshold == encoded length compresses, threshold == length+1 does
-		// not. Both paths must survive the boundary and agree on the flag.
+		// The compression decision uses the codec's encoded output length: a
+		// threshold equal to the encoded length compresses, one byte more does not.
 		codec := &protoBinaryCodec{}
 		for _, size := range []int{511, 512, 513} {
 			msg := newMarshalPerfMessage(size)
@@ -338,10 +323,6 @@ func TestMarshalPerfPoolInvariants(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------
-// 3. backupCodec fallback parity (fast and slow paths)
-// ---------------------------------------------------------------
-
 // errorCodec implements Codec and marshalAppender, always failing. It forces
 // the envelopeWriter fast path (MarshalAppend) and slow path (Marshal) into
 // their backup-codec fallback branches.
@@ -364,6 +345,8 @@ func (errorCodec) Unmarshal([]byte, any) error {
 	return errors.New("primary codec unmarshal failed")
 }
 
+// TestMarshalPerfBackupCodecFallback verifies the backup-codec fallback on the
+// fast (MarshalAppend) and slow (Marshal) paths.
 func TestMarshalPerfBackupCodecFallback(t *testing.T) {
 	msg := &pingv1.PingRequest{Text: "fallback"}
 	// Reference wire bytes produced by the healthy codec.
@@ -402,11 +385,8 @@ func TestMarshalPerfBackupCodecFallback(t *testing.T) {
 	})
 
 	t.Run("write failure with healthy appender does not fall back", func(t *testing.T) {
-		// Regression: the fast path may fall back only on a marshal failure.
-		// A healthy appender codec whose marshal succeeds but whose write fails
-		// (I/O error, compression, or the sendMaxBytes limit) must surface that
-		// error as-is; the backup codec must not be consulted and the writer
-		// must not see a second write attempt.
+		// The fast path falls back only on a marshal failure: a write error
+		// must surface as-is, without consulting the backup codec or retrying.
 		backup := &countingNamedCodec{Codec: &protoBinaryCodec{}, name: "hessian2"}
 		out := &failingWriter{}
 		w := &envelopeWriter{
@@ -425,10 +405,8 @@ func TestMarshalPerfBackupCodecFallback(t *testing.T) {
 	})
 
 	t.Run("same name does not double fallback", func(t *testing.T) {
-		// Backup shares the failing codec's name; no fallback may occur (that
-		// would risk infinite recursion), so the error surfaces. errorCodec
-		// implements marshalAppender (fast leg); wrapping it hides the
-		// extension (slow leg).
+		// A backup sharing the codec's name must not be consulted, so the error
+		// surfaces on both the fast and slow legs.
 		legs := []struct {
 			name  string
 			codec Codec
@@ -497,10 +475,8 @@ func (c *countingNamedCodec) Marshal(message any) ([]byte, error) {
 	return c.Codec.Marshal(message)
 }
 
-// ---------------------------------------------------------------
-// 4. Compression threshold and sendMaxBytes consistency
-// ---------------------------------------------------------------
-
+// TestMarshalPerfCompressionAndMaxBytes verifies the sendMaxBytes limit and
+// compression headers on both paths.
 func TestMarshalPerfCompressionAndMaxBytes(t *testing.T) {
 	t.Parallel()
 
@@ -552,10 +528,8 @@ func TestMarshalPerfCompressionAndMaxBytes(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------
-// 5. >8MiB buffers are dropped, not recycled (no residue)
-// ---------------------------------------------------------------
-
+// TestMarshalPerfLargeBufferDropped verifies that buffers larger than
+// maxRecycleBufferSize are dropped rather than recycled.
 func TestMarshalPerfLargeBufferDropped(t *testing.T) {
 	t.Parallel()
 
@@ -611,9 +585,7 @@ func TestMarshalPerfLargeBufferDropped(t *testing.T) {
 					}
 				}
 				// Marshal the huge message first, then the tiny one through the
-				// SAME marshaler and buffer pool: if an 8MiB+1 buffer were ever
-				// recycled without being dropped/reset, residue would leak into
-				// the small message's wire bytes below.
+				// same pool; recycled residue would leak into the small output.
 				shared := newMarshalTo(newBufferPool())
 				if _, err := shared(large); err != nil {
 					t.Fatalf("%s/%s large marshal: %v", wire, c.name, err)
@@ -641,16 +613,10 @@ func TestMarshalPerfLargeBufferDropped(t *testing.T) {
 	})
 }
 
-// ---------------------------------------------------------------
-// 6. Concurrency (run under -race)
-// ---------------------------------------------------------------
-
+// TestMarshalPerfConcurrentSend verifies bufferPool safety under concurrent use.
 func TestMarshalPerfConcurrentSend(t *testing.T) {
-	// Production sends are serialized per connection, but bufferPool is shared
-	// across connections/goroutines. This test drives many goroutines, each
-	// with its own envelopeWriter but sharing one bufferPool, to lock the
-	// sync.Pool race-safety invariant under -race and verify no errors and no
-	// lost/corrupted output.
+	// Drive concurrent envelopeWriters sharing one bufferPool to verify
+	// sync.Pool race safety and that no output is lost or corrupted.
 	msg := newMarshalPerfMessage(128)
 	sharedPool := newBufferPool()
 	// Per-iteration output length on a single reference call.
@@ -695,12 +661,9 @@ func TestMarshalPerfConcurrentSend(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------
-// 7. Type guard: the fast path is limited to codecs whose MarshalAppend
-//    semantics are byte-identical to Marshal (protoBinaryCodec and the
-//    server codec session, which delegates to it for IDL proto messages).
-// ---------------------------------------------------------------
-
+// Type guard: only protoBinaryCodec and the tripleServerCodecSession wrapper
+// may expose the marshalAppender fast path; all other codecs must stay on
+// codec.Marshal.
 func TestMarshalPerfTypeGuard(t *testing.T) {
 	t.Parallel()
 
@@ -736,10 +699,9 @@ func TestMarshalPerfTypeGuard(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------
-// 8. Error guard: non-proto message never panics, errors as CodeInternal
-// ---------------------------------------------------------------
-
+// TestMarshalPerfErrorGuard verifies that non-proto messages never panic:
+// MarshalAppend returns errNotProto, and the envelope and triple marshalers
+// surface CodeInternal on both the fast and slow paths.
 func TestMarshalPerfErrorGuard(t *testing.T) {
 	t.Parallel()
 
@@ -781,11 +743,8 @@ func TestMarshalPerfErrorGuard(t *testing.T) {
 	})
 }
 
-// fastPathProbeCodec distinguishes the marshalAppender fast path from the
-// codec.Marshal slow path: Marshal always fails, MarshalAppend counts calls.
-// Wire-parity tests alone cannot catch a silent regression back to the slow
-// path because both paths emit byte-equal output; this probe turns any such
-// leak into a hard test failure.
+// fastPathProbeCodec distinguishes the fast and slow paths: Marshal always
+// fails while MarshalAppend counts calls, so a slow-path leak fails the test.
 type fastPathProbeCodec struct {
 	appendCalls int
 }
@@ -803,17 +762,10 @@ func (c *fastPathProbeCodec) MarshalAppend(dst []byte, _ any) ([]byte, error) {
 	return append(dst, "probe-payload"...), nil
 }
 
-// ---------------------------------------------------------------
-// 9. Server codec session fast path: triple server responses reach the
-//    MarshalAppend branch with byte-identical output
-// ---------------------------------------------------------------
-
-// TestMarshalPerfServerSessionFastPath locks the server-side fix: the triple
-// handler always wraps the proto codec in tripleServerCodecSession
-// (protocol_triple.go), which now implements marshalAppender. IDL proto
-// responses must marshal through the same fast path as the naked codec, and
-// Non-IDL wrapped responses must produce the same bytes via MarshalAppend as
-// via Marshal.
+// TestMarshalPerfServerSessionFastPath verifies that tripleServerCodecSession
+// responses reach the MarshalAppend fast path: IDL proto output stays
+// byte-identical to the naked codec, non-IDL MarshalAppend equals Marshal,
+// and delegates without the appender extension fall back gracefully.
 func TestMarshalPerfServerSessionFastPath(t *testing.T) {
 	t.Parallel()
 
@@ -881,10 +833,8 @@ func TestMarshalPerfServerSessionFastPath(t *testing.T) {
 	})
 
 	t.Run("server response must hit MarshalAppend, not the slow path", func(t *testing.T) {
-		// The probe's Marshal always fails, so a successful Marshal can only
-		// have gone through MarshalAppend. Catches the regression where the
-		// codecSession wrapper stops implementing marshalAppender or the
-		// marshaler silently falls back to codec.Marshal.
+		// The probe's Marshal always fails, so a successful Marshal proves the
+		// MarshalAppend fast path was taken.
 		for _, compress := range []bool{false, true} {
 			probe := &fastPathProbeCodec{}
 			session := &tripleServerCodecSession{delegate: probe}

--- a/protocol/triple/triple_protocol/marshal_perf_regression_test.go
+++ b/protocol/triple/triple_protocol/marshal_perf_regression_test.go
@@ -185,7 +185,6 @@ func TestMarshalPerfWireParity(t *testing.T) {
 	for _, compress := range []bool{false, true} {
 		t.Run(fmt.Sprintf("compressed=%v", compress), func(t *testing.T) {
 			for _, size := range regressionPayloadSizes() {
-				size := size
 				t.Run(regressionSizeLabel(size), func(t *testing.T) {
 					t.Parallel()
 					msg := newMarshalPerfMessage(size)

--- a/protocol/triple/triple_protocol/marshal_perf_regression_test.go
+++ b/protocol/triple/triple_protocol/marshal_perf_regression_test.go
@@ -37,7 +37,6 @@ import (
 // ---------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------
-
 // syncBuffer is an io.Writer that is safe for concurrent use. It lets
 // concurrency tests share one envelopeWriter without corrupting output.
 type syncBuffer struct {
@@ -670,17 +669,15 @@ func TestMarshalPerfConcurrentSend(t *testing.T) {
 	const iters = 100
 	var wg sync.WaitGroup
 	errCh := make(chan error, goroutines)
-	for g := 0; g < goroutines; g++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range goroutines {
+		wg.Go(func() {
 			out := &syncBuffer{}
 			w := &envelopeWriter{
 				writer:     out,
 				codec:      &protoBinaryCodec{},
 				bufferPool: sharedPool,
 			}
-			for i := 0; i < iters; i++ {
+			for range iters {
 				if err := w.Marshal(msg); err != nil {
 					errCh <- fmt.Errorf("concurrent marshal: %w", err)
 					return
@@ -689,7 +686,7 @@ func TestMarshalPerfConcurrentSend(t *testing.T) {
 			if out.Len() != iters*perIter {
 				errCh <- fmt.Errorf("goroutine output length %d, want %d", out.Len(), iters*perIter)
 			}
-		}()
+		})
 	}
 	wg.Wait()
 	close(errCh)

--- a/protocol/triple/triple_protocol/marshal_perf_regression_test.go
+++ b/protocol/triple/triple_protocol/marshal_perf_regression_test.go
@@ -34,8 +34,11 @@ import (
 	pingv1 "dubbo.apache.org/dubbo-go/v3/protocol/triple/triple_protocol/internal/gen/proto/connect/ping/v1"
 )
 
-// syncBuffer is an io.Writer that is safe for concurrent use. It lets
-// concurrency tests share one envelopeWriter without corrupting output.
+// syncBuffer is an io.Writer whose individual Write calls are safe for
+// concurrent use. Each goroutine in the concurrency test writes to its own
+// syncBuffer: emitting an envelope frame takes two Write calls (5-byte prefix
+// then payload), so giving each writer its own buffer prevents frames from
+// interleaving.
 type syncBuffer struct {
 	mu  sync.Mutex
 	buf bytes.Buffer
@@ -615,50 +618,101 @@ func TestMarshalPerfLargeBufferDropped(t *testing.T) {
 
 // TestMarshalPerfConcurrentSend verifies bufferPool safety under concurrent use.
 func TestMarshalPerfConcurrentSend(t *testing.T) {
-	// Drive concurrent envelopeWriters sharing one bufferPool to verify
-	// sync.Pool race safety and that no output is lost or corrupted.
-	msg := newMarshalPerfMessage(128)
-	sharedPool := newBufferPool()
-	// Per-iteration output length on a single reference call.
-	ref := &envelopeWriter{writer: &syncBuffer{}, codec: &protoBinaryCodec{}, bufferPool: sharedPool}
-	refOut := &syncBuffer{}
-	ref.writer = refOut
-	if err := ref.Marshal(msg); err != nil {
-		t.Fatal(err)
-	}
-	perIter := refOut.Len()
-	if perIter <= 5 {
-		t.Fatalf("unexpected reference envelope length %d", perIter)
-	}
-
-	const goroutines = 32
-	const iters = 100
-	var wg sync.WaitGroup
-	errCh := make(chan error, goroutines)
-	for range goroutines {
-		wg.Go(func() {
-			out := &syncBuffer{}
-			w := &envelopeWriter{
-				writer:     out,
-				codec:      &protoBinaryCodec{},
-				bufferPool: sharedPool,
+	for _, c := range regressionCodecList() {
+		t.Run(c.name, func(t *testing.T) {
+			// Drive concurrent envelopeWriters sharing one bufferPool. Each
+			// goroutine sends a globally unique payload per message, then
+			// decodes every emitted frame and verifies its content. Distinct
+			// content plus per-frame decode prevents cross-goroutine corruption
+			// from going unnoticed without -race: overwritten frames keep the
+			// same length, which a length-only check would not catch.
+			sharedPool := newBufferPool()
+			const goroutines = 32
+			const iters = 100
+			var wg sync.WaitGroup
+			errCh := make(chan error, goroutines)
+			// Start gate: every goroutine blocks until all 32 are ready. This
+			// keeps the pool actually contended and prevents the outcome from
+			// depending on the scheduler interleaving the goroutines.
+			var ready sync.WaitGroup
+			ready.Add(goroutines)
+			start := make(chan struct{})
+			for g := range goroutines {
+				wg.Go(func() {
+					ready.Done()
+					<-start
+					out := &syncBuffer{}
+					w := &envelopeWriter{
+						writer:     out,
+						codec:      c.codec,
+						bufferPool: sharedPool,
+					}
+					// Number uniquely identifies (goroutine, iteration) across
+					// the whole test, so content swapped between goroutines is
+					// reported, not silently accepted.
+					want := make([]*pingv1.PingRequest, 0, iters)
+					for i := range iters {
+						msg := &pingv1.PingRequest{
+							Number: int64(g*iters + i),
+							Text:   fmt.Sprintf("goroutine-%02d-message-%03d", g, i),
+						}
+						want = append(want, msg)
+						if err := w.Marshal(msg); err != nil {
+							errCh <- fmt.Errorf("goroutine %d marshal message %d: %w", g, i, err)
+							return
+						}
+					}
+					if err := verifyEnvelopeFrames(out.Bytes(), c.codec, want); err != nil {
+						errCh <- fmt.Errorf("goroutine %d: %w", g, err)
+					}
+				})
 			}
-			for range iters {
-				if err := w.Marshal(msg); err != nil {
-					errCh <- fmt.Errorf("concurrent marshal: %w", err)
-					return
-				}
-			}
-			if out.Len() != iters*perIter {
-				errCh <- fmt.Errorf("goroutine output length %d, want %d", out.Len(), iters*perIter)
+			ready.Wait()
+			close(start)
+			wg.Wait()
+			close(errCh)
+			for err := range errCh {
+				t.Fatal(err)
 			}
 		})
 	}
-	wg.Wait()
-	close(errCh)
-	for err := range errCh {
-		t.Fatal(err)
+}
+
+// verifyEnvelopeFrames walks the gRPC/Triple envelope stream written by
+// envelopeWriter and checks that every frame unmarshals to the corresponding
+// expected message. The frames must be uncompressed (flags == 0) and exactly
+// account for the whole stream.
+func verifyEnvelopeFrames(wire []byte, codec Codec, want []*pingv1.PingRequest) error {
+	pos := 0
+	for n, expected := range want {
+		if len(wire)-pos < 5 {
+			return fmt.Errorf("frame %d: truncated envelope prefix (%d bytes left)", n, len(wire)-pos)
+		}
+		if flags := wire[pos]; flags != 0 {
+			return fmt.Errorf("frame %d: unexpected flags 0x%x (only uncompressed frames expected)", n, flags)
+		}
+		length := int(binary.BigEndian.Uint32(wire[pos+1 : pos+5]))
+		pos += 5
+		if len(wire)-pos < length {
+			return fmt.Errorf("frame %d: payload length %d exceeds remaining %d bytes", n, length, len(wire)-pos)
+		}
+		payload := wire[pos : pos+length]
+		pos += length
+		var got pingv1.PingRequest
+		if err := codec.Unmarshal(payload, &got); err != nil {
+			return fmt.Errorf("frame %d: unmarshal: %w", n, err)
+		}
+		if got.Number != expected.Number || got.Text != expected.Text {
+			return fmt.Errorf(
+				"frame %d: content mismatch: got Number=%d Text=%q, want Number=%d Text=%q",
+				n, got.Number, got.Text, expected.Number, expected.Text,
+			)
+		}
 	}
+	if pos != len(wire) {
+		return fmt.Errorf("%d trailing bytes after %d frames", len(wire)-pos, len(want))
+	}
+	return nil
 }
 
 // Type guard: only protoBinaryCodec and the tripleServerCodecSession wrapper
@@ -696,6 +750,25 @@ func TestMarshalPerfTypeGuard(t *testing.T) {
 		if implements(tc.codec) {
 			t.Fatalf("%s must NOT implement marshalAppender (fast path scope leak)", tc.name)
 		}
+	}
+}
+
+// TestMarshalPerfEnvelopeWriterFastPath verifies that envelopeWriter.Marshal
+// really takes the MarshalAppend fast path when the codec implements
+// marshalAppender. fastPathProbeCodec.Marshal always fails, so only the
+// appender branch can produce a successful write; the probe counts the
+// appender calls to make the branch observable.
+func TestMarshalPerfEnvelopeWriterFastPath(t *testing.T) {
+	probe := &fastPathProbeCodec{}
+	w, out := newEnvelopeWriterForTest(t, probe, false, 0, 0)
+	if err := w.Marshal(&pingv1.PingRequest{Text: "fast-path"}); err != nil {
+		t.Fatalf("envelopeWriter.Marshal with appender codec failed: %v", err)
+	}
+	if probe.appendCalls != 1 {
+		t.Fatalf("MarshalAppend called %d times, want 1 (fast path not taken)", probe.appendCalls)
+	}
+	if out.Len() == 0 {
+		t.Fatal("fast path wrote no bytes")
 	}
 }
 

--- a/protocol/triple/triple_protocol/protocol_triple.go
+++ b/protocol/triple/triple_protocol/protocol_triple.go
@@ -505,6 +505,11 @@ func (m *tripleUnaryMarshaler) Marshal(message any) *Error {
 	if message == nil {
 		return m.write(nil)
 	}
+	// Fast path: if the codec can append to a caller-provided buffer, marshal
+	// directly into a pooled buffer to avoid the per-request allocation.
+	if appender, ok := m.codec.(marshalAppender); ok {
+		return m.marshalAndWrite(message, appender)
+	}
 	data, err := m.codec.Marshal(message)
 	if err != nil {
 		return errorf(CodeInternal, "marshal message: %w", err)
@@ -512,15 +517,36 @@ func (m *tripleUnaryMarshaler) Marshal(message any) *Error {
 	// Can't avoid allocating the slice, but we can reuse it.
 	uncompressed := bytes.NewBuffer(data)
 	defer m.bufferPool.Put(uncompressed)
-	if len(data) < m.compressMinBytes || m.compressionPool == nil {
-		if m.sendMaxBytes > 0 && len(data) > m.sendMaxBytes {
-			return NewError(CodeResourceExhausted, fmt.Errorf("message size %d exceeds sendMaxBytes %d", len(data), m.sendMaxBytes))
+	return m.compressAndWrite(uncompressed)
+}
+
+// marshalAndWrite serializes message into a pooled *bytes.Buffer, compressing if
+// necessary, and writes it.
+func (m *tripleUnaryMarshaler) marshalAndWrite(message any, appender marshalAppender) *Error {
+	buffer, err := marshalToPool(m.bufferPool, appender, message)
+	if err != nil {
+		return err
+	}
+	defer m.bufferPool.Put(buffer)
+	return m.compressAndWrite(buffer)
+}
+
+// compressAndWrite enforces the compression threshold and the sendMaxBytes
+// limit on the marshaled bytes in buffer, sets the compression header when the
+// payload is compressed, and writes the result. It is the shared tail of both
+// Marshal (slow path, bytes produced by codec.Marshal) and marshalAndWrite
+// (fast path, bytes produced by marshalAppender.MarshalAppend), so the
+// compression policy can never drift between the two paths.
+func (m *tripleUnaryMarshaler) compressAndWrite(buffer *bytes.Buffer) *Error {
+	if buffer.Len() < m.compressMinBytes || m.compressionPool == nil {
+		if m.sendMaxBytes > 0 && buffer.Len() > m.sendMaxBytes {
+			return NewError(CodeResourceExhausted, fmt.Errorf("message size %d exceeds sendMaxBytes %d", buffer.Len(), m.sendMaxBytes))
 		}
-		return m.write(data)
+		return m.write(buffer.Bytes())
 	}
 	compressed := m.bufferPool.Get()
 	defer m.bufferPool.Put(compressed)
-	if err := m.compressionPool.Compress(compressed, uncompressed); err != nil {
+	if err := m.compressionPool.Compress(compressed, buffer); err != nil {
 		return err
 	}
 	if m.sendMaxBytes > 0 && compressed.Len() > m.sendMaxBytes {


### PR DESCRIPTION
### Description
Fixes #3717
Triple unary RPCs serialize every payload through `codec.Marshal`, which calls `proto.Marshal`. Because `proto.Marshal` always starts from `nil`, each message pays a structural per-request allocation tax: a fresh `[]byte` of ~L bytes is allocated and zeroed (`memclr`) from scratch, then `bytes.NewBuffer(raw)` wraps it with a ~40B escaping allocation before the bytes are written to the transport. 

1. **Per-message output slice (optimization point A)**: `proto.Marshal` builds the encoded payload from a `nil` starting point, so the slice can never reuse the pooled capacity that `bufferPool` already holds. Each message allocates ~L bytes and memclr-zeroes them (~53µs at 1MiB), even though the pool hands out a reusable `*bytes.Buffer` on the same call path.
2. **Fresh wrapper + transport copy (optimization point B)**: the freshly allocated slice is wrapped by `bytes.NewBuffer(raw)` (a ~40B escaping allocation) and then copied wholesale into the transport writer, while the pooled buffer underneath is returned without its underlying array ever being reused.
3. **Server-side generic responses allocate twice**: non-IDL server responses are wrapped in a `TripleResponseWrapper` by `tripleServerCodecSession`, serializing the payload and the wrapper as two separate allocations.

The fix mirrors the approach upstream connect-go already ships (`marshalAppend`): marshal into the caller-provided pooled buffer instead of into a fresh slice. It is purely additive, codecs without the extension are untouched and keep their exact previous behavior.

### Changes

**1. Optional `marshalAppender` codec extension (non-breaking)**

`protocol/triple/triple_protocol/codec.go`:
- Add optional interface `marshalAppender { MarshalAppend(dst []byte, message any) ([]byte, error) }`; implementing codecs serialize into a caller-provided buffer. The `Codec` interface itself is unchanged, so hessian2/json/msgpack and third-party codecs compile and behave exactly as before.
- `protoBinaryCodec.MarshalAppend` delegates to `proto.MarshalOptions{}.MarshalAppend`, which drives the same protobuf encoder, so output is byte-identical to `Marshal`, and the cap-gated pure-append path means zero allocation when the buffer's spare capacity suffices.
- `tripleServerCodecSession.MarshalAppend` extends the per-request server codec: the IDL leg forwards to the delegate's appender, and the non-IDL leg marshals the inner payload with its own codec but appends the outer `TripleResponseWrapper` into the caller-provided buffer instead of allocating a fresh slice, so server responses reach the fast path too.

`protocol/triple/triple_protocol/buffer_pool.go`:
- Add shared helper `marshalToPool(pool, appender, message)`: borrow a `*bytes.Buffer` from `bufferPool`, call `MarshalAppend` into its spare capacity; when the appender had to grow the slice, swap the larger array back into the pooled buffer so the capacity is recycled instead of dropped; on failure the buffer is returned and a `CodeInternal` error surfaces. Both marshalers now share one borrow/marshal/adopt dance.

**2. Fast path in both unary marshalers + a shared compression tail**

`protocol/triple/triple_protocol/envelope.go` (`envelopeWriter.Marshal`, gRPC/Triple envelope wire):
- Probe the codec for `marshalAppender`; on hit run the new `marshalAndWrite` (marshalToPool → `Write(&envelope{Data: buffer})`), preserving the backup-codec fallback semantics of the slow path. On miss the existing `marshalWithFallback` slow path is kept unchanged.

`protocol/triple/triple_protocol/protocol_triple.go` (`tripleUnaryMarshaler.Marshal`, Triple unary body wire):
- Same probe: capable codecs take the new `marshalAndWrite` fast path; codecs without the extension keep the old `codec.Marshal` slow path unchanged.
- The compression tail previously inlined at the end of `Marshal` is extracted into one shared `compressAndWrite`, called by both the fast and slow paths, so the compression threshold, pooled gzip, `sendMaxBytes` enforcement, compression header and final write can never drift between the two.

```mermaid
flowchart TD
    classDef base fill:#f6f8fa,stroke:#8b949e
    classDef added fill:#fff3b0,stroke:#e3a008,stroke-width:2px

    C["Client sends request<br/>conn.Send → marshaler<br/>codec = configured codec (proto → protoBinaryCodec)"]:::base
    S["Server sends response<br/>conn.Send → marshaler<br/>codec = wrapped as tripleServerCodecSession (supports generic calls)"]:::base

    M["tripleUnaryMarshaler.Marshal (L504)<br/>Shared by both sides"]:::base
    P["Capability probe: m.codec.(marshalAppender)"]:::added

    F["Optimized path<br/>marshalAndWrite → marshalToPool<br/>→ MarshalAppender with buffer pooling → zero allocation<br/>(Implementers: protoBinaryCodec / server session wrapper)"]:::added
    SL["Legacy path<br/>codec.Marshal → always allocates"]:::base

    T["compressAndWrite (L540)<br/>Compression / size limit / write header / write body<br/>Common tail path shared by fast & slow (extracted in this change)"]:::added
    O["HTTP body"]:::base

    C --> M
    S --> M
    M --> P
    P -->|hit| F
    P -->|miss| SL
    F --> T
    SL --> T
    T --> O
```

### Test

`marshal_perf_regression_test.go`

| Test | Description |
|---|---|
| `TestMarshalPerfWireParity` | Core invariant: for the same message and compression setting the MarshalAppend fast path emits byte-for-byte the same wire output as the slow `codec.Marshal` path, on both the triple body wire and the envelope wire |
| `TestMarshalPerfPoolInvariants` | `bufferPool.Get` returns an empty buffer, `Put` resets length; `nil` message writes nothing; an empty proto yields a zero-length (5-byte prefix only) envelope; the `compressMinBytes` boundary anchored on the real encoded length never panics and both paths agree on the compression flag |
| `TestMarshalPerfBackupCodecFallback` | A failing codec implementing both `Codec` and `marshalAppender` forces both paths into the backup-codec fallback; output is byte-identical to the healthy reference, with no double fallback, `CodeInternal` on final error, and no panic when the backup is nil |
| `TestMarshalPerfCompressionAndMaxBytes` | Both paths enforce the compression threshold and `sendMaxBytes` identically: over-limit messages return `CodeResourceExhausted`, compressed messages set the `Content-Encoding` header on both |
| `TestMarshalPerfLargeBufferDropped` | Buffers grown beyond the 8MiB recycle cap are dropped, not reused, and a large message leaves no residue for the next small message |
| `TestMarshalPerfConcurrentSend` | Concurrent sends share the same marshaler and `bufferPool` with no data races (run under `-race`) |
| `TestMarshalPerfTypeGuard` | Scope guard: codecs whose `MarshalAppend` is not byte-identical to `Marshal` (hessian2/json/msgpack/backup wrapper) must not implement `marshalAppender`; only `protoBinaryCodec` and `tripleServerCodecSession` do |
| `TestMarshalPerfErrorGuard` | A non-proto message never panics on either path and surfaces as `CodeInternal`, matching slow-path behavior |
| `TestMarshalPerfServerSessionFastPath` | `tripleServerCodecSession` reaches the MarshalAppend branch end to end for both IDL and non-IDL responses with byte-identical output |

`marshal_perf_bench_test.go`

| Benchmark | Description |
|---|---|
| `BenchmarkUnaryMarshalerFastPath` | `tripleUnaryMarshaler.Marshal` with `protoBinaryCodec` (MarshalAppend fast path), payloads 128B / 1KiB / 16KiB / 1MiB |
| `BenchmarkUnaryMarshalerSlowPath` | Control: same marshaler with `noAppenderCodec` (no `marshalAppender`, old `codec.Marshal` path), same payloads |
| `BenchmarkUnaryMarshalerFastPathCompressed` / `SlowPathCompressed` | Fast/slow A/B on the gzip-compressed branch (second pooled buffer, compression header, compressed-size limit check) |
| `BenchmarkEnvelopeWriterFastPath` / `SlowPath` | Same A/B for `envelopeWriter.Marshal` (gRPC/Triple envelope wire) |
| `BenchmarkEnvelopeWriterFastPathCompressed` / `SlowPathCompressed` | Same A/B on the compressed envelope branch |

### Validation
#### pprof CPU Profile diff

<img width="1915" height="958" alt="image" src="https://github.com/user-attachments/assets/da23768b-0a92-4a41-93ab-0634ac295604" />

#### Marshal Fast-Path Benchmark Results

**go test bench -bench=BenchmarkMarshal**

**allocs/op reduced from 3 to 1**

| Message | Before  | After |
| ------- | ------------------ | ----------------- |
| 128B    | 3                  | 1                 |
| 1KiB    | 3                  | 1                 |
| 16KiB   | 3                  | 1                 |
| 1MiB    | 3                  | 1                 |

Both wire slow paths incurred 3 allocations per op, coming from proto marshal + gzip compression buffer + envelope/header overhead. After optimization, only 1 allocation remains, from the gzip compression pool's initial buffer, which is then reused by the pool.

**B/op reduced by approximately −99.8%**

| Message | Before | After  | Reduction |
| ------- | ------------- | ------------ | --------- |
| 128B    | 237           | 6            | -97.47%   |
| 1KiB    | 1252          | 7            | -99.44%   |
| 16KiB   | 18712         | 23           | -99.88%   |
| 1MiB    | 1069533       | 3482         | -99.67%   |

Before optimization, B/op ≈ message size, with full payload copy/allocation per request. After optimization, only fixed overhead remains, and it no longer grows with payload size.

Reproduce:

```bash
# pprof
go test -run '^$' -bench '^BenchmarkUnaryMarshalerSlowPath$' -benchtime=30000x \
  -cpuprofile cpu_slow.out ./protocol/triple/triple_protocol/
go test -run '^$' -bench '^BenchmarkUnaryMarshalerFastPath$' -benchtime=30000x \
  -cpuprofile cpu_fast.out ./protocol/triple/triple_protocol/
go tool pprof -top -diff_base cpu_slow.out cpu_fast.out
# go test bench
go test -run '^$' -bench '^BenchmarkEnvelopeWriter(FastPath|SlowPath)Compressed$' \
  -benchmem -count=3 ./protocol/triple/triple_protocol/

```
### Checklist
- [x] I confirm the target branch is `develop`
- [x] I have run `make fmt` to format my code
- [x] I have run `make test` to run local tests
- [x] I have added tests that prove my fix is effective or that my feature works
