### PR TITLE
fix(config-center): emit delete for empty Nacos callbacks

### DIFF
--- a/config_center/nacos/listener.go
+++ b/config_center/nacos/listener.go
@@ -83,7 +83,7 @@ func (s *keyListenerSet) snapshot() []config_center.ConfigurationListener {
 func callback(set *keyListenerSet, _, group, dataId, data string) {
 	eventType := remoting.EventTypeUpdate
 	// Nacos invokes configuration listeners for both changes and deletions;
-	// see https://nacos.io/en/docs/v3.0/manual/user/python-sdk/usage/.
+	// see https://nacos.io/en/docs/v3.0/manual/user/go-sdk/usage/.
 	// The Nacos Go SDK represents a deleted configuration with empty callback
 	// data, so translate it to Del instead of asking downstream parsers to
 	// process an empty update.

--- a/config_center/nacos/listener.go
+++ b/config_center/nacos/listener.go
@@ -82,6 +82,11 @@ func (s *keyListenerSet) snapshot() []config_center.ConfigurationListener {
 
 func callback(set *keyListenerSet, _, group, dataId, data string) {
 	eventType := remoting.EventTypeUpdate
+	// Nacos invokes configuration listeners for both changes and deletions;
+	// see https://nacos.io/en/docs/v3.0/manual/user/python-sdk/usage/.
+	// The Nacos Go SDK represents a deleted configuration with empty callback
+	// data, so translate it to Del instead of asking downstream parsers to
+	// process an empty update.
 	if data == "" {
 		eventType = remoting.EventTypeDel
 	}

--- a/config_center/nacos/listener.go
+++ b/config_center/nacos/listener.go
@@ -81,9 +81,13 @@ func (s *keyListenerSet) snapshot() []config_center.ConfigurationListener {
 }
 
 func callback(set *keyListenerSet, _, group, dataId, data string) {
+	eventType := remoting.EventTypeUpdate
+	if data == "" {
+		eventType = remoting.EventTypeDel
+	}
 	for _, l := range set.snapshot() {
-		l.Process(&config_center.ConfigChangeEvent{Key: dataId, Value: data, ConfigType: remoting.EventTypeUpdate})
-		metrics.Publish(metricsConfigCenter.NewIncMetricEvent(dataId, group, remoting.EventTypeUpdate, metricsConfigCenter.Nacos))
+		l.Process(&config_center.ConfigChangeEvent{Key: dataId, Value: data, ConfigType: eventType})
+		metrics.Publish(metricsConfigCenter.NewIncMetricEvent(dataId, group, eventType, metricsConfigCenter.Nacos))
 	}
 }
 

--- a/config_center/nacos/listener_test.go
+++ b/config_center/nacos/listener_test.go
@@ -49,6 +49,21 @@ func TestCallback(t *testing.T) {
 	}
 }
 
+func TestCallbackDelete(t *testing.T) {
+	l := &recordingListener{}
+	set := newKeyListenerSet("test-group")
+	set.add(l)
+
+	callback(set, "", "g", "data", "")
+
+	if len(l.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(l.events))
+	}
+	if l.events[0].Key != "data" || l.events[0].Value != "" || l.events[0].ConfigType != remoting.EventTypeDel {
+		t.Fatalf("unexpected event %+v", l.events[0])
+	}
+}
+
 func TestRemoveListener(t *testing.T) {
 	n := &nacosDynamicConfiguration{}
 	key := "k"


### PR DESCRIPTION
## Problem

`ListenConfig` uses one `OnChange` callback for configuration updates and deletions; it does not provide an operation type. In the current Nacos 2.x/nacos-sdk-go flow, deleting a configuration reaches that callback with an empty payload.

Before this change, Dubbo-Go classified every callback as `EventTypeUpdate`:

```text
Nacos delete -> OnChange(data="") -> EventTypeUpdate -> downstream parses empty content
```

Consumers that rely on `EventTypeDel` therefore did not clear local state. In particular, a deleted Script Router could remain active after its empty payload failed to parse.

## Change

```text
Nacos delete -> OnChange(data="") -> EventTypeDel -> downstream clears the deleted rule
```

- map an empty callback payload to `EventTypeDel`; non-empty payloads remain `EventTypeUpdate`
- publish metrics with the same event type delivered to listeners
- add unit coverage for the empty-payload delete mapping

## Scope

This is a nacos-sdk-go/Nacos 2.x compatibility mapping; it does not change normal configuration update handling. Nacos documents that configuration listeners are notified for both changes and deletions: https://nacos.io/en/docs/v3.0/manual/user/go-sdk/usage/.

## Testing

- `go test ./config_center/nacos`